### PR TITLE
Put GCSWeb behind Ingress

### DIFF
--- a/dns/zone-configs/k8s.io.yaml
+++ b/dns/zone-configs/k8s.io.yaml
@@ -127,7 +127,7 @@ features:
 # Web frontend for unauthenticated GCS access.  Running in GKE (@thockin).
 gcsweb:
   type: A
-  value: 104.197.177.166
+  value: 35.244.175.21
 get:
   type: CNAME
   value: redirect.k8s.io.

--- a/gcsweb.k8s.io/deployment.yaml
+++ b/gcsweb.k8s.io/deployment.yaml
@@ -43,3 +43,10 @@ spec:
             initialDelaySeconds: 3
             timeoutSeconds: 2
             failureThreshold: 2
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 3
+            timeoutSeconds: 2
+            failureThreshold: 2

--- a/gcsweb.k8s.io/ingress.yaml
+++ b/gcsweb.k8s.io/ingress.yaml
@@ -1,0 +1,13 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: gcsweb
+  labels:
+    app: gcsweb
+  # Uncomment this when service is turned down and the ingress IP is named
+  #annotations:
+  # kubernetes.io/ingress.global-static-ip-name: gcsweb-k8s-io
+spec:
+  backend:
+    serviceName: gcsweb
+    servicePort: http


### PR DESCRIPTION
After this rolls out through DNS, we can turn down the old Service LB.

xref: #38 