### PR TITLE
Test https on all subdomains

### DIFF
--- a/k8s.io/Dockerfile-test
+++ b/k8s.io/Dockerfile-test
@@ -1,0 +1,10 @@
+FROM python:2
+MAINTAINER Jeff Grafton <jgrafton@google.com>
+
+WORKDIR /workspace
+
+RUN pip install pyyaml
+
+COPY test.py configmap-*.yaml /workspace/
+
+ENTRYPOINT /workspace/test.py

--- a/k8s.io/Makefile
+++ b/k8s.io/Makefile
@@ -19,3 +19,8 @@ deploy:
 .PHONY: test
 test:
 	python test.py -q
+
+.PHONY: docker-test
+docker-test:
+	docker build -t k8s-io-test -f Dockerfile-test .
+	docker run -it --rm -e TARGET_IP=${TARGET_IP} k8s-io-test

--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -52,6 +52,7 @@ data:
       server {
         server_name apt.kubernetes.io apt.k8s.io;
         listen 80;
+        listen 443 ssl;
 
         rewrite ^/(.*)?$    https://packages.cloud.google.com/apt/$1 redirect;
       }
@@ -59,6 +60,7 @@ data:
       server {
         server_name yum.kubernetes.io yum.k8s.io;
         listen 80;
+        listen 443 ssl;
 
         rewrite ^/(.*)?$    https://packages.cloud.google.com/yum/$1 redirect;
       }

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -10,6 +10,7 @@ except ImportError:
     import urllib.parse as urlparse
 import os
 import random
+import socket
 import subprocess
 import unittest
 import urllib
@@ -38,25 +39,26 @@ def do_get(url):
 
 
 class RedirTest(unittest.TestCase):
-    def assert_redirect(self, url, expected_loc, **kwargs):
-        for k, v in kwargs.items():
-            k = '$%s' % k
-            v = '%s' % v
-            url = url.replace(k, v)
-            expected_loc = expected_loc.replace(k, v)
-        print('REDIR: %s => %s' % (url, expected_loc))
-        resp, body = do_get(url)
-        self.assertEqual(resp.status, 302)
-        self.assertEqual(resp.getheader('location'), expected_loc)
+    def assert_redirect(self, partial_url, expected_loc, **kwargs):
+        for scheme in ('http', 'https'):
+            url = scheme + '://' + partial_url
+            for k, v in kwargs.items():
+                k = '$%s' % k
+                v = '%s' % v
+                url = url.replace(k, v)
+                expected_loc = expected_loc.replace(k, v)
+            print('REDIR: %s => %s' % (url, expected_loc))
+            resp, body = do_get(url)
+            self.assertEqual(resp.status, 302)
+            self.assertEqual(resp.getheader('location'), expected_loc)
 
     def test_main(self):
         path = '/%s' % rand_num()
-        for url in ('http://k8s.io', 'https://k8s.io', 'http://kubernet.es'):
+        for url in ('k8s.io', 'kubernet.es'):
             self.assert_redirect(url + path, 'http://kubernetes.io' + path)
 
     def test_go(self):
-        # The go. subdomains are not on the SSL cert
-        for base in ('http://go.k8s.io/', 'http://go.kubernetes.io/'):
+        for base in ('go.k8s.io/', 'go.kubernetes.io/'):
             self.assert_redirect(base + 'bounty',
                 'https://github.com/kubernetes/kubernetes.github.io/'
                 'issues?q=is%3Aopen+is%3Aissue+label%3ABounty')
@@ -71,22 +73,19 @@ class RedirTest(unittest.TestCase):
     # TODO: external go-get ???
 
     def test_yum_test(self):
-        # FIXME: https://yum.kubernetes.io is not on the cert
-        for base in ('http://yum.k8s.io', 'http://yum.kubernetes.io'):
+        for base in ('yum.k8s.io', 'yum.kubernetes.io'):
             self.assert_redirect(base, 'https://packages.cloud.google.com/yum/')
             self.assert_redirect(base + '/$id',
                 'https://packages.cloud.google.com/yum/$id', id=rand_num())
 
     def test_apt_test(self):
-        # FIXME: https://apt.kubernetes.io is not on the cert
-        for base in ('http://apt.k8s.io', 'http://apt.kubernetes.io'):
+        for base in ('apt.k8s.io', 'apt.kubernetes.io'):
             self.assert_redirect(base, 'https://packages.cloud.google.com/apt/')
             self.assert_redirect(base + '/$id',
                 'https://packages.cloud.google.com/apt/$id', id=rand_num())
 
     def test_ci_test(self):
