### PR TITLE
releng: Grant access to push images in build-image GCP project

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,13 @@
+aliases:
+  build-image-approvers:
+    - BenTheElder
+    - cblecker
+    - dims
+    - justaugustus
+    - listx
+  build-image-reviewers:
+    - BenTheElder
+    - cblecker
+    - dims
+    - justaugustus
+    - listx

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -487,9 +487,11 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
+      - bentheelder@google.com
+      - cblecker@gmail.com
       - davanum@gmail.com
-      - jbperez@google.com
       - linusa@google.com
+      - stephen.k8s@agst.us
 
   - email-id: k8s-infra-staging-capi-docker@kubernetes.io
     name: k8s-infra-staging-capi-docker

--- a/k8s.gcr.io/images/k8s-staging-build-image/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-build-image/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - build-image-approvers
+reviewers:
+  - build-image-reviewers
+
+labels:
+  - sig/release
+  - area/release-eng

--- a/k8s.gcr.io/manifests/k8s-staging-build-image/OWNERS
+++ b/k8s.gcr.io/manifests/k8s-staging-build-image/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - build-image-approvers
+reviewers:
+  - build-image-reviewers
+
+labels:
+  - sig/release
+  - area/release-eng


### PR DESCRIPTION
One of the follow-up items in our [quarterly golang update](https://github.com/kubernetes/release/issues/1134) is to transition ownership of Golang bumps to the @kubernetes/release-engineering group. Part of the Golang bump is updating the `kube-cross` image, which today can only be done by a few Googlers (@BenTheElder, @javier-b-perez, @listx).

This PR grants access to push & promote images in the `k8s-staging-build-image` GCP project (where the `kube-cross` image will live) to the following contributors:
- @BenTheElder
- @cblecker
- @dims
- @justaugustus
- @listx

Once we've defined policies for handling these images, we'll expand the scope of this group to include the @kubernetes/release-managers.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

ref: https://github.com/kubernetes/release/issues/1133, https://github.com/kubernetes/kubernetes/pull/88562