### PR TITLE
releng: Revoke Sascha's temporary access to GCP

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -313,7 +313,6 @@ groups:
       - dmaceachern@vmware.com
       - hhorl@pivotal.io
       - idealhack@gmail.com
-      - saschagrunert@gmail.com
 
   - email-id: k8s-infra-release-viewers@kubernetes.io
     name: k8s-infra-release-viewers


### PR DESCRIPTION
We granted Sascha temporary access to cut the 1.17.0-beta.1 release.
Revoking it here.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

Closes: https://github.com/kubernetes/sig-release/issues/851

/assign @tpepper @calebamiles @saschagrunert 
cc: @kubernetes/release-engineering 