### PR TITLE
Update gcsweb deployment to v1.0.6

### DIFF
--- a/gcsweb.k8s.io/deployment.yaml
+++ b/gcsweb.k8s.io/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: gcsweb
-          image: k8s.gcr.io/gcsweb-amd64:v1.0.4
+          image: k8s.gcr.io/gcsweb-amd64:v1.0.6
           args:
             - -b=crreleases
             - -b=istio-prow


### PR DESCRIPTION
The main change this gives us is https://github.com/kubernetes/test-infra/pull/5942, which serves the CSS directly, rather than relying on yahooapis.com.

/assign @thockin 
cc @BenTheElder 