### PR TITLE
releng: Enable elevated privileges for Release Managers on SIG Release GCP projects

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -484,6 +484,79 @@ groups:
       - thockin@google.com
       - bartsmykla@gmail.com  # sock-puppet for testing
 
+  - email-id: k8s-infra-release-admins@kubernetes.io
+    name: k8s-infra-release-admins
+    description: |-
+      ACL for Release Engineering subproject owners (partial admin access to Release GCP projects)
+      https://git.k8s.io/sig-release/release-managers.md
+    settings:
+      AllowExternalMembers: "true"
+      WhoCanJoin: "INVITED_CAN_JOIN"
+      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanDiscoverGroup: "ALL_IN_DOMAIN_CAN_DISCOVER"
+      WhoCanInvite: "ALL_MANAGERS_CAN_INVITE"
+      WhoCanAdd: "ALL_MANAGERS_CAN_ADD"
+      WhoCanApproveMembers: "ALL_MANAGERS_CAN_APPROVE"
+      WhoCanModifyMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      ReconcileMembers: "true"
+    owners:
+      - caselim@gmail.com
+      - Stephen@agst.us
+      - tpepper@gmail.com
+
+  - email-id: k8s-infra-release-editors@kubernetes.io
+    name: k8s-infra-release-editors
+    description: |-
+      ACL for Patch Release Team and Branch Managers (edit access to Release GCP projects)
+      https://git.k8s.io/sig-release/release-managers.md
+    settings:
+      AllowExternalMembers: "true"
+      WhoCanJoin: "INVITED_CAN_JOIN"
+      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanDiscoverGroup: "ALL_IN_DOMAIN_CAN_DISCOVER"
+      WhoCanInvite: "ALL_MANAGERS_CAN_INVITE"
+      WhoCanAdd: "ALL_MANAGERS_CAN_ADD"
+      WhoCanApproveMembers: "ALL_MANAGERS_CAN_APPROVE"
+      WhoCanModifyMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      ReconcileMembers: "true"
+    owners:
+      - caselim@gmail.com
+      - Stephen@agst.us
+      - tpepper@gmail.com
+    members:
+      - aleksandram@google.com
+      - feiskyer@gmail.com
+      - ctadeu@gmail.com
+      - dmaceachern@vmware.com
+      - hhorl@pivotal.io
+      - idealhack@gmail.com
+
+  - email-id: k8s-infra-release-viewers@kubernetes.io
+    name: k8s-infra-release-viewers
+    description: |-
+      ACL for Release Manager Associates (view access to Release GCP projects)
+      https://git.k8s.io/sig-release/release-managers.md
+    settings:
+      AllowExternalMembers: "true"
+      WhoCanJoin: "INVITED_CAN_JOIN"
+      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanDiscoverGroup: "ALL_IN_DOMAIN_CAN_DISCOVER"
+      WhoCanInvite: "ALL_MANAGERS_CAN_INVITE"
+      WhoCanAdd: "ALL_MANAGERS_CAN_ADD"
+      WhoCanApproveMembers: "ALL_MANAGERS_CAN_APPROVE"
+      WhoCanModifyMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      ReconcileMembers: "true"
+    owners:
+      - caselim@gmail.com
+      - Stephen@agst.us
+      - tpepper@gmail.com
+
   - email-id: k8s-infra-sig-release-prototype@kubernetes.io
     name: k8s-infra-sig-release-prototype
     description: |-
@@ -1005,9 +1078,9 @@ groups:
   - email-id: release-managers-private@kubernetes.io
     name: release-managers-private
     description: |-
-      Release managers for security releases. Membership should include release leads and patch release managers.
-
-      Membership by release leads and patch release managers.
+      Private communications for SIG Chairs, Patch Release Team, and Branch Managers.
+      (internal scheduling and security release coordination)
+      https://git.k8s.io/sig-release/release-managers.md
     settings:
       AllowExternalMembers: "true"
       WhoCanJoin: "INVITED_CAN_JOIN"
@@ -1039,7 +1112,9 @@ groups:
   - email-id: release-managers@kubernetes.io
     name: release-managers
     description: |-
-      Release Managers communications
+      Release Managers communications.
+      Includes all Release Managers.
+      https://git.k8s.io/sig-release/release-managers.md
     settings:
       AllowExternalMembers: "true"
       WhoCanJoin: "INVITED_CAN_JOIN"

