### PR TITLE
Redirect dl.k8s.io/ci-cross/ appropriately

### DIFF
--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -98,7 +98,7 @@ data:
           # Don't require /release/ if you want to get at the Kubernetes release artifacts, the common case.
           rewrite ^/(v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9]+)?/.*)$   https://storage.googleapis.com/kubernetes-release/release/$1 redirect;
           # Provide a convenient redirect for CI (continuous integration) artifacts as well, which live in a different bucket.
-          rewrite ^/ci/?(.*)$              https://storage.googleapis.com/kubernetes-release-dev/ci/$1 redirect;
+          rewrite ^/ci(-cross)?/?(.*)$              https://storage.googleapis.com/kubernetes-release-dev/ci$1/$2 redirect;
           rewrite ^/(.*)$                  https://storage.googleapis.com/kubernetes-release/$1 redirect;
         }
       }

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -146,6 +146,10 @@ class RedirTest(unittest.TestCase):
                 base + '/ci/latest-$ver.txt',
                 'https://storage.googleapis.com/kubernetes-release-dev/ci/latest-$ver.txt',
                 ver=rand_num())
+            self.assert_redirect(
+                base + '/ci-cross/v$ver/$path',
+                'https://storage.googleapis.com/kubernetes-release-dev/ci-cross/v$ver/$path',
+                ver=rand_num(), path=rand_num())
             # Base case
             self.assert_redirect(
                 base + '/$path',


### PR DESCRIPTION
x-ref https://github.com/kubernetes/test-infra/issues/670

We'll soon be uploading cross-build artifacts to gs://kubernetes-release-dev/ci-cross, so we should support that on dl.k8s.io too.

Tested on my own cluster, haven't pushed to the real canary,

cc @mikedanese

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/k8s.io/21)
<!-- Reviewable:end -->
