### PR TITLE
fixes to promoter manifests

### DIFF
--- a/k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml
@@ -1,7 +1,7 @@
 # google group for gcr.io/k8s-staging-cluster-api is k8s-infra-gcr-staging-cluster-api@googlegroups.com
-src-registry: gcr.io/k8s-staging-cluster-api
 registries:
 - name: gcr.io/k8s-staging-cluster-api
+  src: true
 - name: us.gcr.io/k8s-gcr-prod
   service-account: k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
 - name: eu.gcr.io/k8s-gcr-prod
@@ -9,3 +9,4 @@ registries:
 - name: asia.gcr.io/k8s-gcr-prod
   service-account: k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
 images: []
+renames: []

--- a/k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml
@@ -2,6 +2,10 @@
 src-registry: gcr.io/k8s-staging-cluster-api
 registries:
 - name: gcr.io/k8s-staging-cluster-api
-- name: gcr.io/k8s-gcr-prod
+- name: us.gcr.io/k8s-gcr-prod
+  service-account: k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-gcr-prod
+  service-account: k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-gcr-prod
   service-account: k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
 images: []

--- a/k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml
@@ -2,7 +2,6 @@
 src-registry: gcr.io/k8s-staging-cluster-api
 registries:
 - name: gcr.io/k8s-staging-cluster-api
-  service-account: service-account@kubernetes-public.iam.gserviceaccount.com
 - name: gcr.io/k8s-gcr-prod
-  service-account: service-account@kubernetes-public.iam.gserviceaccount.com
+  service-account: k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
 images: []

--- a/k8s.gcr.io/k8s-staging-coredns/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-coredns/manifest.yaml
@@ -1,7 +1,7 @@
 # google group for gcr.io/k8s-staging-coredns is k8s-infra-gcr-staging-coredns@googlegroups.com
-src-registry: gcr.io/k8s-staging-coredns
 registries:
 - name: gcr.io/k8s-staging-coredns
+  src: true
 - name: us.gcr.io/k8s-gcr-prod
   service-account: k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
 - name: eu.gcr.io/k8s-gcr-prod
@@ -9,3 +9,4 @@ registries:
 - name: asia.gcr.io/k8s-gcr-prod
   service-account: k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
 images: []
+renames: []

--- a/k8s.gcr.io/k8s-staging-coredns/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-coredns/manifest.yaml
@@ -2,9 +2,8 @@
 src-registry: gcr.io/k8s-staging-csi
 registries:
 - name: gcr.io/k8s-staging-csi
-  service-account: service-account@kubernetes-public.iam.gserviceaccount.com
 - name: gcr.io/k8s-gcr-prod
-  service-account: service-account@kubernetes-public.iam.gserviceaccount.com
+  service-account: k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
 images:
 - name: coredns
   dmap:

--- a/k8s.gcr.io/k8s-staging-coredns/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-coredns/manifest.yaml
@@ -8,7 +8,4 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
 - name: asia.gcr.io/k8s-gcr-prod
   service-account: k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
-images:
-- name: coredns
-  dmap:
-    "sha256:02382353821b12c21b062c59184e227e001079bb13ebd01f9d3270ba0fcbf1e4": ["1.3.1"] # Manifest list.
+images: []

--- a/k8s.gcr.io/k8s-staging-coredns/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-coredns/manifest.yaml
@@ -2,7 +2,11 @@
 src-registry: gcr.io/k8s-staging-coredns
 registries:
 - name: gcr.io/k8s-staging-coredns
-- name: gcr.io/k8s-gcr-prod
+- name: us.gcr.io/k8s-gcr-prod
+  service-account: k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-gcr-prod
+  service-account: k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-gcr-prod
   service-account: k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
 images:
 - name: coredns

--- a/k8s.gcr.io/k8s-staging-coredns/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-coredns/manifest.yaml
@@ -1,7 +1,7 @@
 # google group for gcr.io/k8s-staging-coredns is k8s-infra-gcr-staging-coredns@googlegroups.com
-src-registry: gcr.io/k8s-staging-csi
+src-registry: gcr.io/k8s-staging-coredns
 registries:
-- name: gcr.io/k8s-staging-csi
+- name: gcr.io/k8s-staging-coredns
 - name: gcr.io/k8s-gcr-prod
   service-account: k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
 images:

--- a/k8s.gcr.io/k8s-staging-csi/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-csi/manifest.yaml
@@ -2,6 +2,10 @@
 src-registry: gcr.io/k8s-staging-csi
 registries:
 - name: gcr.io/k8s-staging-csi
-- name: gcr.io/k8s-gcr-prod
+- name: us.gcr.io/k8s-gcr-prod
+  service-account: k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-gcr-prod
+  service-account: k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-gcr-prod
   service-account: k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
 images: []

--- a/k8s.gcr.io/k8s-staging-csi/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-csi/manifest.yaml
@@ -2,7 +2,6 @@
 src-registry: gcr.io/k8s-staging-csi
 registries:
 - name: gcr.io/k8s-staging-csi
-  service-account: service-account@kubernetes-public.iam.gserviceaccount.com
 - name: gcr.io/k8s-gcr-prod
-  service-account: service-account@kubernetes-public.iam.gserviceaccount.com
+  service-account: k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
 images: []

--- a/k8s.gcr.io/k8s-staging-csi/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-csi/manifest.yaml
@@ -1,7 +1,7 @@
 # google group for gcr.io/k8s-staging-csi is k8s-infra-gcr-staging-csi@googlegroups.com
-src-registry: gcr.io/k8s-staging-csi
 registries:
 - name: gcr.io/k8s-staging-csi
+  src: true
 - name: us.gcr.io/k8s-gcr-prod
   service-account: k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
 - name: eu.gcr.io/k8s-gcr-prod
@@ -9,3 +9,4 @@ registries:
 - name: asia.gcr.io/k8s-gcr-prod
   service-account: k8s-infra-gcr-promoter@k8s-gcr-prod.iam.gserviceaccount.com
 images: []
+renames: []


### PR DESCRIPTION
There is no better source of clarity than real-world testing.

Functionally, we remove coredns 1.3.1 from `gcr.io/k8s-staging-coredns`'s manifest, because it was used for testing the promotion of manifest lists (verified with local testing).

/cc @thockin @dims