### PR TITLE
Bump reviewable release

### DIFF
--- a/reviewable.k8s.io/deployment.yaml
+++ b/reviewable.k8s.io/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         - name: docker-pull
       containers:
         - name: reviewable
-          image: reviewable/enterprise:1531.2183
+          image: reviewable/enterprise:1592.2216
           resources:
             limits:
               cpu: 1


### PR DESCRIPTION
1575.2214 (min 1549.2198) 2017-05-20

* New: allow organization owners to request automatic connection of all
  newly created repos to Reviewable. You can find the new toggles on the
  Repositories page. You can do it for personal repos as well, but the
  reaction to a new repo may be delayed by up to 2 minutes (since there's
  no webhook for personal repo creation).
* Upd: upgrade all connected repos to listen to all GitHub webhook events.
  This process will kick off automatically within minutes of starting up
  the new version and continue (with checkpoints) until finished, probably
  within a few minutes and definitely in less than 30 minutes. (If you're
  doing a rolling upgrade, it may get delayed or start right away — either
  one is fine.) While running, the upgrade process will keep one instance
  pretty busy so you might not want to upgrade during peak hours. If you
  want to follow along, look for log lines with the token "migrate1549"
  for (minimal) status updates, and a final summary log line starting with
  "Migrated NNN legacy repositories" that indicates completion. It's OK
  even if there's a few failures, as any repo that isn't completely idle
  will get updated the next time it sends a webhook anyway. This upgrade
  process just hurries things along.
* Fix: prevent occasional "permission denied" crash when upgrading OAuth
  scopes on the Reviews or Repositories page.
* Fix: prune obsolete webhooks more aggressively in case they got migrated
  from github.com to GHE.

1592.2216 (min 1549.2198) 2017-06-07

* Upd: create a sample Reviewable commit status when connecting a repo so
  that it's visible when configuring branch protection settings in GitHub
  before creating a PR.
* Upd: update syntax highlighting module and add Kotlin source file
  extension mappings.
* Fix: correctly enforce minimum version requirements; the previous logic
  was too strict and would disallow rollbacks that should've been
  permitted.