### PR TITLE
Update apiVersion on all cert-manager resources

### DIFF
--- a/cert-manager/letsencrypt-prod.yaml
+++ b/cert-manager/letsencrypt-prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-prod

--- a/cert-manager/letsencrypt-staging.yaml
+++ b/cert-manager/letsencrypt-staging.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-staging

--- a/cert-manager/selfsigning-clusterissuer.yaml
+++ b/cert-manager/selfsigning-clusterissuer.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
 metadata:
   name: selfsigning-issuer

--- a/gcsweb.k8s.io/certificate.yaml
+++ b/gcsweb.k8s.io/certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: gcsweb-k8s-io

--- a/k8s.io/certificate-canary.yaml
+++ b/k8s.io/certificate-canary.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: k8s-io-selfsigned

--- a/k8s.io/certificate-prod.yaml
+++ b/k8s.io/certificate-prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: certmanager.k8s.io/v1alpha1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: k8s-io-letsencrypt-prod


### PR DESCRIPTION
Following on from #586, the apiVersion for all cert-manager resources needs updating.

I have applied this change, along with #586, to AAA already (as v1alpha1 does not exist since I have upgraded to v0.13.1, meaning these manifests cannot otherwise be applied).

```
kubectl get clusterissuer,certificate --all-namespaces
NAME                                                READY   AGE
clusterissuer.cert-manager.io/letsencrypt-prod      True    3m
clusterissuer.cert-manager.io/letsencrypt-staging   True    3m
clusterissuer.cert-manager.io/selfsigning-issuer    True    3m
NAMESPACE       NAME                                                  READY   SECRET              AGE
gcsweb          certificate.cert-manager.io/gcsweb-k8s-io             True    gcsweb-k8s-io-tls   2m
k8s-io-canary   certificate.cert-manager.io/k8s-io-selfsigned         True    k8s-io-tls          1m
k8s-io-prod     certificate.cert-manager.io/k8s-io-letsencrypt-prod   True    k8s-io-tls          1m
```

🎉 

/assign @bartsmykla @dims 