### PR TITLE
allow artifact admins to resolve Stackdriver Error Reporting events

### DIFF
--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -296,6 +296,11 @@ function empower_group_to_admin_artifact_auditor() {
         "${acct}" \
         --member="group:${group}" \
         --role="roles/iam.serviceAccountUser"
+    # Also grant privileges to resolve Stackdriver Error Reporting errors.
+    gcloud \
+        projects add-iam-policy-binding "${project}" \
+        --member "group:${group}" \
+        --role roles/errorreporting.user
 }
 
 # Grant full privileges to the GCR promoter bot


### PR DESCRIPTION
The `errorreporting.user` grants the critical
`errorreporting.groupMetadata.update` permission which allows the user
to resolve the statuses of Stackdriver Error Reporting events. We
currently use Stackdriver Error Reporting to record all errors detected
by the cip-auditor (audits GCR state transitions).

See https://cloud.google.com/error-reporting/docs/iam