### PR TITLE
Update the go.k8s.io/cluster-api redirect

### DIFF
--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -258,7 +258,7 @@ data:
         location / {
           rewrite ^/bounty$          https://github.com/kubernetes/kubernetes.github.io/issues?q=is%3Aopen+is%3Aissue+label%3ABounty redirect;
           rewrite ^/bot-commands$    https://prow.k8s.io/command-help.html redirect;
-          rewrite ^/cluster-api$     https://github.com/kubernetes/kube-deploy/blob/master/cluster-api/README.md redirect;
+          rewrite ^/cluster-api$     https://github.com/kubernetes-sigs/cluster-api/blob/master/README.md redirect;
           rewrite ^/github-labels$   https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md redirect;
           rewrite ^/help-wanted$     https://github.com/kubernetes/kubernetes/labels/help%20wanted redirect;
           rewrite ^/needs-ok-to-test$ https://github.com/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+user%3Akubernetes+label%3Aneeds-ok-to-test+-label%3Aneeds-rebase redirect;


### PR DESCRIPTION
We moved the repo a while ago. This should update as well.

/cc @roberthbailey 