### PR TITLE
Remove some over-precise leftovers

### DIFF
--- a/reviewable.k8s.io/configmap.yaml
+++ b/reviewable.k8s.io/configmap.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: reviewable
-  namespace: reviewable
 data:
   meta-config-version: "1"
   reviewable-host-url: https://reviewable.kubernetes.io

--- a/reviewable.k8s.io/deployment.yaml
+++ b/reviewable.k8s.io/deployment.yaml
@@ -2,11 +2,9 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: reviewable
-  namespace: reviewable
   labels:
     app: reviewable
     version: v1
-    stage: test
 spec:
   replicas: 2
   # selector defaults to template's labels
@@ -20,7 +18,6 @@ spec:
       labels:
         app: reviewable
         version: v1
-        stage: test
     spec:
       terminationGracePeriodSeconds: 30
       imagePullSecrets:

--- a/reviewable.k8s.io/secret-docker-pull.yaml
+++ b/reviewable.k8s.io/secret-docker-pull.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: docker-pull
-  namespace: reviewable
 type: kubernetes.io/dockercfg
 data:
   .dockercfg: <REDACTED>

--- a/reviewable.k8s.io/secret-firebase.yaml
+++ b/reviewable.k8s.io/secret-firebase.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: firebase
-  namespace: reviewable
 data:
   reviewable-firebase: <REDACTED>
   reviewable-firebase-auth: <REDACTED>

--- a/reviewable.k8s.io/secret-github-oauth.yaml
+++ b/reviewable.k8s.io/secret-github-oauth.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: github-oauth
-  namespace: reviewable
 data:
   reviewable-github-client-id: <REDACTED>
   reviewable-github-client-secret: <REDACTED>

--- a/reviewable.k8s.io/secret-github-webhook.yaml
+++ b/reviewable.k8s.io/secret-github-webhook.yaml
@@ -2,6 +2,5 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: github-webhook
-  namespace: reviewable
 data:
   reviewable-github-secret-token: <REDACTED>

--- a/reviewable.k8s.io/secret-license.yaml
+++ b/reviewable.k8s.io/secret-license.yaml
@@ -2,6 +2,5 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: license
-  namespace: reviewable
 data:
   reviewable-license: <REDACTED>

--- a/reviewable.k8s.io/secret-sentry.yaml
+++ b/reviewable.k8s.io/secret-sentry.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: sentry
-  namespace: reviewable
 data:
   reviewable-server-sentry-dsn: <REDACTED>
   reviewable-client-sentry-dsn: <REDACTED>

--- a/reviewable.k8s.io/secret-ssl.yaml
+++ b/reviewable.k8s.io/secret-ssl.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: ssl
-  namespace: reviewable
 type: kubernetes.io/tls
 data:
   tls.crt: <REDACTED>

--- a/reviewable.k8s.io/service.yaml
+++ b/reviewable.k8s.io/service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: reviewable
-  namespace: reviewable
   labels:
     app: reviewable
 spec:


### PR DESCRIPTION
Don't need namespace in every file - assume it is in the kubectl context.