### PR TITLE
Add image for cluster-api-provider-aws v0.3.7

### DIFF
--- a/k8s.gcr.io/k8s-staging-cluster-api-aws/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-cluster-api-aws/manifest.yaml
@@ -12,6 +12,7 @@ images:
 - name: cluster-api-aws-controller
   dmap:
     "sha256:7397e3ef7dfa72b102197eaa6bd20ca8b572ccbc31a30f3d262188376e95836a": ["v0.3.6"]
+    "sha256:e167eec012a77eb6f1741bcb7c6b9514ffdd5ac154137cba86c14f40db979913": ["v0.3.7"]
 renames:
 - - "gcr.io/k8s-staging-cluster-api-aws/cluster-api-aws-controller"
   - "us.gcr.io/k8s-artifacts-prod/cluster-api-aws/cluster-api-aws-controller"


### PR DESCRIPTION
Ads the image for the v0.3.7 release for kubernetes-sigs/cluster-api-provider-aws

/assign @ncdc @dims 