### PR TITLE
Removed etag property from audit iam files

### DIFF
--- a/audit/audit-gcp.sh
+++ b/audit/audit-gcp.sh
@@ -21,11 +21,13 @@ gcloud \
     gcloud iam roles describe "${ROLE}" \
         --organization="${CNCF_GCP_ORG}" \
         --format=json \
+        | jq 'del(.etag)' \
         > "org_kubernetes.io/roles/${ROLE}.json"
 done
 gcloud \
     organizations get-iam-policy "${CNCF_GCP_ORG}" \
     --format=json \
+    | jq 'del(.etag)' \
     > "org_kubernetes.io/iam.json"
 
 echo "## Iterating over Projects"
@@ -48,6 +50,7 @@ gcloud \
     gcloud \
         projects get-iam-policy "${PROJECT}" \
         --format=json \
+        | jq 'del(.etag)' \
         > "projects/${PROJECT}/iam.json"
 
     echo "#### ${PROJECT} ServiceAccounts"
@@ -61,11 +64,13 @@ gcloud \
             iam service-accounts describe "${SVCACCT}" \
             --project="${PROJECT}" \
             --format=json \
+            | jq 'del(.etag)' \
             > "projects/${PROJECT}/service-accounts/${SVCACCT}/description.json"
         gcloud \
             iam service-accounts get-iam-policy "${SVCACCT}" \
             --project="${PROJECT}" \
             --format=json \
+            | jq 'del(.etag)' \
             > "projects/${PROJECT}/service-accounts/${SVCACCT}/iam.json"
     done
 
@@ -81,6 +86,7 @@ gcloud \
             iam roles describe "${ROLE}" \
             --project="${PROJECT}" \
             --format=json \
+            | jq 'del(.etag)' \
             > "projects/${PROJECT}/roles/${ROLE}.json"
     done
 
@@ -168,6 +174,7 @@ gcloud \
                     gsutil logging get "gs://${BUCKET}/" \
                         > "projects/${PROJECT}/buckets/${BUCKET}/logging.txt"
                     gsutil iam get "gs://${BUCKET}/" \
+                        | jq 'del(.etag)' \
                         > "projects/${PROJECT}/buckets/${BUCKET}/iam.json"
                 done
                 ;;

--- a/audit/org_kubernetes.io/iam.json
+++ b/audit/org_kubernetes.io/iam.json
@@ -95,6 +95,5 @@
       "role": "roles/serviceusage.serviceUsageConsumer"
     }
   ],
-  "etag": "BwWWnB5ourM=",
   "version": 1
 }

--- a/audit/org_kubernetes.io/roles/CustomRole.json
+++ b/audit/org_kubernetes.io/roles/CustomRole.json
@@ -1,6 +1,5 @@
 {
   "description": "Can view billing info",
-  "etag": "BwWLI_e8Xyo=",
   "includedPermissions": [
     "billing.accounts.getSpendingInformation",
     "billing.budgets.get",

--- a/audit/org_kubernetes.io/roles/StorageBucketLister.json
+++ b/audit/org_kubernetes.io/roles/StorageBucketLister.json
@@ -1,6 +1,5 @@
 {
   "description": "Can list storage buckets",
-  "etag": "BwWMa3osHUc=",
   "includedPermissions": [
     "storage.buckets.get"
   ],

--- a/audit/projects/k8s-artifacts-prod-bak/buckets/asia.artifacts.k8s-artifacts-prod-bak.appspot.com/iam.json
+++ b/audit/projects/k8s-artifacts-prod-bak/buckets/asia.artifacts.k8s-artifacts-prod-bak.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-artifacts-prod-bak/buckets/eu.artifacts.k8s-artifacts-prod-bak.appspot.com/iam.json
+++ b/audit/projects/k8s-artifacts-prod-bak/buckets/eu.artifacts.k8s-artifacts-prod-bak.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-artifacts-prod-bak/buckets/k8s-artifacts-prod-bak/iam.json
+++ b/audit/projects/k8s-artifacts-prod-bak/buckets/k8s-artifacts-prod-bak/iam.json
@@ -26,6 +26,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-artifacts-prod-bak/buckets/us.artifacts.k8s-artifacts-prod-bak.appspot.com/iam.json
+++ b/audit/projects/k8s-artifacts-prod-bak/buckets/us.artifacts.k8s-artifacts-prod-bak.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-artifacts-prod-bak/iam.json
+++ b/audit/projects/k8s-artifacts-prod-bak/iam.json
@@ -33,6 +33,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWWyaJyfjU=",
   "version": 1
 }

--- a/audit/projects/k8s-artifacts-prod-bak/service-accounts/1057569514213-compute@developer.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-artifacts-prod-bak/service-accounts/1057569514213-compute@developer.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "Compute Engine default service account",
   "email": "1057569514213-compute@developer.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-artifacts-prod-bak/serviceAccounts/1057569514213-compute@developer.gserviceaccount.com",
   "oauth2ClientId": "110479582546125634164",
   "projectId": "k8s-artifacts-prod-bak",

--- a/audit/projects/k8s-artifacts-prod-bak/service-accounts/1057569514213-compute@developer.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-artifacts-prod-bak/service-accounts/1057569514213-compute@developer.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-artifacts-prod-bak/service-accounts/k8s-infra-gcr-promoter@k8s-artifacts-prod-bak.iam.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-artifacts-prod-bak/service-accounts/k8s-infra-gcr-promoter@k8s-artifacts-prod-bak.iam.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "k8s-infra container image promoter",
   "email": "k8s-infra-gcr-promoter@k8s-artifacts-prod-bak.iam.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-artifacts-prod-bak/serviceAccounts/k8s-infra-gcr-promoter@k8s-artifacts-prod-bak.iam.gserviceaccount.com",
   "oauth2ClientId": "106943260743373668522",
   "projectId": "k8s-artifacts-prod-bak",

--- a/audit/projects/k8s-artifacts-prod-bak/service-accounts/k8s-infra-gcr-promoter@k8s-artifacts-prod-bak.iam.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-artifacts-prod-bak/service-accounts/k8s-infra-gcr-promoter@k8s-artifacts-prod-bak.iam.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-artifacts-prod/buckets/asia.artifacts.k8s-artifacts-prod.appspot.com/iam.json
+++ b/audit/projects/k8s-artifacts-prod/buckets/asia.artifacts.k8s-artifacts-prod.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CBU="
+  ]
 }

--- a/audit/projects/k8s-artifacts-prod/buckets/eu.artifacts.k8s-artifacts-prod.appspot.com/iam.json
+++ b/audit/projects/k8s-artifacts-prod/buckets/eu.artifacts.k8s-artifacts-prod.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CBU="
+  ]
 }

--- a/audit/projects/k8s-artifacts-prod/buckets/k8s-artifacts-cni/iam.json
+++ b/audit/projects/k8s-artifacts-prod/buckets/k8s-artifacts-cni/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAk="
+  ]
 }

--- a/audit/projects/k8s-artifacts-prod/buckets/k8s-artifacts-prod/iam.json
+++ b/audit/projects/k8s-artifacts-prod/buckets/k8s-artifacts-prod/iam.json
@@ -26,6 +26,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CCQ="
+  ]
 }

--- a/audit/projects/k8s-artifacts-prod/buckets/us.artifacts.k8s-artifacts-prod.appspot.com/iam.json
+++ b/audit/projects/k8s-artifacts-prod/buckets/us.artifacts.k8s-artifacts-prod.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CBU="
+  ]
 }

--- a/audit/projects/k8s-artifacts-prod/iam.json
+++ b/audit/projects/k8s-artifacts-prod/iam.json
@@ -70,6 +70,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWfXCYkUis=",
   "version": 1
 }

--- a/audit/projects/k8s-artifacts-prod/service-accounts/388270116193-compute@developer.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-artifacts-prod/service-accounts/388270116193-compute@developer.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "Compute Engine default service account",
   "email": "388270116193-compute@developer.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-artifacts-prod/serviceAccounts/388270116193-compute@developer.gserviceaccount.com",
   "oauth2ClientId": "101053061482102339752",
   "projectId": "k8s-artifacts-prod",

