### PR TITLE
Add munnerz to k8s-infra-team-private

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -849,6 +849,7 @@ groups:
       - spiffxp@google.com
       - thockin@google.com
       - bartek@smykla.com
+      - james@munnelly.eu
 
   - email-id: k8s-infra-staging-apisnoop@kubernetes.io
     name: k8s-infra-staging-apisnoop


### PR DESCRIPTION
Requesting to be added to this list in order to receive Let's Encrypt account & expiry related emails.

Right now the configured address in our ClusterIssuer resources is `k8s-infra-team-private+letsencrypt`.

If there's sensitive conversation going on there, can we consider changing the email address used to something that can be shared more widely/with me? 😅