### PR TITLE
Remove redirection for code search

### DIFF
--- a/k8s.io/README.md
+++ b/k8s.io/README.md
@@ -12,7 +12,7 @@ Vanity URL(s)
 | Changelog | https://changelog.k8s.io | https://changelog.kubernetes.io |
 | CI logs | https://ci-test.k8s.io | https://ci-test.kubernetes.io |
 | Git repo | https://code.k8s.io | https://code.kubernetes.io |
-| Search Git repo | https://cs.k8s.io | https://cs.kubernetes.io |
+| Search Git repo | http://cs.k8s.io | http://cs.kubernetes.io |
 | Community submit queue | https://community.submit-queue.k8s.io |
 | Contrib submit queue | https://contrib.submit-queue.k8s.io |
 | Downloads | https://dl.k8s.io | https://dl.kubernetes.io |

--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -173,13 +173,6 @@ data:
         rewrite ^/(.*)?$    https://github.com/kubernetes/kubernetes/tree/master/$1 redirect;
       }
       server {
-        server_name cs.kubernetes.io cs.k8s.io;
-        listen 80;
-        listen 443 ssl;
-
-        rewrite ^/(.*)?$    https://k8s-code.appspot.com/?q=$1 redirect;
-      }
-      server {
         server_name dl.k8s.io dl.kubernetes.io;
         listen 80;
         listen 443 ssl;

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -329,12 +329,6 @@ class RedirTest(unittest.TestCase):
         self.assert_temp_redirect(base + '/$id',
             'https://k8s-gubernator.appspot.com/pr/$id', id=rand_num())
 
-    def test_code_search(self):
-        base = 'cs.kubernetes.io'
-        self.assert_temp_redirect(base, 'https://k8s-code.appspot.com/?q=')
-        self.assert_temp_redirect(base + '/$id',
-                                  'https://k8s-code.appspot.com/?q=$id', id=rand_num())
-
     def test_release(self):
         for base in ('releases.k8s.io', 'rel.k8s.io',
                      'releases.kubernetes.io', 'rel.kubernetes.io'):


### PR DESCRIPTION
Instead of redirect to GAE, we will use a DNS entry

/assign @thockin 