### PR TITLE
Fix DNS lame delegation of canary.canary

### DIFF
--- a/dns/zone-configs/canary.k8s.io.yaml
+++ b/dns/zone-configs/canary.k8s.io.yaml
@@ -1,1 +1,1 @@
-k8s.io.yaml
+k8s.io._0_base.yaml

--- a/dns/zone-configs/canary.kubernetes.io.yaml
+++ b/dns/zone-configs/canary.kubernetes.io.yaml
@@ -1,1 +1,1 @@
-kubernetes.io.yaml
+kubernetes.io._0_base.yaml

--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -1,4 +1,3 @@
----
 # The top-level k8s.io zone
 '':
   - type: A
@@ -22,15 +21,6 @@
 www:
   type: CNAME
   value: k8s.io.
-
-# Canary zone for testing DNS pushes.
-canary:
-  type: NS
-  values:
-  - ns-cloud-c1.googledomains.com.
-  - ns-cloud-c2.googledomains.com.
-  - ns-cloud-c3.googledomains.com.
-  - ns-cloud-c4.googledomains.com.
 
 # Our vanity redirector.  This is not just 'k8s.io', on the off chance this
 # becomes different from the main record. (@thockin)

--- a/dns/zone-configs/k8s.io._1_canary.yaml
+++ b/dns/zone-configs/k8s.io._1_canary.yaml
@@ -1,5 +1,3 @@
-# The top-level k8s-e2e.com zone
-
 # Canary zone for testing DNS pushes.
 canary:
   type: NS

--- a/dns/zone-configs/kubernetes.io._0_base.yaml
+++ b/dns/zone-configs/kubernetes.io._0_base.yaml
@@ -1,4 +1,3 @@
----
 # The top-level kubernetes.io zone
 #
 # In general, every name here has an equivalent in k8s.io.  For many of these
@@ -26,15 +25,6 @@
 www:
   type: CNAME
   value: kubernetes.io.
-
-# Canary zone for testing DNS pushes.
-canary:
-  type: NS
-  values:
-  - ns-cloud-b1.googledomains.com.
-  - ns-cloud-b2.googledomains.com.
-  - ns-cloud-b3.googledomains.com.
-  - ns-cloud-b4.googledomains.com.
 
 # Main docs site is a redirect (@chenopis)
 docs:

--- a/dns/zone-configs/kubernetes.io._1_canary.yaml
+++ b/dns/zone-configs/kubernetes.io._1_canary.yaml
@@ -1,0 +1,8 @@
+# Canary zone for testing DNS pushes.
+canary:
+  type: NS
+  values:
+  - ns-cloud-b1.googledomains.com.
+  - ns-cloud-b2.googledomains.com.
+  - ns-cloud-b3.googledomains.com.
+  - ns-cloud-b4.googledomains.com.

--- a/dns/zone-configs/x-k8s.io.yaml
+++ b/dns/zone-configs/x-k8s.io.yaml
@@ -1,6 +1,4 @@
----
 # The top-level x-k8s.io zone
-
 
 # Canary zone for testing DNS pushes.
 canary:


### PR DESCRIPTION
To fix this, we need to not delegate canary.canary, which means loading
SLIGHTLY different yaml in canary than prod.

This change makes the push script "pre-cook" config files by joining
them together.  These are saved in a temporary dir and octodns reads
from there.  This works because records are top-level items in the YAML
schema.

I could not find a way to make octodns do this itself.

Dry-run shows 2 deletions, as expected.