### PR TITLE
Add a new group for conformance HUAWEI CLOUD

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -438,6 +438,26 @@ groups:
     - jichenjc@cn.ibm.com
     - sbueringer@gmail.com
 
+  - email-id: k8s-infra-conform-huaweicloud@kubernetes.io
+    name: k8s-infra-conform-huaweicloud
+    description: |-
+      ACL for conformance HUAWEI CLOUD
+    settings:
+      AllowExternalMembers: "true"
+      WhoCanJoin: "INVITED_CAN_JOIN"
+      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanDiscoverGroup: "ALL_MEMBERS_CAN_DISCOVER"
+      WhoCanInvite: "NONE_CAN_INVITE"
+      WhoCanAdd: "NONE_CAN_ADD"
+      WhoCanApproveMembers: "NONE_CAN_APPROVE"
+      WhoCanModifyMembers: "NONE"
+      WhoCanModerateMembers: "NONE"
+      ReconcileMembers: "true"
+    members:
+      - kevinwzf0126@gmail.com
+      - qdurenhongcai@gmail.com
+
   - email-id: k8s-infra-staging-artifact-promoter@kubernetes.io
     name: k8s-infra-staging-artifact-promoter
     description: |-

--- a/infra/gcp/ensure-conformance-storage.sh
+++ b/infra/gcp/ensure-conformance-storage.sh
@@ -47,6 +47,7 @@ PROJECT="k8s-conform"
 CONFORMANCE_BUCKETS=(
     capi-openstack
     cri-o
+    huaweicloud
 )
 if [ $# = 0 ]; then
     # default to all conformance buckets


### PR DESCRIPTION
This PR requests a group for HUAWEI CLOUD as well as a GCS bucket.

The bucket used to store cloud provider conformance test results of  [cloud-provider-huaweicloud](https://github.com/huawei-cloudnative/cloud-provider-huaweicloud) and it'll report to TestGrid according to [Contributing Test Results](https://github.com/kubernetes/test-infra/blob/92e4176fa4877ba1823eabfc576fe1665f8f3762/docs/contributing-test-results.md#contributing-test-results).

cc @BenTheElder @dims @andrewsykim 