### PR TITLE
Remove specific redirection for cluster-api

### DIFF
--- a/k8s.io/README.md
+++ b/k8s.io/README.md
@@ -35,7 +35,6 @@ Redirections
 ====
 - https://go.k8s.io/bounty
 - https://go.k8s.io/bot-commands
-- https://go.k8s.io/cluster-api
 - https://go.k8s.io/github-labels
 - https://go.k8s.io/help-wanted
 - https://go.k8s.io/needs-ok-to-test

--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -82,7 +82,8 @@ data:
         server_name sigs.k8s.io;
         listen 443 ssl;
 
-        location ~ ^/(?<sig_repo>[^/]*)(?<repo_subpath>/.*)?$ {
+        # The ?! block is negative-lookahead to prevent `/repo/` from grouping into (`repo`, `/`) while `/repo/path` will still group as (`repo`, `/path`).
+        location ~ ^/(?<sig_repo>.*?)(?!/+$)(?<repo_subpath>/.*)?$ {
           if ($arg_go-get = "1") {
             # This is a go-get operation.
             return 200 '

--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -258,7 +258,6 @@ data:
         location / {
           rewrite ^/bounty$          https://github.com/kubernetes/kubernetes.github.io/issues?q=is%3Aopen+is%3Aissue+label%3ABounty redirect;
           rewrite ^/bot-commands$    https://prow.k8s.io/command-help.html redirect;
-          rewrite ^/cluster-api$     https://github.com/kubernetes-sigs/cluster-api/blob/master/README.md redirect;
           rewrite ^/github-labels$   https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md redirect;
           rewrite ^/help-wanted$     https://github.com/kubernetes/kubernetes/labels/help%20wanted redirect;
           rewrite ^/needs-ok-to-test$ https://github.com/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+user%3Akubernetes+label%3Aneeds-ok-to-test+-label%3Aneeds-rebase redirect;

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -104,6 +104,28 @@ class RedirTest(unittest.TestCase):
             'kubernet.es' + path,
             'https://kubernetes.io' + path, 301)
 
+    def test_sig_urls(self):
+        base = 'https://sigs.k8s.io'
+        self.assert_scheme_redirect(
+                base,
+                'https://github.com/kubernetes-sigs/',
+                301)
+        self.assert_scheme_redirect(
+                base + '/$sig_repo',
+                'https://github.com/kubernetes-sigs/$sig_repo',
+                301,
+                sig_repo=rand_num())
+        self.assert_scheme_redirect(
+                base + '/$sig_repo/',
+                'https://github.com/kubernetes-sigs/$sig_repo/',
+                301,
+                sig_repo=rand_num())
+        self.assert_scheme_redirect(
+                base + '/$sig_repo/$repo_subpath',
+                'https://github.com/kubernetes-sigs/$sig_repo/blob/master/$repo_subpath',
+                301,
+                sig_repo=rand_num(), repo_subpath=rand_num())
+
     def test_protocol_upgrade(self):
         for url in ('kubernetes.io', 'k8s.io', 'sigs.k8s.io'):
             self.assert_scheme_redirect(


### PR DESCRIPTION
Cluster API exists under kubernetes-sigs and follows the default
redirection rules. This redirection rule is not needed anymore.

Fixes https://github.com/kubernetes-sigs/cluster-api/issues/118