### PR TITLE
empower KSA used in the promoter's prow jobs to use Workload Identity

### DIFF
--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -221,8 +221,10 @@ empower_artifact_auditor "${PROD_PROJECT}"
 empower_artifact_auditor_invoker "${PROD_PROJECT}"
 
 # Special case: empower Prow account to have access to GCR for Workload Identity.
-empower_prowacct_for_workload_identity \
-    "k8s-prow-builds.svc.id.googtest-pods/k8s-artifacts-prod" \
+empower_ksa_to_svcacct \
+    "k8s-prow-builds" \
+    "test-pods" \
+    "${PROD_PROJECT}" \
     $(svc_acct_email "${PROD_PROJECT}" "${PROMOTER_SVCACCT}")
 
 color 6 "Done"

--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -223,8 +223,7 @@ empower_artifact_auditor_invoker "${PROD_PROJECT}"
 # Special case: empower Kubernetes service account to authenticate as a GCP
 # service account.
 empower_ksa_to_svcacct \
-    "k8s-prow-builds" \
-    "test-pods" \
+    "k8s-prow-builds.svc.id.goog[test-pods/k8s-artifacts-prod]" \
     "${PROD_PROJECT}" \
     $(svc_acct_email "${PROD_PROJECT}" "${PROMOTER_SVCACCT}")
 

--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -220,7 +220,8 @@ empower_group_to_admin_artifact_auditor \
 empower_artifact_auditor "${PROD_PROJECT}"
 empower_artifact_auditor_invoker "${PROD_PROJECT}"
 
-# Special case: empower Prow account to have access to GCR for Workload Identity.
+# Special case: empower Kubernetes service account to authenticate as a GCP
+# service account.
 empower_ksa_to_svcacct \
     "k8s-prow-builds" \
     "test-pods" \

--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -220,4 +220,9 @@ empower_group_to_admin_artifact_auditor \
 empower_artifact_auditor "${PROD_PROJECT}"
 empower_artifact_auditor_invoker "${PROD_PROJECT}"
 
+# Special case: empower Prow account to have access to GCR for Workload Identity.
+empower_prowacct_for_workload_identity \
+    "k8s-prow-builds.svc.id.googtest-pods/k8s-artifacts-prod" \
+    $(svc_acct_email "${PROD_PROJECT}" "${PROMOTER_SVCACCT}")
+
 color 6 "Done"

--- a/infra/gcp/lib_gcr.sh
+++ b/infra/gcp/lib_gcr.sh
@@ -149,3 +149,22 @@ function empower_svcacct_to_admin_gcr () {
 
     empower_svcacct_to_admin_gcs_bucket "${group}" "${bucket}"
 }
+
+# Grant the Prow service account access to the same perms as the given GCP
+# service account (for Workload Identity).
+# $1: The Prow service account being empowered
+# $2: The GCP service account to draw powers from
+function empower_prowacct_for_workload_identity() {
+    if [ ! $# -eq 2 -o -z "$1" -o -z "$2" ]; then
+        echo "empower_prowacct_for_workload_identity(prow_acct, gcp_acct) requires 2 arguments" >&2
+        return 1
+    fi
+
+    prow_acct="$1"
+    gcp_acct="$2"
+
+    gcloud iam service-accounts add-iam-policy-binding \
+        --role roles/iam.workloadIdentityUser \
+        --member "serviceAccount:${prow_acct}" \
+        "${gcp_acct}"
+}

--- a/infra/gcp/lib_gcr.sh
+++ b/infra/gcp/lib_gcr.sh
@@ -149,22 +149,3 @@ function empower_svcacct_to_admin_gcr () {
 
     empower_svcacct_to_admin_gcs_bucket "${group}" "${bucket}"
 }
-
-# Grant the Prow service account access to the same perms as the given GCP
-# service account (for Workload Identity).
-# $1: The Prow service account being empowered
-# $2: The GCP service account to draw powers from
-function empower_prowacct_for_workload_identity() {
-    if [ ! $# -eq 2 -o -z "$1" -o -z "$2" ]; then
-        echo "empower_prowacct_for_workload_identity(prow_acct, gcp_acct) requires 2 arguments" >&2
-        return 1
-    fi
-
-    prow_acct="$1"
-    gcp_acct="$2"
-
-    gcloud iam service-accounts add-iam-policy-binding \
-        --role roles/iam.workloadIdentityUser \
-        --member "serviceAccount:${prow_acct}" \
-        "${gcp_acct}"
-}


### PR DESCRIPTION
This gives the "k8s-prow-builds.svc.id.goog[test-pods/k8s-artifacts-prod]"
service account powers to act as the
"k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com" for
purposes of Workload Identity. This way, the Prow jobs for the promoter (which live in the `k8s-prow-builds` GKE project, and run in the `test-pods` namespace with the `k8s-artifacts-prod` KSA)
won't have to have service account keys injected into them.

/cc @thockin @fejta 

More context: https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/180#issuecomment-597334257