### PR TITLE
Promote v0.2.1 of capd

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-capi-docker/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-capi-docker/images.yaml
@@ -1,0 +1,3 @@
+- name: capd-manager
+  dmap:
+    "sha256:6c4dd8cb6c7efe69796a96343494c3a046bd80f46f7a89680cc42b61ce6f294c": ["v0.2.1"]


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

@detiber can you make sure this looks right?

I'm expecting my image to end up `us.gcr.io/k8s-artifacts-prod/capi-docker/capd-manager:v0.2.1`
My staging image you can find here: `gcr.io/k8s-staging-capi-docker/capd-manager:v0.2.1`

This does not have the Arch stuff. The next version of CAPD will (v0.3 series).