### PR TITLE
Remove kubernetes.io proxy passthru to GitHub pages

### DIFF
--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -59,29 +59,6 @@ data:
           return 301 https://kubernetes.io$request_uri;
         }
       }
-      # Keep the legacy github-hosted path, in case we need it again.
-      server {
-        server_name kubernetes.io;
-        listen 80;
-        return 301 https://$host$request_uri;
-      }
-      server {
-        server_name kubernetes.io;
-        listen 443 ssl;
-
-        # Proxy to the real site.
-        # We set the host to the vanity domain `kubernetes.io` but proxy to
-        # `kubernetes.github.io` so that any relative redirects it generates on
-        # the github side are to the vanity domain.  DNS points the vanity
-        # domain at this nginx.
-        location / {
-          proxy_set_header Host kubernetes.io;
-          proxy_set_header X-Real-IP $remote_addr;
-          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-          proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
-          proxy_pass https://kubernetes.github.io;
-        }
-      }
       # Silly vanity domain we don't really do anything with.
       server {
         server_name kubernet.es;

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -64,9 +64,6 @@ class RedirTest(unittest.TestCase):
         self.assert_multischeme_redirect(partial_url, expected_loc, 302, **kwargs)
 
     def test_main_urls(self):
-        # Main URL.
-        self.assert_code('https://kubernetes.io', 200)
-
         # Main redirects, HTTPS to avoid protocol upgrade redirect.
         path = '/%s' % rand_num()
         self.assert_scheme_redirect(


### PR DESCRIPTION
The https://kubernetes.io test started failing, but we've completely switched to netlify, so we don't need it anymore anyway.

Already deployed and tested on canary.