### PR TITLE
k8s.gcr.io: Fix name of bucket for capi-vsphere

### DIFF
--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -47,10 +47,10 @@ STAGING_PROJECTS=(
     cluster-api-aws
     cluster-api-azure
     cluster-api-gcp
-    cluster-api-vsphere
     capi-openstack
     capi-kubeadm
     capi-docker
+    capi-vsphere
     coredns
     csi
     descheduler

--- a/k8s.gcr.io/manifests/k8s-staging-capi-vsphere/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-capi-vsphere/promoter-manifest.yaml
@@ -1,4 +1,4 @@
-# google group for gcr.io/k8s-staging-cluster-api-vsphere is k8s-infra-staging-cluster-api-vsphere@kubernetes.io
+# google group for gcr.io/k8s-staging-capi-vsphere is k8s-infra-staging-capi-vsphere@kubernetes.io
 registries:
 - name: gcr.io/k8s-staging-capi-vsphere
   src: true


### PR DESCRIPTION
Fix for correct staging bucket name from #628 