### PR TITLE
The challenge subdomain is _acme-challenge, not _acme_challenge.

### DIFF
--- a/dns/zone-configs/k8s.io.yaml
+++ b/dns/zone-configs/k8s.io.yaml
@@ -48,7 +48,7 @@ docs:
   value: netlifyglobalcdn.com.
 # Create a dummy A record so that the Let's Encrypt TXT records are not caught
 # by the wildcard CNAME record. (@ixdy)
-_acme_challenge.docs:
+_acme-challenge.docs:
   type: A
   value: 0.0.0.0
 

--- a/dns/zone-configs/kubernetes.io.yaml
+++ b/dns/zone-configs/kubernetes.io.yaml
@@ -46,7 +46,7 @@ docs:
   value: netlifyglobalcdn.com.
 # Create a dummy A record so that the Let's Encrypt TXT records are not caught
 # by the wildcard CNAME record. (@ixdy)
-_acme_challenge.docs:
+_acme-challenge.docs:
   type: A
   value: 0.0.0.0
 


### PR DESCRIPTION
Followup to #162. :man_facepalming: 

/assign @thockin 