### PR TITLE
Move perfdash to new infrastructure

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -170,6 +170,9 @@ node-perf-dash:
 perf-dash:
   type: A
   value: 35.188.102.189
+perf-dash-canary:
+  type: A
+  value: 34.102.200.94
 pr:
   type: CNAME
   value: redirect.k8s.io.

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -136,6 +136,7 @@ groups:
       - k8s-infra-rbac-gcsweb@kubernetes.io
       - k8s-infra-rbac-k8s-io-canary@kubernetes.io
       - k8s-infra-rbac-k8s-io-prod@kubernetes.io
+      - k8s-infra-rbac-perfdash@kubernetes.io
       - k8s-infra-rbac-publishing-bot@kubernetes.io
 
   - email-id: k8s-infra-alerts@kubernetes.io
@@ -347,6 +348,22 @@ groups:
       - bentheelder@google.com
       - cblecker@gmail.com
       - thockin@google.com
+
+  - email-id: k8s-infra-rbac-perfdash@kubernetes.io
+    name: k8s-infra-rbac-perfdash
+    description: |-
+      ACL for Perfdash
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - bartek@smykla.com
+      - janluk@google.com
+      - jkaniuk@google.com
+      - jprzychodzen@google.com
+      - maciejborsz@google.com
+      - mmatejczyk@google.com
+      - shyam123.jvs95@gmail.com
+      - wojtekt@google.com
 
   - email-id: k8s-infra-rbac-publishing-bot@kubernetes.io
     name: k8s-infra-rbac-publishing-bot

--- a/infra/gcp/namespaces/ensure-namespaces.sh
+++ b/infra/gcp/namespaces/ensure-namespaces.sh
@@ -146,6 +146,7 @@ ALL_PROJECTS=(
     "publishing-bot"
     "k8s-io-prod"
     "k8s-io-canary"
+    "perfdash"
 )
 
 for prj in "${ALL_PROJECTS[@]}"; do

--- a/perf-dash.k8s.io/OWNERS
+++ b/perf-dash.k8s.io/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+  - bartsmykla
+  - mm4tt
+  - wojtek-t

--- a/perf-dash.k8s.io/README.md
+++ b/perf-dash.k8s.io/README.md
@@ -1,0 +1,8 @@
+To bootstrap [Perfdash](https://github.com/kubernetes/perf-tests/tree/master/perfdash):
+
+```bash
+kubectl apply -f certificate.yaml
+kubectl apply -f deployment.yaml
+kubectl apply -f ingress.yaml
+kubectl apply -f service.yaml
+```

--- a/perf-dash.k8s.io/certificate.yaml
+++ b/perf-dash.k8s.io/certificate.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: perfdash-k8s-io
+  namespace: perfdash
+  annotations:
+    acme.cert-manager.io/http01-override-ingress-name: "perfdash"
+spec:
+  secretName: perfdash-k8s-io-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-prod
+  dnsNames:
+  - perf-dash-canary.k8s.io
+  - perf-dash-canary.kubernetes.io

--- a/perf-dash.k8s.io/deployment.yaml
+++ b/perf-dash.k8s.io/deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: perfdash
+  namespace: perfdash
+  labels:
+    app: perfdash
+spec:
+  selector:
+    matchLabels:
+      app: perfdash
+  template:
+    metadata:
+      labels:
+        app: perfdash
+    spec:
+      containers:
+      - name: perfdash
+        image: gcr.io/k8s-testimages/perfdash:2.22
+        command:
+          - /perfdash
+          -   --www=true
+          -   --dir=/www
+          -   --address=0.0.0.0:8080
+          -   --builds=100
+          -   --githubConfigDir=https://api.github.com/repos/kubernetes/test-infra/contents/config/jobs/kubernetes/sig-scalability
+          -   --githubConfigDir=https://api.github.com/repos/kubernetes/test-infra/contents/config/jobs/kubernetes/sig-release/release-branch-jobs
+        imagePullPolicy: Always
+        ports:
+        - name: status
+          containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 10
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 600m
+            memory: 8Gi
+          limits:
+            cpu: 600m
+            memory: 8Gi
+      restartPolicy: Always

--- a/perf-dash.k8s.io/ingress.yaml
+++ b/perf-dash.k8s.io/ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: perfdash
+  namespace: perfdash
+  labels:
+    app: perfdash
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: perf-dash-k8s-io-ingress-prod
+spec:
+  tls:
+  - secretName: perfdash-k8s-io-tls
+  backend:
+    serviceName: perfdash-status
+    servicePort: status

--- a/perf-dash.k8s.io/service.yaml
+++ b/perf-dash.k8s.io/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: perfdash-status
+  namespace: perfdash
+  labels:
+    app: perfdash
+spec:
+  selector:
+    app: perfdash
+  ports:
+  - name: status
+    port: 80
+    targetPort: status
+  type: NodePort


### PR DESCRIPTION
Applies to: https://github.com/kubernetes/k8s.io/issues/549
Closes https://github.com/kubernetes/k8s.io/issues/732

I have tested these manifests by deploying them and using my own temporary domain.

Next steps:
- Groups reconciliation
- Running [`ensure-namespaces.sh`](https://github.com/kubernetes/k8s.io/blob/master/infra/gcp/namespaces/ensure-namespaces.sh) script
- Deploying perfdash manifests in `aaa`
- ~Somebody with permissions should add new static IP address in GCP console named `perf-dash-k8s-io-ingress-prod`~ done
- Creation of Pull Request with DNS change for `perf-dash.k8s.io` which should now point to created earlier static IP for perfdash Ingress

@mm4tt @wojtek-t do you want to add anyone else to OWNERS file for directory with perfdash manifests?
/cc @munnerz @mm4tt @wojtek-t 

Signed-off-by: Bart Smykla <bsmykla@vmware.com>