### PR TITLE
add KSA binding for workload identity

### DIFF
--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -235,9 +235,24 @@ empower_artifact_auditor_invoker "${PROD_PROJECT}"
 
 # Special case: empower Kubernetes service account to authenticate as a GCP
 # service account.
+#
+# For write access to k8s-artifacts-prod GCR.
 empower_ksa_to_svcacct \
     "k8s-prow.svc.id.goog[test-pods/k8s-infra-gcr-promoter]" \
     "${PROD_PROJECT}" \
     $(svc_acct_email "${PROD_PROJECT}" "${PROMOTER_SVCACCT}")
+# For write access to:
+#   (1) k8s-gcr-backup-test-prod GCR
+#   (2) k8s-gcr-backup-test-prod-bak GCR.
+# Even though we only grant authentication to 1 SA
+# (k8s-infra-gcr-promoter@k8s-gcr-backup-test-prod-bak.iam.gserviceaccount.com),
+# this SA has write access to the above 2 GCRs, fulfilling our needs.
+#
+# Also, note that the project name for the GKE cluster is "k8s-prow-builds",
+# which is the non-trusted Prow cluster.
+empower_ksa_to_svcacct \
+    "k8s-prow-builds.svc.id.goog[test-pods/k8s-infra-gcr-promoter-test]" \
+    "${GCR_BACKUP_TEST_PRODBAK_PROJECT}" \
+    $(svc_acct_email "${GCR_BACKUP_TEST_PRODBAK_PROJECT}" "${PROMOTER_SVCACCT}")
 
 color 6 "Done"


### PR DESCRIPTION
This lets the `k8s-infra-gcr-promoter-test` Kubernetes service account
in the `test-pods` Kubernetes namespace in the "k8s-prow-builds" GCP
project's GKE cluster authenticate as
`k8s-infra-gcr-promoter@k8s-gcr-backup-test-prod-bak.iam.gserviceaccount.com`.
This GCP SA has write access to the test-only GCRs for testing the
backup logic.

This is a follow-up to #708 and #709.