### PR TITLE
GCS: Remove unused project argument from empower_group_to_bucket

### DIFF
--- a/k8s.gcr.io/ensure-staging-storage.sh
+++ b/k8s.gcr.io/ensure-staging-storage.sh
@@ -113,6 +113,6 @@ empower_gcs_admins "${PROJECT}" "${BUCKET}"
 
 # Enable writers on the bucket
 color 6 "Empowering ${WRITERS} to GCS"
-empower_group_to_bucket "${PROJECT}" "${WRITERS}" "${BUCKET}"
+empower_group_to_bucket "${WRITERS}" "${BUCKET}"
 
 color 6 "Done"

--- a/k8s.gcr.io/lib.sh
+++ b/k8s.gcr.io/lib.sh
@@ -267,17 +267,15 @@ function empower_group_to_repo() {
 }
 
 # Grant write privileges on a bucket to a group
-# $1: The GCP project
-# $2: The googlegroups group
-# $3: The bucket
+# $1: The googlegroups group
+# $2: The bucket
 function empower_group_to_bucket() {
-    if [ $# -lt 3 -o -z "$1" -o -z "$2" -o -z "$3" ]; then
-        echo "empower_group_to_bucket(project, group_name, bucket) requires 3 arguments" >&2
+    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+        echo "empower_group_to_bucket(group_name, bucket) requires 2 arguments" >&2
         return 1
     fi
-    project="$1"
-    group="$2"
-    bucket="$3"
+    group="$1"
+    bucket="$2"
 
     gsutil iam ch \
         "group:${group}:objectAdmin" \


### PR DESCRIPTION
As we don't need the project, we shouldn't pass it.