### PR TITLE
Add plantuml image for cluster-api

### DIFF
--- a/k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml
@@ -13,8 +13,15 @@ images:
   dmap:
     "sha256:9057a2875d6620521ddea456f31655b8480f07f6a31a50c15b111c1ae09af487": ["v0.1.5", "v0.1.6"]
     "sha256:663829ece3a14201b71ec1e211c3d33f99ecdf0ea8081f7486806442a61d925d": ["v0.1.7", "v0.1.8"]
+- name: plantuml
+  dmap:
+    "sha256:befa605d8640516f9fbada5c1969638c5cb60fb042f598a432cbd22345570bc5": ["1.2019.6"]
 renames:
 - - "gcr.io/k8s-staging-cluster-api/cluster-api-controller"
   - "us.gcr.io/k8s-artifacts-prod/cluster-api/cluster-api-controller"
   - "eu.gcr.io/k8s-artifacts-prod/cluster-api/cluster-api-controller"
   - "asia.gcr.io/k8s-artifacts-prod/cluster-api/cluster-api-controller"
+- - "gcr.io/k8s-staging-cluster-api/plantuml"
+  - "us.gcr.io/k8s-artifacts-prod/cluster-api/plantuml"
+  - "eu.gcr.io/k8s-artifacts-prod/cluster-api/plantuml"
+  - "asia.gcr.io/k8s-artifacts-prod/cluster-api/plantuml"


### PR DESCRIPTION
Adds a plantuml image for cluster-api which is used for docs generation.

/assign @dims 
