### PR TITLE
Update gcr.io/k8s-staging-descheduler Permissions

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -576,6 +576,7 @@ groups:
     members:
       - avesh.ncsu@gmail.com
       - davanum@gmail.com
+      - mdame@redhat.com
       - ravisantoshgudimetla@gmail.com
       - spiffxp@google.com
 


### PR DESCRIPTION
Giving Mike Dame from SIG scheduling push access to descheduler
container registry, gcr.io/k8s-staging-descheduler.