### PR TITLE
capz: update owners to match capz repo

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cluster-api-azure/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api-azure/OWNERS
@@ -3,11 +3,12 @@
 
 approvers:
 - awesomenix
+- CecileRobertMichon
 - justaugustus
 - soggiest
 reviewers:
-- CecileRobertMichon
 - juan-lee
+- nader-ziada
 - serbrech
 - vincepri
 


### PR DESCRIPTION
ref: https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/master/OWNERS_ALIASES

/sig cluster-lifecycle
/assign @justaugustus @soggiest 