### PR TITLE
Use https directly for redirects

### DIFF
--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -132,8 +132,8 @@ data:
         listen 443 ssl;
 
         location / {
-          rewrite ^/v[0-9]+\.[0-9]+(/.*)?$     http://kubernetes.io/docs$1   redirect; # legacy
-          rewrite ^/(.*)$                      http://kubernetes.io/docs/$1  redirect;
+          rewrite ^/v[0-9]+\.[0-9]+(/.*)?$     https://kubernetes.io/docs$1   redirect; # legacy
+          rewrite ^/(.*)$                      https://kubernetes.io/docs/$1  redirect;
         }
       }
       server {
@@ -200,7 +200,7 @@ data:
           rewrite ^/help-wanted$     https://github.com/kubernetes/kubernetes/labels/help-wanted redirect;
           rewrite ^/oncall$          https://storage.googleapis.com/kubernetes-jenkins/oncall.html redirect;
           rewrite ^/partner-request$ https://docs.google.com/forms/d/e/1FAIpQLSdN1KtSKX2VAOPGABFlShkSd6CajQynoL4QCVtY0dj76MNDKg/viewform redirect;
-          rewrite ^/start$           http://kubernetes.io/docs/getting-started-guides/ redirect;
+          rewrite ^/start$           https://kubernetes.io/docs/setup/pick-right-solution/ redirect;
           rewrite ^/stuck-prs$       https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Aopen%20label%3Algtm%20label%3Aapproved%20-label%3Ado-not-merge%20-label%3Aneeds-rebase%20sort%3Aupdated-asc%20-status%3Asuccess redirect;
           rewrite ^/test-history$    https://storage.googleapis.com/kubernetes-test-history/static/index.html redirect;
           rewrite ^/triage$          https://storage.googleapis.com/k8s-gubernator/triage/index.html redirect;

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -99,7 +99,7 @@ class RedirTest(unittest.TestCase):
                 base + 'partner-request',
                 'https://docs.google.com/forms/d/e/1FAIpQLSdN1KtSKX2VAOPGABFlShkSd6CajQynoL4QCVtY0dj76MNDKg/viewform')
             self.assert_temp_redirect(base + 'start',
-                'http://kubernetes.io/docs/getting-started-guides/')
+                'https://kubernetes.io/docs/setup/pick-right-solution/')
             self.assert_temp_redirect(
                 base + 'test-history',
                 'https://storage.googleapis.com/kubernetes-test-history/static/index.html')
@@ -201,12 +201,12 @@ class RedirTest(unittest.TestCase):
 
     def test_docs(self):
         for base in ('docs.k8s.io', 'docs.kubernetes.io'):
-            self.assert_temp_redirect(base, 'http://kubernetes.io/docs/')
+            self.assert_temp_redirect(base, 'https://kubernetes.io/docs/')
             ver = '%d.%d' % (rand_num(), rand_num())
-            self.assert_temp_redirect(base + '/v$ver', 'http://kubernetes.io/docs', ver=ver)
+            self.assert_temp_redirect(base + '/v$ver', 'https://kubernetes.io/docs', ver=ver)
             path = rand_num()
-            self.assert_temp_redirect(base + '/v$ver/$path', 'http://kubernetes.io/docs/$path', ver=ver, path=path)
-            self.assert_temp_redirect(base + '/$path', 'http://kubernetes.io/docs/$path', path=path)
+            self.assert_temp_redirect(base + '/v$ver/$path', 'https://kubernetes.io/docs/$path', ver=ver, path=path)
+            self.assert_temp_redirect(base + '/$path', 'https://kubernetes.io/docs/$path', path=path)
 
     def test_examples(self):
         for base in ('examples.k8s.io', 'examples.kubernetes.io'):


### PR DESCRIPTION
Sending people directly to https://kubernetes.io/. Also updating go.k8s.io to
the new page directly without client-side redirect.