--- a/audit/projects/k8s-artifacts-prod/service-accounts/388270116193-compute@developer.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-artifacts-prod/service-accounts/388270116193-compute@developer.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-artifacts-prod/service-accounts/k8s-infra-gcr-auditor-invoker@k8s-artifacts-prod.iam.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-artifacts-prod/service-accounts/k8s-infra-gcr-auditor-invoker@k8s-artifacts-prod.iam.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "k8s-infra container image auditor invoker",
   "email": "k8s-infra-gcr-auditor-invoker@k8s-artifacts-prod.iam.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-artifacts-prod/serviceAccounts/k8s-infra-gcr-auditor-invoker@k8s-artifacts-prod.iam.gserviceaccount.com",
   "oauth2ClientId": "117608484255608739343",
   "projectId": "k8s-artifacts-prod",

--- a/audit/projects/k8s-artifacts-prod/service-accounts/k8s-infra-gcr-auditor-invoker@k8s-artifacts-prod.iam.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-artifacts-prod/service-accounts/k8s-infra-gcr-auditor-invoker@k8s-artifacts-prod.iam.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-artifacts-prod/service-accounts/k8s-infra-gcr-auditor@k8s-artifacts-prod.iam.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-artifacts-prod/service-accounts/k8s-infra-gcr-auditor@k8s-artifacts-prod.iam.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "k8s-infra container image auditor",
   "email": "k8s-infra-gcr-auditor@k8s-artifacts-prod.iam.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-artifacts-prod/serviceAccounts/k8s-infra-gcr-auditor@k8s-artifacts-prod.iam.gserviceaccount.com",
   "oauth2ClientId": "111422293292441494221",
   "projectId": "k8s-artifacts-prod",

--- a/audit/projects/k8s-artifacts-prod/service-accounts/k8s-infra-gcr-auditor@k8s-artifacts-prod.iam.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-artifacts-prod/service-accounts/k8s-infra-gcr-auditor@k8s-artifacts-prod.iam.gserviceaccount.com/iam.json
@@ -7,6 +7,5 @@
       "role": "roles/iam.serviceAccountUser"
     }
   ],
-  "etag": "BwWfXCXzA3I=",
   "version": 1
 }

--- a/audit/projects/k8s-artifacts-prod/service-accounts/k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-artifacts-prod/service-accounts/k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "k8s-infra container image promoter",
   "email": "k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-artifacts-prod/serviceAccounts/k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com",
   "oauth2ClientId": "106731315085709606135",
   "projectId": "k8s-artifacts-prod",

--- a/audit/projects/k8s-artifacts-prod/service-accounts/k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-artifacts-prod/service-accounts/k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-cip-test-prod/buckets/asia.artifacts.k8s-cip-test-prod.appspot.com/iam.json
+++ b/audit/projects/k8s-cip-test-prod/buckets/asia.artifacts.k8s-cip-test-prod.appspot.com/iam.json
@@ -30,6 +30,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CB0="
+  ]
 }

--- a/audit/projects/k8s-cip-test-prod/buckets/eu.artifacts.k8s-cip-test-prod.appspot.com/iam.json
+++ b/audit/projects/k8s-cip-test-prod/buckets/eu.artifacts.k8s-cip-test-prod.appspot.com/iam.json
@@ -30,6 +30,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CB0="
+  ]
 }

--- a/audit/projects/k8s-cip-test-prod/buckets/k8s-cip-test-prod/iam.json
+++ b/audit/projects/k8s-cip-test-prod/buckets/k8s-cip-test-prod/iam.json
@@ -26,6 +26,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CBU="
+  ]
 }

--- a/audit/projects/k8s-cip-test-prod/buckets/us.artifacts.k8s-cip-test-prod.appspot.com/iam.json
+++ b/audit/projects/k8s-cip-test-prod/buckets/us.artifacts.k8s-cip-test-prod.appspot.com/iam.json
@@ -30,6 +30,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CB0="
+  ]
 }

--- a/audit/projects/k8s-cip-test-prod/iam.json
+++ b/audit/projects/k8s-cip-test-prod/iam.json
@@ -40,6 +40,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWWyZoifPQ=",
   "version": 1
 }

--- a/audit/projects/k8s-cip-test-prod/service-accounts/693665670941-compute@developer.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-cip-test-prod/service-accounts/693665670941-compute@developer.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "Compute Engine default service account",
   "email": "693665670941-compute@developer.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-cip-test-prod/serviceAccounts/693665670941-compute@developer.gserviceaccount.com",
   "oauth2ClientId": "113460353900960755434",
   "projectId": "k8s-cip-test-prod",

--- a/audit/projects/k8s-cip-test-prod/service-accounts/693665670941-compute@developer.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-cip-test-prod/service-accounts/693665670941-compute@developer.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-cip-test-prod/service-accounts/k8s-infra-gcr-promoter@k8s-cip-test-prod.iam.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-cip-test-prod/service-accounts/k8s-infra-gcr-promoter@k8s-cip-test-prod.iam.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "k8s-infra container image promoter",
   "email": "k8s-infra-gcr-promoter@k8s-cip-test-prod.iam.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-cip-test-prod/serviceAccounts/k8s-infra-gcr-promoter@k8s-cip-test-prod.iam.gserviceaccount.com",
   "oauth2ClientId": "113771710350401012134",
   "projectId": "k8s-cip-test-prod",

--- a/audit/projects/k8s-cip-test-prod/service-accounts/k8s-infra-gcr-promoter@k8s-cip-test-prod.iam.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-cip-test-prod/service-accounts/k8s-infra-gcr-promoter@k8s-cip-test-prod.iam.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-conform/iam.json
+++ b/audit/projects/k8s-conform/iam.json
@@ -26,6 +26,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWfZa0EzCo=",
   "version": 1
 }

--- a/audit/projects/k8s-conform/service-accounts/228988630781-compute@developer.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-conform/service-accounts/228988630781-compute@developer.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "Compute Engine default service account",
   "email": "228988630781-compute@developer.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-conform/serviceAccounts/228988630781-compute@developer.gserviceaccount.com",
   "oauth2ClientId": "100363543100901022828",
   "projectId": "k8s-conform",

--- a/audit/projects/k8s-conform/service-accounts/228988630781-compute@developer.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-conform/service-accounts/228988630781-compute@developer.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-gcr-audit-test-prod/buckets/artifacts.k8s-gcr-audit-test-prod.appspot.com/iam.json
+++ b/audit/projects/k8s-gcr-audit-test-prod/buckets/artifacts.k8s-gcr-audit-test-prod.appspot.com/iam.json
@@ -19,6 +19,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAI="
+  ]
 }

--- a/audit/projects/k8s-gcr-audit-test-prod/buckets/asia.artifacts.k8s-gcr-audit-test-prod.appspot.com/iam.json
+++ b/audit/projects/k8s-gcr-audit-test-prod/buckets/asia.artifacts.k8s-gcr-audit-test-prod.appspot.com/iam.json
@@ -30,6 +30,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAk="
+  ]
 }

--- a/audit/projects/k8s-gcr-audit-test-prod/buckets/eu.artifacts.k8s-gcr-audit-test-prod.appspot.com/iam.json
+++ b/audit/projects/k8s-gcr-audit-test-prod/buckets/eu.artifacts.k8s-gcr-audit-test-prod.appspot.com/iam.json
@@ -30,6 +30,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAk="
+  ]
 }

--- a/audit/projects/k8s-gcr-audit-test-prod/buckets/k8s-gcr-audit-test-prod/iam.json
+++ b/audit/projects/k8s-gcr-audit-test-prod/buckets/k8s-gcr-audit-test-prod/iam.json
@@ -26,6 +26,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAY="
+  ]
 }

--- a/audit/projects/k8s-gcr-audit-test-prod/buckets/us.artifacts.k8s-gcr-audit-test-prod.appspot.com/iam.json
+++ b/audit/projects/k8s-gcr-audit-test-prod/buckets/us.artifacts.k8s-gcr-audit-test-prod.appspot.com/iam.json
@@ -30,6 +30,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAk="
+  ]
 }

