### PR TITLE
Add cloudkms.cryptoKeyEncrypterDecrypter role to empower_group_for_kms

### DIFF
--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -302,6 +302,11 @@ function empower_group_for_kms() {
         projects add-iam-policy-binding "${project}" \
         --member "group:${group}" \
         --role roles/cloudkms.admin
+
+    gcloud \
+        projects add-iam-policy-binding "${project}" \
+        --member "group:${group}" \
+        --role roles/cloudkms.cryptoKeyEncrypterDecrypter
 }
 
 # Grant privileges to prow in a staging project


### PR DESCRIPTION
Without this, k8s-infra-release-admins will not be able to
encrypt/decrypt assets, which will be necessary to manage the
k8s-release-robot GitHub token, among other things in the future.

Continuation of #434.

Here's the error:

```shell
gcloud kms encrypt --location global --keyring <KEYRING> --key <KEY> --ciphertext-file=- --plaintext-file=<(echo -n '<GITHUB_TOKEN>')
ERROR: (gcloud.kms.encrypt) PERMISSION_DENIED: Permission 'cloudkms.cryptoKeyVersions.useToEncrypt' denied on resource 'projects/k8s-staging-release-test/locations/global/keyRings/<KEYRING>/cryptoKeys/<KEY>' (or it may not exist).
```

/assign @cblecker @thockin 
/sig release

Signed-off-by: Stephen Augustus <saugustus@vmware.com>