### PR TITLE
DNS test retry for propagation delay

### DIFF
--- a/dns/README.md
+++ b/dns/README.md
@@ -155,9 +155,6 @@ Administrative:
   * Usage report
   * Monitoring / alerts / on-call for DNS?
 
-RFE:
-  * Add retry+timeout for testing when adding records and getting no answer.
-
 How to automate:
   * Need a k8s cluster to run it
   * PR to github, cronjob in a cluster syncs

--- a/dns/octodns-docker/check-zone.py
+++ b/dns/octodns-docker/check-zone.py
@@ -123,7 +123,8 @@ def verify_dns(queries):
 
             # the responses need a quick test / cleanup
             response_values=record_response_values(record, response)
-            stdout.write(' '.join(response_values))
+            if response_values:
+                stdout.write(' '.join(response_values))
 
             # NS Records will need to be handled differently
             if record._type == "NS":

--- a/dns/zone-configs/k8s.io.yaml
+++ b/dns/zone-configs/k8s.io.yaml
@@ -231,4 +231,4 @@ velodrome:
 # https://github.com/kubernetes-sigs/kind docs (@bentheelder, @munnerz)
 kind.sigs:
   type: CNAME
-  value: kindocs.netlify.com
+  value: kindocs.netlify.com.


### PR DESCRIPTION
DNS test runs against all DNS servers, but sometimes there's a delay in
propagation, as long as 60+ seconds.  Now the test will retry up to 2
minutes.

Also fix a bug in DNS zone config (trailing dot required).

Also fix a bug in python to not throw exceptions.