### PR TITLE
releng: Revert temporary Branch Manager access for hasheddan

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -362,7 +362,6 @@ groups:
       - feiskyer@gmail.com
       - ctadeu@gmail.com
       - dmaceachern@vmware.com
-      - georgedanielmangum@gmail.com
       - hhorl@pivotal.io
       - idealhack@gmail.com
       - saschagrunert@gmail.com


### PR DESCRIPTION
Reverts elevated privileges that will be granted in https://github.com/kubernetes/k8s.io/pull/565.
/hold until https://github.com/kubernetes/sig-release/issues/985 is closed and this is rebased

cc: @hasheddan @kubernetes/release-engineering