### PR TITLE
Added go.k8s.io/test-health redirect

### DIFF
--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -203,6 +203,7 @@ data:
           rewrite ^/start$           http://kubernetes.io/docs/getting-started-guides/ redirect;
           rewrite ^/test-history$    https://storage.googleapis.com/kubernetes-test-history/static/index.html redirect;
           rewrite ^/triage$          https://storage.googleapis.com/k8s-gubernator/triage/index.html redirect;
+          rewrite ^/test-health$     http://velodrome.k8s.io/dashboard/db/bigquery-metrics redirect;
         }
       }
       server {

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -106,6 +106,9 @@ class RedirTest(unittest.TestCase):
             self.assert_temp_redirect(
                 base + 'triage',
                 'https://storage.googleapis.com/k8s-gubernator/triage/index.html')
+            self.assert_temp_redirect(
+                base + 'test-health',
+                'http://velodrome.k8s.io/dashboard/db/bigquery-metrics')
 
     def test_yum_test(self):
         for base in ('yum.k8s.io', 'yum.kubernetes.io'):


### PR DESCRIPTION
Makes https://go.k8s.io/test-health redirect to velodrome Bigquery metrics dashboard at http://velodrome.k8s.io/dashboard/db/bigquery-metrics
/cc @fejta @ixdy 