### PR TITLE
Fix typos in reconcile.go

### DIFF
--- a/groups/reconcile.go
+++ b/groups/reconcile.go
@@ -343,8 +343,8 @@ func updateGroupSettingsToAllowExternalMembers(srv *groupssettings.Service, grou
 		g2.WhoCanDiscoverGroup != settings.WhoCanDiscoverGroup ||
 		g2.WhoCanInvite != settings.WhoCanInvite ||
 		g2.WhoCanAdd != settings.WhoCanAdd ||
-		g2.WhoCanApproveMembers != settings.WhoCanApproveManagers ||
-		g2.WhoCanModifyMembers != settings.WhoCanModifiyMembers ||
+		g2.WhoCanApproveMembers != settings.WhoCanApproveMembers ||
+		g2.WhoCanModifyMembers != settings.WhoCanModifyMembers ||
 		g2.WhoCanModerateMembers != settings.WhoCanModerateMembers {
 
 		if config.ConfirmChanges {


### PR DESCRIPTION
@justinsb a couple of typos sneaked in

```
[dims@dims-vmware-laptop 16:36] ~/go/src/k8s.io/k8s.io/groups ⟩ make run
git-crypt unlock
GO111MODULE=on go run reconcile.go
# command-line-arguments
./reconcile.go:346:38: settings.WhoCanApproveManagers undefined (type *groupssettings.Groups has no field or method WhoCanApproveManagers)
./reconcile.go:347:37: settings.WhoCanModifiyMembers undefined (type *groupssettings.Groups has no field or method WhoCanModifiyMembers)
make: *** [run] Error 2
```