### PR TITLE
Don't request www.kubernetes.io SAN on TLS certificate

### DIFF
--- a/k8s.io/certificate-canary.yaml
+++ b/k8s.io/certificate-canary.yaml
@@ -56,6 +56,5 @@ spec:
   - submit-queue.k8s.io
   - submit-queue.kubernetes.io
   - www.k8s.io
-  - www.kubernetes.io
   - yum.k8s.io
   - yum.kubernetes.io

--- a/k8s.io/certificate-prod.yaml
+++ b/k8s.io/certificate-prod.yaml
@@ -56,7 +56,6 @@ spec:
   - submit-queue.k8s.io
   - submit-queue.kubernetes.io
   - www.k8s.io
-  - www.kubernetes.io
   - yum.k8s.io
   - yum.kubernetes.io
   acme:
@@ -110,6 +109,5 @@ spec:
       - submit-queue.k8s.io
       - submit-queue.kubernetes.io
       - www.k8s.io
-      - www.kubernetes.io
       - yum.k8s.io
       - yum.kubernetes.io


### PR DESCRIPTION
www.kubernetes.io is a CNAME to the real kubernetes.io site, not our redirector, so we shouldn't request a cert for it, especially since we can't solve HTTP challenges for it.