### PR TITLE
Point artifacts.k8s.io to GCLB for artifact serving

### DIFF
--- a/dns/zone-configs/k8s.io.yaml
+++ b/dns/zone-configs/k8s.io.yaml
@@ -89,6 +89,14 @@ releases:
   type: CNAME
   value: redirect.k8s.io.
 
+# artifacts.k8s.io is for the (under development) binary artifact serving.
+# The IP points to a GCLB in front of a GCS bucket,
+# in the k8s-artifacts-prod project.
+artifacts:
+  type: A
+  values:
+  - 35.244.192.77
+
 # Vanity CNAMEs.
 blog:
   type: CNAME


### PR DESCRIPTION
This is the IP address allocated in the k8s-artifacts-prod project.

This should enable us to get a TLS certificate (possibly subject to
domain validation).