### PR TITLE
dns: remove devstats CNAME entries

### DIFF
--- a/dns/zone-configs/k8s.io.yaml
+++ b/dns/zone-configs/k8s.io.yaml
@@ -116,10 +116,6 @@ cs:
   type: A
   value: 147.75.97.58
 # sig-contributor-experience
-devstats:
-  type: CNAME
-  value: k8s.devstats.cncf.io.
-# sig-contributor-experience
 discuss:
   type: CNAME
   value: kubernetes.hosted-by-discourse.com.

--- a/dns/zone-configs/kubernetes.io.yaml
+++ b/dns/zone-configs/kubernetes.io.yaml
@@ -108,9 +108,6 @@ code:
 cs:
   type: CNAME
   value: cs.k8s.io.
-devstats:
-  type: CNAME
-  value: devstats.k8s.io.
 discuss:
   type: CNAME
   value: kubernetes.hosted-by-discourse.com.


### PR DESCRIPTION
The official preferred url is https://k8s.devstats.cncf.io and after
changes recently using the Kubernetes org CNAMEs results in a
certificate error.  No docs appear to reference the vanity url, and since
it now errors and is not a supported config on the cncf/devstats side,
the CNAMEs should be removed.

Signed-off-by: Tim Pepper <tpepper@vmware.com>