### PR TITLE
Changes SPF validation from soft to hard fail

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -17,7 +17,7 @@
   - type: TXT
     values:
     - google-site-verification=RJbZ_ganmSWvslSKOBG-QHv62XTjJZcigpWIFttStFs
-    - v=spf1 include:_spf.google.com ~all
+    - v=spf1 include:_spf.google.com -all
 www:
   type: CNAME
   value: k8s.io.

--- a/dns/zone-configs/kubernetes.io._0_base.yaml
+++ b/dns/zone-configs/kubernetes.io._0_base.yaml
@@ -21,7 +21,7 @@
   - type: TXT
     values:
     - google-site-verification=oPORCoq9XU6CmaR7G_bV00CLmEz-wLGOL7SXpeEuTt8
-    - v=spf1 include:_spf.google.com ~all
+    - v=spf1 include:_spf.google.com -all
 www:
   type: CNAME
   value: kubernetes.io.


### PR DESCRIPTION
Fixes: #554 

This PR changes the SPF validation in domains from soft to hard fail (~all to -all) enforcing the validation to came only from the desired TXT record from _spf.google.com ("v=spf1 include:_netblocks.google.com include:_netblocks2.google.com include:_netblocks3.google.com ~all") but overriding the soft fail in the end of this record.

