### PR TITLE
Fix members list for security-release-team

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -787,7 +787,7 @@ groups:
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
-    owners:
+    members:
       - release-managers-private@kubernetes.io
       - security@kubernetes.io
 


### PR DESCRIPTION
DLs can't be owners of other DLs. This fixes that for security-release-team

/assign @dims @justaugustus 
/approve