### PR TITLE
Refactor infra/gcp #516

### DIFF
--- a/infra/gcp/deployments/staging/resources.tf
+++ b/infra/gcp/deployments/staging/resources.tf
@@ -1,0 +1,29 @@
+module "project-artifact-promoter" {
+  source       = "../tf_modules/project"
+  project_name = "artifcat-promoter"
+  project_id   = var.project_id
+  env_name     = "staging"
+  writer       = "k8s-infra-${env_name}-artifact-promoter@kubernetes.io"
+  enable_api   = "containerregistry.googleapis.com"
+  billing_account =  var.gcp_billing
+}
+
+module "build-image" {
+  source       = "../tf_modules/project"
+  project_name = "build-image"
+  project_id   = var.project_id
+  env_name     = "staging"
+  writer       = "k8s-infra-${env_name}-build-image@kubernetes.io"
+  enable_api   = "containerregistry.googleapis.com"
+  billing_account =  var.gcp_billing
+}
+
+module "cip-test" {
+  source       = "../tf_modules/project"
+  project_name = "cip-test"
+  project_id   = var.project_id
+  env_name     = "staging"
+  writers      = "k8s-infra-${env_name}-cip-test@kubernetes.io"
+  enable_api   = "containerregistry.googleapis.com"
+  billing_account =  var.gcp_billing
+}

--- a/infra/gcp/deployments/staging/terraform.tfvars
+++ b/infra/gcp/deployments/staging/terraform.tfvars
@@ -1,0 +1,3 @@
+var.env_name = "staging"
+
+var.gcp_billing = "018801-93540E-22A20E"

--- a/infra/gcp/deployments/staging/vars.tf
+++ b/infra/gcp/deployments/staging/vars.tf
@@ -1,0 +1,11 @@
+variable "gcp_billing" {
+    type = string
+}
+
+variable "env_name" {
+    type = string
+}
+
+varaible "project_id" {
+    type = string
+}

--- a/infra/gcp/tf_modules/project/resources.tf
+++ b/infra/gcp/tf_modules/project/resources.tf
@@ -1,0 +1,40 @@
+#
+# definitions
+# 
+
+locals {
+    project_name    = var.project_name
+    project_id      = var.project_id
+    billing_account = var.billing_account
+    env_name        = var.env_name
+    writer          = var.writer
+		enable_api      = var.enable_api
+}
+
+#
+# resources
+#
+
+resource "google_project" project" {
+  name       = "k8s-${local.env_name}-${local.project_name}"
+  project_id = local.project_id
+  billing_account = local.billing_account
+}
+
+
+data "google_iam_policy" "read" {
+  binding {
+    role = "roles/viewer"
+
+    members = [
+      "group:${local.writer}",
+    ]
+  }
+
+}
+
+resource "google_project_service" "project" {
+  project = local.project_id
+  service =  local.enable_api
+}
+

--- a/infra/gcp/tf_modules/project/variables.tf
+++ b/infra/gcp/tf_modules/project/variables.tf
@@ -1,0 +1,40 @@
+#
+# required
+#
+variable "project_name" {
+    type = string
+}
+
+variable "project_id" {
+    type = string
+}
+
+variable "env_name" {
+    type = string
+}
+
+
+variable "group" { 
+    type = string
+}
+
+variable "writer" {
+    type = string
+}
+
+variable "enable_api" {
+    type = string
+}
+
+variable "billing_account" {
+	type = string
+}
+
+#
+# optional
+#
+
+variable "custom_labels" {
+    type = map
+    default = {}
+}


### PR DESCRIPTION
I think it would make sense to have terraform modules and define deployments per environment,  I work mainly on AWS with Terraform 0.11.X so still trying to catch up with the new syntax, but I would like help with this. WDYT?