### PR TITLE
cert-manager: remove 'old-format' HTTP01 configuration

### DIFF
--- a/cert-manager/letsencrypt-prod.yaml
+++ b/cert-manager/letsencrypt-prod.yaml
@@ -9,10 +9,6 @@ spec:
     privateKeySecretRef:
       name: letencrypt-prod-account-key
 
-    # Leave the old-format HTTP01 config *enabled* until we have confirmed that
-    # all Certificate resources no longer specify a spec.acme field.
-    http01: {}
-
     solvers:
 
     # Make a special exception for gcsweb - it has its own Ingress resource, so

--- a/cert-manager/letsencrypt-staging.yaml
+++ b/cert-manager/letsencrypt-staging.yaml
@@ -9,10 +9,6 @@ spec:
     privateKeySecretRef:
       name: letencrypt-staging-account-key
 
-    # Leave the old-format HTTP01 config *enabled* until we have confirmed that
-    # all Certificate resources no longer specify a spec.acme field.
-    http01: {}
-
     solvers:
 
     # Make a special exception for gcsweb - it has its own Ingress resource, so


### PR DESCRIPTION
Following up on #347, since we've migrated all Certificate resources to the 'new format' we can safely remove the old HTTP01 configuration on the Let's Encrypt ClusterIssuer resources.

/assign @thockin 