### PR TITLE
Add actual list of redirectors currently active

### DIFF
--- a/k8s.io/README.md
+++ b/k8s.io/README.md
@@ -3,6 +3,22 @@ Overview
 This contains the Nginx configuration for k8s.io and the associated subdomain
 redirectors.
 
+Redirections
+====
+- https://go.k8s.io/bounty
+- https://go.k8s.io/help-wanted
+- https://go.k8s.io/needs-ok-to-test
+- https://go.k8s.io/oncall
+- https://go.k8s.io/partner-request
+- https://go.k8s.io/pr-dashboard
+- https://go.k8s.io/start
+- https://go.k8s.io/stuck-prs
+- https://go.k8s.io/test-health
+- https://go.k8s.io/test-history
+- https://go.k8s.io/triage
+
+NOTE: please see configmap-nginx.yaml for rewrite rules.
+
 Testing
 ====
 Configure kubectl to target a test cluster on GKE.

--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -195,6 +195,7 @@ data:
         listen 80;
         listen 443 ssl;
 
+        # Please update README.md when you update the list below.
         location / {
           rewrite ^/bounty$          https://github.com/kubernetes/kubernetes.github.io/issues?q=is%3Aopen+is%3Aissue+label%3ABounty redirect;
           rewrite ^/help-wanted$     https://github.com/kubernetes/kubernetes/labels/help-wanted redirect;


### PR DESCRIPTION
We don't have a list of these url(s) anywhere on a single page which
makes it harder to discover