### PR TITLE
Enable bucket-only policy for GCS buckets

### DIFF
--- a/k8s.gcr.io/lib.sh
+++ b/k8s.gcr.io/lib.sh
@@ -166,6 +166,7 @@ function ensure_repo() {
     fi
 
     gsutil iam ch allUsers:objectViewer "${bucket}"
+    gsutil bucketpolicyonly set on "${bucket}"
 }
 
 # Grant full privileges to GCR admins


### PR DESCRIPTION
Simpler auth is better - we do not want per-object rules.