### PR TITLE
Update slack.k8s.io image to v3 tag

### DIFF
--- a/slack.k8s.io/replicationcontroller.yaml
+++ b/slack.k8s.io/replicationcontroller.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: slackin-kubernetes
-        image: kantrn/k8s-slackin-tmp:v2
+        image: kantrn/k8s-slackin-tmp:v3
         env:
         - name: PORT
           value: "80"


### PR DESCRIPTION
I manually updated it in cluster as part of https://github.com/kubernetes/k8s.io/pull/191#issuecomment-466504010

Before I noticed https://github.com/kubernetes/k8s.io/pull/192

Back in sync now