### PR TITLE
Promote k/k test e2e images

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-e2e-test-images/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-e2e-test-images/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- listx
+- mkumatag

--- a/k8s.gcr.io/images/k8s-staging-e2e-test-images/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-e2e-test-images/images.yaml
@@ -1,0 +1,15 @@
+- name: agnhost
+  dmap:
+    "sha256:3a09e7cc09aab76ac52f0447c16d6a6ec3e0537aa405301b165f5823aa6047e0": ["2.9"]
+- name: jessie-dnsutils
+  dmap:
+    "sha256:31183fd28aa9b4af81329e1886060492cfa67dd94e9d1132e00ed032ce685187": ["1.2"]
+- name: nonewprivs
+  dmap:
+    "sha256:553fcda2222ccea7cd534c8da34b709feb768d6389eb7333444b13f296bd168f": ["1.1"]
+- name: resource-consumer
+  dmap:
+    "sha256:74e800780d7656d42fb0f28e153619044a826e5f532d1871cac4b7c4d66d946f": ["1.6"]
+- name: sample-apiserver
+  dmap:
+    "sha256:eb820c8133a6bbe63a97268713fb85bfc9129e380e8c06f99a34ba0051665c92": ["1.17.2"]

--- a/k8s.gcr.io/manifests/k8s-staging-e2e-test-images/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-e2e-test-images/promoter-manifest.yaml
@@ -8,5 +8,3 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia.gcr.io/k8s-artifacts-prod/e2e-test-images
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-images: []
-renames: []


### PR DESCRIPTION
Adds the images.yaml file containing the E2E test images to be promoted, their digests, and versions.

Adds the OWNERS file, based on the kubernetes/test/images/OWNERS file.

Moves the manifest.yaml file to its appropriate location.