### PR TITLE
Add link to doc about running publishing-bot

### DIFF
--- a/k8s.io/README.md
+++ b/k8s.io/README.md
@@ -69,3 +69,10 @@ Use `make test` to run unit tests to verify the various endpoints on the server.
 Deploying
 ===
 Set kubectl to target the production cluster, then run `make deploy`.
+
+Publishing-bot
+===
+
+Details about running the [publishing-bot](https://git.k8s.io/publishing-bot)
+for the Kubernetes project can be found
+[here](https://git.k8s.io/publishing-bot/k8s-publishing-bot.md).


### PR DESCRIPTION
Fixes https://github.com/kubernetes/k8s.io/issues/183

Not sure if the k8s.io/README is the right place to add a link to it, but I can't think of any other place either.

/cc @dims @sttts @spiffxp 
/assign @dims 