### PR TITLE
Add v0.3.8 image for cluster-api-aws

### DIFF
--- a/k8s.gcr.io/k8s-staging-cluster-api-aws/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-cluster-api-aws/manifest.yaml
@@ -13,6 +13,7 @@ images:
   dmap:
     "sha256:7397e3ef7dfa72b102197eaa6bd20ca8b572ccbc31a30f3d262188376e95836a": ["v0.3.6"]
     "sha256:e167eec012a77eb6f1741bcb7c6b9514ffdd5ac154137cba86c14f40db979913": ["v0.3.7"]
+    "sha256:b04cd8882f99aec51ef714a60bd16b7d1f6bae3e4f955bee834744c35b6fb21f": ["v0.3.8"]
     "sha256:76cf7f26e0abfb5bd862670606a93593f4ac9c51a2ba1c281cc7d709869a2cc1": ["v0.4.0"]
 - name: cluster-api-aws-controller-amd64
   dmap:


### PR DESCRIPTION
/assign @detiber

Please pull `gcr.io/k8s-staging-cluster-api-aws/cluster-api-aws-controller:v0.3.8` and confirm the digest. Thanks!