### PR TITLE
GCS: configure index.html as default page on bucket

### DIFF
--- a/k8s.gcr.io/ensure-prod-storage.sh
+++ b/k8s.gcr.io/ensure-prod-storage.sh
@@ -102,4 +102,8 @@ ensure_gcs_bucket "${PROD_PROJECT}" "${PROD_BUCKET}"
 color 6 "Empowering GCS admins"
 empower_gcs_admins "${PROD_PROJECT}" "${PROD_BUCKET}"
 
+# Set the web policy on the bucket
+color 6 "Configuring the web policy on the bucket"
+ensure_gcs_web_policy "${PROD_BUCKET}"
+
 color 6 "Done"

--- a/k8s.gcr.io/lib.sh
+++ b/k8s.gcr.io/lib.sh
@@ -191,6 +191,18 @@ function ensure_gcs_bucket() {
     gsutil iam ch allUsers:objectViewer "${bucket}"
 }
 
+# Sets the web policy on the bucket, including a default index.html page
+# $1: The bucket
+function ensure_gcs_web_policy() {
+    if [ $# -lt 1 -o -z "$1" ]; then
+        echo "ensure_gcs_web_policy(bucket) requires 1 argument" >&2
+        return 1
+    fi
+    bucket="$1"
+
+    gsutil web set -m index.html "${bucket}"
+}
+
 # Grant full privileges to GCR admins
 # $1: The GCP project
 # $2: The GCR region (optional)


### PR DESCRIPTION
This stops us serving listings by default (which will end pretty big!)