### PR TITLE
releng: Use a temp namespace for k8s-staging-kubernetes promotion

### DIFF
--- a/k8s.gcr.io/manifests/k8s-staging-kubernetes/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-kubernetes/promoter-manifest.yaml
@@ -15,9 +15,11 @@
 registries:
 - name: gcr.io/k8s-staging-kubernetes
   src: true
-- name: us.gcr.io/k8s-artifacts-prod
+# TODO(justaugustus): Change these values to {us,eu,asia}.gcr.io/k8s-artifacts-prod (ROOT level)
+#                     after releng image promotion testing is complete AND BEFORE the vanity domain flip.
+- name: us.gcr.io/k8s-artifacts-prod/releng-vdf-temp-prod
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod
+- name: eu.gcr.io/k8s-artifacts-prod/releng-vdf-temp-prod
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod
+- name: asia.gcr.io/k8s-artifacts-prod/releng-vdf-temp-prod
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
As the [k8s.gcr.io VDF (Vanity Domain Flip)](https://github.com/kubernetes/release/issues/270) hasn't occurred yet, Release Managers should use a temporary namespace (`releng-vdf-temp-prod`) to test image promotion for production official k8s.gcr.io container images.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

@listx -- This shouldn't cause any issues, right?

/assign @thockin @dims @cblecker 
cc: @tpepper @kubernetes/release-engineering 
ref: https://github.com/kubernetes/release/issues/911