### PR TITLE
Add k8s.io URL for testing_frameworks repo

### DIFF
--- a/k8s.io/configmap-www-golang.yaml
+++ b/k8s.io/configmap-www-golang.yaml
@@ -142,6 +142,11 @@ data:
       <meta name="go-import" content="k8s.io/test-infra git https://github.com/kubernetes/test-infra">
       <meta name="go-source" content="k8s.io/test-infra     https://github.com/kubernetes/test-infra https://github.com/kubernetes/test-infra/tree/master{/dir} https://github.com/kubernetes/test-infra/blob/master{/dir}/{file}#L{line}">
     </head></html>
+  testing_frameworks.html: |
+    <html><head>
+      <meta name="go-import" content="k8s.io/testing_frameworks git https://github.com/kubernetes-sigs/testing_frameworks">
+      <meta name="go-source" content="k8s.io/testing_frameworks     https://github.com/kubernetes-sigs/testing_frameworks https://github.com/kubernetes-sigs/testing_frameworks/tree/master{/dir} https://github.com/kubernetes-sigs/testing_frameworks/blob/master{/dir}/{file}#L{line}">
+    </head></html>
   metrics.html: |
     <html><head>
       <meta name="go-import" content="k8s.io/metrics git https://github.com/kubernetes/metrics">


### PR DESCRIPTION
The testing_frameworks repo currently has no canonical k8s.io URL. To
reduce the pain of potential migrations if the repo moves in the future,
we would like a k8s.io URL to be the canonical import path.

This might eventually end up being covered in the general case by #101 , but there has been no movement on that PR for over a month and in that time the testing_frameworks repo has already moved once.

CCing @timothysc just in case there's anything else we should do before merging this.