### PR TITLE
dns: add minikube.sigs.k8s.io

### DIFF
--- a/dns/zone-configs/k8s.io.yaml
+++ b/dns/zone-configs/k8s.io.yaml
@@ -255,3 +255,7 @@ cluster-api.sigs:
 cloud-provider-vsphere.sigs:
   type: CNAME
   value: kubernetes-sigs-cloud-provider-vsphere.netlify.com.
+# https://github.com/kubernetes/minikube docs (@tstromberg, @afbjorklund)
+minikube.sigs:
+  type: CNAME
+  value: kubernetes-sigs-minikube.netlify.com.


### PR DESCRIPTION
Fixes https://github.com/kubernetes/k8s.io/issues/284
Ref: https://github.com/kubernetes/org/issues/855

The netlify site is live here: https://kubernetes-sigs-minikube.netlify.com/

/cc @tstromberg @afbjorklund
/assign @cblecker 