### PR TITLE
Update DNS for redirector to point to Ingress IP

### DIFF
--- a/.github/ISSUE_TEMPLATE/dns-request.md
+++ b/.github/ISSUE_TEMPLATE/dns-request.md
@@ -21,7 +21,7 @@ www:
 # this is the record type, e.g A, CNAME, MX, TXT, etc.
 - type: A
   # This depends on the record type, see existing YAML files for more examples.
-  value: 23.236.58.218
+  value: 35.201.71.162
 ```
 
 ### New DNS Record:

--- a/dns/README.md
+++ b/dns/README.md
@@ -62,7 +62,7 @@ www:
 # this is the record type, e.g A, CNAME, MX, TXT, etc.
 - type: A
   # This depends on the record type, see existing YAML files for more examples.
-  value: 23.236.58.218
+  value: 35.201.71.162
 ```
 
 *New DNS Record:*

--- a/dns/zone-configs/k8s.io.yaml
+++ b/dns/zone-configs/k8s.io.yaml
@@ -2,7 +2,7 @@
 # The top-level k8s.io zone
 '':
   - type: A
-    value: 23.236.58.218 # Our vanity redirector, hosted in GKE
+    value: 35.201.71.162 # Our vanity redirector, hosted in GKE
   - type: MX
     values:
     - exchange: aspmx.l.google.com.
@@ -36,7 +36,7 @@ canary:
 # becomes different from the main record. (@thockin)
 redirect:
   type: A
-  value: 23.236.58.218
+  value: 35.201.71.162
 
 # Main docs site is a redirect (@chenopis)
 docs:


### PR DESCRIPTION
This is the next part of https://github.com/kubernetes/k8s.io/issues/215 (item 3).

The `Ingress` has been set up, and tests consistently pass when targeted against it.

/assign @thockin 