### PR TITLE
Add owners file under groups

### DIFF
--- a/groups/OWNERS
+++ b/groups/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+options:
+  no_parent_owners: true
+approvers:
+  - cblecker
+  - dims
+  - thockin
+
+labels:
+  - wg/k8s-infra


### PR DESCRIPTION
Add owner files under kubernetes/k8s.io/groups.
The guys in the file will more focus on dealing `G Suite`  stuff.
Get the context at https://github.com/kubernetes/test-infra/pull/16515 