### PR TITLE
use e2e-test-images instead of e2e-test in ensure-staging-storage

### DIFF
--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -52,7 +52,7 @@ STAGING_PROJECTS=(
     coredns
     csi
     descheduler
-    e2e-test
+    e2e-test-images
     kas-network-proxy
     kops
     kube-state-metrics


### PR DESCRIPTION
we have a pattern baked into the scripts, so we should name the bucket `e2e-test-images`

```
[dims@dims-a02 12:15] ~/go/src/k8s.io/k8s.io/infra/gcp ⟩ ./ensure-staging-storage.sh e2e-test
Configuring staging: e2e-test
Ensuring project exists: k8s-staging-e2e-test
billingAccountName: billingAccounts/018801-93540E-22A20E
billingEnabled: true
name: projects/k8s-staging-e2e-test/billingInfo
projectId: k8s-staging-e2e-test
Empowering k8s-infra-staging-e2e-test@kubernetes.io as project viewers
ERROR: Policy modification failed. For a binding with condition, run "gcloud alpha iam policies lint-condition" to identify issues in condition.
ERROR: (gcloud.projects.add-iam-policy-binding) INVALID_ARGUMENT: Group k8s-infra-staging-e2e-test@kubernetes.io does not exist.
```