### PR TITLE
Add stp-ip to CoreDNS staging group

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -526,6 +526,7 @@ groups:
       ReconcileMembers: "true"
     members:
       - davanum@gmail.com
+      - michaelg@okkur.org
 
   - email-id: k8s-infra-staging-csi@kubernetes.io
     name: k8s-infra-staging-csi


### PR DESCRIPTION
Thought it might be helpful for testing or pushing critical CoreDNS patch releases to add myself due to the intersection of CoreDNS maintainer and helping with the infra wg.

Happy for this to be closed without merge, if this doesn't make sense.