### PR TITLE
Add CoreDNS maintainers to the CoreDNS group and image staging

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -675,6 +675,7 @@ groups:
     members:
       - davanum@gmail.com
       - michaelg@okkur.org
+      - srajan@infoblox.com
 
   - email-id: k8s-infra-staging-csi@kubernetes.io
     name: k8s-infra-staging-csi

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -678,7 +678,6 @@ groups:
       - srajan@infoblox.com
       - jbelamaric@google.com
       - cohaver@infoblox.com
-      - yong.tang.github@outlook.com
 
   - email-id: k8s-infra-staging-csi@kubernetes.io
     name: k8s-infra-staging-csi

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -676,6 +676,9 @@ groups:
       - davanum@gmail.com
       - michaelg@okkur.org
       - srajan@infoblox.com
+      - jbelamaric@google.com
+      - cohaver@infoblox.com
+      - yong.tang.github@outlook.com
 
   - email-id: k8s-infra-staging-csi@kubernetes.io
     name: k8s-infra-staging-csi

--- a/k8s.gcr.io/images/k8s-staging-coredns/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-coredns/OWNERS
@@ -6,4 +6,3 @@ approvers:
 - rajansandeep
 - johnbelamaric
 - chrisohaver
-- yongtang

--- a/k8s.gcr.io/images/k8s-staging-coredns/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-coredns/OWNERS
@@ -4,3 +4,6 @@ approvers:
 - dims
 - stp-ip
 - rajansandeep
+- johnbelamaric
+- chrisohaver
+- yongtang

--- a/k8s.gcr.io/images/k8s-staging-coredns/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-coredns/OWNERS
@@ -3,3 +3,4 @@
 approvers:
 - dims
 - stp-ip
+- rajansandeep


### PR DESCRIPTION
Adding myself and CoreDNS maintainers to help in pushing CoreDNS release to promoter.
I'm a CoreDNS maintainer and also involved in upgrading the CoreDNS version in upstream k8s every release.