### PR TITLE
capz: Remove soggiest from OWNERS

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cluster-api-azure/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api-azure/OWNERS
@@ -5,7 +5,6 @@ approvers:
 - awesomenix
 - CecileRobertMichon
 - justaugustus
-- soggiest
 reviewers:
 - juan-lee
 - nader-ziada


### PR DESCRIPTION
Wrapping up @soggiest's offboarding from capz.
ref: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/387

Signed-off-by: Stephen Augustus <saugustus@vmware.com>