### PR TITLE
Redirect examples to new repo

### DIFF
--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -152,7 +152,7 @@ data:
 
         location / {
           rewrite ^/v([0-9]+\.[0-9]+)(/.*)?$    https://github.com/kubernetes/kubernetes/tree/release-$1/examples$2  redirect;
-          rewrite ^/(.*)$                       https://github.com/kubernetes/kubernetes/tree/master/examples/$1     redirect;
+          rewrite ^/(.*)$                       https://github.com/kubernetes/examples/tree/master/$1                redirect;
         }
       }
       server {

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -260,7 +260,8 @@ class RedirTest(unittest.TestCase):
 
     def test_examples(self):
         for base in ('examples.k8s.io', 'examples.kubernetes.io'):
-            self.assert_temp_redirect(base, 'https://github.com/kubernetes/kubernetes/tree/master/examples/')
+            self.assert_temp_redirect(base, 'https://github.com/kubernetes/examples/tree/master/')
+            self.assert_temp_redirect(base + '/', 'https://github.com/kubernetes/examples/tree/master/')
 
             ver = '%d.%d' % (rand_num(), rand_num())
             self.assert_temp_redirect(base + '/v$ver',


### PR DESCRIPTION
Examples directory will be removed from main repo with https://github.com/kubernetes/kubernetes/issues/60887
To preserve links we will redirect all new releases to new repo https://github.com/kubernetes/examples

Because of different directory structure subdirectories will be dropped, and all link will point to main directory.We could try to write rules per each example, but I don't think it would be maintainable.

cc @ahmetb