### PR TITLE
Add node-feature-discovery (nfd) to k8s.gcr.io

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -684,6 +684,18 @@ groups:
       - srampal@cisco.com
       - tasha.drew@gmail.com
 
+  - email-id: k8s-infra-staging-nfd@kubernetes.io
+    name: k8s-infra-staging-nfd
+    description: |-
+      ACL for staging node-feature-discovery (nfd)
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - alexander.kanevskiy@intel.com
+      - jordanjacobelli04@gmail.com
+      - markus.lehtonen@intel.com
+      - zkosic@redhat.com
+
   - email-id: k8s-infra-staging-npd@kubernetes.io
     name: k8s-infra-staging-npd
     description: |-

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -61,6 +61,7 @@ STAGING_PROJECTS=(
     kubeadm
     metrics-server
     multitenancy
+    nfd
     npd
     provider-azure
     publishing-bot

--- a/k8s.gcr.io/images/k8s-staging-nfd/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-nfd/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- kad

--- a/k8s.gcr.io/images/k8s-staging-nfd/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-nfd/images.yaml
@@ -1,0 +1,1 @@
+# TODO: add images

--- a/k8s.gcr.io/manifests/k8s-staging-nfd/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-nfd/promoter-manifest.yaml
@@ -1,0 +1,11 @@
+# google group for gcr.io/k8s-staging-nfd is k8s-infra-staging-nfd@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-nfd
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/nfd
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/nfd
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/nfd
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+imagesPath: "../../images/k8s-staging-nfd/images.yaml"


### PR DESCRIPTION
We would like to host images for [node-feature-discovery](https://github.com/kubernetes-sigs/node-feature-discovery) in k8s.gcr.io, see kubernetes-sigs/node-feature-discovery#177

Upstream project name (**node-feature-discovery**) exceeds the 18 character limit mentioned in [k8s.gcr.io/README.md](https://github.com/kubernetes/k8s.io/blob/master/k8s.gcr.io/README.md) so it was abbreviated to **nfd** here. I don't know if it would be possible/make sense to use the full name in the name of the registry (i.e. in `ensure-staging-storage.sh` and `k8s-staging-nfd/promoter-manifest.yaml`)(?)

/sig node