### PR TITLE
Delete redirects for kubernet.es

### DIFF
--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -111,14 +111,6 @@ data:
         }
       }
 
-      # Silly vanity domain we don't really do anything with.
-      server {
-        server_name kubernet.es;
-        listen 80;
-        listen 443 ssl;
-        return 301 https://kubernetes.io$request_uri;
-      }
-
       #
       # Vanity redirect rules.
       #

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -92,18 +92,6 @@ class RedirTest(unittest.TestCase):
                 'https://k8s.io/' + path,
                 'https://kubernetes.io/' + path, 301)
 
-        # Vanity domains.
-        path = '/%s' % rand_num()
-        self.assert_multischeme_redirect(
-                'kubernet.es',
-                'https://kubernetes.io/', 301)
-        self.assert_multischeme_redirect(
-            'kubernet.es/',
-            'https://kubernetes.io/', 301)
-        self.assert_multischeme_redirect(
-            'kubernet.es' + path,
-            'https://kubernetes.io' + path, 301)
-
     def test_sig_urls(self):
         base = 'https://sigs.k8s.io'
         self.assert_scheme_redirect(


### PR DESCRIPTION
We're no longer serving DNS for kubernet.es, so remove it from the redirector.

/assign @thockin 