### PR TITLE
Add slack.k8s.io existing config

### DIFF
--- a/slack.k8s.io/TODO.md
+++ b/slack.k8s.io/TODO.md
@@ -1,0 +1,8 @@
+# TODO
+
+* convert to deployment
+* token moved to a secret
+* run as non-root
+* appropriate request/limit settings
+* probably put behind an ingress with TLS
+

--- a/slack.k8s.io/replicationcontroller.yaml
+++ b/slack.k8s.io/replicationcontroller.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  name: slackin-controller
+  annotations:
+    original-image-before-attacks: gcr.io/kubernetes-tools/slackin-kubernetes
+  labels:
+    app: slackin
+spec:
+  replicas: 1
+  selector:
+    app: slackin
+  template:
+    metadata:
+      labels:
+        app: slackin
+    spec:
+      containers:
+      - name: slackin-kubernetes
+        image: kantrn/k8s-slackin-tmp:v2
+        env:
+        - name: PORT
+          value: "80"
+        - name: SLACK_SUBDOMAIN
+          value: "kubernetes"
+        - name: SLACK_API_TOKEN
+          value: "<REDACTED>"
+        ports:
+        - containerPort: 80
+        resources: {}
+        securityContext: {}
+      securityContext: {}

--- a/slack.k8s.io/service.yaml
+++ b/slack.k8s.io/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: slackin-controller
+  labels:
+    app: slackin
+spec:
+  type: LoadBalancer
+  selector:
+    app: slackin
+  ports:
+  - port: 80


### PR DESCRIPTION
These are imperfect in many ways, but worth capturing.  Before we
convert this to new cluster it needs at least:

* convert to deployment
* token moved to a secret
* run as non-root
* appropriate request/limit settings
* probably put behind an ingress with TLS