### PR TITLE
switch netlify instance for kind.sigs.k8s.io

### DIFF
--- a/dns/zone-configs/k8s.io.yaml
+++ b/dns/zone-configs/k8s.io.yaml
@@ -231,4 +231,4 @@ velodrome:
 # https://github.com/kubernetes-sigs/kind docs (@bentheelder, @munnerz)
 kind.sigs:
   type: CNAME
-  value: kindocs.netlify.com.
+  value: k8s-kind.netlify.com.


### PR DESCRIPTION
ref: #185 #184

This just clarifies the backing instance, the current DNS actually works as-is: https://kind.sigs.k8s.io/

... but the domain was actually added to netlify against the https://k8s-kind.netlify.com entry which is not hosted at the same team as the https://kindocs.netlify.com for DNS verification reasons on netlify's end. Thank you @chenopis for figuring that out.

/assign @thockin 
