### PR TITLE
fix some permission errors around the cip-auditor deployment script

### DIFF
--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -480,6 +480,7 @@ function empower_group_to_admin_artifact_auditor() {
         --member "group:${group}" \
         --role roles/run.admin
     gcloud \
+        --project="${project}" \
         iam service-accounts add-iam-policy-binding \
         "${acct}" \
         --member="group:${group}" \


### PR DESCRIPTION
These errors were encountered today while trying to run the deployment script (`infra/gcp/cip-auditor/deploy.sh`).

/cc @thockin @dims
/hold