### PR TITLE
Redirect submit-queue.k8s.io to tide status page

### DIFF
--- a/k8s.io/README.md
+++ b/k8s.io/README.md
@@ -25,11 +25,11 @@ Vanity URL(s)
 | PR Dashboard | https://pr-test.k8s.io | https://pr-test.kubernetes.io |
 | Pull requests | https://pr.k8s.io <br> https://prs.k8s.io | https://pr.kubernetes.io <br> https://prs.kubernetes.io |
 | Downloads | https://releases.k8s.io <br> https://rel.k8s.io | https://releases.kubernetes.io <br> https://rel.kubernetes.io |
-| Submit queue status | https://submit-queue.k8s.io | https://kubernetes.submit-queue.k8s.io |
+| Tide status (formerly submit queue) | https://submit-queue.k8s.io | https://kubernetes.submit-queue.k8s.io |
 | Test grid | https://testgrid.k8s.io | https://testgrid.kubernetes.io |
 | YUM downloads | https://yum.k8s.io | https://yum.kubernetes.io |
 
-NOTE: please see k8s.io/k8s.io/configmap-nginx.yaml and mungegithub/submit-queue/nginx-redirect/nginx.conf for `server` definitions
+NOTE: please see k8s.io/k8s.io/configmap-nginx.yaml for `server` definitions
 
 Redirections
 ====

--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -313,6 +313,16 @@ data:
       }
 
       server {
+        server_name submit-queue.k8s.io submit-queue.kubernetes.io;
+        listen 80;
+        listen 443 ssl;
+
+        location / {
+          rewrite ^/.*$  https://prow.k8s.io/tide redirect;
+        }
+      }
+
+      server {
         server_name testgrid.kubernetes.io testgrid.k8s.io;
         listen 80;
         listen 443 ssl;

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -359,6 +359,12 @@ class RedirTest(unittest.TestCase):
                 'https://github.com/kubernetes/kubernetes/tree/$ver/$path',
                 ver=rand_num(), path=rand_num())
 
+    def test_submit_queue(self):
+        for base in ('submit-queue.k8s.io', 'submit-queue.kubernetes.io'):
+            self.assert_temp_redirect(base, 'https://prow.k8s.io/tide')
+            self.assert_temp_redirect(base + '/$path', 'https://prow.k8s.io/tide',
+                path=rand_num())
+
     def test_testgrid(self):
         for base in ('testgrid.k8s.io', 'testgrid.kubernetes.io'):
             self.assert_temp_redirect(base, 'https://k8s-testgrid.appspot.com/')


### PR DESCRIPTION
The mungegithub submit queue has been turned down in favor of tide (part of prow).

We should redirect the old submit-queue status page to tide (https://github.com/kubernetes/test-infra/issues/3866#issuecomment-420037144).

We still need to update DNS to point to the redirector.

/assign @thockin @spiffxp 