### PR TITLE
add kubernetes/kube-state-metrics to golang metadata for k8s.io

### DIFF
--- a/k8s.io/configmap-www-golang.yaml
+++ b/k8s.io/configmap-www-golang.yaml
@@ -105,6 +105,11 @@ data:
       <meta name="go-import" content="k8s.io/kube-aggregator git https://github.com/kubernetes/kube-aggregator">
       <meta name="go-source" content="k8s.io/kube-aggregator     https://github.com/kubernetes/kube-aggregator https://github.com/kubernetes/kube-aggregator/tree/master{/dir} https://github.com/kubernetes/kube-aggregator/blob/master{/dir}/{file}#L{line}">
     </head></html>
+  kube-state-metrics.html: |
+    <html><head>
+      <meta name="go-import" content="k8s.io/kube-state-metrics git https://github.com/kubernetes/kube-state-metrics">
+      <meta name="go-source" content="k8s.io/kube-state-metrics     https://github.com/kubernetes/kube-state-metrics https://github.com/kubernetes/kube-state-metrics/tree/master{/dir} https://github.com/kubernetes/kube-state-metrics/blob/master{/dir}/{file}#L{line}">
+    </head></html>
   sample-apiserver.html: |
     <html><head>
       <meta name="go-import" content="k8s.io/sample-apiserver git https://github.com/kubernetes/sample-apiserver">


### PR DESCRIPTION
So that we can `go get` this repo. Folks have been [confused](https://github.com/kubernetes/kube-state-metrics/issues/166) by this in the past. 