### PR TITLE
Use custom subdomains for gubernator and testgrid

### DIFF
--- a/dns/zone-configs/k8s.io.yaml
+++ b/dns/zone-configs/k8s.io.yaml
@@ -127,10 +127,24 @@ git:
 go:
   type: CNAME
   value: redirect.k8s.io.
-#TODO: seems to send to main site, @ixdy to followup
+# Running on Google App Engine
 gubernator:
+  - type: A
+    values:
+    - 216.239.32.21
+    - 216.239.34.21
+    - 216.239.36.21
+    - 216.239.38.21
+  - type: AAAA
+    values:
+    - 2001:4860:4802:32::15
+    - 2001:4860:4802:34::15
+    - 2001:4860:4802:36::15
+    - 2001:4860:4802:38::15
+# Verify that @ixdy owns gubernator.k8s.io, necessary to set up custom domain in GAE
+aupoulkmindh.gubernator:
   type: CNAME
-  value: redirect.k8s.io.
+  value: gv-afluggfkiwfho7.dv.googlehosted.com.
 issue:
   type: CNAME
   value: redirect.k8s.io.
@@ -181,10 +195,24 @@ test-cncf-aws:
   - ns-1825.awsdns-36.co.uk.
   - ns-265.awsdns-33.com.
   - ns-687.awsdns-21.net.
-# @michelle192837
+# Running on Google App Engine (@michelle192837)
 testgrid:
+  - type: A
+    values:
+    - 216.239.32.21
+    - 216.239.34.21
+    - 216.239.36.21
+    - 216.239.38.21
+  - type: AAAA
+    values:
+    - 2001:4860:4802:32::15
+    - 2001:4860:4802:34::15
+    - 2001:4860:4802:36::15
+    - 2001:4860:4802:38::15
+# Verify that @ixdy owns testgrid.k8s.io, necessary to set up custom domain in GAE
+7ujw4gp3z2cq.testgrid:
   type: CNAME
-  value: redirect.k8s.io.
+  value: gv-t2drtmd73nsutd.dv.googlehosted.com.
 # Project metrics.  Running in GKE (@spiffxp, @cjwagner)
 velodrome:
   type: A

--- a/dns/zone-configs/kubernetes.io.yaml
+++ b/dns/zone-configs/kubernetes.io.yaml
@@ -127,6 +127,10 @@ go:
 gubernator:
   type: CNAME
   value: gubernator.k8s.io.
+# Verify that @ixdy owns gubernator.kubernetes.io, necessary to set up custom domain in GAE
+hpxqcdbptcka.gubernator:
+  type: CNAME
+  value: gv-lld4xxz7bimg2e.dv.googlehosted.com.
 issue:
   type: CNAME
   value: issue.k8s.io.
@@ -164,6 +168,10 @@ submit-queue:
 testgrid:
   type: CNAME
   value: testgrid.k8s.io.
+# Verify that @ixdy owns testgrid.kubernetes.io, necessary to set up custom domain in GAE
+pfjqlwt67ty3.testgrid:
+  type: CNAME
+  value: gv-bymjxdpk6uolpo.dv.googlehosted.com.
 velodrome:
   type: CNAME
   value: velodrome.k8s.io.


### PR DESCRIPTION
These are DNS changes only, already deployed.

https://gubernator.k8s.io and https://testgrid.k8s.io seem to work, though the gubernator PR dashboard isn't working due to some configuration issues with GitHub OAuth which @rmmh is looking into.

Once that's fixed, I'll update the redirectors on k8s.io as well.

/assign @thockin 