### PR TITLE
switch Workload Identity grant to Prow's trusted cluster

### DIFF
--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -223,7 +223,7 @@ empower_artifact_auditor_invoker "${PROD_PROJECT}"
 # Special case: empower Kubernetes service account to authenticate as a GCP
 # service account.
 empower_ksa_to_svcacct \
-    "k8s-prow-builds.svc.id.goog[test-pods/k8s-artifacts-prod]" \
+    "k8s-prow.svc.id.goog[test-pods/k8s-artifacts-prod]" \
     "${PROD_PROJECT}" \
     $(svc_acct_email "${PROD_PROJECT}" "${PROMOTER_SVCACCT}")
 

--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -223,7 +223,7 @@ empower_artifact_auditor_invoker "${PROD_PROJECT}"
 # Special case: empower Kubernetes service account to authenticate as a GCP
 # service account.
 empower_ksa_to_svcacct \
-    "k8s-prow.svc.id.goog[test-pods/k8s-artifacts-prod]" \
+    "k8s-prow.svc.id.goog[test-pods/k8s-infra-gcr-promoter]" \
     "${PROD_PROJECT}" \
     $(svc_acct_email "${PROD_PROJECT}" "${PROMOTER_SVCACCT}")
 


### PR DESCRIPTION
This is a followup to https://github.com/kubernetes/test-infra/pull/16917.

The problem is that there are 2 completely separate Prow clusters, one
called k8s-prow-builds, which runs random presubmits from the public and
k8s-prow, which only runs trusted jobs. The ci-k8sio-cip job runs in the
trusted cluster, and so the Workload Identity grant must be for
"k8s-prow", not "k8s-prow-builds".

The incorrect grant to
"k8s-prow-builds.svc.id.goog[test-pods/k8s-artifacts-prod]" must
manually be removed.

/cc @fejta @thockin 