### PR TITLE
Bump reviewable to 1193.1907

### DIFF
--- a/reviewable.k8s.io/deployment.yaml
+++ b/reviewable.k8s.io/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         - name: docker-pull
       containers:
         - name: reviewable
-          image: reviewable/enterprise:1168.1901
+          image: reviewable/enterprise:1193.1907
           resources:
             limits:
               cpu: 1


### PR DESCRIPTION
Fix: balance GitHub calls among other admins for connected repositories when
API quota gets low

Fix: guesstimate GitHub burst quota usage and postpone or reassign tasks that
might trigger an abuse warning

Fix: set GitHub request timeouts based on remaining task lease time

Fix: don't query /rate_limit on GitHub Enterprise instances

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/k8s.io/11)
<!-- Reviewable:end -->
