### PR TITLE
backup.sh: add tracing for more verbosity

### DIFF
--- a/infra/gcp/backup_tools/backup.sh
+++ b/infra/gcp/backup_tools/backup.sh
@@ -31,6 +31,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -o xtrace
 
 GCRANE_CHECKOUT_DIR="${GOPATH}/src/github.com/google/go-containerregistry"
 


### PR DESCRIPTION
The backup job is failing (turned it on over the weekend...!), but it is not clear why exactly. Hopefully this will help debug it.

Failing job: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-k8sio-backup/1196579787003400192