--- a/audit/projects/k8s-gcr-audit-test-prod/iam.json
+++ b/audit/projects/k8s-gcr-audit-test-prod/iam.json
@@ -95,6 +95,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWfWmuPdOQ=",
   "version": 1
 }

--- a/audit/projects/k8s-gcr-audit-test-prod/service-accounts/375340694213-compute@developer.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-gcr-audit-test-prod/service-accounts/375340694213-compute@developer.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "Compute Engine default service account",
   "email": "375340694213-compute@developer.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-gcr-audit-test-prod/serviceAccounts/375340694213-compute@developer.gserviceaccount.com",
   "oauth2ClientId": "106620148485369978745",
   "projectId": "k8s-gcr-audit-test-prod",

--- a/audit/projects/k8s-gcr-audit-test-prod/service-accounts/375340694213-compute@developer.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-gcr-audit-test-prod/service-accounts/375340694213-compute@developer.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-gcr-audit-test-prod/service-accounts/k8s-infra-gcr-promoter@k8s-gcr-audit-test-prod.iam.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-gcr-audit-test-prod/service-accounts/k8s-infra-gcr-promoter@k8s-gcr-audit-test-prod.iam.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "k8s-infra container image promoter",
   "email": "k8s-infra-gcr-promoter@k8s-gcr-audit-test-prod.iam.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-gcr-audit-test-prod/serviceAccounts/k8s-infra-gcr-promoter@k8s-gcr-audit-test-prod.iam.gserviceaccount.com",
   "oauth2ClientId": "100006926642424002701",
   "projectId": "k8s-gcr-audit-test-prod",

--- a/audit/projects/k8s-gcr-audit-test-prod/service-accounts/k8s-infra-gcr-promoter@k8s-gcr-audit-test-prod.iam.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-gcr-audit-test-prod/service-accounts/k8s-infra-gcr-promoter@k8s-gcr-audit-test-prod.iam.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-gcr-backup-test-prod-bak/buckets/asia.artifacts.k8s-gcr-backup-test-prod-bak.appspot.com/iam.json
+++ b/audit/projects/k8s-gcr-backup-test-prod-bak/buckets/asia.artifacts.k8s-gcr-backup-test-prod-bak.appspot.com/iam.json
@@ -30,6 +30,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAs="
+  ]
 }

--- a/audit/projects/k8s-gcr-backup-test-prod-bak/buckets/eu.artifacts.k8s-gcr-backup-test-prod-bak.appspot.com/iam.json
+++ b/audit/projects/k8s-gcr-backup-test-prod-bak/buckets/eu.artifacts.k8s-gcr-backup-test-prod-bak.appspot.com/iam.json
@@ -30,6 +30,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAs="
+  ]
 }

--- a/audit/projects/k8s-gcr-backup-test-prod-bak/buckets/k8s-gcr-backup-test-prod-bak/iam.json
+++ b/audit/projects/k8s-gcr-backup-test-prod-bak/buckets/k8s-gcr-backup-test-prod-bak/iam.json
@@ -26,6 +26,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-gcr-backup-test-prod-bak/buckets/us.artifacts.k8s-gcr-backup-test-prod-bak.appspot.com/iam.json
+++ b/audit/projects/k8s-gcr-backup-test-prod-bak/buckets/us.artifacts.k8s-gcr-backup-test-prod-bak.appspot.com/iam.json
@@ -30,6 +30,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAs="
+  ]
 }

--- a/audit/projects/k8s-gcr-backup-test-prod-bak/iam.json
+++ b/audit/projects/k8s-gcr-backup-test-prod-bak/iam.json
@@ -26,6 +26,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWWyZsNOWU=",
   "version": 1
 }

--- a/audit/projects/k8s-gcr-backup-test-prod-bak/service-accounts/k8s-infra-gcr-promoter@k8s-gcr-backup-test-prod-bak.iam.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-gcr-backup-test-prod-bak/service-accounts/k8s-infra-gcr-promoter@k8s-gcr-backup-test-prod-bak.iam.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "k8s-infra container image promoter",
   "email": "k8s-infra-gcr-promoter@k8s-gcr-backup-test-prod-bak.iam.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-gcr-backup-test-prod-bak/serviceAccounts/k8s-infra-gcr-promoter@k8s-gcr-backup-test-prod-bak.iam.gserviceaccount.com",
   "oauth2ClientId": "101493623593470215507",
   "projectId": "k8s-gcr-backup-test-prod-bak",

--- a/audit/projects/k8s-gcr-backup-test-prod-bak/service-accounts/k8s-infra-gcr-promoter@k8s-gcr-backup-test-prod-bak.iam.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-gcr-backup-test-prod-bak/service-accounts/k8s-infra-gcr-promoter@k8s-gcr-backup-test-prod-bak.iam.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-gcr-backup-test-prod/buckets/asia.artifacts.k8s-gcr-backup-test-prod.appspot.com/iam.json
+++ b/audit/projects/k8s-gcr-backup-test-prod/buckets/asia.artifacts.k8s-gcr-backup-test-prod.appspot.com/iam.json
@@ -30,6 +30,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-gcr-backup-test-prod/buckets/eu.artifacts.k8s-gcr-backup-test-prod.appspot.com/iam.json
+++ b/audit/projects/k8s-gcr-backup-test-prod/buckets/eu.artifacts.k8s-gcr-backup-test-prod.appspot.com/iam.json
@@ -30,6 +30,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-gcr-backup-test-prod/buckets/k8s-gcr-backup-test-prod/iam.json
+++ b/audit/projects/k8s-gcr-backup-test-prod/buckets/k8s-gcr-backup-test-prod/iam.json
@@ -26,6 +26,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAg="
+  ]
 }

--- a/audit/projects/k8s-gcr-backup-test-prod/buckets/us.artifacts.k8s-gcr-backup-test-prod.appspot.com/iam.json
+++ b/audit/projects/k8s-gcr-backup-test-prod/buckets/us.artifacts.k8s-gcr-backup-test-prod.appspot.com/iam.json
@@ -30,6 +30,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-gcr-backup-test-prod/iam.json
+++ b/audit/projects/k8s-gcr-backup-test-prod/iam.json
@@ -26,6 +26,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWWyZqUyXw=",
   "version": 1
 }

--- a/audit/projects/k8s-gcr-backup-test-prod/service-accounts/k8s-infra-gcr-promoter@k8s-gcr-backup-test-prod.iam.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-gcr-backup-test-prod/service-accounts/k8s-infra-gcr-promoter@k8s-gcr-backup-test-prod.iam.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "k8s-infra container image promoter",
   "email": "k8s-infra-gcr-promoter@k8s-gcr-backup-test-prod.iam.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-gcr-backup-test-prod/serviceAccounts/k8s-infra-gcr-promoter@k8s-gcr-backup-test-prod.iam.gserviceaccount.com",
   "oauth2ClientId": "118381907748722022998",
   "projectId": "k8s-gcr-backup-test-prod",

--- a/audit/projects/k8s-gcr-backup-test-prod/service-accounts/k8s-infra-gcr-promoter@k8s-gcr-backup-test-prod.iam.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-gcr-backup-test-prod/service-accounts/k8s-infra-gcr-promoter@k8s-gcr-backup-test-prod.iam.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-gsuite/iam.json
+++ b/audit/projects/k8s-gsuite/iam.json
@@ -8,6 +8,5 @@
       "role": "roles/owner"
     }
   ],
-  "etag": "BwWIfLtm8Eg=",
   "version": 1
 }

--- a/audit/projects/k8s-gsuite/service-accounts/gsuite-groups-manager@k8s-gsuite.iam.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-gsuite/service-accounts/gsuite-groups-manager@k8s-gsuite.iam.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "Grants access to the googlegroups API in kubernetes.io GSuite",
   "email": "gsuite-groups-manager@k8s-gsuite.iam.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-gsuite/serviceAccounts/gsuite-groups-manager@k8s-gsuite.iam.gserviceaccount.com",
   "oauth2ClientId": "116748693853528872690",
   "projectId": "k8s-gsuite",

