### PR TITLE
dns: automatically apply area/dns label

### DIFF
--- a/dns/OWNERS
+++ b/dns/OWNERS
@@ -6,3 +6,5 @@ approvers:
   - hh
   - idvoretskyi
   - thockin
+labels:
+  - area/dns


### PR DESCRIPTION
We have the `area/dns` label now, so let's automatically apply it.

/assign @dims 
/shrug