### PR TITLE
infra/gcp: Grant Service Usage Consumer role for GCB users

### DIFF
--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -275,6 +275,16 @@ function empower_group_for_gcb() {
         projects add-iam-policy-binding "${project}" \
         --member "group:${group}" \
         --role roles/cloudbuild.builds.editor
+
+    # TODO(justaugustus/thockin): This only exists to grant the 
+    #      serviceusage.services.use permission allow writers access to execute
+    #      Cloud Builds. We should refactor this once we develop custom roles.
+    #
+    #      Ref: https://cloud.google.com/storage/docs/access-control/iam-console
+    gcloud \
+        projects add-iam-policy-binding "${project}" \
+        --member "group:${group}" \
+        --role roles/serviceusage.serviceUsageConsumer
 }
 
 # Grant privileges to prow in a staging project


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes/k8s.io/pull/414.

Users granted access to GCB will not have access to submit GCB jobs
without the serviceusage.services.use permission.

The following error will be displayed:
```
Caller does not have required permission to use project project:<project>.
Grant the caller the Owner or Editor role, or a custom role with
the serviceusage.services.use permission.
```

All actions that include a billing project in the request require
serviceusage.services.use permission for the project that's specified.

The Service Usage Consumer role appears to be the least-privilege
default role that grants this permission.

Ref: https://cloud.google.com/storage/docs/access-control/iam-console

Example failure:
```
$ RELEASE_TOOL_REPO="https://github.com/justaugustus/release.git" \
> RELEASE_TOOL_BRANCH="parameterize-gcp" \
> PROJECT="k8s-staging-release-test" \
> ./gcbmgr stage master --build-at-head --nomock
gcbmgr: BEGIN main on auggievmw01 Thu Oct 24 05:13:26 EDT 2019

Checking required system packages: OK
Checking /home/augustus/go/src/k8s.io/release state: OK
Checking/setting cloud tools: OK

Trying to get kubecross version for master ... OK: v1.12.12-1
FAILED: Job was not submitted.  Details:
ERROR: (gcloud.builds.submit) User [Stephen@agst.us] does not have permission to access project [k8s-staging-release-test] (or it may not exist): Caller does not have required
permission to use project project:k8s-staging-release-test. Grant the caller the Owner or Editor role, or a custom role with the serviceusage.services.use permission, by visiting
https://console.developers.google.com/iam-admin/iam/project?project=project:k8s-staging-release-test and then retry (propagation of new permission may take a few minutes).  - '@type': type.googleapis.com/google.rpc.Help
  links: - description: Google developers console
    url: https://console.developers.google.com
- '@type': type.googleapis.com/google.rpc.Help
  links: - description: Google developer console IAM admin
    url: https://console.developers.google.com/iam-admin/iam/project?project=project:k8s-staging-release-test

If you want to invoke the command from a project different from the target resource project, use `--billing-project` or `billing/quota_project` property.
```

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @dims @thockin @cblecker 
/sig release
/area release-eng