### PR TITLE
releng: Add Daniel Mangum (hasheddan) as a Release Manager Associate

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -362,6 +362,7 @@ groups:
       - feiskyer@gmail.com
       - ctadeu@gmail.com
       - dmaceachern@vmware.com
+      - georgedanielmangum@gmail.com
       - hhorl@pivotal.io
       - idealhack@gmail.com
       - saschagrunert@gmail.com

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -384,6 +384,7 @@ groups:
       - ctadeu@gmail.com
       - dmaceachern@vmware.com
       - feiskyer@gmail.com
+      - georgedanielmangum@gmail.com
       - hhorl@pivotal.io
       - idealhack@gmail.com
       - jameswangel@gmail.com
@@ -895,6 +896,7 @@ groups:
       - daminisatya@gmail.com
       - dmaceachern@vmware.com
       - feiskyer@gmail.com
+      - georgedanielmangum@gmail.com
       - hhorl@pivotal.io
       - idealhack@gmail.com
       - jameswangel@gmail.com


### PR DESCRIPTION
- Add Daniel Mangum (hasheddan) as a Release Manager Associate (ref: https://github.com/kubernetes/sig-release/issues/978)
- Temporarily grant hasheddan access to cut v1.18.0-alpha.4 (ref: https://github.com/kubernetes/sig-release/issues/985)

/assign @dims @cblecker
cc: @hasheddan @kubernetes/release-engineering 