### PR TITLE
Add redirect for go.k8s.io/oncall

### DIFF
--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -187,6 +187,7 @@ data:
         location / {
           rewrite ^/bounty$          https://github.com/kubernetes/kubernetes.github.io/issues?q=is%3Aopen+is%3Aissue+label%3ABounty redirect;
           rewrite ^/help-wanted$     https://github.com/kubernetes/kubernetes/labels/help-wanted redirect;
+          rewrite ^/oncall$          https://storage.googleapis.com/kubernetes-jenkins/oncall.html;
           rewrite ^/partner-request$ https://docs.google.com/forms/d/e/1FAIpQLSdN1KtSKX2VAOPGABFlShkSd6CajQynoL4QCVtY0dj76MNDKg/viewform redirect;
           rewrite ^/start$           http://kubernetes.io/docs/getting-started-guides/ redirect;
         }

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -93,6 +93,9 @@ class RedirTest(unittest.TestCase):
             self.assert_temp_redirect(base + 'help-wanted',
                 'https://github.com/kubernetes/kubernetes/labels/help-wanted')
             self.assert_temp_redirect(
+                base + 'oncall',
+                'https://storage.googleapis.com/kubernetes-jenkins/oncall.html')
+            self.assert_temp_redirect(
                 base + 'partner-request',
                 'https://docs.google.com/forms/d/e/1FAIpQLSdN1KtSKX2VAOPGABFlShkSd6CajQynoL4QCVtY0dj76MNDKg/viewform')
             self.assert_temp_redirect(base + 'start',


### PR DESCRIPTION
Easier to tell folks to use https://go.k8s.io/oncall rather than trying to remember the GCS path.

Already pushed and tested on canary.