### PR TITLE
Add missing dot for image-builder.sigs dns

### DIFF
--- a/dns/zone-configs/k8s.io.yaml
+++ b/dns/zone-configs/k8s.io.yaml
@@ -275,4 +275,4 @@ kops.sigs:
   value: kubernetes-kops.netlify.com.
 image-builder.sigs:
   type: CNAME
-  value: kubernetes-sigs-image-builder.netlify.com
+  value: kubernetes-sigs-image-builder.netlify.com.


### PR DESCRIPTION
Fix for error

```
2019-12-06T18:25:25  [139647256235336] DEBUG Record __init__: zone.name=canary.k8s.io., type=CnameRecord, name=issue
Traceback (most recent call last):
  File "/usr/local/bin/octodns-sync", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/site-packages/octodns/cmds/sync.py", line 39, in main
    dry_run=not args.doit, force=args.force)
  File "/usr/local/lib/python2.7/site-packages/octodns/manager.py", line 301, in sync
    plans = [p for f in futures for p in f.result()]
  File "/usr/local/lib/python2.7/site-packages/octodns/manager.py", line 56, in result
    return self.func(*self.args, **self.kwargs)
  File "/usr/local/lib/python2.7/site-packages/octodns/manager.py", line 224, in _populate_and_plan
    source.populate(zone)
  File "/usr/local/lib/python2.7/site-packages/octodns/provider/yaml.py", line 77, in populate
    self._populate_from_file(filename, zone, lenient)
  File "/usr/local/lib/python2.7/site-packages/octodns/provider/yaml.py", line 61, in _populate_from_file
    lenient=lenient)
  File "/usr/local/lib/python2.7/site-packages/octodns/record/__init__.py", line 108, in new
    raise ValidationError(fqdn, reasons)
octodns.record.ValidationError: Invalid record image-builder.sigs.canary.k8s.io.
```