--- a/audit/projects/k8s-gsuite/service-accounts/gsuite-groups-manager@k8s-gsuite.iam.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-gsuite/service-accounts/gsuite-groups-manager@k8s-gsuite.iam.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-release-test-prod/buckets/artifacts.k8s-release-test-prod.appspot.com/iam.json
+++ b/audit/projects/k8s-release-test-prod/buckets/artifacts.k8s-release-test-prod.appspot.com/iam.json
@@ -30,6 +30,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAk="
+  ]
 }

--- a/audit/projects/k8s-release-test-prod/buckets/asia.artifacts.k8s-release-test-prod.appspot.com/iam.json
+++ b/audit/projects/k8s-release-test-prod/buckets/asia.artifacts.k8s-release-test-prod.appspot.com/iam.json
@@ -30,6 +30,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CA4="
+  ]
 }

--- a/audit/projects/k8s-release-test-prod/buckets/eu.artifacts.k8s-release-test-prod.appspot.com/iam.json
+++ b/audit/projects/k8s-release-test-prod/buckets/eu.artifacts.k8s-release-test-prod.appspot.com/iam.json
@@ -30,6 +30,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CA4="
+  ]
 }

--- a/audit/projects/k8s-release-test-prod/buckets/k8s-release-test-prod-gcb/iam.json
+++ b/audit/projects/k8s-release-test-prod/buckets/k8s-release-test-prod-gcb/iam.json
@@ -37,6 +37,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAs="
+  ]
 }

--- a/audit/projects/k8s-release-test-prod/buckets/k8s-release-test-prod/iam.json
+++ b/audit/projects/k8s-release-test-prod/buckets/k8s-release-test-prod/iam.json
@@ -30,6 +30,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CBE="
+  ]
 }

--- a/audit/projects/k8s-release-test-prod/buckets/us.artifacts.k8s-release-test-prod.appspot.com/iam.json
+++ b/audit/projects/k8s-release-test-prod/buckets/us.artifacts.k8s-release-test-prod.appspot.com/iam.json
@@ -30,6 +30,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CA4="
+  ]
 }

--- a/audit/projects/k8s-release-test-prod/iam.json
+++ b/audit/projects/k8s-release-test-prod/iam.json
@@ -76,6 +76,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWd7ZRxpyA=",
   "version": 1
 }

--- a/audit/projects/k8s-release-test-prod/service-accounts/925892675446-compute@developer.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-release-test-prod/service-accounts/925892675446-compute@developer.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "Compute Engine default service account",
   "email": "925892675446-compute@developer.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-release-test-prod/serviceAccounts/925892675446-compute@developer.gserviceaccount.com",
   "oauth2ClientId": "113219924149219724443",
   "projectId": "k8s-release-test-prod",

--- a/audit/projects/k8s-release-test-prod/service-accounts/925892675446-compute@developer.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-release-test-prod/service-accounts/925892675446-compute@developer.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-release-test-prod/service-accounts/k8s-infra-gcr-promoter@k8s-release-test-prod.iam.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-release-test-prod/service-accounts/k8s-infra-gcr-promoter@k8s-release-test-prod.iam.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "k8s-infra container image promoter",
   "email": "k8s-infra-gcr-promoter@k8s-release-test-prod.iam.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-release-test-prod/serviceAccounts/k8s-infra-gcr-promoter@k8s-release-test-prod.iam.gserviceaccount.com",
   "oauth2ClientId": "105695964713766714110",
   "projectId": "k8s-release-test-prod",

--- a/audit/projects/k8s-release-test-prod/service-accounts/k8s-infra-gcr-promoter@k8s-release-test-prod.iam.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-release-test-prod/service-accounts/k8s-infra-gcr-promoter@k8s-release-test-prod.iam.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-sig-release-prototype/buckets/k8s-sig-release-prototype/iam.json
+++ b/audit/projects/k8s-sig-release-prototype/buckets/k8s-sig-release-prototype/iam.json
@@ -38,6 +38,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAU="
+  ]
 }

--- a/audit/projects/k8s-sig-release-prototype/iam.json
+++ b/audit/projects/k8s-sig-release-prototype/iam.json
@@ -20,6 +20,5 @@
       "role": "roles/owner"
     }
   ],
-  "etag": "BwWHdcL3Us4=",
   "version": 1
 }

--- a/audit/projects/k8s-sig-release-prototype/service-accounts/248671828424-compute@developer.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-sig-release-prototype/service-accounts/248671828424-compute@developer.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "Compute Engine default service account",
   "email": "248671828424-compute@developer.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-sig-release-prototype/serviceAccounts/248671828424-compute@developer.gserviceaccount.com",
   "oauth2ClientId": "110271817996764836707",
   "projectId": "k8s-sig-release-prototype",

--- a/audit/projects/k8s-sig-release-prototype/service-accounts/248671828424-compute@developer.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-sig-release-prototype/service-accounts/248671828424-compute@developer.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-staging-apisnoop/buckets/artifacts.k8s-staging-apisnoop.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-apisnoop/buckets/artifacts.k8s-staging-apisnoop.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAg="
+  ]
 }

--- a/audit/projects/k8s-staging-apisnoop/buckets/k8s-staging-apisnoop-gcb/iam.json
+++ b/audit/projects/k8s-staging-apisnoop/buckets/k8s-staging-apisnoop-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-apisnoop/buckets/k8s-staging-apisnoop/iam.json
+++ b/audit/projects/k8s-staging-apisnoop/buckets/k8s-staging-apisnoop/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAg="
+  ]
 }

--- a/audit/projects/k8s-staging-apisnoop/iam.json
+++ b/audit/projects/k8s-staging-apisnoop/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWeaifkuKg=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-artifact-promoter/buckets/artifacts.k8s-staging-artifact-promoter.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-artifact-promoter/buckets/artifacts.k8s-staging-artifact-promoter.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAk="
+  ]
 }

--- a/audit/projects/k8s-staging-artifact-promoter/buckets/k8s-staging-artifact-promoter-gcb/iam.json
+++ b/audit/projects/k8s-staging-artifact-promoter/buckets/k8s-staging-artifact-promoter-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAw="
+  ]
 }

--- a/audit/projects/k8s-staging-artifact-promoter/buckets/k8s-staging-artifact-promoter/iam.json
+++ b/audit/projects/k8s-staging-artifact-promoter/buckets/k8s-staging-artifact-promoter/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CA4="
+  ]
 }

--- a/audit/projects/k8s-staging-artifact-promoter/iam.json
+++ b/audit/projects/k8s-staging-artifact-promoter/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWd6coeN5w=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-build-image/buckets/artifacts.k8s-staging-build-image.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-build-image/buckets/artifacts.k8s-staging-build-image.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CA8="
+  ]
 }

--- a/audit/projects/k8s-staging-build-image/buckets/k8s-staging-build-image-gcb/iam.json
+++ b/audit/projects/k8s-staging-build-image/buckets/k8s-staging-build-image-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAw="
+  ]
 }

--- a/audit/projects/k8s-staging-build-image/buckets/k8s-staging-build-image/iam.json
+++ b/audit/projects/k8s-staging-build-image/buckets/k8s-staging-build-image/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CB0="
+  ]
 }

--- a/audit/projects/k8s-staging-build-image/iam.json
+++ b/audit/projects/k8s-staging-build-image/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWdZatIg8U=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-capi-docker/buckets/artifacts.k8s-staging-capi-docker.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-capi-docker/buckets/artifacts.k8s-staging-capi-docker.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAg="
+  ]
 }

--- a/audit/projects/k8s-staging-capi-docker/buckets/k8s-staging-capi-docker-gcb/iam.json
+++ b/audit/projects/k8s-staging-capi-docker/buckets/k8s-staging-capi-docker-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-capi-docker/buckets/k8s-staging-capi-docker/iam.json
+++ b/audit/projects/k8s-staging-capi-docker/buckets/k8s-staging-capi-docker/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAs="
+  ]
 }

--- a/audit/projects/k8s-staging-capi-docker/iam.json
+++ b/audit/projects/k8s-staging-capi-docker/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWdaQrgVF4=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-capi-kubeadm/buckets/artifacts.k8s-staging-capi-kubeadm.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-capi-kubeadm/buckets/artifacts.k8s-staging-capi-kubeadm.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAg="
+  ]
 }

--- a/audit/projects/k8s-staging-capi-kubeadm/buckets/k8s-staging-capi-kubeadm-gcb/iam.json
+++ b/audit/projects/k8s-staging-capi-kubeadm/buckets/k8s-staging-capi-kubeadm-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-capi-kubeadm/buckets/k8s-staging-capi-kubeadm/iam.json
+++ b/audit/projects/k8s-staging-capi-kubeadm/buckets/k8s-staging-capi-kubeadm/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAw="
+  ]
 }

--- a/audit/projects/k8s-staging-capi-kubeadm/iam.json
+++ b/audit/projects/k8s-staging-capi-kubeadm/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWdtvfN_4I=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-capi-openstack/buckets/artifacts.k8s-staging-capi-openstack.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-capi-openstack/buckets/artifacts.k8s-staging-capi-openstack.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAk="
+  ]
 }

--- a/audit/projects/k8s-staging-capi-openstack/buckets/k8s-staging-capi-openstack-gcb/iam.json
+++ b/audit/projects/k8s-staging-capi-openstack/buckets/k8s-staging-capi-openstack-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-capi-openstack/buckets/k8s-staging-capi-openstack/iam.json
+++ b/audit/projects/k8s-staging-capi-openstack/buckets/k8s-staging-capi-openstack/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CA4="
+  ]
 }

--- a/audit/projects/k8s-staging-capi-openstack/iam.json
+++ b/audit/projects/k8s-staging-capi-openstack/iam.json
@@ -53,6 +53,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWd20DPYE4=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-capi-openstack/service-accounts/129051311436-compute@developer.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-staging-capi-openstack/service-accounts/129051311436-compute@developer.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "Compute Engine default service account",
   "email": "129051311436-compute@developer.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-staging-capi-openstack/serviceAccounts/129051311436-compute@developer.gserviceaccount.com",
   "oauth2ClientId": "114522581576441073468",
   "projectId": "k8s-staging-capi-openstack",

--- a/audit/projects/k8s-staging-capi-openstack/service-accounts/129051311436-compute@developer.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-staging-capi-openstack/service-accounts/129051311436-compute@developer.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-staging-cip-test/buckets/artifacts.k8s-staging-cip-test.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-cip-test/buckets/artifacts.k8s-staging-cip-test.appspot.com/iam.json
@@ -30,6 +30,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CBk="
+  ]
 }

--- a/audit/projects/k8s-staging-cip-test/buckets/asia.artifacts.k8s-staging-cip-test.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-cip-test/buckets/asia.artifacts.k8s-staging-cip-test.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAc="
+  ]
 }

--- a/audit/projects/k8s-staging-cip-test/buckets/eu.artifacts.k8s-staging-cip-test.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-cip-test/buckets/eu.artifacts.k8s-staging-cip-test.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAc="
+  ]
 }

--- a/audit/projects/k8s-staging-cip-test/buckets/k8s-staging-cip-test-gcb/iam.json
+++ b/audit/projects/k8s-staging-cip-test/buckets/k8s-staging-cip-test-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAs="
+  ]
 }

--- a/audit/projects/k8s-staging-cip-test/buckets/k8s-staging-cip-test/iam.json
+++ b/audit/projects/k8s-staging-cip-test/buckets/k8s-staging-cip-test/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CCQ="
+  ]
 }

--- a/audit/projects/k8s-staging-cip-test/buckets/us.artifacts.k8s-staging-cip-test.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-cip-test/buckets/us.artifacts.k8s-staging-cip-test.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAc="
+  ]
 }

--- a/audit/projects/k8s-staging-cip-test/iam.json
+++ b/audit/projects/k8s-staging-cip-test/iam.json
@@ -59,6 +59,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWdctnoSDs=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-cip-test/service-accounts/324460563566-compute@developer.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-staging-cip-test/service-accounts/324460563566-compute@developer.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "Compute Engine default service account",
   "email": "324460563566-compute@developer.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-staging-cip-test/serviceAccounts/324460563566-compute@developer.gserviceaccount.com",
   "oauth2ClientId": "101237046382178675324",
   "projectId": "k8s-staging-cip-test",

--- a/audit/projects/k8s-staging-cip-test/service-accounts/324460563566-compute@developer.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-staging-cip-test/service-accounts/324460563566-compute@developer.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-staging-cip-test/service-accounts/k8s-infra-gcr-promoter@k8s-staging-cip-test.iam.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-staging-cip-test/service-accounts/k8s-infra-gcr-promoter@k8s-staging-cip-test.iam.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "k8s-infra container image promoter",
   "email": "k8s-infra-gcr-promoter@k8s-staging-cip-test.iam.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-staging-cip-test/serviceAccounts/k8s-infra-gcr-promoter@k8s-staging-cip-test.iam.gserviceaccount.com",
   "oauth2ClientId": "106163575317668102143",
   "projectId": "k8s-staging-cip-test",

--- a/audit/projects/k8s-staging-cip-test/service-accounts/k8s-infra-gcr-promoter@k8s-staging-cip-test.iam.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-staging-cip-test/service-accounts/k8s-infra-gcr-promoter@k8s-staging-cip-test.iam.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-staging-cluster-api-aws/buckets/artifacts.k8s-staging-cluster-api-aws.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-cluster-api-aws/buckets/artifacts.k8s-staging-cluster-api-aws.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CCA="
+  ]
 }

--- a/audit/projects/k8s-staging-cluster-api-aws/buckets/k8s-staging-cluster-api-aws-gcb/iam.json
+++ b/audit/projects/k8s-staging-cluster-api-aws/buckets/k8s-staging-cluster-api-aws-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-cluster-api-aws/buckets/k8s-staging-cluster-api-aws/iam.json
+++ b/audit/projects/k8s-staging-cluster-api-aws/buckets/k8s-staging-cluster-api-aws/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CCg="
+  ]
 }

--- a/audit/projects/k8s-staging-cluster-api-aws/iam.json
+++ b/audit/projects/k8s-staging-cluster-api-aws/iam.json
@@ -53,6 +53,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWd68Lm_cw=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-cluster-api-aws/service-accounts/433651898792-compute@developer.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-staging-cluster-api-aws/service-accounts/433651898792-compute@developer.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "Compute Engine default service account",
   "email": "433651898792-compute@developer.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-staging-cluster-api-aws/serviceAccounts/433651898792-compute@developer.gserviceaccount.com",
   "oauth2ClientId": "114251534546438878491",
   "projectId": "k8s-staging-cluster-api-aws",

--- a/audit/projects/k8s-staging-cluster-api-aws/service-accounts/433651898792-compute@developer.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-staging-cluster-api-aws/service-accounts/433651898792-compute@developer.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-staging-cluster-api-azure/buckets/artifacts.k8s-staging-cluster-api-azure.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-cluster-api-azure/buckets/artifacts.k8s-staging-cluster-api-azure.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAc="
+  ]
 }

--- a/audit/projects/k8s-staging-cluster-api-azure/buckets/k8s-staging-cluster-api-azure-gcb/iam.json
+++ b/audit/projects/k8s-staging-cluster-api-azure/buckets/k8s-staging-cluster-api-azure-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-cluster-api-azure/buckets/k8s-staging-cluster-api-azure/iam.json
+++ b/audit/projects/k8s-staging-cluster-api-azure/buckets/k8s-staging-cluster-api-azure/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAg="
+  ]
 }

--- a/audit/projects/k8s-staging-cluster-api-azure/iam.json
+++ b/audit/projects/k8s-staging-cluster-api-azure/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWdw2hhL9U=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-cluster-api-gcp/buckets/artifacts.k8s-staging-cluster-api-gcp.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-cluster-api-gcp/buckets/artifacts.k8s-staging-cluster-api-gcp.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAg="
+  ]
 }

--- a/audit/projects/k8s-staging-cluster-api-gcp/buckets/k8s-staging-cluster-api-gcp-gcb/iam.json
+++ b/audit/projects/k8s-staging-cluster-api-gcp/buckets/k8s-staging-cluster-api-gcp-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-cluster-api-gcp/buckets/k8s-staging-cluster-api-gcp/iam.json
+++ b/audit/projects/k8s-staging-cluster-api-gcp/buckets/k8s-staging-cluster-api-gcp/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAs="
+  ]
 }

--- a/audit/projects/k8s-staging-cluster-api-gcp/iam.json
+++ b/audit/projects/k8s-staging-cluster-api-gcp/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWdsr0OOtE=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-cluster-api/buckets/artifacts.k8s-staging-cluster-api.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-cluster-api/buckets/artifacts.k8s-staging-cluster-api.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CBo="
+  ]
 }

--- a/audit/projects/k8s-staging-cluster-api/buckets/k8s-staging-cluster-api-gcb/iam.json
+++ b/audit/projects/k8s-staging-cluster-api/buckets/k8s-staging-cluster-api-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-cluster-api/buckets/k8s-staging-cluster-api/iam.json
+++ b/audit/projects/k8s-staging-cluster-api/buckets/k8s-staging-cluster-api/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CCs="
+  ]
 }

--- a/audit/projects/k8s-staging-cluster-api/iam.json
+++ b/audit/projects/k8s-staging-cluster-api/iam.json
@@ -53,6 +53,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWdeQRKtvc=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-cluster-api/service-accounts/190130481896-compute@developer.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-staging-cluster-api/service-accounts/190130481896-compute@developer.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "Compute Engine default service account",
   "email": "190130481896-compute@developer.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-staging-cluster-api/serviceAccounts/190130481896-compute@developer.gserviceaccount.com",
   "oauth2ClientId": "113774457030358190463",
   "projectId": "k8s-staging-cluster-api",

--- a/audit/projects/k8s-staging-cluster-api/service-accounts/190130481896-compute@developer.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-staging-cluster-api/service-accounts/190130481896-compute@developer.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-staging-coredns/buckets/artifacts.k8s-staging-coredns.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-coredns/buckets/artifacts.k8s-staging-coredns.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CBY="
+  ]
 }

--- a/audit/projects/k8s-staging-coredns/buckets/k8s-staging-coredns-gcb/iam.json
+++ b/audit/projects/k8s-staging-coredns/buckets/k8s-staging-coredns-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-coredns/buckets/k8s-staging-coredns/iam.json
+++ b/audit/projects/k8s-staging-coredns/buckets/k8s-staging-coredns/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CCQ="
+  ]
 }

--- a/audit/projects/k8s-staging-coredns/iam.json
+++ b/audit/projects/k8s-staging-coredns/iam.json
@@ -65,6 +65,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWd37KkqDw=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-coredns/service-accounts/848617618266-compute@developer.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-staging-coredns/service-accounts/848617618266-compute@developer.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "Compute Engine default service account",
   "email": "848617618266-compute@developer.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-staging-coredns/serviceAccounts/848617618266-compute@developer.gserviceaccount.com",
   "oauth2ClientId": "110396744106037191461",
   "projectId": "k8s-staging-coredns",

--- a/audit/projects/k8s-staging-coredns/service-accounts/848617618266-compute@developer.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-staging-coredns/service-accounts/848617618266-compute@developer.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-staging-csi/buckets/artifacts.k8s-staging-csi.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-csi/buckets/artifacts.k8s-staging-csi.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CBY="
+  ]
 }

--- a/audit/projects/k8s-staging-csi/buckets/k8s-staging-csi-gcb/iam.json
+++ b/audit/projects/k8s-staging-csi/buckets/k8s-staging-csi-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-csi/buckets/k8s-staging-csi/iam.json
+++ b/audit/projects/k8s-staging-csi/buckets/k8s-staging-csi/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CB8="
+  ]
 }

--- a/audit/projects/k8s-staging-csi/iam.json
+++ b/audit/projects/k8s-staging-csi/iam.json
@@ -53,6 +53,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWdxGtS5MI=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-csi/service-accounts/874328413592-compute@developer.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-staging-csi/service-accounts/874328413592-compute@developer.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "Compute Engine default service account",
   "email": "874328413592-compute@developer.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-staging-csi/serviceAccounts/874328413592-compute@developer.gserviceaccount.com",
   "oauth2ClientId": "116156031177379020104",
   "projectId": "k8s-staging-csi",

--- a/audit/projects/k8s-staging-csi/service-accounts/874328413592-compute@developer.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-staging-csi/service-accounts/874328413592-compute@developer.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-staging-descheduler/buckets/artifacts.k8s-staging-descheduler.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-descheduler/buckets/artifacts.k8s-staging-descheduler.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAg="
+  ]
 }

--- a/audit/projects/k8s-staging-descheduler/buckets/k8s-staging-descheduler-gcb/iam.json
+++ b/audit/projects/k8s-staging-descheduler/buckets/k8s-staging-descheduler-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-descheduler/buckets/k8s-staging-descheduler/iam.json
+++ b/audit/projects/k8s-staging-descheduler/buckets/k8s-staging-descheduler/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAw="
+  ]
 }

--- a/audit/projects/k8s-staging-descheduler/iam.json
+++ b/audit/projects/k8s-staging-descheduler/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWds4BC_Zk=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-e2e-test-images/buckets/artifacts.k8s-staging-e2e-test-images.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-e2e-test-images/buckets/artifacts.k8s-staging-e2e-test-images.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAc="
+  ]
 }

--- a/audit/projects/k8s-staging-e2e-test-images/buckets/k8s-staging-e2e-test-images-gcb/iam.json
+++ b/audit/projects/k8s-staging-e2e-test-images/buckets/k8s-staging-e2e-test-images-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-e2e-test-images/buckets/k8s-staging-e2e-test-images/iam.json
+++ b/audit/projects/k8s-staging-e2e-test-images/buckets/k8s-staging-e2e-test-images/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAg="
+  ]
 }

--- a/audit/projects/k8s-staging-e2e-test-images/iam.json
+++ b/audit/projects/k8s-staging-e2e-test-images/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWdr7FvJnU=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-e2e-test/iam.json
+++ b/audit/projects/k8s-staging-e2e-test/iam.json
@@ -7,6 +7,5 @@
       "role": "roles/owner"
     }
   ],
-  "etag": "BwWZC-6c8DY=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-external-dns/buckets/artifacts.k8s-staging-external-dns.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-external-dns/buckets/artifacts.k8s-staging-external-dns.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAc="
+  ]
 }

--- a/audit/projects/k8s-staging-external-dns/buckets/k8s-staging-external-dns-gcb/iam.json
+++ b/audit/projects/k8s-staging-external-dns/buckets/k8s-staging-external-dns-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-external-dns/buckets/k8s-staging-external-dns/iam.json
+++ b/audit/projects/k8s-staging-external-dns/buckets/k8s-staging-external-dns/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAg="
+  ]
 }

--- a/audit/projects/k8s-staging-external-dns/iam.json
+++ b/audit/projects/k8s-staging-external-dns/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWdY-YjYlc=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-kas-network-proxy/buckets/artifacts.k8s-staging-kas-network-proxy.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-kas-network-proxy/buckets/artifacts.k8s-staging-kas-network-proxy.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAc="
+  ]
 }

--- a/audit/projects/k8s-staging-kas-network-proxy/buckets/k8s-staging-kas-network-proxy-gcb/iam.json
+++ b/audit/projects/k8s-staging-kas-network-proxy/buckets/k8s-staging-kas-network-proxy-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-kas-network-proxy/buckets/k8s-staging-kas-network-proxy/iam.json
+++ b/audit/projects/k8s-staging-kas-network-proxy/buckets/k8s-staging-kas-network-proxy/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAg="
+  ]
 }

--- a/audit/projects/k8s-staging-kas-network-proxy/iam.json
+++ b/audit/projects/k8s-staging-kas-network-proxy/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWd3m6GHZQ=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-kops/buckets/artifacts.k8s-staging-kops.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-kops/buckets/artifacts.k8s-staging-kops.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CBI="
+  ]
 }

--- a/audit/projects/k8s-staging-kops/buckets/k8s-staging-kops-gcb/iam.json
+++ b/audit/projects/k8s-staging-kops/buckets/k8s-staging-kops-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-kops/buckets/k8s-staging-kops/iam.json
+++ b/audit/projects/k8s-staging-kops/buckets/k8s-staging-kops/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CCE="
+  ]
 }

--- a/audit/projects/k8s-staging-kops/iam.json
+++ b/audit/projects/k8s-staging-kops/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWd6_43HxM=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-kube-state-metrics/buckets/k8s-staging-kube-state-metrics-gcb/iam.json
+++ b/audit/projects/k8s-staging-kube-state-metrics/buckets/k8s-staging-kube-state-metrics-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-kube-state-metrics/buckets/k8s-staging-kube-state-metrics/iam.json
+++ b/audit/projects/k8s-staging-kube-state-metrics/buckets/k8s-staging-kube-state-metrics/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAg="
+  ]
 }

--- a/audit/projects/k8s-staging-kube-state-metrics/iam.json
+++ b/audit/projects/k8s-staging-kube-state-metrics/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWd37WwULk=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-kubeadm/buckets/artifacts.k8s-staging-kubeadm.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-kubeadm/buckets/artifacts.k8s-staging-kubeadm.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAc="
+  ]
 }

--- a/audit/projects/k8s-staging-kubeadm/buckets/k8s-staging-kubeadm-gcb/iam.json
+++ b/audit/projects/k8s-staging-kubeadm/buckets/k8s-staging-kubeadm-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-kubeadm/buckets/k8s-staging-kubeadm/iam.json
+++ b/audit/projects/k8s-staging-kubeadm/buckets/k8s-staging-kubeadm/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAg="
+  ]
 }

--- a/audit/projects/k8s-staging-kubeadm/iam.json
+++ b/audit/projects/k8s-staging-kubeadm/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWd2ToMCiw=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-metrics-server/buckets/artifacts.k8s-staging-metrics-server.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-metrics-server/buckets/artifacts.k8s-staging-metrics-server.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAc="
+  ]
 }

--- a/audit/projects/k8s-staging-metrics-server/buckets/k8s-staging-metrics-server-gcb/iam.json
+++ b/audit/projects/k8s-staging-metrics-server/buckets/k8s-staging-metrics-server-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-metrics-server/buckets/k8s-staging-metrics-server/iam.json
+++ b/audit/projects/k8s-staging-metrics-server/buckets/k8s-staging-metrics-server/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAg="
+  ]
 }

--- a/audit/projects/k8s-staging-metrics-server/iam.json
+++ b/audit/projects/k8s-staging-metrics-server/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWd7SdKekw=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-multitenancy/buckets/artifacts.k8s-staging-multitenancy.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-multitenancy/buckets/artifacts.k8s-staging-multitenancy.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAg="
+  ]
 }

--- a/audit/projects/k8s-staging-multitenancy/buckets/k8s-staging-multitenancy-gcb/iam.json
+++ b/audit/projects/k8s-staging-multitenancy/buckets/k8s-staging-multitenancy-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-multitenancy/buckets/k8s-staging-multitenancy/iam.json
+++ b/audit/projects/k8s-staging-multitenancy/buckets/k8s-staging-multitenancy/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAs="
+  ]
 }

--- a/audit/projects/k8s-staging-multitenancy/iam.json
+++ b/audit/projects/k8s-staging-multitenancy/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWdr1npdjU=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-nfd/buckets/artifacts.k8s-staging-nfd.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-nfd/buckets/artifacts.k8s-staging-nfd.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAc="
+  ]
 }

--- a/audit/projects/k8s-staging-nfd/buckets/k8s-staging-nfd-gcb/iam.json
+++ b/audit/projects/k8s-staging-nfd/buckets/k8s-staging-nfd-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-nfd/buckets/k8s-staging-nfd/iam.json
+++ b/audit/projects/k8s-staging-nfd/buckets/k8s-staging-nfd/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAg="
+  ]
 }

--- a/audit/projects/k8s-staging-nfd/iam.json
+++ b/audit/projects/k8s-staging-nfd/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWeAEgZoOI=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-npd/buckets/artifacts.k8s-staging-npd.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-npd/buckets/artifacts.k8s-staging-npd.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAc="
+  ]
 }

--- a/audit/projects/k8s-staging-npd/buckets/k8s-staging-npd-gcb/iam.json
+++ b/audit/projects/k8s-staging-npd/buckets/k8s-staging-npd-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-npd/buckets/k8s-staging-npd/iam.json
+++ b/audit/projects/k8s-staging-npd/buckets/k8s-staging-npd/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAg="
+  ]
 }

--- a/audit/projects/k8s-staging-npd/iam.json
+++ b/audit/projects/k8s-staging-npd/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWd1-mmnBM=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-provider-azure/buckets/artifacts.k8s-staging-provider-azure.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-provider-azure/buckets/artifacts.k8s-staging-provider-azure.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAc="
+  ]
 }

--- a/audit/projects/k8s-staging-provider-azure/buckets/k8s-staging-provider-azure-gcb/iam.json
+++ b/audit/projects/k8s-staging-provider-azure/buckets/k8s-staging-provider-azure-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-provider-azure/buckets/k8s-staging-provider-azure/iam.json
+++ b/audit/projects/k8s-staging-provider-azure/buckets/k8s-staging-provider-azure/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAg="
+  ]
 }

--- a/audit/projects/k8s-staging-provider-azure/iam.json
+++ b/audit/projects/k8s-staging-provider-azure/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWdsdrTy_0=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-publishing-bot/buckets/artifacts.k8s-staging-publishing-bot.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-publishing-bot/buckets/artifacts.k8s-staging-publishing-bot.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CA4="
+  ]
 }

--- a/audit/projects/k8s-staging-publishing-bot/buckets/k8s-staging-publishing-bot-gcb/iam.json
+++ b/audit/projects/k8s-staging-publishing-bot/buckets/k8s-staging-publishing-bot-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-publishing-bot/buckets/k8s-staging-publishing-bot/iam.json
+++ b/audit/projects/k8s-staging-publishing-bot/buckets/k8s-staging-publishing-bot/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CBo="
+  ]
 }

--- a/audit/projects/k8s-staging-publishing-bot/iam.json
+++ b/audit/projects/k8s-staging-publishing-bot/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWd8yPRdXI=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-release-test/buckets/artifacts.k8s-staging-release-test.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-release-test/buckets/artifacts.k8s-staging-release-test.appspot.com/iam.json
@@ -32,6 +32,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CBE="
+  ]
 }

--- a/audit/projects/k8s-staging-release-test/buckets/k8s-staging-release-test-gcb/iam.json
+++ b/audit/projects/k8s-staging-release-test/buckets/k8s-staging-release-test-gcb/iam.json
@@ -39,6 +39,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CA8="
+  ]
 }

--- a/audit/projects/k8s-staging-release-test/buckets/k8s-staging-release-test/iam.json
+++ b/audit/projects/k8s-staging-release-test/buckets/k8s-staging-release-test/iam.json
@@ -32,6 +32,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CB0="
+  ]
 }

--- a/audit/projects/k8s-staging-release-test/iam.json
+++ b/audit/projects/k8s-staging-release-test/iam.json
@@ -72,6 +72,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWdeEEcDiA=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-release-test/service-accounts/634027639865-compute@developer.gserviceaccount.com/description.json
+++ b/audit/projects/k8s-staging-release-test/service-accounts/634027639865-compute@developer.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "Compute Engine default service account",
   "email": "634027639865-compute@developer.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/k8s-staging-release-test/serviceAccounts/634027639865-compute@developer.gserviceaccount.com",
   "oauth2ClientId": "113841052621378931053",
   "projectId": "k8s-staging-release-test",

--- a/audit/projects/k8s-staging-release-test/service-accounts/634027639865-compute@developer.gserviceaccount.com/iam.json
+++ b/audit/projects/k8s-staging-release-test/service-accounts/634027639865-compute@developer.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/k8s-staging-scl-image-builder/buckets/artifacts.k8s-staging-scl-image-builder.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-scl-image-builder/buckets/artifacts.k8s-staging-scl-image-builder.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAc="
+  ]
 }

--- a/audit/projects/k8s-staging-scl-image-builder/buckets/k8s-staging-scl-image-builder-gcb/iam.json
+++ b/audit/projects/k8s-staging-scl-image-builder/buckets/k8s-staging-scl-image-builder-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-scl-image-builder/buckets/k8s-staging-scl-image-builder/iam.json
+++ b/audit/projects/k8s-staging-scl-image-builder/buckets/k8s-staging-scl-image-builder/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAg="
+  ]
 }

--- a/audit/projects/k8s-staging-scl-image-builder/iam.json
+++ b/audit/projects/k8s-staging-scl-image-builder/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWeU6VJPiY=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-service-apis/buckets/artifacts.k8s-staging-service-apis.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-service-apis/buckets/artifacts.k8s-staging-service-apis.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAc="
+  ]
 }

--- a/audit/projects/k8s-staging-service-apis/buckets/k8s-staging-service-apis-gcb/iam.json
+++ b/audit/projects/k8s-staging-service-apis/buckets/k8s-staging-service-apis-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-service-apis/buckets/k8s-staging-service-apis/iam.json
+++ b/audit/projects/k8s-staging-service-apis/buckets/k8s-staging-service-apis/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAg="
+  ]
 }

--- a/audit/projects/k8s-staging-service-apis/iam.json
+++ b/audit/projects/k8s-staging-service-apis/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWd7dwF5YM=",
   "version": 1
 }

--- a/audit/projects/k8s-staging-txtdirect/buckets/artifacts.k8s-staging-txtdirect.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-txtdirect/buckets/artifacts.k8s-staging-txtdirect.appspot.com/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAc="
+  ]
 }

--- a/audit/projects/k8s-staging-txtdirect/buckets/k8s-staging-txtdirect-gcb/iam.json
+++ b/audit/projects/k8s-staging-txtdirect/buckets/k8s-staging-txtdirect-gcb/iam.json
@@ -35,6 +35,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAo="
+  ]
 }

--- a/audit/projects/k8s-staging-txtdirect/buckets/k8s-staging-txtdirect/iam.json
+++ b/audit/projects/k8s-staging-txtdirect/buckets/k8s-staging-txtdirect/iam.json
@@ -28,6 +28,5 @@
       ],
       "role": "roles/storage.objectViewer"
     }
-  ],
-  "etag": "CAg="
+  ]
 }

--- a/audit/projects/k8s-staging-txtdirect/iam.json
+++ b/audit/projects/k8s-staging-txtdirect/iam.json
@@ -45,6 +45,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWd7lIX-mk=",
   "version": 1
 }

--- a/audit/projects/kubernetes-public/buckets/k8s-infra-clusters-terraform/iam.json
+++ b/audit/projects/kubernetes-public/buckets/k8s-infra-clusters-terraform/iam.json
@@ -20,6 +20,5 @@
       ],
       "role": "roles/storage.objectAdmin"
     }
-  ],
-  "etag": "CAQ="
+  ]
 }

--- a/audit/projects/kubernetes-public/buckets/kubernetes_public_billing/iam.json
+++ b/audit/projects/kubernetes-public/buckets/kubernetes_public_billing/iam.json
@@ -19,6 +19,5 @@
       ],
       "role": "roles/storage.legacyBucketWriter"
     }
-  ],
-  "etag": "CAU="
+  ]
 }

--- a/audit/projects/kubernetes-public/iam.json
+++ b/audit/projects/kubernetes-public/iam.json
@@ -119,6 +119,5 @@
       "role": "roles/viewer"
     }
   ],
-  "etag": "BwWfGuwd2WY=",
   "version": 1
 }

--- a/audit/projects/kubernetes-public/roles/ServiceAccountLister.json
+++ b/audit/projects/kubernetes-public/roles/ServiceAccountLister.json
@@ -1,6 +1,5 @@
 {
   "description": "Can list ServiceAccounts.",
-  "etag": "BwV_JE8PWv4=",
   "includedPermissions": [
     "iam.serviceAccounts.list"
   ],

--- a/audit/projects/kubernetes-public/service-accounts/127754664067-compute@developer.gserviceaccount.com/description.json
+++ b/audit/projects/kubernetes-public/service-accounts/127754664067-compute@developer.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "Compute Engine default service account",
   "email": "127754664067-compute@developer.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/kubernetes-public/serviceAccounts/127754664067-compute@developer.gserviceaccount.com",
   "oauth2ClientId": "108720443019014139260",
   "projectId": "kubernetes-public",

--- a/audit/projects/kubernetes-public/service-accounts/127754664067-compute@developer.gserviceaccount.com/iam.json
+++ b/audit/projects/kubernetes-public/service-accounts/127754664067-compute@developer.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "BwV-5pGXWtA=",
   "version": 1
 }

--- a/audit/projects/kubernetes-public/service-accounts/gke-nodes-aaa@kubernetes-public.iam.gserviceaccount.com/description.json
+++ b/audit/projects/kubernetes-public/service-accounts/gke-nodes-aaa@kubernetes-public.iam.gserviceaccount.com/description.json
@@ -1,7 +1,6 @@
 {
   "displayName": "Nodes in GKE cluster 'aaa'",
   "email": "gke-nodes-aaa@kubernetes-public.iam.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/kubernetes-public/serviceAccounts/gke-nodes-aaa@kubernetes-public.iam.gserviceaccount.com",
   "oauth2ClientId": "108417686403743706149",
   "projectId": "kubernetes-public",

--- a/audit/projects/kubernetes-public/service-accounts/gke-nodes-aaa@kubernetes-public.iam.gserviceaccount.com/iam.json
+++ b/audit/projects/kubernetes-public/service-accounts/gke-nodes-aaa@kubernetes-public.iam.gserviceaccount.com/iam.json
@@ -1,4 +1,3 @@
 {
-  "etag": "ACAB",
   "version": 1
 }

--- a/audit/projects/kubernetes-public/service-accounts/k8s-nodes@kubernetes-public.iam.gserviceaccount.com/description.json
+++ b/audit/projects/kubernetes-public/service-accounts/k8s-nodes@kubernetes-public.iam.gserviceaccount.com/description.json
@@ -2,7 +2,6 @@
   "description": "Legacy: delete this once \"dev2\" cluster dies",
   "displayName": "k8s-nodes",
   "email": "k8s-nodes@kubernetes-public.iam.gserviceaccount.com",
-  "etag": "MDEwMjE5MjA=",
   "name": "projects/kubernetes-public/serviceAccounts/k8s-nodes@kubernetes-public.iam.gserviceaccount.com",
   "oauth2ClientId": "102906005417360612620",
   "projectId": "kubernetes-public",

--- a/audit/projects/kubernetes-public/service-accounts/k8s-nodes@kubernetes-public.iam.gserviceaccount.com/iam.json
+++ b/audit/projects/kubernetes-public/service-accounts/k8s-nodes@kubernetes-public.iam.gserviceaccount.com/iam.json
@@ -7,6 +7,5 @@
       "role": "roles/iam.serviceAccountUser"
     }
   ],
-  "etag": "BwV-59tIQKE=",
   "version": 1
 }


### PR DESCRIPTION
This is a folloup for discussion:
https://github.com/kubernetes/k8s.io/pull/678/files#r396568576

etag properties at iam.json files were confusing and unnecessary
for auditing purposes

/assign @thockin 

Signed-off-by: Bart Smykla <bsmykla@vmware.com>