### PR TITLE
Add redirect for features URLs

### DIFF
--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -123,6 +123,15 @@ data:
         }
       }
       server {
+        server_name feature.k8s.io features.k8s.io feature.kubernetes.io features.kubernetes.io;
+        listen 80;
+        listen 443 ssl;
+
+        location / {
+          rewrite ^/(.*)$  https://github.com/kubernetes/features/issues/$1 redirect;
+        }
+      }
+      server {
         server_name get.k8s.io get.kubernetes.io;
         listen 80;
         # 443 is covered below.

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -175,6 +175,14 @@ class RedirTest(unittest.TestCase):
                 'https://github.com/kubernetes/kubernetes/tree/release-$ver/examples/$path',
                 ver=ver, path=rand_num())
 
+    def test_features(self):
+        # FIXME: Make certs cover https://feature{s,}.{k8s,kubernetes}.io
+        for base in ('http://features.k8s.io', 'http://feature.k8s.io',
+                     'http://features.kubernetes.io', 'https://feature.kubernetes.io'):
+            self.assert_redirect(base + '/$path',
+                'https://github.com/kubernetes/kubernetes/features/$path',
+                path=rand_num())
+
     def test_issues(self):
         # FIXME: https://issue.kubernetes.io is not on the cert
         for base in ('http://issues.k8s.io', 'https://issues.k8s.io', 'http://issue.kubernetes.io'):


### PR DESCRIPTION
Someone will have to add a DNS alias here too but I figure this is half the work.  I'd be happy to join in in helping to admin this stuff.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/k8s.io/17)
<!-- Reviewable:end -->
