### PR TITLE
psc/releng: Update membership for security/release-focused Google Groups

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -760,9 +760,9 @@ groups:
   - email-id: security-discuss-private@kubernetes.io
     name: security-discuss-private
     description: |-
-      Private discussion forum for PST members.
+      Private discussion forum for PSC members.
 
-      https://github.com/kubernetes/sig-release/blob/master/security-release-process-documentation/security-release-process.md#product-security-team-pst
+      https://github.com/kubernetes/security#product-security-committee-psc
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -780,12 +780,16 @@ groups:
   - email-id: security-release-team@kubernetes.io
     name: security-release-team
     description: |-
-      security release team mailing list
+      Private list for coordinating security releases.
+
+      Membership is restricted to the Product Security Committee,
+      SIG Release Chairs, Patch Release Team, and Branch Managers.
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
-      - stephen.k8s@agst.us
+      - release-managers-private@kubernetes.io
+      - security@kubernetes.io
 
   - email-id: security@kubernetes.io
     name: security

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -713,6 +713,7 @@ groups:
       - hhorl@pivotal.io
       - idealhack@gmail.com
       - kubernetes-release-managers-private@googlegroups.com
+      - saschagrunert@gmail.com
       - saugustus@vmware.com
       - tpepper@gmail.com
 

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -712,7 +712,6 @@ groups:
       - feiskyer@gmail.com
       - hhorl@pivotal.io
       - idealhack@gmail.com
-      - kubernetes-release-managers-private@googlegroups.com
       - saschagrunert@gmail.com
       - saugustus@vmware.com
       - tpepper@gmail.com


### PR DESCRIPTION
- Update membership for security-release-team
  
  After discussing with PSC, we've decided to fork communications around
  security releases into a separate mailing list -- security-release-team

  Membership is restricted to:
  - Product Security Committee
  - SIG Release Chairs
  - Patch Release Team
  - Branch Managers

- Add Sascha Grunert to release-managers-private
  
  Sascha was recently promoted to Branch Manager, which means he needs to
  be a part of the private discussion list for Release Managers now.

- Drop non-kubernetes.io group from release-managers-private
  
  kubernetes-release-managers-private@googlegroups.com existed before
  Release Engineering received a kubernetes.io group. We initially nested
  it within release-managers-private to ensure messages were not missed
  while transitioning over to the kubernetes.io group.

  Overall the lists are pretty low-traffic and a non-auditable,
  non-kubernetes.io group nested within a group that receives sensitive
  communications is a risk.

- Update list description for security-discuss-private 

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

We will need to issue updates to documentation as well:
- [Security Release Process](https://git.k8s.io/security/security-release-process.md)
- [Release Managers](https://github.com/kubernetes/sig-release/blob/master/release-managers.md)
- [Release Manager onboarding template](https://github.com/kubernetes/sig-release/blob/master/.github/ISSUE_TEMPLATE/release-manager.md)

/hold for any discussion
Supersedes most of https://github.com/kubernetes/k8s.io/pull/427.
ref: https://github.com/kubernetes/sig-release/issues/732#issuecomment-561828879, https://groups.google.com/a/kubernetes.io/d/topic/security/E_yV--bf-8c/discussion

For Release Engineering subproject approval:
/assign @tpepper @calebamiles

For PSC approval:
/assign @tallclair @liggitt @cjcullen @lukehinds 

For groups reconciliation:
/assign @dims @cblecker 

cc: @kubernetes/product-security-committee @kubernetes/release-engineering 