### PR TITLE
Sync k8s.io files to current site, prep canary

### DIFF
--- a/k8s.io/Makefile
+++ b/k8s.io/Makefile
@@ -18,4 +18,4 @@ deploy:
 
 .PHONY: test
 test:
-	python test.py
+	python test.py -q

--- a/k8s.io/canary.sh
+++ b/k8s.io/canary.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+function kc() {
+  kubectl --context=utilicluster --namespace=k8s-io-canary "$@"
+}
+
+kc apply \
+    -f configmap-nginx.yaml \
+    -f configmap-www-get.yaml \
+    -f configmap-www-golang.yaml \
+    -f deployment.yaml \
+    -f service-canary.yaml
+
+while true; do
+  echo "waiting for all replicas to be up"
+  sleep 3
+  read WANT HAVE < <( \
+      kc get deployment k8s-io \
+          -o go-template='{{.spec.replicas}} {{.status.replicas}}{{"\n"}}'
+  )
+  if [ -n "${WANT}" -a -n "${HAVE}" -a "${WANT}" == "${HAVE}" ]; then
+    break
+  fi
+  echo "want ${WANT}, found ${HAVE}"
+done
+
+make test TARGET_IP=104.197.208.221

--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -50,6 +50,13 @@ data:
       #
 
       server {
+        server_name apt.kubernetes.io apt.k8s.io;
+        listen 80;
+
+        rewrite ^/(.*)?$    http://storage.googleapis.com/k8s-releases/apt/$1 redirect;
+      }
+
+      server {
         server_name changelog.kubernetes.io changelog.k8s.io;
         listen 80;
         listen 443 ssl;
@@ -148,10 +155,9 @@ data:
         listen 80;
         listen 443 ssl;
 
-        # This is really not ideal, but there's no obvious way to browse GCS that handles directories and files.
-        rewrite ^/$             https://console.developers.google.com/storage/browser/kubernetes-jenkins/pr-logs/pull redirect;
-        rewrite ^/(.*)/$        https://console.developers.google.com/storage/browser/kubernetes-jenkins/pr-logs/pull/$1 redirect;
-        rewrite ^/(.*)$         https://storage.cloud.google.com/kubernetes-jenkins/pr-logs/pull/$1 redirect;
+        rewrite ^/$       https://k8s-gubernator.appspot.com redirect;
+        rewrite ^/(.*)$   https://k8s-gubernator.appspot.com/pr/$1 redirect;
+
       }
       server {
         server_name releases.k8s.io rel.k8s.io releases.kubernetes.io rel.kubernetes.io;

--- a/k8s.io/configmap-www-golang.yaml
+++ b/k8s.io/configmap-www-golang.yaml
@@ -14,6 +14,11 @@ data:
       <meta name="go-import" content="k8s.io/examples git https://github.com/kubernetes/examples">
       <meta name="go-source" content="k8s.io/examples     https://github.com/kubernetes/examples https://github.com/kubernetes/examples/tree/master{/dir} https://github.com/kubernetes/examples/blob/master{/dir}/{file}#L{line}">
     </head></html>
+  git-sync.html: |
+    <html><head>
+      <meta name="go-import" content="k8s.io/git-sync git https://github.com/kubernetes/git-sync">
+      <meta name="go-source" content="k8s.io/git-sync     https://github.com/kubernetes/git-sync https://github.com/kubernetes/git-sync/tree/master{/dir} https://github.com/kubernetes/git-sync/blob/master{/dir}/{file}#L{line}">
+    </head></html>
   heapster.html: |
     <html><head>
       <meta name="go-import" content="k8s.io/heapster git https://github.com/kubernetes/heapster">
@@ -23,6 +28,11 @@ data:
     <html><head>
       <meta name="go-import" content="k8s.io/helm git https://github.com/kubernetes/helm">
       <meta name="go-source" content="k8s.io/helm     https://github.com/kubernetes/helm https://github.com/kubernetes/helm/tree/master{/dir} https://github.com/kubernetes/helm/blob/master{/dir}/{file}#L{line}">
+    </head></html>
+  kops.html: |
+    <html><head>
+      <meta name="go-import" content="k8s.io/kops git https://github.com/kubernetes/kops">
+      <meta name="go-source" content="k8s.io/kops     https://github.com/kubernetes/kops https://github.com/kubernetes/kops/tree/master{/dir} https://github.com/kubernetes/kops/blob/master{/dir}/{file}#L{line}">
     </head></html>
   kubedash.html: |
     <html><head>

--- a/k8s.io/deployment.yaml
+++ b/k8s.io/deployment.yaml
@@ -42,8 +42,8 @@ spec:
         image: nginx:1.10 # = :stable as of 6/25/2016
         resources:
           limits:
-            cpu: .3
-            memory: 128Mi
+            cpu: 1
+            memory: 512Mi
         ports:
         - name: http
           containerPort: 80
@@ -60,7 +60,6 @@ spec:
         - name: nginx
           mountPath: /etc/nginx
           readOnly: true
-          #TODO: use subPath when upgrading to kube-1.3
         - name: www-get
           mountPath: /www/get
           readOnly: true

--- a/k8s.io/service-canary.yaml
+++ b/k8s.io/service-canary.yaml
@@ -2,14 +2,11 @@ apiVersion: v1
 kind: Service
 metadata:
   name: k8s-io
-  labels:
-    app: k8s-io
 spec:
   selector:
     app: k8s-io
   type: LoadBalancer
-  # FIXME: Enable this for the final changeover
-  # LoadBalancerIP: {LBIP}
+  loadBalancerIP: 104.197.208.221
   ports:
   - name: http
     port: 80

--- a/k8s.io/service-prod.yaml
+++ b/k8s.io/service-prod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8s-io
+spec:
+  selector:
+    app: k8s-io
+  type: LoadBalancer
+  # FIXME: Enable this for the final changeover
+  # LoadBalancerIP: {LBIP}
+  ports:
+  - name: http
+    port: 80
+  - name: https
+    port: 443

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -66,6 +66,13 @@ class RedirTest(unittest.TestCase):
 
     # TODO: external go-get ???
 
+    def test_apt_test(self):
+        # FIXME: https://apt.kubernetes.io is not on the cert
+        base = 'http://apt.kubernetes.io'
+        self.assert_redirect(base, 'http://storage.googleapis.com/k8s-releases/apt/')
+        self.assert_redirect(base + '/$id',
+            'http://storage.googleapis.com/k8s-releases/apt/$id', id=rand_num())
+
     def test_ci_test(self):
         # FIXME: https://ci-test.kubernetes.io is not on the cert
         base = 'http://ci-test.kubernetes.io'
@@ -144,18 +151,9 @@ class RedirTest(unittest.TestCase):
         # PR tests
         # FIXME: https://pr-test.kubernetes.io is not on the cert.
         base = 'http://pr-test.kubernetes.io'
-        self.assert_redirect(base, 'https://console.developers.google.com/storage/browser/kubernetes-jenkins/pr-logs/pull')
-        # trailing slash
-        self.assert_redirect(base + '/',
-            'https://console.developers.google.com/storage/browser/kubernetes-jenkins/pr-logs/pull')
-        # trailing slash
-        self.assert_redirect(base + '/$id/',
-            'https://console.developers.google.com/storage/browser/kubernetes-jenkins/pr-logs/pull/$id',
-            id=rand_num())
-        # no trailing slash
-        self.assert_redirect(base + '/$id/file',
-            'https://storage.cloud.google.com/kubernetes-jenkins/pr-logs/pull/$id/file',
-            id=rand_num())
+        self.assert_redirect(base, 'https://k8s-gubernator.appspot.com')
+        self.assert_redirect(base + '/$id',
+            'https://k8s-gubernator.appspot.com/pr/$id', id=rand_num())
 
     def test_release(self):
         # FIXME: https://releases.kubernetes.io is not on the cert
@@ -219,7 +217,6 @@ if __name__ == '__main__':
     TARGET_IP = os.environ.get('TARGET_IP')
     if not TARGET_IP:
         print('Attempting to autodiscover service TARGET_IP, set env var to override...')
-        TARGET_IP = subprocess.check_output(
-            ['kubectl', 'get', 'svc/k8s-io', '--template={{range .status.loadBalancer.ingress}}{{.ip}}{{end}}'])
+        TARGET_IP = subprocess.check_output(['dig', '+short', 'k8s.io'])
         print('Testing against service at', TARGET_IP)
     unittest.main()


### PR DESCRIPTION
This launches the k8s.io site in a canary namespace with a canary IP and can
run the test against it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/k8s.io/4)
<!-- Reviewable:end -->
