### PR TITLE
Fix Docs DNS for cluster-api v1alpha1

### DIFF
--- a/dns/zone-configs/k8s.io.yaml
+++ b/dns/zone-configs/k8s.io.yaml
@@ -250,7 +250,7 @@ cluster-api.sigs:
 # https://github.com/kubernetes-sigs/cluster-api v1alpha1 docs (@dwat, @jdetiber, @justinsb)
 v1alpha1.cluster-api.sigs:
   type: CNAME
-  value: release-0.1--kubernetes-sigs-cluster-api.netlify.com.
+  value: release-0-1--kubernetes-sigs-cluster-api.netlify.com.
 # https://github.com/kubernetes/cloud-provider-vsphere docs (@andrewsykim, @frapposelli)
 cloud-provider-vsphere.sigs:
   type: CNAME


### PR DESCRIPTION
Fixes the netlify subdomain for the release-0.1 branch of cluster-api

/assign @davidewatson @dims 