### PR TITLE
promoter manifests: avoid rename feature

### DIFF
--- a/k8s.gcr.io/k8s-staging-build-image/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-build-image/manifest.yaml
@@ -2,11 +2,11 @@
 registries:
 - name: gcr.io/k8s-staging-build-image
   src: true
-- name: us.gcr.io/k8s-artifacts-prod
+- name: us.gcr.io/k8s-artifacts-prod/build-image
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod
+- name: eu.gcr.io/k8s-artifacts-prod/build-image
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod
+- name: asia.gcr.io/k8s-artifacts-prod/build-image
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 images: []
 renames: []

--- a/k8s.gcr.io/k8s-staging-cluster-api-aws/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-cluster-api-aws/manifest.yaml
@@ -2,19 +2,15 @@
 registries:
 - name: gcr.io/k8s-staging-cluster-api-aws
   src: true
-- name: us.gcr.io/k8s-artifacts-prod
+- name: us.gcr.io/k8s-artifacts-prod/cluster-api-aws
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod
+- name: eu.gcr.io/k8s-artifacts-prod/cluster-api-aws
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod
+- name: asia.gcr.io/k8s-artifacts-prod/cluster-api-aws
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 images:
 - name: cluster-api-aws-controller
   dmap:
     "sha256:7397e3ef7dfa72b102197eaa6bd20ca8b572ccbc31a30f3d262188376e95836a": ["v0.3.6"]
     "sha256:e167eec012a77eb6f1741bcb7c6b9514ffdd5ac154137cba86c14f40db979913": ["v0.3.7"]
-renames:
-- - "gcr.io/k8s-staging-cluster-api-aws/cluster-api-aws-controller"
-  - "us.gcr.io/k8s-artifacts-prod/cluster-api-aws/cluster-api-aws-controller"
-  - "eu.gcr.io/k8s-artifacts-prod/cluster-api-aws/cluster-api-aws-controller"
-  - "asia.gcr.io/k8s-artifacts-prod/cluster-api-aws/cluster-api-aws-controller"
+renames: []

--- a/k8s.gcr.io/k8s-staging-cluster-api-kubeadm/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-cluster-api-kubeadm/manifest.yaml
@@ -2,11 +2,11 @@
 registries:
 - name: gcr.io/k8s-staging-capi-kubeadm
   src: true
-- name: us.gcr.io/k8s-artifacts-prod
+- name: us.gcr.io/k8s-artifacts-prod/capi-kubeadm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod
+- name: eu.gcr.io/k8s-artifacts-prod/capi-kubeadm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod
+- name: asia.gcr.io/k8s-artifacts-prod/capi-kubeadm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 images: []
 renames: []

--- a/k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-cluster-api/manifest.yaml
@@ -2,11 +2,11 @@
 registries:
 - name: gcr.io/k8s-staging-cluster-api
   src: true
-- name: us.gcr.io/k8s-artifacts-prod
+- name: us.gcr.io/k8s-artifacts-prod/cluster-api
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod
+- name: eu.gcr.io/k8s-artifacts-prod/cluster-api
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod
+- name: asia.gcr.io/k8s-artifacts-prod/cluster-api
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 images:
 - name: cluster-api-controller
@@ -17,12 +17,4 @@ images:
 - name: plantuml
   dmap:
     "sha256:befa605d8640516f9fbada5c1969638c5cb60fb042f598a432cbd22345570bc5": ["1.2019.6"]
-renames:
-- - "gcr.io/k8s-staging-cluster-api/cluster-api-controller"
-  - "us.gcr.io/k8s-artifacts-prod/cluster-api/cluster-api-controller"
-  - "eu.gcr.io/k8s-artifacts-prod/cluster-api/cluster-api-controller"
-  - "asia.gcr.io/k8s-artifacts-prod/cluster-api/cluster-api-controller"
-- - "gcr.io/k8s-staging-cluster-api/plantuml"
-  - "us.gcr.io/k8s-artifacts-prod/cluster-api/plantuml"
-  - "eu.gcr.io/k8s-artifacts-prod/cluster-api/plantuml"
-  - "asia.gcr.io/k8s-artifacts-prod/cluster-api/plantuml"
+renames: []

--- a/k8s.gcr.io/k8s-staging-coredns/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-coredns/manifest.yaml
@@ -2,11 +2,11 @@
 registries:
 - name: gcr.io/k8s-staging-coredns
   src: true
-- name: us.gcr.io/k8s-artifacts-prod
+- name: us.gcr.io/k8s-artifacts-prod/coredns
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod
+- name: eu.gcr.io/k8s-artifacts-prod/coredns
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod
+- name: asia.gcr.io/k8s-artifacts-prod/coredns
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 images: []
 renames: []

--- a/k8s.gcr.io/k8s-staging-csi/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-csi/manifest.yaml
@@ -2,11 +2,11 @@
 registries:
 - name: gcr.io/k8s-staging-csi
   src: true
-- name: us.gcr.io/k8s-artifacts-prod
+- name: us.gcr.io/k8s-artifacts-prod/csi
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod
+- name: eu.gcr.io/k8s-artifacts-prod/csi
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod
+- name: asia.gcr.io/k8s-artifacts-prod/csi
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 images: []
 renames: []

--- a/k8s.gcr.io/k8s-staging-descheduler/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-descheduler/manifest.yaml
@@ -2,11 +2,11 @@
 registries:
 - name: gcr.io/k8s-staging-descheduler
   src: true
-- name: us.gcr.io/k8s-artifacts-prod
+- name: us.gcr.io/k8s-artifacts-prod/descheduler
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod
+- name: eu.gcr.io/k8s-artifacts-prod/descheduler
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod
+- name: asia.gcr.io/k8s-artifacts-prod/descheduler
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 images: []
 renames: []

--- a/k8s.gcr.io/k8s-staging-publishing-bot/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-publishing-bot/manifest.yaml
@@ -2,11 +2,11 @@
 registries:
 - name: gcr.io/k8s-staging-publishing-bot
   src: true
-- name: us.gcr.io/k8s-artifacts-prod
+- name: us.gcr.io/k8s-artifacts-prod/publishing-bot
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod
+- name: eu.gcr.io/k8s-artifacts-prod/publishing-bot
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod
+- name: asia.gcr.io/k8s-artifacts-prod/publishing-bot
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 images: []
 renames: []


### PR DESCRIPTION
The "rename" feature provides the power to rename images in an arbitrary
way, but this power is not really needed in the existing use cases we
have. We can get the same effect by just renaming the destination
registry slightly differently.

No functional change.