-        # FIXME: https://ci-test.kubernetes.io is not on the cert
-        base = 'http://ci-test.kubernetes.io'
+        base = 'ci-test.kubernetes.io'
         self.assert_redirect(base, 'https://console.developers.google.com/storage/browser/kubernetes-jenkins/logs')
 
         # trailing slash
@@ -113,20 +112,18 @@ class RedirTest(unittest.TestCase):
             num=num)
 
     def test_code(self):
-        # FIXME: https://code.kubernetes.io is not on the cert. Same for changelog.
         path = rand_num()
-        for base in ('http://changelog.kubernetes.io', 'http://changelog.k8s.io'):
+        for base in ('changelog.kubernetes.io', 'changelog.k8s.io'):
             self.assert_redirect(base + '/$path',
                 'https://github.com/kubernetes/kubernetes/releases/tag/$path',
                 path=path)
-        for base in ('http://code.kubernetes.io', 'http://code.k8s.io'):
+        for base in ('code.kubernetes.io', 'code.k8s.io'):
             self.assert_redirect(base + '/$path',
                 'https://github.com/kubernetes/kubernetes/tree/master/$path',
                 path=path)
 
     def test_dl(self):
-        # FIXME: https://dl.{k8s,kubernetes}.io is not on the cert
-        for base in ('http://dl.k8s.io', 'http://dl.kubernetes.io'):
+        for base in ('dl.k8s.io', 'dl.kubernetes.io'):
             # Valid release version numbers
             for extra in ('', '-alpha.$rc_ver', '-beta.$rc_ver'):
                 self.assert_redirect(
@@ -161,8 +158,7 @@ class RedirTest(unittest.TestCase):
                 path=rand_num())
 
     def test_docs(self):
-        # FIXME: https://docs.kubernetes.io is not on the cert
-        for base in ('http://docs.k8s.io', 'https://docs.k8s.io', 'http://docs.kubernetes.io'):
+        for base in ('docs.k8s.io', 'docs.kubernetes.io'):
             self.assert_redirect(base, 'http://kubernetes.io/docs/')
             ver = '%d.%d' % (rand_num(), rand_num())
             self.assert_redirect(base + '/v$ver', 'http://kubernetes.io/docs', ver=ver)
@@ -171,8 +167,7 @@ class RedirTest(unittest.TestCase):
             self.assert_redirect(base + '/$path', 'http://kubernetes.io/docs/$path', path=path)
 
     def test_examples(self):
-        # FIXME: https://examples.kubernetes.io is not on the cert
-        for base in ('http://examples.k8s.io', 'https://examples.k8s.io', 'http://examples.kubernetes.io'):
+        for base in ('examples.k8s.io', 'examples.kubernetes.io'):
             self.assert_redirect(base, 'https://github.com/kubernetes/kubernetes/tree/master/examples/')
 
             ver = '%d.%d' % (rand_num(), rand_num())
@@ -184,9 +179,8 @@ class RedirTest(unittest.TestCase):
                 ver=ver, path=rand_num())
 
     def test_features(self):
-        # FIXME: Make certs cover https://feature{s,}.{k8s,kubernetes}.io
-        for base in ('http://features.k8s.io', 'http://feature.k8s.io',
-                     'http://features.kubernetes.io', 'https://feature.kubernetes.io'):
+        for base in ('features.k8s.io', 'feature.k8s.io',
+                     'features.kubernetes.io', 'feature.kubernetes.io'):
             self.assert_redirect(base,
                 'https://github.com/kubernetes/features/issues/',
                 path=rand_num())
@@ -195,53 +189,42 @@ class RedirTest(unittest.TestCase):
                 path=rand_num())
 
     def test_issues(self):
-        # FIXME: https://issue.kubernetes.io is not on the cert
-        for base in ('http://issues.k8s.io', 'https://issues.k8s.io', 'http://issue.kubernetes.io'):
+        for base in ('issues.k8s.io', 'issue.k8s.io',
+                     'issues.kubernetes.io', 'issue.kubernetes.io'):
             self.assert_redirect(base + '/$path',
                 'https://github.com/kubernetes/kubernetes/issues/$path',
                 path=rand_num())
 
     def test_prs(self):
