### PR TITLE
Bump rviewable to 1445.2150

### DIFF
--- a/reviewable.k8s.io/deployment.yaml
+++ b/reviewable.k8s.io/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         - name: docker-pull
       containers:
         - name: reviewable
-          image: reviewable/enterprise:1394.2104
+          image: reviewable/enterprise:1445.2150
           resources:
             limits:
               cpu: 1


### PR DESCRIPTION
1445.2150 (min 1313.2023) 2017-01-15

* New: support REVIEWABLE_ANALYTICS_URL to allow for tracking of major user
  actions and customized stats. Please see the config guide for details.
* New: enable subscription admin to restrict Reviewable users to members of a set
  of teams. (The default is to continue to allow any GHE user to sign in.)
* Upd: upgrade server environment to Node v6.
* Upd: remove support for GAE_MODULE_INSTANCE, as the new GAE flex environment no
  longer provides this value and AFAIK no other container runner provides an
  ordinal instance number either.
* Upd: have server log errors with full stack traces to console if Sentry
  monitoring not set up.
* Fix: improve workaround for Firebase stuck transaction bug. The condition will
  now be detected earlier, reducing thrashing, and can now recover without
  restarting the instance in many cases.
* Fix: set correct disposition on button-initiated "Done" reply when the user is
  the PR author and also a reviewer due to marking files as reviewed. (Yes, all
  of those conditions are necessary to trigger the bug!)
* Fix: handle mixed-case emoji tokens correctly.
* Fix: handle a repo renaming corner case correctly (repo renamed then original
  recreated).