### PR TITLE
Update bot-commands link to point to prow's help page

### DIFF
--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -207,7 +207,7 @@ data:
         # Please update README.md when you update the list below.
         location / {
           rewrite ^/bounty$          https://github.com/kubernetes/kubernetes.github.io/issues?q=is%3Aopen+is%3Aissue+label%3ABounty redirect;
-          rewrite ^/bot-commands$    https://github.com/kubernetes/test-infra/blob/master/commands.md redirect;
+          rewrite ^/bot-commands$    https://prow.k8s.io/command-help.html redirect;
           rewrite ^/cluster-api$     https://github.com/kubernetes/kube-deploy/blob/master/cluster-api/README.md redirect;
           rewrite ^/help-wanted$     https://github.com/kubernetes/kubernetes/labels/help%20wanted redirect;
           rewrite ^/needs-ok-to-test$ https://github.com/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+user%3Akubernetes+label%3Aneeds-ok-to-test+-label%3Aneeds-rebase redirect;


### PR DESCRIPTION
Prow's command page is pretty complete, and we should start using it.
/cc fejta spiffxp cjwagner
/assign ixdy
/hold