### PR TITLE
Update k8sio test.py to use python 3 & fix PyYAML load warning

### DIFF
--- a/k8s.io/Dockerfile-test
+++ b/k8s.io/Dockerfile-test
@@ -1,4 +1,4 @@
-FROM python:2
+FROM python:3
 MAINTAINER Jeff Grafton <jgrafton@google.com>
 
 WORKDIR /workspace

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -369,7 +369,7 @@ class ContentTest(unittest.TestCase):
         self.assertEqual(resp.status, 200)
         configmap = 'configmap-www-%s.yaml' % os.path.dirname(filename)
         with open(configmap) as f:
-            expected_body = yaml.load(f)['data'][os.path.basename(filename)]
+            expected_body = yaml.load(f, yaml.SafeLoader)['data'][os.path.basename(filename)]
         self.assertMultiLineEqual(body, expected_body)
 
     def assert_body_url(self, url, expected_content_url):

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 try:
     import HTMLParser
@@ -16,7 +14,7 @@ import socket
 import ssl
 import subprocess
 import unittest
-import urllib
+import urllib.request
 
 import yaml
 
@@ -378,7 +376,7 @@ class ContentTest(unittest.TestCase):
         print('GET', url)
         resp, body = do_get(url)
         self.assertEqual(resp.status, 200)
-        expected_body = urllib.urlopen(expected_content_url).read()
+        expected_body = urllib.request.urlopen(expected_content_url).read().decode('utf-8')
         self.assertMultiLineEqual(body, expected_body)
 
     def assert_body_go_get(self, host, org, repo, path):


### PR DESCRIPTION
Python 3...[figured it's time](https://pythonclock.org/) 😬 

Also -- for security purposes PyYAML 5.1 has [deprecated the use](https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation) `yaml.load()` without specifying a Loader (It works for now, just throws a warning). I think `SafeLoader` should be fine for what it's doing :)