### PR TITLE
Add k8s-infra-cluster-operators-test google group.

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -27,6 +27,14 @@ groups:
       - justinsb@google.com
       - stefan.schimanski@gmail.com
       - nikitaraghunath@gmail.com
+  - email-id: k8s-infra-cluster-operators@kubernetes.io
+    members:
+      - ameukam@gmail.com
+      - davanum@gmail.com
+      - hh@ii.coop
+      - justinsb@google.com
+      - spiffxp@google.com
+      - thockin@google.com
   - email-id: k8s-infra-dns-admins@kubernetes.io
     members:
       - bentheelder@google.com


### PR DESCRIPTION
Reference issue : #275 

The purpose of this Google group is to test the Google Group for GKE
feature.


