### PR TITLE
Add cluster-api-provider-vsphere to image promoter

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -573,6 +573,20 @@ groups:
       - hi@amycod.es
       - prignanov@vmware.com
 
+  - email-id: k8s-infra-staging-capi-vsphere@kubernetes.io
+    name: k8s-infra-staging-capi-vsphere
+    description: |-
+      ACL for staging CAPI for vSphere
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - davanum@gmail.com
+      - detiber@gmail.com
+      - goldsteina@vmware.com
+      - prignanov@vmware.com
+      - jeewan@vmware.com
+      - ytijani@vmware.com
+
   - email-id: k8s-infra-staging-cluster-api-azure@kubernetes.io
     name: k8s-infra-staging-cluster-api-azure
     description: |-

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -47,6 +47,7 @@ STAGING_PROJECTS=(
     cluster-api-aws
     cluster-api-azure
     cluster-api-gcp
+    cluster-api-vsphere
     capi-openstack
     capi-kubeadm
     capi-docker

--- a/k8s.gcr.io/images/k8s-staging-capi-vsphere/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-capi-vsphere/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- randomvariable
+- yastij
+- detiber
+- ncdc
+- vincepri

--- a/k8s.gcr.io/images/k8s-staging-capi-vsphere/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-capi-vsphere/images.yaml
@@ -1,0 +1,2 @@
+#- name: cluster-api-vsphere-controller
+#  dmap: {}

--- a/k8s.gcr.io/manifests/k8s-staging-capi-vsphere/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-capi-vsphere/promoter-manifest.yaml
@@ -1,0 +1,11 @@
+# google group for gcr.io/k8s-staging-cluster-api-vsphere is k8s-infra-staging-cluster-api-vsphere@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-capi-vsphere
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/capi-vsphere
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/capi-vsphere
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/capi-vsphere
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+imagesPath: "../../images/k8s-staging-capi-vsphere/images.yaml"


### PR DESCRIPTION
Adding https://github.com/kubernetes-sigs/cluster-api-provider-vsphere to image promotion, as per https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/795

/assign @dims 
cc @yastij 