### PR TITLE
ExternalDNS: promote v0.5.18

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-external-dns/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-external-dns/images.yaml
@@ -1,0 +1,3 @@
+- name: external-dns
+  dmap:
+    "sha256:403b9b0a8a7428c0d3fe57fe0aebf7ac8a69467d2660c2384a7463c574f3dbb2": ["v0.5.18"]


### PR DESCRIPTION
This promotes `v0.5.18` from staging to production.

I wonder if the docker image described by the `sha256` must already be tagged `v0.5.18` in the staging registry or if that is taken care of when promoting it.

Background: We didn't manage to push to the staging repository with our desired tags yet. They still are prefixed with the date, [see here](https://console.cloud.google.com/gcr/images/k8s-staging-external-dns/GLOBAL/external-dns@sha256:403b9b0a8a7428c0d3fe57fe0aebf7ac8a69467d2660c2384a7463c574f3dbb2/details?tab=info).

Anyway, we figured it might be worth a try :smiley: 