### PR TITLE
Add OWNERS for k8s.gcr.io/k8s-staging-capi-openstack

### DIFF
--- a/k8s.gcr.io/k8s-staging-capi-openstack/OWNERS
+++ b/k8s.gcr.io/k8s-staging-capi-openstack/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- sbueringer
+- jichenic
+- chrigl


### PR DESCRIPTION
Adds OWNERS files for capo related staging directories. Approvers are based on the active approvers for the code repo: https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/master/OWNERS_ALIASES#L21