--- a/infra/gcp/ensure-release-projects.sh
+++ b/infra/gcp/ensure-release-projects.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used to ensure Release Managers have the appropriate access
+# to SIG Release GCP projects.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+. "${SCRIPT_DIR}/lib.sh"
+
+function usage() {
+    echo "usage: $0 [project...]" > /dev/stderr
+    echo "example:" > /dev/stderr
+    echo "  $0 # do all release projects" > /dev/stderr
+    echo "  $0 k8s-staging-release-test # just do one" > /dev/stderr
+    echo > /dev/stderr
+}
+
+# NB: Please keep this sorted.
+PROJECTS=(
+    k8s-staging-release-test
+    k8s-release-test-prod
+)
+
+if [ $# = 0 ]; then
+    # default to all release projects
+    set -- "${PROJECTS[@]}"
+fi
+
+ADMINS="k8s-infra-release-admins@kubernetes.io"
+WRITERS="k8s-infra-release-editors@kubernetes.io"
+VIEWERS="k8s-infra-release-viewers@kubernetes.io"
+
+for PROJECT; do
+    color 3 "Configuring: ${REPO}"
+
+    # The names of the buckets
+    STAGING_BUCKET="gs://${PROJECT}" # used by humans
+    GCB_BUCKET="gs://${PROJECT}-gcb" # used by GCB
+    ALL_BUCKETS=("${STAGING_BUCKET}" "${GCB_BUCKET}")
+
+    # Make the project, if needed
+    color 6 "Ensuring project exists: ${PROJECT}"
+    ensure_project "${PROJECT}"
+
+    for group in ${ADMINS} ${WRITERS} ${VIEWERS}; do
+        # Enable admins to use the UI
+        color 6 "Empowering ${group} as project viewers"
+        empower_group_as_viewer "${PROJECT}" "${group}"
+    done
+
+    # Every project gets a GCR repo
+
+    # Enable container registry APIs
+    color 6 "Enabling the container registry API"
+    enable_api "${PROJECT}" containerregistry.googleapis.com
+
+    # Push an image to trigger the bucket to be created
+    color 6 "Ensuring the registry exists and is readable"
+    ensure_gcr_repo "${PROJECT}"
+
+    # Enable GCR admins
+    color 6 "Empowering GCR admins"
+    empower_gcr_admins "${PROJECT}"
+
+    # Enable GCR writers
+    for group in ${ADMINS} ${WRITERS}; do
+        color 6 "Empowering ${group} to GCR"
+        empower_group_to_gcr "${PROJECT}" "${group}"
+    done
+
+    # Every project gets some GCS buckets
+
+    # Enable GCS APIs
+    color 6 "Enabling the GCS API"
+    enable_api "${PROJECT}" storage-component.googleapis.com
+
+    for BUCKET in "${ALL_BUCKETS[@]}"; do
+        color 3 "Configuring bucket: ${BUCKET}"
+
+        # Create the bucket
+        color 6 "Ensuring the bucket exists and is world readable"
+        ensure_public_gcs_bucket "${PROJECT}" "${BUCKET}"
+
+        # Enable admins on the bucket
+        color 6 "Empowering GCS admins"
+        empower_gcs_admins "${PROJECT}" "${BUCKET}"
+
+        # Enable writers on the bucket
+        for group in ${ADMINS} ${WRITERS}; do
+            color 6 "Empowering ${group} to GCS"
+            empower_group_to_gcs_bucket "${group}" "${BUCKET}"
+        done
+    done
+
+    # Enable GCB and Prow to build and push images.
+
+    # Enable GCB APIs
+    color 6 "Enabling the GCB API"
+    enable_api "${PROJECT}" cloudbuild.googleapis.com
+
+    # Let project writers use GCB.
+    for group in ${ADMINS} ${WRITERS}; do
+        color 6 "Empowering ${group} as GCB editors"
+        empower_group_for_gcb "${PROJECT}" "${group}"
+    done
+
+    # Let prow trigger builds and access the scratch bucket
+    color 6 "Empowering Prow"
+    empower_prow "${PROJECT}" "${GCB_BUCKET}"
+
+    # Enable KMS APIs
+    color 6 "Enabling the KMS API"
+    enable_api "${PROJECT}" cloudkms.googleapis.com
+
+    # Let project admins use KMS.
+    color 6 "Empowering ${ADMINS} as KMS admins"
+    empower_group_for_kms "${PROJECT}" "${ADMINS}"
+
+    color 6 "Done"
+done

--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -287,6 +287,23 @@ function empower_group_for_gcb() {
         --role roles/serviceusage.serviceUsageConsumer
 }
 
+# Grant KMS admin privileges to a principal
+# $1: The GCP project
+# $2: The group email
+function empower_group_for_kms() {
+    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+        echo "empower_group_for_kms(project, group) requires 2 arguments" >&2
+        return 1
+    fi
+    project="$1"
+    group="$2"
+
+    gcloud \
+        projects add-iam-policy-binding "${project}" \
+        --member "group:${group}" \
+        --role roles/cloudkms.admin
+}
+
 # Grant privileges to prow in a staging project
 # $1: The GCP project
 # $2: The GCS scratch bucket


### PR DESCRIPTION
- Add groups to delegate IAM access to Release Managers

  - `k8s-infra-release-admins@`: Partial Admin
  - `k8s-infra-release-editors@`: Editor
  - `k8s-infra-release-viewers@`: Viewer

- Add ensure-release-projects to grant rights to Release Managers
  Establishes rights to GCS, GCB, and KMS for Release Managers

Required for prototyping build/stage/release process on k8s-infra (https://github.com/kubernetes/release/issues/911).

/assign @dims @thockin @cblecker 
cc: @kubernetes/sig-release-admins @kubernetes/release-engineering 
/sig release
/area release-eng