### PR TITLE
[WIP] Create Test GCR service account for container image promoter

### DIFF
--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -34,7 +34,7 @@ if [ $# != 0 ]; then
     exit 1
 fi
 
-# Grant access to "fake prod" projects for tol testing
+# Grant access to "fake prod" projects for tool testing
 # $1: The GCP project
 # $2: The googlegroups group
 function empower_group_to_fake_prod() {
@@ -54,6 +54,11 @@ function empower_group_to_fake_prod() {
         empower_group_to_gcr "${project}" "${group}" "${r}"
     done
 }
+# The service account name for the image promoter.
+PROMOTER_SVCACCT="k8s-infra-gcr-promoter"
+
+# Permissions to grant GCR service account
+PERMISSIONS=("objectAdmin" "legacyBucketOwner")
 
 # The GCP project names.
 PROD_PROJECT="k8s-artifacts-prod"
@@ -97,7 +102,10 @@ for prj in "${ALL_PROJECTS[@]}"; do
     color 6 "Empowering image promoter: ${prj}"
     for r in "${PROD_REGIONS[@]}"; do
         color 3 "region $r"
-        empower_artifact_promoter "${prj}" "${r}"
+        for p in "${PERMISSIONS[@]}"; do
+            color 6 "Granting permission: ${p}"
+            empower_artifact_promoter "${PROMOTER_SVCACCT}" "${prj}" "${p}" "${r}"
+        done
     done
 
     color 6 "Enabling the GCS API: ${prj}"

--- a/infra/gcp/ensure-test-storage.sh
+++ b/infra/gcp/ensure-test-storage.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used to create a new test service account for running container image promoter e2e tests.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+. "${SCRIPT_DIR}/lib.sh"
+
+function usage() {
+    echo "usage: $0" > /dev/stderr
+    echo > /dev/stderr
+}
+
+if [ $# != 0 ]; then
+    usage
+    exit 1
+fi
+
+# The service account name for the image promoter test account
+PROMOTER_TEST_SVC="k8s-infra-gcr-promoter-test"
+
+# GCP project names.
+STAGING_PROJECT="k8s-staging-cip-test"
+PROD_PROJECT="k8s-cip-test-prod"
+
+ALL_PROJECTS=("${STAGING_PROJECT}" "${PROD_PROJECT}")
+
+# GCR service account permissions
+PERMISSIONS=("objectAdmin" "legacyBucketOwner")
+
+# Empower image promoter
+for prj in "${ALL_PROJECTS[@]}"; do
+    color 6 "Empowering image promoter to GCR: ${prj}"
+    for p in "${PERMISSIONS[@]}"; do
+        color 6 "Granting permission: ${p}"
+        empower_artifact_promoter "${PROMOTER_TEST_SVC}" "${prj}" "${p}"
+    done
+done


### PR DESCRIPTION
This PR creates the new service account `k8s-infra-gcr-promoter-test` for gcr projects `k8s-staging-cip-test` and `k8s-cip-test-prod` then gives the account `objectAdmin` and `admin` permissions.

Address: https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/65

cc/ @listx & @thockin 