### PR TITLE
'unicode()' was removed in Python 3

### DIFF
--- a/dns/octodns-docker/check-zone.py
+++ b/dns/octodns-docker/check-zone.py
@@ -33,6 +33,11 @@ from octodns.cmds.args import ArgumentParser
 from octodns.manager import Manager
 from octodns.zone import Zone
 
+try:
+    unicode
+except NameError:
+    unicode = str
+
 log = getLogger('check-zone')
 
 class AsyncResolver(Resolver):


### PR DESCRIPTION
Calling __unicode()__ (lines 65, 78, 131) will raise NameError at runtime on Python 3.