### PR TITLE
Create gcr.io/k8s-staging-publishing-bot

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -103,6 +103,11 @@ groups:
       - spiffxp@google.com
       - thockin@google.com
       - justinsb@google.com
+  - email-id: k8s-infra-staging-publishing-bot@kubernetes.io
+    members:
+      - davanum@gmail.com
+      - stefan.schimanski@gmail.com
+      - nikitaraghunath@gmail.com
   - email-id: k8s-infra-team-private@kubernetes.io
     members:
       - jgrafton@google.com

--- a/k8s.gcr.io/ensure-staging-storage.sh
+++ b/k8s.gcr.io/ensure-staging-storage.sh
@@ -43,6 +43,7 @@ STAGING_PROJECTS=(
     cluster-api
     csi
     kops
+    publishing-bot
 )
 if [ $# = 0 ]; then
     # default to all staging projects

--- a/k8s.gcr.io/k8s-staging-publishing-bot/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-publishing-bot/manifest.yaml
@@ -1,0 +1,12 @@
+# google group for gcr.io/k8s-staging-publishing-bot is k8s-infra-staging-publishing-bot@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-publishing-bot
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+images: []
+renames: []


### PR DESCRIPTION
This will house the [publishing-bot](https://github.com/kubernetes/publishing-bot/) image. For context, the publishing-bot runs on a CNCF cluster, moving the images also completely moves the publishing-bot to CNCF infra.

Currently, we use https://hub.docker.com/r/sttts/k8s-publishing-bot and @sttts needs to deploy each time we merge something.

Let me know if someone else should also be added to the google group.

/assign @dims @sttts 