### PR TITLE
releng: Temporarily grant hasheddan access to cut v1.18.0-beta.2

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -391,6 +391,7 @@ groups:
       - feiskyer@gmail.com
       - ctadeu@gmail.com
       - dmaceachern@vmware.com
+      - georgedanielmangum@gmail.com
       - hhorl@pivotal.io
       - idealhack@gmail.com
       - saschagrunert@gmail.com


### PR DESCRIPTION
- Temporarily grant [hasheddan](https://github.com/hasheddan) access to cut v1.18.0-beta.2 (ref: https://github.com/kubernetes/sig-release/issues/1006)

/hold

/assign @dims @cblecker
cc: @justaugustus @saschagrunert  @hasheddan @kubernetes/release-engineering