### PR TITLE
Add go.k8s.io/github-labels redirect

### DIFF
--- a/k8s.io/README.md
+++ b/k8s.io/README.md
@@ -39,6 +39,7 @@ Redirections
 - https://go.k8s.io/bounty
 - https://go.k8s.io/bot-commands
 - https://go.k8s.io/cluster-api
+- https://go.k8s.io/github-labels
 - https://go.k8s.io/help-wanted
 - https://go.k8s.io/needs-ok-to-test
 - https://go.k8s.io/oncall

--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -209,6 +209,7 @@ data:
           rewrite ^/bounty$          https://github.com/kubernetes/kubernetes.github.io/issues?q=is%3Aopen+is%3Aissue+label%3ABounty redirect;
           rewrite ^/bot-commands$    https://prow.k8s.io/command-help.html redirect;
           rewrite ^/cluster-api$     https://github.com/kubernetes/kube-deploy/blob/master/cluster-api/README.md redirect;
+          rewrite ^/github-labels$   https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md redirect;
           rewrite ^/help-wanted$     https://github.com/kubernetes/kubernetes/labels/help%20wanted redirect;
           rewrite ^/needs-ok-to-test$ https://github.com/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+user%3Akubernetes+label%3Aneeds-ok-to-test+-label%3Aneeds-rebase redirect;
           rewrite ^/oncall$          https://storage.googleapis.com/kubernetes-jenkins/oncall.html redirect;


### PR DESCRIPTION
It's an easier URI to remember than https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md and I would like to point people to it

ref: kubernetes/test-infra#7349
ref: kubernetes/kubernetes#34255