### PR TITLE
Redirect blog.k8s.io => blog.kubernetes.io

### DIFF
--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -89,6 +89,14 @@ data:
       }
 
       server {
+        server_name blog.k8s.io;
+        listen 80;
+        listen 443 ssl;
+
+        rewrite ^/(.*)?$    http://blog.kubernetes.io/$1 redirect;
+      }
+
+      server {
         server_name changelog.kubernetes.io changelog.k8s.io;
         listen 80;
         listen 443 ssl;

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -161,6 +161,11 @@ class RedirTest(unittest.TestCase):
             self.assert_temp_redirect(base + '/$id',
                 'https://packages.cloud.google.com/apt/$id', id=rand_num())
 
+    def test_blog(self):
+        self.assert_temp_redirect('blog.k8s.io', 'http://blog.kubernetes.io/')
+        self.assert_temp_redirect('blog.k8s.io/$path',
+                'http://blog.kubernetes.io/$path', path=rand_num())
+
     def test_ci_test(self):
         base = 'ci-test.kubernetes.io'
         self.assert_temp_redirect(base, 'https://console.developers.google.com/storage/browser/kubernetes-jenkins/logs')


### PR DESCRIPTION
TLS cert has already been updated with `blog.k8s.io`.

I've already deployed this change to the canary namespace.

Fixes #91.

cc @mml 