### PR TITLE
www-golang: add metrics

### DIFF
--- a/k8s.io/configmap-www-golang.yaml
+++ b/k8s.io/configmap-www-golang.yaml
@@ -90,3 +90,8 @@ data:
       <meta name="go-import" content="k8s.io/test-infra git https://github.com/kubernetes/test-infra">
       <meta name="go-source" content="k8s.io/test-infra     https://github.com/kubernetes/test-infra https://github.com/kubernetes/test-infra/tree/master{/dir} https://github.com/kubernetes/test-infra/blob/master{/dir}/{file}#L{line}">
     </head></html>
+  metrics.html: |
+    <html><head>
+      <meta name="go-import" content="k8s.io/metrics git https://github.com/kubernetes/metrics">
+      <meta name="go-source" content="k8s.io/metrics     https://github.com/kubernetes/metrics https://github.com/kubernetes/metrics/tree/master{/dir} https://github.com/kubernetes/metrics/blob/master{/dir}/{file}#L{line}">
+    </head></html>


### PR DESCRIPTION
Adds k8s.io/metrics to the go-get meta definitions.