### PR TITLE
Add redirect for go.k8s.io/partner-request

### DIFF
--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -161,8 +161,9 @@ data:
 
         location / {
           rewrite ^/bounty$          https://github.com/kubernetes/kubernetes.github.io/issues?q=is%3Aopen+is%3Aissue+label%3ABounty redirect;
-          rewrite ^/start$           http://kubernetes.io/docs/getting-started-guides/ redirect;
           rewrite ^/help-wanted$     https://github.com/kubernetes/kubernetes/labels/help-wanted redirect;
+          rewrite ^/partner-request$ https://docs.google.com/forms/d/e/1FAIpQLSdN1KtSKX2VAOPGABFlShkSd6CajQynoL4QCVtY0dj76MNDKg/viewform redirect;
+          rewrite ^/start$           http://kubernetes.io/docs/getting-started-guides/ redirect;
         }
       }
       server {

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -62,6 +62,9 @@ class RedirTest(unittest.TestCase):
                 'issues?q=is%3Aopen+is%3Aissue+label%3ABounty')
             self.assert_redirect(base + 'help-wanted',
                 'https://github.com/kubernetes/kubernetes/labels/help-wanted')
+            self.assert_redirect(
+                base + 'partner-request',
+                'https://docs.google.com/forms/d/e/1FAIpQLSdN1KtSKX2VAOPGABFlShkSd6CajQynoL4QCVtY0dj76MNDKg/viewform')
             self.assert_redirect(base + 'start',
                 'http://kubernetes.io/docs/getting-started-guides/')
 


### PR DESCRIPTION
Tested on my own cluster, not yet on canary.

cc @sarahnovotny

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.kubernetes.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.kubernetes.io/reviews/kubernetes/k8s.io/34)
<!-- Reviewable:end -->
