### PR TITLE
expose kube-aggregator and sample-apiserver

### DIFF
--- a/k8s.io/configmap-www-golang.yaml
+++ b/k8s.io/configmap-www-golang.yaml
@@ -85,6 +85,16 @@ data:
       <meta name="go-import" content="k8s.io/apiserver git https://github.com/kubernetes/apiserver">
       <meta name="go-source" content="k8s.io/apiserver     https://github.com/kubernetes/apiserver https://github.com/kubernetes/apiserver/tree/master{/dir} https://github.com/kubernetes/apiserver/blob/master{/dir}/{file}#L{line}">
     </head></html>
+  kube-aggregator.html: |
+    <html><head>
+      <meta name="go-import" content="k8s.io/kube-aggregator git https://github.com/kubernetes/kube-aggregator">
+      <meta name="go-source" content="k8s.io/kube-aggregator     https://github.com/kubernetes/kube-aggregator https://github.com/kubernetes/kube-aggregator/tree/master{/dir} https://github.com/kubernetes/kube-aggregator/blob/master{/dir}/{file}#L{line}">
+    </head></html>
+  sample-apiserver.html: |
+    <html><head>
+      <meta name="go-import" content="k8s.io/sample-apiserver git https://github.com/kubernetes/sample-apiserver">
+      <meta name="go-source" content="k8s.io/sample-apiserver     https://github.com/kubernetes/sample-apiserver https://github.com/kubernetes/sample-apiserver/tree/master{/dir} https://github.com/kubernetes/sample-apiserver/blob/master{/dir}/{file}#L{line}">
+    </head></html>
   test-infra.html: |
     <html><head>
       <meta name="go-import" content="k8s.io/test-infra git https://github.com/kubernetes/test-infra">


### PR DESCRIPTION
expose kube-aggregator and sample-apiserver so they are `go get`able.

@lavalamp 