### PR TITLE
Create k8s-infra-aws-admins group, that will own AWS accounts

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -140,3 +140,9 @@ groups:
       - ihor@cncf.io
       - bentheelder@google.com
       - brendan.d.burns@gmail.com
+  # Group that owns administrative access to AWS accounts
+  - email-id: k8s-infra-aws-admins@kubernetes.io
+    members:
+      - ihor@cncf.io
+      - justinsb@google.com
+      - thockin@google.com


### PR DESCRIPTION
This group will be the administrative email for AWS accounts.