### PR TITLE
releng: revoke temporary access for hasheddan

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -414,7 +414,6 @@ groups:
       - ctadeu@gmail.com
       - dmaceachern@vmware.com
       - feiskyer@gmail.com
-      - georgedanielmangum@gmail.com
       - hhorl@pivotal.io
       - idealhack@gmail.com
       - jameswangel@gmail.com


### PR DESCRIPTION
Revoke temporary access to [hasheddan](https://github.com/hasheddan) granted here: https://github.com/kubernetes/k8s.io/pull/646

/hold until xref: https://github.com/kubernetes/sig-release/issues/1006 is completed or 1.18.0-beta.2 is released.


/assign @dims @cblecker
cc: @justaugustus @saschagrunert  @hasheddan @kubernetes/release-engineering
