### PR TITLE
Add owner search redirect to go.k8s.io

### DIFF
--- a/k8s.io/README.md
+++ b/k8s.io/README.md
@@ -43,6 +43,7 @@ Redirections
 - https://go.k8s.io/needs-ok-to-test
 - https://go.k8s.io/oncall
 - https://go.k8s.io/owners
+- https://go.k8s.io/owners/${GITHUB_USER}
 - https://go.k8s.io/partner-request
 - https://go.k8s.io/pr-dashboard
 - https://go.k8s.io/start

--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -235,6 +235,7 @@ data:
           rewrite ^/needs-ok-to-test$ https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-incubator+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Apr+label%3Aneeds-ok-to-test+label%3A%22cncf-cla%3A+yes%22+-label%3Aneeds-rebase&type=Issues redirect;
           rewrite ^/oncall$          https://storage.googleapis.com/test-infra-oncall/oncall.html redirect;
           rewrite ^/owners$          https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md redirect;
+          rewrite ^/owners/([^/]*)/?$ https://cs.k8s.io/?q=$1&i=fosho&files=.*(%5E%5B%5Ev%5D.*OWNERS%24)%7C(%5Ev%5B%5Ee%5D.*OWNERS%24)%20%7C(%5Eve%5B%5En%5D.*OWNERS%24)%7C(%5Even%5B%5Ed%5D.*OWNERS%24)%7C(%5Evend%5B%5Eo%5D.*OWNERS%24)%7C(%5Evendo%5B%5Er%5D.*OWNERS%24)%7C(%5E%5B%5Ev%5D%5B%5Ee%5D%5B%5En%5D%5B%5Ed%5D%5B%5Eo%5D%5B%5Er%5D%2F.*OWNERS%24)%7C%5EOWNERS%24%7C%5EOWNERS_ALIASES%24&repos= redirect;
           rewrite ^/partner-request$ https://docs.google.com/forms/d/e/1FAIpQLSdN1KtSKX2VAOPGABFlShkSd6CajQynoL4QCVtY0dj76MNDKg/viewform redirect;
           rewrite ^/pr-dashboard$    https://k8s-gubernator.appspot.com/pr redirect;
           rewrite ^/start$           https://kubernetes.io/docs/setup/pick-right-solution/ redirect;


### PR DESCRIPTION
Redirect `go.k8s.io/owners/${GITHUB_USER}` to a custom cs.k8s.io query that searches for the passed user in OWNERS files.

xref: https://github.com/kubernetes/community/issues/4018

/cc @cblecker @thockin 