### PR TITLE
k8s.io redirector: remove/fix old sites

### DIFF
--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -64,7 +64,7 @@ data:
 
       # Vanity redirects for the new kubernetes-sigs repos
       server {
-        server_name sigs.k8s.io;
+        server_name sigs.k8s.io sigs.kubernetes.io;
         listen 80;
         listen 443 ssl;
 
@@ -128,11 +128,11 @@ data:
       }
 
       server {
-        server_name blog.k8s.io;
+        server_name blog.kubernetes.io blog.k8s.io;
         listen 80;
         listen 443 ssl;
 
-        rewrite ^/(.*)?$    http://blog.kubernetes.io/$1 redirect;
+        rewrite ^/(.*)?$    https://kubernetes.io/blog/$1 redirect;
       }
 
       server {
@@ -313,13 +313,5 @@ data:
         location / {
           rewrite ^/.*$  https://prow.k8s.io/tide redirect;
         }
-      }
-
-      server {
-        server_name testgrid.kubernetes.io testgrid.k8s.io;
-        listen 80;
-        listen 443 ssl;
-
-        rewrite ^/(.*)?$    https://k8s-testgrid.appspot.com/$1 redirect;
       }
     }

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -93,26 +93,26 @@ class RedirTest(unittest.TestCase):
                 'https://kubernetes.io/' + path, 301)
 
     def test_sig_urls(self):
-        base = 'https://sigs.k8s.io'
-        self.assert_scheme_redirect(
-                base,
-                'https://github.com/kubernetes-sigs/',
-                301)
-        self.assert_scheme_redirect(
-                base + '/$sig_repo',
-                'https://github.com/kubernetes-sigs/$sig_repo',
-                301,
-                sig_repo=rand_num())
-        self.assert_scheme_redirect(
-                base + '/$sig_repo/',
-                'https://github.com/kubernetes-sigs/$sig_repo/',
-                301,
-                sig_repo=rand_num())
-        self.assert_scheme_redirect(
-                base + '/$sig_repo/$repo_subpath',
-                'https://github.com/kubernetes-sigs/$sig_repo/blob/master/$repo_subpath',
-                301,
-                sig_repo=rand_num(), repo_subpath=rand_num())
+        for base in ('https://sigs.k8s.io', 'https://sigs.kubernetes.io'):
+            self.assert_scheme_redirect(
+                    base,
+                    'https://github.com/kubernetes-sigs/',
+                    301)
+            self.assert_scheme_redirect(
+                    base + '/$sig_repo',
+                    'https://github.com/kubernetes-sigs/$sig_repo',
+                    301,
+                    sig_repo=rand_num())
+            self.assert_scheme_redirect(
+                    base + '/$sig_repo/',
+                    'https://github.com/kubernetes-sigs/$sig_repo/',
+                    301,
+                    sig_repo=rand_num())
+            self.assert_scheme_redirect(
+                    base + '/$sig_repo/$repo_subpath',
+                    'https://github.com/kubernetes-sigs/$sig_repo/blob/master/$repo_subpath',
+                    301,
+                    sig_repo=rand_num(), repo_subpath=rand_num())
 
     def test_protocol_upgrade(self):
         for url in ('kubernetes.io', 'k8s.io', 'sigs.k8s.io'):
@@ -200,9 +200,10 @@ class RedirTest(unittest.TestCase):
                 'https://packages.cloud.google.com/apt/$id', id=rand_num())
 
     def test_blog(self):
-        self.assert_temp_redirect('blog.k8s.io', 'http://blog.kubernetes.io/')
-        self.assert_temp_redirect('blog.k8s.io/$path',
-                'http://blog.kubernetes.io/$path', path=rand_num())
+        for base in ('blog.k8s.io', 'blog.kubernetes.io'):
+            self.assert_temp_redirect(base, 'https://kubernetes.io/blog/')
+            self.assert_temp_redirect(base + '/$path',
+                'https://kubernetes.io/blog/$path', path=rand_num())
 
     def test_ci_test(self):
         base = 'ci-test.kubernetes.io'
@@ -357,12 +358,6 @@ class RedirTest(unittest.TestCase):
         for base in ('submit-queue.k8s.io', 'submit-queue.kubernetes.io'):
             self.assert_temp_redirect(base, 'https://prow.k8s.io/tide')
             self.assert_temp_redirect(base + '/$path', 'https://prow.k8s.io/tide',
-                path=rand_num())
-
-    def test_testgrid(self):
-        for base in ('testgrid.k8s.io', 'testgrid.kubernetes.io'):
-            self.assert_temp_redirect(base, 'https://k8s-testgrid.appspot.com/')
-            self.assert_temp_redirect(base + '/$path', 'https://k8s-testgrid.appspot.com/$path',
                 path=rand_num())
 
 


### PR DESCRIPTION
This is tangentially related to #215.

After looking at our DNS records, I noticed that testgrid no longer points at the redirector, so we can remove it (and not request its subdomain in our new cert).

The blog now seems to be hosted on https://kubernetes.io/blog, whereas blog.kubernetes.io points at the redirector. This makes both https://blog.kubernetes.io/ and https://blog.k8s.io/ now actually go to the blog.

I also added a handler for `sigs.kubernetes.io`, since that name points at the redirector, though most folks will probably be using sigs.k8s.io.

/assign @thockin 