### PR TITLE
Redirect dl.k8s.io to the kubernetes-release GCS bucket

### DIFF
--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -90,6 +90,19 @@ data:
         rewrite ^/(.*)?$    https://github.com/kubernetes/kubernetes/tree/master/$1 redirect;
       }
       server {
+        server_name dl.k8s.io dl.kubernetes.io;
+        listen 80;
+        listen 443 ssl;
+
+        location / {
+          # Don't require /release/ if you want to get at the Kubernetes release artifacts, the common case.
+          rewrite ^/(v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9]+)?/.*)$   https://storage.googleapis.com/kubernetes-release/release/$1 redirect;
+          # Provide a convenient redirect for CI (continuous integration) artifacts as well, which live in a different bucket.
+          rewrite ^/ci/?(.*)$              https://storage.googleapis.com/kubernetes-release-dev/ci/$1 redirect;
+          rewrite ^/(.*)$                  https://storage.googleapis.com/kubernetes-release/$1 redirect;
+        }
+      }
+      server {
         server_name docs.k8s.io docs.kubernetes.io;
         listen 80;
         listen 443 ssl;

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -120,6 +120,38 @@ class RedirTest(unittest.TestCase):
                 'https://github.com/kubernetes/kubernetes/tree/master/$path',
                 path=path)
 
+    def test_dl(self):
+        # FIXME: https://dl.{k8s,kubernetes}.io is not on the cert
+        for base in ('http://dl.k8s.io', 'http://dl.kubernetes.io'):
+            # Valid release version numbers
+            for extra in ('', '-alpha.$rc_ver', '-beta.$rc_ver'):
+                self.assert_redirect(
+                    base + '/v$major_ver.$minor_ver.$patch_ver' + extra + '/$path',
+                    'https://storage.googleapis.com/kubernetes-release/release/v$major_ver.$minor_ver.$patch_ver' + extra + '/$path',
+                    major_ver=rand_num(), minor_ver=rand_num(), patch_ver=rand_num(), rc_ver=rand_num(), path=rand_num())
+            # Not a release version
+            self.assert_redirect(
+                base + '/v8/engine',
+                'https://storage.googleapis.com/kubernetes-release/v8/engine')
+            # Not a valid release version (gamma)
+            self.assert_redirect(
+                base + '/v1.2.3-gamma.4/kubernetes.tar.gz',
+                'https://storage.googleapis.com/kubernetes-release/v1.2.3-gamma.4/kubernetes.tar.gz')
+            # A few /ci/ tests
+            self.assert_redirect(
+                base + '/ci/v$ver/$path',
+                'https://storage.googleapis.com/kubernetes-release-dev/ci/v$ver/$path',
+                ver=rand_num(), path=rand_num())
+            self.assert_redirect(
+                base + '/ci/latest-$ver.txt',
+                'https://storage.googleapis.com/kubernetes-release-dev/ci/latest-$ver.txt',
+                ver=rand_num())
+            # Base case
+            self.assert_redirect(
+                base + '/$path',
+                'https://storage.googleapis.com/kubernetes-release/$path',
+                path=rand_num())
+
     def test_docs(self):
         # FIXME: https://docs.kubernetes.io is not on the cert
         for base in ('http://docs.k8s.io', 'https://docs.k8s.io', 'http://docs.kubernetes.io'):


### PR DESCRIPTION
Idea is that scripts can use https://releases.k8s.io/downloads/release/v1.4.0/kubernetes.tar.gz rather than needing to know the GCS bucket name (kubernetes-release) or use the github URL (which doesn't have anything besides kubernetes.tar.gz).

More concrete example: I want to update https://github.com/kubernetes/kubernetes/blob/master/cluster/centos/config-build.sh#L44 to use `https://releases.k8s.io/downloads/release/v${K8S_VERSION}/kubernetes-server-linux-amd64.tar.gz`.

Open to bikeshedding if you have a better suggestion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/k8s.io/15)
<!-- Reviewable:end -->
