### PR TITLE
Yet More Groups Fixes

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -9,7 +9,6 @@ groups:
       Created via https://github.com/kubernetes/community/issues/3763
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
-      MessageModerationLevel: "MODERATE_NONE"
       ReconcileMembers: "true"
     owners:
       - jorgec@vmware.com
@@ -27,7 +26,6 @@ groups:
 
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
-      MessageModerationLevel: "MODERATE_NONE"
       ReconcileMembers: "true"
     owners:
       - ihor@cncf.io
@@ -46,7 +44,6 @@ groups:
 
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
-      MessageModerationLevel: "MODERATE_NONE"
       ReconcileMembers: "true"
     owners:
       - aeva.online@gmail.com
@@ -102,7 +99,6 @@ groups:
       Kubernetes elections committee
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
-      MessageModerationLevel: "MODERATE_NONE"
       ReconcileMembers: "true"
     owners:
       - briangrant@google.com
@@ -116,7 +112,6 @@ groups:
       Kubernetes GitHub Admins
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
-      MessageModerationLevel: "MODERATE_NONE"
       ReconcileMembers: "true"
     owners:
       - cblecker@gmail.com
@@ -134,7 +129,6 @@ groups:
       alerts for wg-k8s-infra
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
-      MessageModerationLevel: "MODERATE_NONE"
       ReconcileMembers: "true"
     members:
       - amwat@google.com
@@ -602,7 +596,6 @@ groups:
       Mailing list for wg-infra-team private communications
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
-      MessageModerationLevel: "MODERATE_NONE"
       ReconcileMembers: "true"
     members:
       - bentheelder@google.com
@@ -621,7 +614,6 @@ groups:
       Moderators for various Community properties
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
-      MessageModerationLevel: "MODERATE_NONE"
       ReconcileMembers: "true"
     owners:
       - parispittman@google.com
@@ -659,7 +651,6 @@ groups:
       https://git.k8s.io/sig-release/release-managers.md
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
-      MessageModerationLevel: "MODERATE_NONE"
       ReconcileMembers: "true"
     owners:
       - Stephen@agst.us
@@ -685,7 +676,6 @@ groups:
       https://git.k8s.io/sig-release/release-managers.md
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
-      MessageModerationLevel: "MODERATE_NONE"
       ReconcileMembers: "false"
     owners:
       - caselim@gmail.com
@@ -703,7 +693,6 @@ groups:
       https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#product-security-team-pst
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
-      MessageModerationLevel: "MODERATE_NONE"
       ReconcileMembers: "true"
     owners:
       - bphilips@redhat.com
@@ -722,7 +711,6 @@ groups:
       security release team mailing list
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
-      MessageModerationLevel: "MODERATE_NONE"
       ReconcileMembers: "true"
     owners:
       - Stephen@agst.us
@@ -733,7 +721,6 @@ groups:
 
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
-      MessageModerationLevel: "MODERATE_NONE"
       ReconcileMembers: "false"
     owners:
       - bphilips@redhat.com
@@ -752,7 +739,6 @@ groups:
       Private list for the Kubernetes Steering Committee
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
-      MessageModerationLevel: "MODERATE_NONE"
       ReconcileMembers: "true"
     owners:
       - cblecker@gmail.com
@@ -773,7 +759,6 @@ groups:
       https://github.com/kubernetes/steering
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
-      MessageModerationLevel: "MODERATE_NONE"
       ReconcileMembers: "false"
     owners:
       - cblecker@gmail.com

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -150,23 +150,6 @@ groups:
     members:
       - k8s-infra-rbac-cert-manager@kubernetes.io
 
-  - email-id: k8s-infra-alerts@kubernetes.io
-    name: k8s-infra-alerts
-    description: |-
-      alerts for wg-k8s-infra
-    settings:
-      ReconcileMembers: "true"
-    members:
-      - amwat@google.com
-      - bentheelder@google.com
-      - cblecker@gmail.com
-      - davanum@gmail.com
-      - ihor@cncf.io
-      - jgrafton@google.com
-      - mkumatag@in.ibm.com
-      - spiffxp@google.com
-      - thockin@google.com
-
   - email-id: k8s-infra-artifact-admins@kubernetes.io
     name: k8s-infra-artifact-admins
     description: |-

--- a/groups/reconcile.go
+++ b/groups/reconcile.go
@@ -428,7 +428,7 @@ func updateGroupSettings(srv *groupssettings.Service, groupEmailId string, group
 	wantSettings.WhoCanModerateMembers = "OWNERS_AND_MANAGERS"
 	wantSettings.WhoCanModerateContent = "OWNERS_AND_MANAGERS"
 	wantSettings.WhoCanPostMessage = "ALL_MEMBERS_CAN_POST"
-	wantSettings.MessageModerationLevel = "MODERATE_NON_MEMBERS"
+	wantSettings.MessageModerationLevel = "MODERATE_NONE"
 
 	for key, value := range groupSettings {
 		switch key {

--- a/groups/reconcile.go
+++ b/groups/reconcile.go
@@ -422,9 +422,6 @@ func updateGroupSettings(srv *groupssettings.Service, groupEmailId string, group
 	wantSettings.WhoCanViewMembership = "ALL_MEMBERS_CAN_VIEW"
 	wantSettings.WhoCanViewGroup = "ALL_MEMBERS_CAN_VIEW"
 	wantSettings.WhoCanDiscoverGroup = "ALL_IN_DOMAIN_CAN_DISCOVER"
-	wantSettings.WhoCanInvite = "NONE_CAN_INVITE"
-	wantSettings.WhoCanAdd = "NONE_CAN_ADD"
-	wantSettings.WhoCanApproveMembers = "NONE_CAN_APPROVE"
 	wantSettings.WhoCanModerateMembers = "OWNERS_AND_MANAGERS"
 	wantSettings.WhoCanModerateContent = "OWNERS_AND_MANAGERS"
 	wantSettings.WhoCanPostMessage = "ALL_MEMBERS_CAN_POST"
@@ -442,12 +439,6 @@ func updateGroupSettings(srv *groupssettings.Service, groupEmailId string, group
 			wantSettings.WhoCanViewGroup = value
 		case "WhoCanDiscoverGroup":
 			wantSettings.WhoCanDiscoverGroup = value
-		case "WhoCanInvite":
-			wantSettings.WhoCanInvite = value
-		case "WhoCanAdd":
-			wantSettings.WhoCanAdd = value
-		case "WhoCanApproveMembers":
-			wantSettings.WhoCanApproveMembers = value
 		case "WhoCanModerateMembers":
 			wantSettings.WhoCanModerateMembers = value
 		case "WhoCanPostMessage":
@@ -466,7 +457,8 @@ func updateGroupSettings(srv *groupssettings.Service, groupEmailId string, group
 			log.Printf("> Successfully updated group settings for %s to allow external members and other security settings\n", groupEmailId)
 		} else {
 			log.Printf("dry-run : skipping updating group settings for %s\n", groupEmailId)
-			log.Printf("dry-run : settings %q", wantSettings)
+			log.Printf("dry-run : current settings %+q", haveSettings)
+			log.Printf("dry-run : desired settings %+q", wantSettings)
 		}
 	}
 	return nil


### PR DESCRIPTION
- There are some Google Groups API fields that are reported, but deprecated. Remove these from our configuration.
- "ALL_MEMBERS_CAN_POST" + "MODERATE_NON_MEMBERS" is apparently an invalid combination of moderation settings. Change default to "ALL_MEMBERS_CAN_POST" and "MODERATE_NONE".
- k8s-infra-alerts@ was duplicated. Fix this.