### PR TITLE
add go.k8s.io/needs-ok-to-test

### DIFF
--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -229,6 +229,7 @@ data:
           rewrite ^/triage$          https://storage.googleapis.com/k8s-gubernator/triage/index.html redirect;
           rewrite ^/test-health$     http://velodrome.k8s.io/dashboard/db/bigquery-metrics redirect;
           rewrite ^/pr-dashboard$    https://k8s-gubernator.appspot.com/pr redirect;
+          rewrite ^/needs-ok-to-test https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=label%3Aneeds-ok-to-test%20-label%3Aneeds-rebase redirect;
         }
       }
       server {

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -148,6 +148,10 @@ class RedirTest(unittest.TestCase):
                 base + 'stuck-prs',
                 'https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Aopen%20label%3Algtm%20label%3Aapproved%20-label%3Ado-not-merge%20-label%3Aneeds-rebase%20sort%3Aupdated-asc%20-status%3Asuccess')
 
+            self.assert_temp_redirect(
+                base + 'needs-ok-to-test',
+                'https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=label%3Aneeds-ok-to-test%20-label%3Aneeds-rebase')
+
     def test_yum(self):
         for base in ('yum.k8s.io', 'yum.kubernetes.io'):
             self.assert_temp_redirect(base, 'https://packages.cloud.google.com/yum/')


### PR DESCRIPTION
this adds a short link to a github search for PRs that need an /ok-to-test from a kubernetes member

/cc @fejta @spiffxp @dims