### PR TITLE
Update DNS for development branch for the cluster-api documentation

### DIFF
--- a/dns/zone-configs/k8s.io.yaml
+++ b/dns/zone-configs/k8s.io.yaml
@@ -258,7 +258,7 @@ release-0-1.cluster-api.sigs:
   type: CNAME
   value: release-0-1--kubernetes-sigs-cluster-api.netlify.com.
 # https://github.com/kubernetes-sigs/cluster-api development docs (@dwat, @jdetiber, @justinsb)
-dev.cluster-api.sigs:
+master.cluster-api.sigs:
   type: CNAME
   value: master--kubernetes-sigs-cluster-api.netlify.com.
 # https://github.com/kubernetes/cloud-provider-vsphere docs (@andrewsykim, @frapposelli)


### PR DESCRIPTION
I had previously forgotten that the subdomain used needs to be the same as the branch prefix for the Netlify URL, updated the DNS records accordingly.

/assign @ncdc @cblecker @dims 