### PR TITLE
Adds k8s-infra-staging-e2e-test-images@kubernetes.io group

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -812,3 +812,26 @@ groups:
       - ihor.dvoretskyi@gmail.com
       - jdumars@gmail.com
       - jorge@heptio.com
+
+  - email-id: k8s-infra-staging-e2e-test-images@kubernetes.io
+    name: Kubernetes E2E test image staging registry owners
+    description: |-
+      Group that owns pushing rights to the gcr.io/k8s-staging-e2e-test-images staging registry
+    settings:
+      AllowExternalMembers: "true"
+      WhoCanJoin: "INVITED_CAN_JOIN"
+      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanDiscoverGroup: "ALL_IN_DOMAIN_CAN_DISCOVER"
+      WhoCanInvite: "ALL_MANAGERS_CAN_INVITE"
+      WhoCanAdd: "ALL_MANAGERS_CAN_ADD"
+      WhoCanApproveMembers: "ALL_MANAGERS_CAN_APPROVE"
+      WhoCanModifyMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      ReconcileMembers: "true"
+    owners:
+      - cblecker@gmail.com
+      - davanum@gmail.com
+      - justinsb@google.com
+      - thockin@google.com
+      - spiffxp@google.com

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -52,6 +52,7 @@ STAGING_PROJECTS=(
     coredns
     csi
     descheduler
+    e2e-test
     kas-network-proxy
     kops
     kube-state-metrics

--- a/k8s.gcr.io/k8s-staging-e2e-test-images/manifest.yaml
+++ b/k8s.gcr.io/k8s-staging-e2e-test-images/manifest.yaml
@@ -1,0 +1,12 @@
+# google group for gcr.io/k8s-staging-e2e-test-images is k8s-infra-staging-e2e-test-images@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-e2e-test-images
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/e2e-test-images
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/e2e-test-images
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/e2e-test-images
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+images: []
+renames: []


### PR DESCRIPTION
The group is meant to own pushing rights to the ``gcr.io/kubernetes-staging-e2e-test-images`` registry, which will contain the images to be promoted to the ``gcr.io/kubernetes-e2e-test-images`` registry.