### PR TITLE
re-add some deleted image references

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cluster-api-aws/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api-aws/images.yaml
@@ -1,3 +1,18 @@
+- name: cluster-api-aws-controller-amd64
+  dmap:
+    "sha256:0bd88bcba94f800715fca33ffc4bde430646a7c797237313cbccdcdef9f80f2d": ["v0.4.0"]
+- name: cluster-api-aws-controller-arm
+  dmap:
+    "sha256:19016ec3ce30985a128494909993aef9109a5bdd749874e9b3be20bd65056fee": ["v0.4.0"]
+- name: cluster-api-aws-controller-arm64
+  dmap:
+    "sha256:5c434128d7e28d96d25f11a096e6b9d666d52c5bb683662ba708d22792a0f154": ["v0.4.0"]
+- name: cluster-api-aws-controller-ppc64le
+  dmap:
+    "sha256:e0af472014f7639b6362e1649717a63e621faf91a5be1ed89f1055689111214c": ["v0.4.0"]
+- name: cluster-api-aws-controller-s390x
+  dmap:
+    "sha256:0ad4f92011b2fa5de88a6e6a2d8b97f38371246021c974760e5fc54b9b7069e5": ["v0.4.0"]
 - name: cluster-api-aws-controller
   dmap:
     "sha256:7397e3ef7dfa72b102197eaa6bd20ca8b572ccbc31a30f3d262188376e95836a": ["v0.3.6"]

--- a/k8s.gcr.io/images/k8s-staging-cluster-api-kubeadm/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api-kubeadm/images.yaml
@@ -1,3 +1,18 @@
+- name: cluster-api-kubeadm-controller-amd64
+  dmap:
+    "sha256:51e5a17ac02cf8f2f9ce0bd0892da6fc52fa15d0a9d4ffd6a623d0e20d2eaacb": ["v0.1.0"]
+- name: cluster-api-kubeadm-controller-arm
+  dmap:
+    "sha256:3f53bf8a424f1d70ee58c1b94930ce892c9bad7874cd1a2d8ab4598a60545005": ["v0.1.0"]
+- name: cluster-api-kubeadm-controller-arm64
+  dmap:
+    "sha256:b3745c214ea8ca87339b58e898bcaaedeffc05015d22c5febdf50017a96626e8": ["v0.1.0"]
+- name: cluster-api-kubeadm-controller-ppc64le
+  dmap:
+    "sha256:801beba208ba51f1b8c5be64bb6c5c99e87449eef3544d4e082ac4e2044a148e": ["v0.1.0"]
+- name: cluster-api-kubeadm-controller-s390x
+  dmap:
+    "sha256:90d53f71722e6b3a1410747c261fc9a23fc6c4a5d02f67852cdec602dc43ced0": ["v0.1.0"]
 - name: cluster-api-kubeadm-controller
   dmap:
     "sha256:c3ee2e114b6bf81d0cf0686bc80ba3281d70782ffd56b2ae8ef281aec319530b": ["v0.1.0"]

--- a/k8s.gcr.io/images/k8s-staging-cluster-api/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api/images.yaml
@@ -1,3 +1,18 @@
+- name: cluster-api-controller-amd64
+  dmap:
+    "sha256:ea0e994082f56bf7713d36002abfbffbad43b2c257b89842b3e3694c987d3a07": ["v0.2.0"]
+- name: cluster-api-controller-arm
+  dmap:
+    "sha256:ddac971ea0e62e0bc969263c57d10bcdaace99918ff5b304b0531ad115459a1f": ["v0.2.0"]
+- name: cluster-api-controller-arm64
+  dmap:
+    "sha256:86e2ae014190d8ab6f511ba8ed9c60658e906f4a2e6eab7adbb65debd91f51b7": ["v0.2.0"]
+- name: cluster-api-controller-ppc64le
+  dmap:
+    "sha256:d7ec2c3a3c353e5dccff16e5ca9253415d3e3b5398a7beb3f95bf54f1e270fb8": ["v0.2.0"]
+- name: cluster-api-controller-s390x
+  dmap:
+    "sha256:47e89f01c17f66513adddac0b48e035ab937469f3b93df7ab704d725d1e611c1": ["v0.2.0"]
 - name: cluster-api-controller
   dmap:
     "sha256:9057a2875d6620521ddea456f31655b8480f07f6a31a50c15b111c1ae09af487": ["v0.1.5", "v0.1.6"]

--- a/k8s.gcr.io/images/k8s-staging-external-dns/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-external-dns/images.yaml
@@ -1,3 +1,4 @@
 - name: external-dns
   dmap:
+    "sha256:403b9b0a8a7428c0d3fe57fe0aebf7ac8a69467d2660c2384a7463c574f3dbb2": ["v0.5.18"]
     "sha256:5f50d2660a41ed48bf263a85b92822d6c95a7973425f9e07f3535314ad05a168": ["v0.6.0"]


### PR DESCRIPTION
This effectively reverts the following commits:

    7958a485433a2cf54f1b618b0d041f8708ca8a29
    fcc4b7af0ac9f683dc36690196c51687d928d693
    ca4467dd0e9f16e2950980ac6b5a9248aa9b31e6
    ba005de40c78faf32cd7a65fd8d588b902d51483

This is to make the promoter manifests more accurate, to account for
what has already been promoted into production (otherwise, when auditing
the production GCR contents, one is forced to dig into the commit
history).

Deletions of items in the promoter manifests shouldn't normally be
allowed because they make the manifests ignore the reality of the images
actually still existing in production.