### PR TITLE
Promote network proxy image v0.0.4

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-kas-network-proxy/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-kas-network-proxy/images.yaml
@@ -1,0 +1,6 @@
+- name: proxy-agent
+  dmap:
+    "sha256:7479f04932b89ea42c9a1bc260ca52b0bb2575596962481fe9be0e6b4a583615": ["v0.0.4"]
+- name: proxy-server
+  dmap:
+    "sha256:5431119507b1da03ead713e5cfd79b7231d38026bb97189e5bd76d252f91fc3f": ["v0.0.4"]


### PR DESCRIPTION
Using latest digest for both proxy agent and server. Version number starts at v0.0.4 because we released v0.0.3 via `k8s.gcr.io`.

[Agent images](https://console.cloud.google.com/gcr/images/k8s-staging-kas-network-proxy/GLOBAL/proxy-agent?gcrImageListsize=30)

[Server images](https://console.cloud.google.com/gcr/images/k8s-staging-kas-network-proxy/GLOBAL/proxy-server?gcrImageListsize=30)

/assign @cheftako 
/cc @caesarxuchao 
/cc @Sh4d1 

@listx would you mind double checking that this follows the proper conventions?