### PR TITLE
groups: validate length of emails used for staging repos

### DIFF
--- a/groups/reconcile.go
+++ b/groups/reconcile.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2019 The Kubernetes Authors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -83,7 +86,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	err = readGroupsConfig(config.GroupsFile)
+	err = readGroupsConfig(config.GroupsFile, &groupsConfig)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -162,7 +165,7 @@ func readConfig(configFilePath *string, confirmChanges *bool) error {
 	return err
 }
 
-func readGroupsConfig(groupsConfigFilePath string) error {
+func readGroupsConfig(groupsConfigFilePath string, config *GroupsConfig) error {
 	var content []byte
 	var err error
 	groupsUrl, err := url.ParseRequestURI(groupsConfigFilePath)
@@ -179,7 +182,7 @@ func readGroupsConfig(groupsConfigFilePath string) error {
 			return fmt.Errorf("error reading groups config from file: %v", err)
 		}
 	}
-	if err = yaml.Unmarshal(content, &groupsConfig); err != nil {
+	if err = yaml.Unmarshal(content, config); err != nil {
 		return fmt.Errorf("error reading groups config: %v", err)
 	}
 	return nil

--- a/groups/reconcile_test.go
+++ b/groups/reconcile_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+// TestStagingEmailLength tests that the number of characters in the
+// project name in emails used for staging repos does not exceed 18.
+//
+// This validation is needed because gcloud allows PROJECT_IDs of length
+// between 6 and 30. So after discounting the "k8s-staging" prefix,
+// we are left with 18 chars for the project name.
+func TestStagingEmailLength(t *testing.T) {
+	var cfg GroupsConfig
+	if err := readGroupsConfig("groups.yaml", &cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	var errs []error
+	for _, g := range cfg.Groups {
+		if strings.HasPrefix(g.EmailId, "k8s-infra-staging-") {
+			projectName := strings.TrimSuffix(strings.TrimPrefix(g.EmailId, "k8s-infra-staging-"), "@kubernetes.io")
+
+			len := utf8.RuneCountInString(projectName)
+			if len > 18 {
+				errs = append(errs, fmt.Errorf("Number of characters in project name \"%s\" should not exceed 18; is: %d", projectName, len))
+			}
+		}
+	}
+
+	if errs != nil {
+		for _, err := range errs {
+			t.Error(err)
+		}
+	}
+}

--- a/k8s.gcr.io/README.md
+++ b/k8s.gcr.io/README.md
@@ -20,13 +20,14 @@ cannot be used yet. Only staging repositories can be used.
 
 1. Create a google group for granting push access by adding an email
 alias for it in [groups.yaml]. The email alias should be of the form
-`k8s-infra-staging-<project-name>@kubernetes.io`.
+`k8s-infra-staging-<project-name>@kubernetes.io`. The project name
+can have a maximum of 18 characters.
 
 2. Create a directory `k8s-staging-<project-name>` and add a manifest
 file for it. You can look at the existing staging repos for examples.
 
 3. Add the project name to `STAGING_PROJECTS` in
-   [../infra/gcp/ensure-staging-storage.sh].
+   [ensure-staging-storage.sh].
 
 4. Once the PR merges:
     - ping @dims or @cblecker to create the necessary google group.
@@ -55,5 +56,5 @@ Essentially, in order to get images published to a production repo, you have to
 use the image promotion (PR creation) process defined above.
 
 [1]: https://k8s-testgrid.appspot.com/sig-release-misc#post-k8sio-cip
-[ensure-staging-storage.sh]: /k8s.gcr.io/ensure-staging-storage.sh
+[ensure-staging-storage.sh]: /infra/gcp/ensure-staging-storage.sh
 [groups.yaml]: /groups/groups.yaml


### PR DESCRIPTION
Ref: https://github.com/kubernetes/k8s.io/pull/289#issuecomment-508806417

For a staging repo, PROJECT_ID is equal to `k8s-staging-<project-name>`.
gcloud only allows PROJECT_ID values between lengths of 6 and 30.

After discounting the number of characters in `k8s-staging-` (12), we
are left with 18 characters for the project name. This project name is
also used in the email ID for the google group used to provide access to
the staging repo.

To ensure that the project name stays within the character limit, this
commit adds a test to validate that the project name in the email ID
doesn't have more than 18 characters.

/assign @dims @cblecker 