### PR TITLE
Add k8s.io/api to k8s.io golang metadata

### DIFF
--- a/k8s.io/configmap-www-golang.yaml
+++ b/k8s.io/configmap-www-golang.yaml
@@ -75,6 +75,11 @@ data:
       <meta name="go-import" content="k8s.io/client-go git https://github.com/kubernetes/client-go">
       <meta name="go-source" content="k8s.io/client-go     https://github.com/kubernetes/client-go https://github.com/kubernetes/client-go/tree/master{/dir} https://github.com/kubernetes/client-go/blob/master{/dir}/{file}#L{line}">
     </head></html>
+  api.html: |
+    <html><head>
+      <meta name="go-import" content="k8s.io/api git https://github.com/kubernetes/api">
+      <meta name="go-source" content="k8s.io/api     https://github.com/kubernetes/api https://github.com/kubernetes/api/tree/master{/dir} https://github.com/kubernetes/api/blob/master{/dir}/{file}#L{line}">
+    </head></html>
   apimachinery.html: |
     <html><head>
       <meta name="go-import" content="k8s.io/apimachinery git https://github.com/kubernetes/apimachinery">


### PR DESCRIPTION
Same fix as https://github.com/kubernetes/k8s.io/pull/61

Addresses https://github.com/kubernetes/client-go/issues/226

cc @caesarxuchao @lavalamp