### PR TITLE
Remove non-k8s targets for gcsweb

### DIFF
--- a/gcsweb.k8s.io/deployment.yaml
+++ b/gcsweb.k8s.io/deployment.yaml
@@ -23,9 +23,6 @@ spec:
           image: k8s.gcr.io/gcsweb:v1.1.0
           args:
             - -upgrade-proxied-http-to-https
-            - -b=android-ci
-            - -b=crreleases
-            - -b=istio-prow
             - -b=kubernetes-jenkins
             - -b=kubernetes-release
             - -b=kubernetes-release-dev


### PR DESCRIPTION
I cleared this with the owners of each line item.

