### PR TITLE
Create dummy A records for _acme-challenge.docs

### DIFF
--- a/dns/zone-configs/k8s.io.yaml
+++ b/dns/zone-configs/k8s.io.yaml
@@ -46,6 +46,11 @@ docs:
 '*.docs':
   type: CNAME
   value: netlifyglobalcdn.com.
+# Create a dummy A record so that the Let's Encrypt TXT records are not caught
+# by the wildcard CNAME record. (@ixdy)
+_acme_challenge.docs:
+  type: A
+  value: 0.0.0.0
 
 # Prove that we own these github orgs. sig-contributor-experience
 _github-challenge-kubernetes:

--- a/dns/zone-configs/kubernetes.io.yaml
+++ b/dns/zone-configs/kubernetes.io.yaml
@@ -44,6 +44,11 @@ docs:
 '*.docs':
   type: CNAME
   value: netlifyglobalcdn.com.
+# Create a dummy A record so that the Let's Encrypt TXT records are not caught
+# by the wildcard CNAME record. (@ixdy)
+_acme_challenge.docs:
+  type: A
+  value: 0.0.0.0
 
 # Prove that we own these github orgs. sig-contributor-experience
 _github-challenge-kubernetes:


### PR DESCRIPTION
This prevents resolvers from following the wildcard CNAME for *.docs
when trying to resolve the _acme-challenge.docs TXT record.

This should partially address https://github.com/kubernetes/k8s.io/issues/160; I still need to update the DNS records and then re-request a cert.

/assign @thockin 