### PR TITLE
Add Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: python
+python:
+  - "2.7"
+install: pip install pyyaml
+script: make -C k8s.io all

--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # k8s.io
+
+[![BuildStatus Widget]][BuildStatus Result]
+
 Kubernetes files for various sites and infrastructure.
+
+[BuildStatus Result]: https://travis-ci.org/kubernetes/k8s.io
+[BuildStatus Widget]: https://travis-ci.org/kubernetes/k8s.io.svg?branch=master


### PR DESCRIPTION
So that we can catch test failures early: https://github.com/kubernetes/k8s.io/pull/135#issuecomment-424085461

Created https://github.com/kubernetes/test-infra/pull/9731 to make sure that required contexts are enforced.

/hold
an admin needs to enable travis for this repo

/cc @ixdy @cblecker @spiffxp @dims @BenTheElder 
/assign @ixdy 