### PR TITLE
backup.sh: do not depend on docker

### DIFF
--- a/infra/gcp/backup_tools/backup.sh
+++ b/infra/gcp/backup_tools/backup.sh
@@ -17,65 +17,68 @@
 # USAGE NOTES
 #
 # Backs up prod registries. This is a thin orchestrator as all the heavy lifting
-# is done by the gcrane binary. The only required argument is the path to the
-# service account that has write access to the backup GCRs.
+# is done by the gcrane binary.
+#
+# This script requires 3 environment variables to be defined:
+#
+# 1) GOPATH: toplevel path for checking out gcrane's source code.
+#
+# 2) GCRANE_REF: the commit SHA to use for building the gcrane binary.
+#
+# 3) GOOGLE_APPLICATION_CREDENTIALS: path to the service account (JSON file)
+# that has write access to the backup GCRs.
 
 set -o errexit
 set -o nounset
 set -o pipefail
 
+GCRANE_CHECKOUT_DIR="${GOPATH}/src/github.com/google/go-containerregistry"
+
+build_gcrane()
+{
+    git clone https://github.com/google/go-containerregistry "${GCRANE_CHECKOUT_DIR}"
+    pushd "${GCRANE_CHECKOUT_DIR}/cmd/gcrane"
+    git reset --hard "${GCRANE_REF}"
+    # Build offline from vendored sources.
+    go build -mod=vendor
+    popd
+}
+
 copy_with_date()
 {
-    local gcrane_img
-    local gcrane_digest
     local timestamp
     local source_gcr_repo
     local backup_gcr_repo
-    local sa_key_path
-
-    # The image is pinned to an exact sha256 version because the gcrane binary's
-    # behavior must never change (otherwise, the "docker run" invocation below
-    # might explode unexpectedly).
-    gcrane_digest="560757a7b63c85e9b95d2d971a18aa2a2425899e36f1550ce3584018d9ac49ea" # version 7683b4ee5f6150cb47a791309f781c522b95a58f
-    gcrane_img="gcr.io/go-containerregistry/gcrane@sha256:${gcrane_digest}"
 
     # We use a timestamp of the form YYYY/MM/DD/HH because this makes the backup
     # folders more easily traversable from a human perspective.
     timestamp="$(date -u +"%Y/%m/%d/%H")"
 
-    if (( $# != 3 )); then
+    if (( $# != 2 )); then
         cat << EOF >&2
-copy_with_date: usage <source_gcr_repo> <backup_gcr_repo> <sa_key_path>
-e.g. copy_with_date "us.gcr.io/k8s-artifacts-prod" "us.gcr.io/k8s-artifacts-prod-bak" /path/to/sa/key.json
+copy_with_date: usage <source_gcr_repo> <backup_gcr_repo>
+e.g. copy_with_date "us.gcr.io/k8s-artifacts-prod" "us.gcr.io/k8s-artifacts-prod-bak"
 EOF
         exit 1
     fi
 
     source_gcr_repo="${1}" # "us.gcr.io/k8s-artifacts-prod"
     backup_gcr_repo="${2}" # "us.gcr.io/k8s-artifacts-prod-bak"
-    sa_key_path="${3}"
 
     # Perform backup by copying all images recursively over.
-    docker run \
-        -v "${sa_key_path}":/auth.json \
-        --env GOOGLE_APPLICATION_CREDENTIALS=/auth.json \
-        "${gcrane_img}" \
-            cp -r "${source_gcr_repo}" "${backup_gcr_repo}/${timestamp}"
+    "${GCRANE_CHECKOUT_DIR}/cmd/gcrane/gcrane" cp -r "${source_gcr_repo}" "${backup_gcr_repo}/${timestamp}"
 }
-
-if (( $# != 1 )); then
-    "usage: ./backup.sh <svc_acct_key_path_for_backup_gcr>"
-    exit 1
-fi
 
 prod_repos=(
     asia.gcr.io/k8s-artifacts-prod
     eu.gcr.io/k8s-artifacts-prod
     us.gcr.io/k8s-artifacts-prod
 )
-sa_key_path="${1}"
+
+# Build gcrane first.
+build_gcrane
 
 # Copy each region to its backup.
 for prod_repo in "${prod_repos[@]}"; do
-    copy_with_date "${prod_repo}" "${prod_repo}-bak" "${sa_key_path}"
+    copy_with_date "${prod_repo}" "${prod_repo}-bak"
 done


### PR DESCRIPTION
This change removes the dependency on Docker and instead compiles the
gcrane binary from source. This makes it so that we don't have to create
a container just for the backup job.

If we do want a backup container (that is, have this script containerized, which could be run directly from Prow), then we need to set up some more infra around that (probably use https://github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing).

/cc @justinsb @thockin