### PR TITLE
sig-release: Create release-comms list (external release communications)

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -861,6 +861,31 @@ groups:
       - ramamoorthypandiyaraja@gmail.com
       - spiffxp@google.com
 
+  - email-id: release-comms@kubernetes.io
+    name: release-comms
+    description: |-
+      External Release Communications list.
+      Should be used when coordinating external release timelines e.g., with the CNCF.
+
+      Membership should include SIG Chairs, Release Team Leads and Lead Shadows, and 
+      the Communications team for the current release cycle.
+    settings:
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      ReconcileMembers: "true"
+    owners:
+      - cmiles@pivotal.io
+      - stephen.k8s@agst.us
+      - tpepper@vmware.com
+    members:
+      - alarcj137@gmail.com
+      - chu.karen.h@gmail.com
+      - k8s@thatmightbe.com
+      - killen.bob@gmail.com
+      - max@koerbaecher.io
+      - meenakshi.kaushik@gmail.com
+      - nadolny.claudia@gmail.com
+      - onlydole@gmail.com
+
   - email-id: release-managers-private@kubernetes.io
     name: release-managers-private
     description: |-


### PR DESCRIPTION
We've had a comms snafu or two in past release cycles.
This list is to ensure multiple Release Team members and SIG Release
representatives are in the feedback loop when communicating to external
stakeholders, like the CNCF, to provide additional context, identify
potential gaps, and miscommunications.

release-comms@ currently includes:
- 1.18 Release Team Lead & Lead Shadows
- 1.18 Communications Lead & Comms Shadows
- SIG Release Chairs

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @cblecker @dims @tpepper @calebamiles 
cc: @kubernetes/release-team 
ref: https://github.com/kubernetes/sig-release/pull/986