### PR TITLE
Add a URL shortening service

### DIFF
--- a/k8s.io/configmap-short-urls.yaml
+++ b/k8s.io/configmap-short-urls.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: short-urls
+data:
+  short-urls: |
+    api-review      https://github.com/kubernetes/community/blob/master/sig-architecture/api-review-process.md
+    bot-commands    https://prow.k8s.io/command-help
+    github-labels   https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md
+    good-first-issue https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-incubator+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22&type=Issues
+    help-wanted     https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-incubator+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Aissue+label%3A%22help+wanted%22&type=Issues
+    needs-ok-to-test https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-incubator+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Apr+label%3Aneeds-ok-to-test+label%3A%22cncf-cla%3A+yes%22+-label%3Aneeds-rebase&type=Issues
+    oncall          https://storage.googleapis.com/test-infra-oncall/oncall.html
+    owners          https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md
+    partner-request https://docs.google.com/forms/d/e/1FAIpQLSdN1KtSKX2VAOPGABFlShkSd6CajQynoL4QCVtY0dj76MNDKg/viewform
+    pr-dashboard    https://k8s-gubernator.appspot.com/pr
+    start           https://kubernetes.io/docs/setup/pick-right-solution/
+    stuck-prs       https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Aopen%20label%3Algtm%20label%3Aapproved%20-label%3Ado-not-merge%20-label%3Aneeds-rebase%20sort%3Aupdated-asc%20-status%3Asuccess
+    test-health     http://velodrome.k8s.io/dashboard/db/bigquery-metrics
+    test-history    https://storage.googleapis.com/kubernetes-test-history/static/index.html
+    triage          https://storage.googleapis.com/k8s-gubernator/triage/index.html

--- a/k8s.io/deployment-short-urls.yaml
+++ b/k8s.io/deployment-short-urls.yaml
@@ -1,0 +1,58 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: short-urls
+spec:
+  selector:
+    matchLabels:
+      app: short-urls
+  template:
+    metadata:
+      labels:
+        app: short-urls
+    spec:
+      containers:
+      - name: shlink
+        image: shlinkio/shlink:1.16.2
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          # Start shlink server in the background.
+          /bin/sh /etc/shlink/docker-entrypoint.sh &
+          PID=$!
+          # Wait for service to become available.
+          while ! shlink short-url:list; do
+            sleep 10s
+          done
+          # Load URLs from the config map.
+          while read slug url; do
+            shlink short-url:generate "--customSlug=${slug}" "${url}"
+          done < /etc/config/short-urls
+          # Create healthcheck URL for our readiness probe.
+          shlink short-url:generate -c shlink-healthcheck https://k8s.io
+          # Block until the config map changes, then exit. This will restart
+          # the container and load the new config.
+          # TODO: live reload without downtime
+          inotifyd - /etc/config/short-urls:e
+        env:
+          - name: SHORT_DOMAIN_HOST
+            value: "go.k8s.io"
+          - name: NOT_FOUND_REDIRECT_TO
+            value: "https://k8s.io"
+          - name: SHORT_DOMAIN_SCHEMA
+            value: "https"
+          - name: DB_DRIVER
+            value: "sqlite"
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          exec:
+            command: ["shlink", "short-url:parse", "shlink-healthcheck"]
+        volumeMounts:
+        - name: short-urls-config
+          mountPath: /etc/config
+        # TODO: set resource requests
+      volumes:
+      - name: short-urls-config
+        configMap:
+          name: short-urls

--- a/k8s.io/service-short-urls.yaml
+++ b/k8s.io/service-short-urls.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: short-url-service
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: short-urls
+  type: LoadBalancer


### PR DESCRIPTION
This defines manifests to create a shlink instance that will serve
redirects from go.k8s.io.

Shlink is the open source URL shortener with the best name and logo. It
is also MIT licensed and readily available on docker hub. While this app
expects to use a persistent database, we inject data from a config map
into an ephemeral SQLITE database during pod startup.


The container's only control is a REST endpoint under /rest/v1, but the
only way to generate an API key is by exec-ing into the shlink
container.

See https://shlink.io/api-docs/authentication

Note: This reloads config by restarting the service when the config map changes.

/ref https://github.com/kubernetes/community/issues/2959