### PR TITLE
Create gcr.io image repo for service-apis

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -897,3 +897,15 @@ groups:
       - timothysc@gmail.com
       - fabrizio.pandini@gmail.com
       - neolit123@gmail.com
+
+  - email-id: k8s-infra-staging-service-apis@kubernetes.io
+    name: k8s-infra-staging-service-apis
+    description: |-
+      ACL for staging SIG-network service APIs
+    settings:
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      ReconcileMembers: "true"
+    owners:
+      - thockin@google.com
+      - bowei@google.com
+      - antonio.ojea.garcia@gmail.com

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -63,6 +63,7 @@ STAGING_PROJECTS=(
     provider-azure
     publishing-bot
     release-test
+    service-apis
 )
 if [ $# = 0 ]; then
     # default to all staging projects

--- a/k8s.gcr.io/images/k8s-staging-service-apis/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-service-apis/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS file documentation:
+#  https://github.com/kubernetes/community/blob/master/contributors/devel/owners.md
+
+approvers:
+- thockin
+- bowei
+reviewers:
+- aojea
+labels:
+- sig/network

--- a/k8s.gcr.io/images/k8s-staging-service-apis/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-service-apis/images.yaml
@@ -1,0 +1,1 @@
+# TODO: add images

--- a/k8s.gcr.io/manifests/k8s-staging-service-apis/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-service-apis/promoter-manifest.yaml
@@ -1,0 +1,11 @@
+# google group for gcr.io/k8s-staging-service-apis is k8s-infra-staging-service-apis@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-service-apis
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/service-apis
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/service-apis
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/service-apis
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+imagesPath: "../../images/k8s-staging-service-apis/images.yaml"


### PR DESCRIPTION
Create the docker image repository to store the sig.k8s.io/service-apis artifacts

xref: https://github.com/kubernetes-sigs/service-apis/issues/3