### PR TITLE
Set bucketpolicyonly on non-GCR buckets

### DIFF
--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -181,6 +181,7 @@ function ensure_gcs_bucket() {
       gsutil mb -p "${project}" -l "${location}" "${bucket}"
     fi
     gsutil iam ch allUsers:objectViewer "${bucket}"
+    gsutil bucketpolicyonly set on "${bucket}"
 }
 
 # Sets the web policy on the bucket, including a default index.html page


### PR DESCRIPTION
I noticed this was not set.  Seems like we want it for consistency and simplicity?