### PR TITLE
capz: Promote latest staging image to v0.3.0

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cluster-api-azure/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api-azure/images.yaml
@@ -1,3 +1,4 @@
 - name: cluster-api-azure-controller
   dmap:
     "sha256:c05429083fb1580c18e0769d94f96486de086298a3abbd779dcf1e41af9f82d8": ["v0.3.0-alpha.1"]
+    "sha256:ff557c077ead935efaeea7ccb2a716c1c732554dd656763b1051ebb93208d2e9": ["v0.3.0"]


### PR DESCRIPTION
ref: https://github.com/kubernetes-sigs/cluster-api-provider-azure/releases/tag/v0.3.0

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/sig cluster-lifecycle
/assign @CecileRobertMichon @soggiest @awesomenix @cblecker @dims 