### PR TITLE
allow workload identity for prod backups

### DIFF
--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -252,6 +252,11 @@ empower_ksa_to_svcacct \
     "k8s-prow.svc.id.goog[test-pods/k8s-infra-gcr-promoter]" \
     "${PROD_PROJECT}" \
     $(svc_acct_email "${PROD_PROJECT}" "${PROMOTER_SVCACCT}")
+# For write access to k8s-artifacts-prod-bak GCR. This is only for backups.
+empower_ksa_to_svcacct \
+    "k8s-prow.svc.id.goog[test-pods/k8s-infra-gcr-promoter-bak]" \
+    "${PRODBAK_PROJECT}" \
+    $(svc_acct_email "${PRODBAK_PROJECT}" "${PROMOTER_SVCACCT}")
 # For write access to:
 #   (1) k8s-gcr-backup-test-prod GCR
 #   (2) k8s-gcr-backup-test-prod-bak GCR.


### PR DESCRIPTION
This empowers the `k8s-infra-gcr-promoter-bak` KSA in the `test-pods`
K8s namespace in the `k8s-prow` GCP Project (where the Prow trusted
cluster lives) to authenticate as
`k8s-infra-gcr-promoter@k8s-artifacts-prod-bak.iam.gserviceaccount.com`.

The `k8s-infra-gcr-promoter-bak` KSA does not exist yet and will be
created when we re-introduce the backup job (pulled on 2020-03-18 due to
quota issues). The backup job itself was optimized in
https://github.com/kubernetes/k8s.io/pull/677.