### PR TITLE
Add cluster-api-provider-digitalocean to image promoter

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -571,6 +571,15 @@ groups:
       - ha.chuck@gmail.com
       - hi@amycod.es
       - prignanov@vmware.com
+  
+  - email-id: k8s-infra-staging-cluster-api-do@kubernetes.io
+    name: k8s-infra-staging-cluster-api-do
+    description: |-
+      ACL for staging CAPI for DigitalOcean
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - mudrinic.mare@gmail.com
 
   - email-id: k8s-infra-staging-capi-vsphere@kubernetes.io
     name: k8s-infra-staging-capi-vsphere

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -579,6 +579,7 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
+      - detiber@gmail.com
       - mudrinic.mare@gmail.com
 
   - email-id: k8s-infra-staging-capi-vsphere@kubernetes.io

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -46,6 +46,7 @@ STAGING_PROJECTS=(
     cluster-api
     cluster-api-aws
     cluster-api-azure
+    cluster-api-do
     cluster-api-gcp
     capi-openstack
     capi-kubeadm

--- a/k8s.gcr.io/images/k8s-staging-cluster-api-do/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api-do/OWNERS
@@ -1,4 +1,5 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+- detiber
 - xmudrii

--- a/k8s.gcr.io/images/k8s-staging-cluster-api-do/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api-do/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- xmudrii

--- a/k8s.gcr.io/images/k8s-staging-cluster-api-do/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api-do/images.yaml
@@ -1,0 +1,2 @@
+#- name: cluster-api-do-controller
+#  dmap: {}

--- a/k8s.gcr.io/manifests/k8s-staging-cluster-api-do/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-cluster-api-do/promoter-manifest.yaml
@@ -1,0 +1,11 @@
+# google group for gcr.io/k8s-staging-cluster-api-do is k8s-infra-staging-cluster-api-do@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-cluster-api-do
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/cluster-api-do
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/cluster-api-do
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/cluster-api-do
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+imagesPath: "../../images/k8s-staging-cluster-api-do/images.yaml"


### PR DESCRIPTION
Add a staging GCR bucket for [cluster-api-provider-digitalocean](https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean).