### PR TITLE
Contributor Summit: Registration shadow

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -34,6 +34,7 @@ groups:
       - parispittman@google.com
     managers:
       - pal.nabarun95@gmail.com
+      - ameukam@gmail.com
     members:
       - dgiles@linuxfoundation.org
       - jberkus@redhat.com


### PR DESCRIPTION
Need access to community private ML for the registration process of the KCS EU 2020. 

cc @dims @palnabarun @jeefy @mrbobbytables 

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>