### PR TITLE
cni: Drop piotr.skarmuk from CNI artifacts push group

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -302,7 +302,6 @@ groups:
       - idealhack@gmail.com
       - matt@tigera.io
       - mcambria@redhat.com
-      - piotr.skarmuk@gmail.com
       - saschagrunert@gmail.com
       - stephen.k8s@agst.us
       - thockin@google.com


### PR DESCRIPTION
Email address is invalid.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @cblecker @dims 