### PR TITLE
descheduler: promote v0.10.0

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-descheduler/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-descheduler/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - ravisantoshgudimetla
+  - aveshagarwal

--- a/k8s.gcr.io/images/k8s-staging-descheduler/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-descheduler/images.yaml
@@ -1,0 +1,3 @@
+- name: descheduler
+  dmap:
+    "sha256:c89ada9df9a950e351d21a1df5a83575e086b975cd665a8e636bcb258caf4fb9": ["v0.10.0"]


### PR DESCRIPTION
Descheduler v0.10.0 was released on February 11, 2020. This pull request promotes the descheduler v0.10.0 container image to the production container registry.

https://github.com/kubernetes-sigs/descheduler/releases/tag/v0.10.0