### PR TITLE
kube-cross: Backfill promotion of active k8s.gcr.io/kube-cross images

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
@@ -1,0 +1,4 @@
+- name: kube-cross
+  dmap:
+    "sha256:97e77164ddc1f9ab56bcbab3e2895b882097b1eabd820497e894f41c0e4908fe": ["v1.12.12-1"]
+    "sha256:df0a50772214025040ea31144a731b5fa76944cbfc9c87db05af98e4aa39aa7f": ["v1.13.6-1"]


### PR DESCRIPTION
We've manually pulled the k8s.gcr.io/kube-cross images for active
release branches (v1.13.6-1, v1.12.12-1) and pushed them to K8s Infra.

This PR promotes the images now in staging over to prod.

Needed for https://github.com/kubernetes/kubernetes/pull/88562, https://github.com/kubernetes/release/issues/1133.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @cblecker @BenTheElder @dims 
cc: @kubernetes/release-engineering 