### PR TITLE
releng: Add new projects for staging/releasing Kubernetes

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,3 +11,21 @@ aliases:
     - dims
     - justaugustus
     - listx
+  release-engineering-approvers:
+    - calebamiles # subproject owner
+    - dougm # Patch Release Team
+    - feiskyer # Patch Release Team
+    - hoegaarden # Patch Release Team
+    - idealhack # Patch Release Team
+    - justaugustus # subproject owner / Patch Release Team
+    - tpepper # subproject owner / Patch Release Team
+  release-engineering-reviewers:
+    - calebamiles # subproject owner
+    - cpanato # Branch Manager
+    - dougm # Patch Release Team
+    - feiskyer # Patch Release Team
+    - hoegaarden # Patch Release Team
+    - idealhack # Patch Release Team
+    - justaugustus # subproject owner / Patch Release Team
+    - saschagrunert # Branch Manager
+    - tpepper # subproject owner / Patch Release Team

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -733,6 +733,18 @@ groups:
       - fabrizio.pandini@gmail.com
       - neolit123@gmail.com
 
+  - email-id: k8s-infra-staging-kubernetes@kubernetes.io
+    name: k8s-infra-staging-kubernetes
+    description: |-
+      ACL for staging Kubernetes
+
+      This project is used to stage official Kubernetes release artifacts.
+    settings:
+      ReconcileMembers: "true"
+    members:
+      # TODO(justaugustus): Add editors group after k8s.gcr.io domain flip
+      - k8s-infra-release-admins@kubernetes.io
+
   - email-id: k8s-infra-staging-kube-state-metrics@kubernetes.io
     name: k8s-infra-staging-kube-state-metrics
     description: |-
@@ -814,13 +826,24 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
-      - caselim@gmail.com
+      - k8s-infra-release-admins@kubernetes.io
+      - k8s-infra-release-editors@kubernetes.io
       - davanum@gmail.com
       - ihor@cncf.io
       - spiffxp@google.com
-      - stephen.k8s@agst.us
       - thockin@google.com
-      - tpepper@gmail.com
+
+  - email-id: k8s-infra-staging-releng@kubernetes.io
+    name: k8s-infra-staging-releng
+    description: |-
+      ACL for staging RelEng
+
+      This project is used to test and stage Release Engineering tooling.
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - k8s-infra-release-admins@kubernetes.io
+      - k8s-infra-release-editors@kubernetes.io
 
   - email-id: k8s-infra-staging-scl-image-builder@kubernetes.io
     name: k8s-infra-staging-scl-image-builder

--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -190,8 +190,12 @@ empower_service_account_for_cip_auditor_e2e_tester \
     $(svc_acct_email "${GCR_AUDIT_TEST_PROD_PROJECT}" "${PROMOTER_SVCACCT}") \
     "${GCR_AUDIT_TEST_PROD_PROJECT}"
 
-# Special case: grant the release tools testing group access to their fake
+# Special case: grant the Release Managers group access to their fake
 # prod project.
+empower_group_to_fake_prod \
+    "${RELEASE_TESTPROD_PROJECT}" \
+    "k8s-infra-staging-kubernetes@kubernetes.io"
+
 empower_group_to_fake_prod \
     "${RELEASE_TESTPROD_PROJECT}" \
     "k8s-infra-staging-release-test@kubernetes.io"

