### PR TITLE
Grant promoter service account access to test resources

### DIFF
--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -180,6 +180,13 @@ empower_service_account_to_artifacts \
     $(svc_acct_email "${PROMOTER_TEST_PROD_PROJECT}" "${PROMOTER_SVCACCT}") \
     "${PROMOTER_TEST_STAGING_PROJECT}"
 
+# Special case: grant the image promoter test service account OWNER access to
+# their testing project (used for running e2e tests for the promoter auditing
+# mechanism).
+empower_service_account_as_owner \
+    $(svc_acct_email "${GCR_AUDIT_TEST_PROD_PROJECT}" "${PROMOTER_SVCACCT}") \
+    "${GCR_AUDIT_TEST_PROD_PROJECT}"
+
 # Special case: grant the release tools testing group access to their fake
 # prod project.
 empower_group_to_fake_prod \

--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -180,10 +180,10 @@ empower_service_account_to_artifacts \
     $(svc_acct_email "${PROMOTER_TEST_PROD_PROJECT}" "${PROMOTER_SVCACCT}") \
     "${PROMOTER_TEST_STAGING_PROJECT}"
 
-# Special case: grant the image promoter test service account OWNER access to
+# Special case: grant the image promoter test service account access to
 # their testing project (used for running e2e tests for the promoter auditing
 # mechanism).
-empower_service_account_as_owner \
+empower_service_account_for_cip_auditor_e2e_tester \
     $(svc_acct_email "${GCR_AUDIT_TEST_PROD_PROJECT}" "${PROMOTER_SVCACCT}") \
     "${GCR_AUDIT_TEST_PROD_PROJECT}"
 

--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -260,21 +260,35 @@ function empower_group_as_viewer() {
         --role roles/viewer
 }
 
-# Grant project owner access.
+# Grant roles for running cip-auditor E2E test
+# (https://github.com/kubernetes-sigs/k8s-container-image-promoter/tree/master/test-e2e#cip-auditor-cip-auditor-e2ego).
+
 # $1: The GCP project
 # $2: The service account
-function empower_service_account_as_owner() {
+function empower_service_account_for_cip_auditor_e2e_tester() {
     if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
-        echo "empower_service_account_as_owner(acct, project) requires 2 arguments" >&2
+        echo "empower_service_account_for_cip_auditor_e2e_tester(acct, project) requires 2 arguments" >&2
         return 1
     fi
     acct="$1"
     project="$2"
 
-    gcloud \
-        projects add-iam-policy-binding "${project}" \
-        --member "serviceAccount:${acct}" \
-        --role roles/owner
+    roles=(
+        roles/errorreporting.admin
+        roles/logging.admin
+        roles/pubsub.admin
+        roles/resourcemanager.projectIamAdmin
+        roles/run.admin
+        roles/serverless.serviceAgent
+        roles/storage.admin
+    )
+
+    for role in "${roles[@]}"; do
+        gcloud \
+            projects add-iam-policy-binding "${project}" \
+            --member "serviceAccount:${acct}" \
+            --role "${role}"
+    done
 }
 
 # Grant GCB admin privileges to a principal

--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -260,6 +260,23 @@ function empower_group_as_viewer() {
         --role roles/viewer
 }
 
+# Grant project owner access.
+# $1: The GCP project
+# $2: The service account
+function empower_service_account_as_owner() {
+    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+        echo "empower_service_account_as_owner(acct, project) requires 2 arguments" >&2
+        return 1
+    fi
+    acct="$1"
+    project="$2"
+
+    gcloud \
+        projects add-iam-policy-binding "${project}" \
+        --member "serviceAccount:${acct}" \
+        --role roles/owner
+}
+
 # Grant GCB admin privileges to a principal
 # $1: The GCP project
 # $2: The group email


### PR DESCRIPTION
This gives the service account for the GCR_AUDIT_TEST_PROD_PROJECT access enough to run the tests. During the course of the e2e test, the test invokes various permission changes to this test project, such as:

    gcloud projects add-iam-policy-binding k8s-gcr-audit-test-prod
        --member=serviceAccount:service-375340694213@gcp-sa-pubsub.iam.gserviceaccount.com --role=roles/iam.serviceAccountTokenCreator

For more context around the auditing mechanism of the promoter, see
https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/170

/cc @thockin @dims