### PR TITLE
Changed possition of arguemnts for echo function

### DIFF
--- a/infra/gcp/namespaces/ensure-namespaces.sh
+++ b/infra/gcp/namespaces/ensure-namespaces.sh
@@ -62,7 +62,7 @@ function parse_args() {
 
   if [[ -z "${KUBECTL:-}" ]]; then
     if ! [ -x "$(command -v kubectl)" ]; then
-      echo >&2 "kubectl not found in \$PATH and --kubectl-path flag is not set. Aborting.";
+      echo "kubectl not found in \$PATH and --kubectl-path flag is not set. Aborting." >&2;
       exit 1;
     else
       KUBECTL="kubectl"


### PR DESCRIPTION
My IDE was complaining a lot about the position of arguments
for `echo >&2 ...` so I'm changing it. The command will work
exactly the same but I think it's more consistent with other
code to have redirections at the end of the command.

Signed-off-by: Bart Smykla <bsmykla@vmware.com>