### PR TITLE
Document blog.k8s.io and sigs.k8s.io

### DIFF
--- a/k8s.io/README.md
+++ b/k8s.io/README.md
@@ -9,6 +9,7 @@ Vanity URL(s)
 |  | k8s.io | kubernetes.io |
 | --- | --- | --- |
 | APT downloads| https://apt.k8s.io | https://apt.kubernetes.io |
+| Blog | https://blog.k8s.io | |
 | Changelog | https://changelog.k8s.io | https://changelog.kubernetes.io |
 | CI logs | https://ci-test.k8s.io | https://ci-test.kubernetes.io |
 | Git repo | https://code.k8s.io | https://code.kubernetes.io |
@@ -25,6 +26,7 @@ Vanity URL(s)
 | PR Dashboard | https://pr-test.k8s.io | https://pr-test.kubernetes.io |
 | Pull requests | https://pr.k8s.io <br> https://prs.k8s.io | https://pr.kubernetes.io <br> https://prs.kubernetes.io |
 | Downloads | https://releases.k8s.io <br> https://rel.k8s.io | https://releases.kubernetes.io <br> https://rel.kubernetes.io |
+| Kubernetes SIGs | https://sigs.k8s.io | |
 | Tide status (formerly submit queue) | https://submit-queue.k8s.io | https://kubernetes.submit-queue.k8s.io |
 | Test grid | https://testgrid.k8s.io | https://testgrid.kubernetes.io |
 | YUM downloads | https://yum.k8s.io | https://yum.kubernetes.io |


### PR DESCRIPTION
This PR has the following changes:

- ~~https://changelog.k8s.io currently leads to a 404 github page. This PR redirects it to https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG.md.~~

- Add https://blog.k8s.io and https://sigs.k8s.io in the README. Should we also have blog.kubernetes.io and sigs.kubernetes.io?

/cc @BenTheElder @dims @cblecker 
/assign @ixdy 