--- a/infra/gcp/ensure-releng.sh
+++ b/infra/gcp/ensure-releng.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used to ensure Release Engineering subproject owners have the
+# appropriate access to SIG Release prod GCP projects.
+#
+# Projects:
+# - k8s-releng-prod - Stores KMS objects which other release projects will
+#                       be granted permission to decrypt e.g., GITHUB_TOKEN
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+. "${SCRIPT_DIR}/lib.sh"
+
+function usage() {
+    echo "usage: $0 [project...]" > /dev/stderr
+    echo "example:" > /dev/stderr
+    echo "  $0 # do all release projects" > /dev/stderr
+    echo "  $0 k8s-releng-prod # just do one" > /dev/stderr
+    echo > /dev/stderr
+}
+
+# NB: Please keep this sorted.
+PROJECTS=(
+    k8s-releng-prod
+)
+
+if [ $# = 0 ]; then
+    # default to all release projects
+    set -- "${PROJECTS[@]}"
+fi
+
+for PROJECT; do
+    color 3 "Configuring: ${PROJECT}"
+
+    # Make the project, if needed
+    color 6 "Ensuring project exists: ${PROJECT}"
+    ensure_project "${PROJECT}"
+
+    # Enable admins to use the UI
+    color 6 "Empowering ${RELEASE_ADMINS} as project viewers"
+    empower_group_as_viewer "${PROJECT}" "${RELEASE_ADMINS}"
+
+    # Enable KMS APIs
+    color 6 "Enabling the KMS API"
+    enable_api "${PROJECT}" cloudkms.googleapis.com
+
+    # Let project admins use KMS.
+    color 6 "Empowering ${RELEASE_ADMINS} as KMS admins"
+    empower_group_for_kms "${PROJECT}" "${RELEASE_ADMINS}"
+
+    color 6 "Done"
+done

--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -57,6 +57,14 @@ PROW_SVCACCT="deployer@k8s-prow.iam.gserviceaccount.com"
 GCP_ORG="758905017065" # kubernetes.io
 GCP_BILLING="018801-93540E-22A20E"
 
+# Release Engineering umbrella groups
+# - admins - edit and KMS access (Release Engineering subproject owners)
+# - managers - access to run stage/release jobs (Patch Release Team / Branch Managers)
+# - viewers - view access to Release Engineering projects (Release Manager Associates)
+RELEASE_ADMINS="k8s-infra-release-admins@kubernetes.io"
+RELEASE_MANAGERS="k8s-infra-release-editors@kubernetes.io"
+RELEASE_VIEWERS="k8s-infra-release-viewers@kubernetes.io"
+
 # Get the GCS bucket name that backs a GCR repo.
 # $1: The GCR repo (same as the GCP project name)
 # $2: The GCR region (optional)

--- a/k8s.gcr.io/images/k8s-staging-kubernetes/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-kubernetes/OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+options:
+  no_parent_owners: true
+approvers:
+  - release-engineering-approvers
+  - cblecker
+  - dims
+  - listx
+  - thockin
+reviewers:
+  - release-engineering-reviewers
+
+labels:
+  - sig/release
+  - area/release-eng

--- a/k8s.gcr.io/images/k8s-staging-kubernetes/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-kubernetes/images.yaml
@@ -1,0 +1,12 @@
+### ATTENTION ###
+# k8s-staging-kubernetes is the staging container registry for ROOT level k8s.gcr.io images.
+# Image promotion for this project is restricted to Release Managers.
+#
+# The following images are managed within this project:
+# - cloud-controller-manager
+# - conformance (will likely be moved to another staging project)
+# - hyperkube (to be deprecated in a future release)
+# - kube-apiserver
+# - kube-controller-manager
+# - kube-proxy
+# - kube-scheduler

--- a/k8s.gcr.io/images/k8s-staging-releng/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-releng/OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+options:
+  no_parent_owners: true
+approvers:
+  - release-engineering-approvers
+  - cblecker
+  - dims
+  - listx
+  - thockin
+reviewers:
+  - release-engineering-reviewers
+
+labels:
+  - sig/release
+  - area/release-eng

--- a/k8s.gcr.io/manifests/k8s-staging-kubernetes/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-kubernetes/promoter-manifest.yaml
@@ -1,0 +1,23 @@
+### ATTENTION ###
+# k8s-staging-kubernetes is the staging container registry for ROOT level k8s.gcr.io images.
+# Image promotion for this project is restricted to Release Managers.
+#
+# The following images are managed within this project:
+# - cloud-controller-manager
+# - conformance (will likely be moved to another staging project)
+# - hyperkube (to be deprecated in a future release)
+# - kube-apiserver
+# - kube-controller-manager
+# - kube-proxy
+# - kube-scheduler
+#
+# google group for gcr.io/k8s-staging-kubernetes is k8s-infra-staging-kubernetes@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-kubernetes
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/k8s.gcr.io/manifests/k8s-staging-releng/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-releng/promoter-manifest.yaml
@@ -1,0 +1,10 @@
+# google group for gcr.io/k8s-staging-releng is k8s-infra-staging-releng@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-releng
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/releng
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/releng
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/releng
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
As part of the [vanity image domain flip](https://github.com/kubernetes/k8s.io/blob/master/k8s.gcr.io/Vanity-Domain-Flip.md), @kubernetes/release-engineering / @kubernetes/release-managers will need a new project to stage artifacts to.

Namely, the images referenced in [k/release/release-engineering/artifacts.md](https://github.com/kubernetes/sig-release/blob/master/release-engineering/artifacts.md):
- cloud-controller-manager
- conformance (will likely be moved to another staging project)
- hyperkube (will likely be removed in a future release)
- kube-apiserver
- kube-controller-manager
- kube-proxy
- kube-scheduler

While we're sorting out exactly how we'd like that to work, I'd like to keep access scoped to only the @kubernetes/sig-release-admins, opening that up once the new flow is documented.

~Here we add a new script, `ensure-release-prod-projects.sh`, which is a copy of `ensure-release-projects.sh` with the writer and viewer groups removed.~

Here we add three new projects:

- `k8s-staging-kubernetes`
- `k8s-staging-releng`
- `k8s-releng-prod`

`k8s-staging-kubernetes` will be the official project for staging and releasing Kubernetes.

`k8s-staging-releng` will be used to stage Release Engineering images.

`k8s-releng-prod` will be a limited-scope near-prod project for Release Admins (Stephen, Tim, Caleb), which will contain KMS keys to be leveraged during staging and release.

We add `ensure-releng.sh`, which configures the new k8s-releng-prod
GCP project now and grants KMS admin access to k8s-infra-release-admins.

Staging release project settings have been replicated in the `ensure-staging-storage.sh` script.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @thockin @listx 
cc: @tpepper 
ref: https://github.com/kubernetes/release/issues/911, https://github.com/kubernetes/k8s.io/pull/623, https://github.com/kubernetes/release/issues/270