### PR TITLE
Make ci-test.k8s.io/e2e/123 redirect to Gubernator.

### DIFF
--- a/k8s.io/Makefile
+++ b/k8s.io/Makefile
@@ -13,7 +13,7 @@ deploy:
 	kubectl apply -f configmap-nginx.yaml
 	kubectl apply -f configmap-www-get.yaml
 	kubectl apply -f configmap-www-golang.yaml
-	kubectl apply -f service.yaml
+	kubectl apply -f service-dev.yaml
 	kubectl apply -f deployment.yaml
 
 .PHONY: test

--- a/k8s.io/README.md
+++ b/k8s.io/README.md
@@ -10,6 +10,10 @@ Configure kubectl to target a test cluster on GKE.
 Run `make deploy-fake-secret deploy` and wait for the service to be available--
 the load balancer may take some time to configure.
 
+Set `TARGET_IP` to the ingress IP of the running service:
+
+    export TARGET_IP=$(kubectl get svc k8s-io '--template={{range .status.loadBalancer.ingress}}{{.ip}}{{end}}')
+
 Use `make test` to run unit tests to verify the various endpoints on the server.
 
 Deploying

--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -70,6 +70,8 @@ data:
 
         # This is really not ideal, but there's no obvious way to browse GCS that handles directories and files.
         rewrite ^/$             https://console.developers.google.com/storage/browser/kubernetes-jenkins/logs redirect;
+        # Things that look like builds should be viewed on Gubernator
+        rewrite ^/(.*/\d+)/?$   https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/$1 redirect;
         rewrite ^/(.*)/$        https://console.developers.google.com/storage/browser/kubernetes-jenkins/logs/$1 redirect;
         rewrite ^/(.*)$         https://storage.cloud.google.com/kubernetes-jenkins/logs/$1 redirect;
       }

--- a/k8s.io/deployment.yaml
+++ b/k8s.io/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           # Map all keys to files.
       containers:
       - name: nginx
-        image: nginx:1.10 # = :stable as of 6/25/2016
+        image: nginx:1.10-alpine  # = :stable-alpine as of 8/23/2016
         resources:
           limits:
             cpu: 1

--- a/k8s.io/service-dev.yaml
+++ b/k8s.io/service-dev.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8s-io
+spec:
+  selector:
+    app: k8s-io
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 80
+  - name: https
+    port: 443

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -87,9 +87,13 @@ class RedirTest(unittest.TestCase):
             'https://console.developers.google.com/storage/browser/kubernetes-jenkins/logs/e2e')
 
         num = rand_num()
-        # trailing slash
+        # numeric with trailing slash
         self.assert_redirect(base + '/e2e/$num/',
-            'https://console.developers.google.com/storage/browser/kubernetes-jenkins/logs/e2e/$num',
+            'https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/e2e/$num',
+            num=num)
+        # numeric without trailing slash
+        self.assert_redirect(base + '/e2e/$num',
+            'https://k8s-gubernator.appspot.com/build/kubernetes-jenkins/logs/e2e/$num',
             num=num)
 
         # no trailing slash


### PR DESCRIPTION
One potential problem: deploying a new configmap changes the files in the running containers, but doesn't restart them *or* force nginx to reload. The deployment should run `nginx -s reload` on the running pods to trigger a config reload.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/k8s.io/7)
<!-- Reviewable:end -->
