### PR TITLE
Add a redirect (short link) for the cluster-api project.

### DIFF
--- a/k8s.io/README.md
+++ b/k8s.io/README.md
@@ -37,6 +37,8 @@ NOTE: please see k8s.io/k8s.io/configmap-nginx.yaml and mungegithub/submit-queue
 Redirections
 ====
 - https://go.k8s.io/bounty
+- https://go.k8s.io/bot-commands
+- https://go.k8s.io/cluster-api
 - https://go.k8s.io/help-wanted
 - https://go.k8s.io/needs-ok-to-test
 - https://go.k8s.io/oncall

--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -208,6 +208,7 @@ data:
         location / {
           rewrite ^/bounty$          https://github.com/kubernetes/kubernetes.github.io/issues?q=is%3Aopen+is%3Aissue+label%3ABounty redirect;
           rewrite ^/bot-commands$    https://github.com/kubernetes/test-infra/blob/master/commands.md redirect;
+          rewrite ^/cluster-api$     https://github.com/kubernetes/kube-deploy/blob/master/cluster-api/README.md redirect;
           rewrite ^/help-wanted$     https://github.com/kubernetes/kubernetes/labels/help-wanted redirect;
           rewrite ^/needs-ok-to-test$ https://github.com/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+user%3Akubernetes+label%3Aneeds-ok-to-test+-label%3Aneeds-rebase redirect;
           rewrite ^/oncall$          https://storage.googleapis.com/kubernetes-jenkins/oncall.html redirect;


### PR DESCRIPTION
I also added documentation for another redirect that was in the nginx config but not in the README. 

/cc @pipejakob 