### PR TITLE
releng: Enable KMS API for all release staging projects and GCS write to test prod

### DIFF
--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -76,6 +76,7 @@ GCR_AUDIT_TEST_PROD_PROJECT="k8s-gcr-audit-test-prod"
 
 # This is for testing the release tools.
 RELEASE_TESTPROD_PROJECT="k8s-release-test-prod"
+RELEASE_STAGING_CLOUDBUILD_ACCOUNT="615281671549@cloudbuild.gserviceaccount.com"
 
 ALL_PROD_PROJECTS=(
     "${PROD_PROJECT}"
@@ -199,6 +200,13 @@ empower_group_to_fake_prod \
 empower_group_to_fake_prod \
     "${RELEASE_TESTPROD_PROJECT}" \
     "k8s-infra-staging-release-test@kubernetes.io"
+
+# Special case: grant the k8s-staging-kubernetes Cloud Build account access to
+# write to the primary test prod GCS bucket. This currently is a requirement
+# for anago.
+empower_svcacct_to_write_gcs_bucket \
+    "${RELEASE_STAGING_CLOUDBUILD_ACCOUNT}" \
+    "${RELEASE_TESTPROD_PROJECT}"
 
 # Special case: don't use retention on cip-test buckets
 gsutil retention clear gs://k8s-cip-test-prod

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -157,6 +157,10 @@ for REPO; do
       empower_group_to_write_gcs_bucket "${WRITERS}" "${BUCKET}"
     done
 
+    # Enable KMS APIs
+    color 6 "Enabling the KMS API"
+    enable_api "${PROJECT}" cloudkms.googleapis.com
+
     # Enable GCB and Prow to build and push images.
 
     # Enable GCB APIs
@@ -192,10 +196,6 @@ for repo in "${RELEASE_STAGING_PROJECTS[@]}"; do
     #                     k8s-staging-release-test GCP project have been
     #                     transferred over.
     if [[ $PROJECT == "k8s-staging-release-test" ]]; then
-        # Enable KMS APIs
-        color 6 "Enabling the KMS API"
-        enable_api "${PROJECT}" cloudkms.googleapis.com
-
         # Let Release Admins administer KMS.
         color 6 "Empowering ${RELEASE_ADMINS} as KMS admins"
         empower_group_for_kms "${PROJECT}" "${RELEASE_ADMINS}"


### PR DESCRIPTION
(Follow-up to https://github.com/kubernetes/k8s.io/pull/624)

- Enable KMS API for all staging projects

  Even though staging projects may not contain their own keys, their
  service accounts could still require the KMS API to be enabled to
  allow decryption using the keys on other GCP projects.

  One such case is the staging release projects requiring access to
  decrypt keys on the `k8s-releng-prod` GCP project.

  (This was originally special-cased for just releng projects, but expanded to 
  every staging project on @thockin's [suggestion in Slack](https://kubernetes.slack.com/archives/CCK68P2Q2/p1583771092152500).)

- Grant `k8s-staging-kubernetes` GCB account GCS write to test prod
  
  gcbmgr+anago kick off a Cloud Build job on the staging project and then
  writes staging assets to the production GCS bucket
  (currently `gs://kubernetes-release`).

  To mirror this behavior in testing, the `k8s-staging-kubernetes` Cloud
  Build service account must have access to the primary GCS bucket on test
  prod (`k8s-release-test-prod`).

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/hold
ref: https://github.com/kubernetes/release/pull/957#issuecomment-596020336, https://github.com/kubernetes/release/pull/1163