-        # FIXME: https://pr.kubernetes.io is not on the cert
-        for base in ('http://prs.k8s.io', 'https://prs.k8s.io', 'http://pr.kubernetes.io'):
+        for base in ('prs.k8s.io', 'pr.k8s.io',
+                     'prs.kubernetes.io', 'pr.kubernetes.io'):
             self.assert_redirect(base, 'https://github.com/kubernetes/kubernetes/pulls')
             self.assert_redirect(base + '/$path',
                 'https://github.com/kubernetes/kubernetes/pull/$path',
                 path=rand_num())
 
     def test_pr_test(self):
-        # PR tests
-        # FIXME: https://pr-test.kubernetes.io is not on the cert.
-        base = 'http://pr-test.kubernetes.io'
+        base = 'pr-test.kubernetes.io'
         self.assert_redirect(base, 'https://k8s-gubernator.appspot.com')
         self.assert_redirect(base + '/$id',
             'https://k8s-gubernator.appspot.com/pr/$id', id=rand_num())
 
     def test_release(self):
-        # FIXME: https://releases.kubernetes.io is not on the cert
-        # FIXME: https://rel.kubernetes.io is not on the cert
-        for base in '''http://releases.k8s.io
-                 https://releases.k8s.io
-                 http://rel.k8s.io
-                 https://rel.k8s.io
-                 http://releases.kubernetes.io
-                 http://rel.kubernetes.io'''.split():
+        for base in ('releases.k8s.io', 'rel.k8s.io',
+                     'releases.kubernetes.io', 'rel.kubernetes.io'):
             self.assert_redirect(base, 'https://github.com/kubernetes/kubernetes/releases')
             self.assert_redirect(base + '/$ver/$path',
                 'https://github.com/kubernetes/kubernetes/tree/$ver/$path',
                 ver=rand_num(), path=rand_num())
 
     def test_reviewable(self):
-        # FIXME: https://reviewable.k8s.io is not on the cert
-        for base in ('http://reviewable.k8s.io',):
-            self.assert_redirect(base, 'https://reviewable.kubernetes.io/')
-            self.assert_redirect(base + '/$path', 'https://reviewable.kubernetes.io/$path',
-                path=rand_num())
+        base = 'reviewable.k8s.io'
+        self.assert_redirect(base, 'https://reviewable.kubernetes.io/')
+        self.assert_redirect(base + '/$path', 'https://reviewable.kubernetes.io/$path',
+            path=rand_num())
 
     def test_testgrid(self):
-        # Testgrid
-        # FIXME: https://testgrid.k8s.io is not on the cert
-        for base in ('http://testgrid.k8s.io', 'http://testgrid.kubernetes.io'):
+        for base in ('testgrid.k8s.io', 'testgrid.kubernetes.io'):
             self.assert_redirect(base, 'https://k8s-testgrid.appspot.com/')
             self.assert_redirect(base + '/$path', 'https://k8s-testgrid.appspot.com/$path',
                 path=rand_num())
@@ -277,8 +260,7 @@ class ContentTest(unittest.TestCase):
         for base in ('http://get.k8s.io', 'http://get.kubernetes.io'):
             self.assert_body_configmap(base, 'get/get-kube-insecure.sh')
 
-        # FIXME: https://get.kubernetes.io is not on the cert
-        for base in ('https://get.k8s.io',):
+        for base in ('https://get.k8s.io', 'https://get.kubernetes.io'):
           self.assert_body_url(
               base,
               'https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/get-kube.sh')
@@ -288,6 +270,6 @@ if __name__ == '__main__':
     TARGET_IP = os.environ.get('TARGET_IP')
     if not TARGET_IP:
         print('Attempting to autodiscover service TARGET_IP, set env var to override...')
-        TARGET_IP = subprocess.check_output(['dig', '+short', 'k8s.io'])
+        TARGET_IP = socket.gethostbyname('k8s.io')
         print('Testing against service at', TARGET_IP)
     unittest.main()


### PR DESCRIPTION
Refactored test.py a bit so that we automatically test http and https in all test cases.

I've also added a Dockerfile and make rule so we can run test.py with a less-ancient version of python that actually validates the cert. This doesn't actually work without @jbeda's fix in #19, but #19 will fail with ancient python because `ssl.create_default_context()` doesn't exist. It's a mess.

I've pushed the updated nginx configmap to canary but not yet prod.