### PR TITLE
Fix groups settings for steering list

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -797,6 +797,9 @@ groups:
 
       https://github.com/kubernetes/steering
     settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "false"
     owners:

--- a/groups/reconcile.go
+++ b/groups/reconcile.go
@@ -419,7 +419,7 @@ func updateGroupSettings(srv *groupssettings.Service, groupEmailId string, group
 	// This sets safe/sane defaults
 	wantSettings.AllowExternalMembers = "true"
 	wantSettings.WhoCanJoin = "INVITED_CAN_JOIN"
-	wantSettings.WhoCanViewMembership = "ALL_MEMBERS_CAN_VIEW"
+	wantSettings.WhoCanViewMembership = "ALL_MANAGERS_CAN_VIEW"
 	wantSettings.WhoCanViewGroup = "ALL_MEMBERS_CAN_VIEW"
 	wantSettings.WhoCanDiscoverGroup = "ALL_IN_DOMAIN_CAN_DISCOVER"
 	wantSettings.WhoCanModerateMembers = "OWNERS_AND_MANAGERS"


### PR DESCRIPTION
I had fixed settings so anyone could post to the steering public list, but it still wasn't publicly viewable

/assign @dims 