### PR TITLE
Give Amy Chen access to pushing to cluster-api staging registry

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -87,6 +87,7 @@ groups:
       - ha.chuck@gmail.com
       - detiber@gmail.com
       - vince@vincepri.com
+      - hi@amycod.es
   - email-id: k8s-infra-staging-kops@kubernetes.io
     members:
       - ihor@cncf.io


### PR DESCRIPTION
Reference Issue: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/795
Summary: I would like to smooth out the release process for cluster-api and need access to pushing images to the staging registry. 