### PR TITLE
Add go.k8s.io/owners redirect

### DIFF
--- a/k8s.io/README.md
+++ b/k8s.io/README.md
@@ -40,6 +40,7 @@ Redirections
 - https://go.k8s.io/help-wanted
 - https://go.k8s.io/needs-ok-to-test
 - https://go.k8s.io/oncall
+- https://go.k8s.io/owners
 - https://go.k8s.io/partner-request
 - https://go.k8s.io/pr-dashboard
 - https://go.k8s.io/start

--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -263,6 +263,7 @@ data:
           rewrite ^/help-wanted$     https://github.com/kubernetes/kubernetes/labels/help%20wanted redirect;
           rewrite ^/needs-ok-to-test$ https://github.com/pulls?utf8=%E2%9C%93&q=is%3Aopen+is%3Apr+user%3Akubernetes+label%3Aneeds-ok-to-test+-label%3Aneeds-rebase redirect;
           rewrite ^/oncall$          https://storage.googleapis.com/kubernetes-jenkins/oncall.html redirect;
+          rewrite ^/owners$          https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md redirect;
           rewrite ^/partner-request$ https://docs.google.com/forms/d/e/1FAIpQLSdN1KtSKX2VAOPGABFlShkSd6CajQynoL4QCVtY0dj76MNDKg/viewform redirect;
           rewrite ^/pr-dashboard$    https://k8s-gubernator.appspot.com/pr redirect;
           rewrite ^/start$           https://kubernetes.io/docs/setup/pick-right-solution/ redirect;


### PR DESCRIPTION
So I can answer "what's OWNERS?" with a shorter uri instead
of having to scrounge for a deep link all the time.