### PR TITLE
Disable SSL certificate verification

### DIFF
--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -36,7 +36,7 @@ def do_get(url):
         # header. Instead we manually TLS wrap the socket for a HTTPConnection
         # and override the hostname to verify.
         conn = httplib.HTTPConnection(TARGET_IP, 443)
-        context = ssl.create_default_context()
+        context = ssl._create_unverified_context()
         conn.connect()
         conn.sock = context.wrap_socket(
             conn.sock, server_hostname=parsed.netloc)


### PR DESCRIPTION
This tests' purpose is not to test the certificates in use. Therefore we
can disable the certificate verification so that tests are easier
(possible? See issue #110) to run locally with self-signed certificates.

The comment
https://github.com/kubernetes/k8s.io/pull/19#issuecomment-265556199
suggests that when these tests were first written, certifiacte
verification was disabled by default. So we're confident that the intent
of the tests doesn't rely on working certificate verification.

Closes: #110 

CC: @hoegaarden 