### PR TITLE
Turn off retention on GCS cip-test buckets

### DIFF
--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -137,4 +137,8 @@ empower_group_to_fake_prod \
     "${RELEASE_TESTPROD_PROJECT}" \
     "k8s-infra-staging-release-test@kubernetes.io"
 
+# Special case: don't use retention on cip-test buckets
+# (the retention appears to have been locked, so we set it to 1s instead)
+gsutil retention set 1s gs://k8s-cip-test-prod
+
 color 6 "Done"

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -129,3 +129,6 @@ for REPO; do
 
     color 6 "Done"
 done
+
+# Special case: don't use retention on cip-test buckets
+gsutil retention clear gs://k8s-staging-cip-test


### PR DESCRIPTION
Otherwise we can't clear the buckets before e2e tests.