### PR TITLE
Add a staging repo for cluster-proportional-vertical-autoscaler

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -687,6 +687,18 @@ groups:
       - jbelamaric@google.com
       - cohaver@infoblox.com
 
+  - email-id: k8s-infra-staging-cpva@kubernetes.io
+    name: k8s-infra-staging-cpva
+    description: |-
+      ACL for staging cluster-proportional-vertical-autoscaler image.
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - bowei@google.com
+      - dnardo@google.com
+      - thockin@google.com
+      - zihongz@google.com
+
   - email-id: k8s-infra-staging-csi@kubernetes.io
     name: k8s-infra-staging-csi
     description: |-

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -54,6 +54,7 @@ STAGING_PROJECTS=(
     capi-docker
     capi-vsphere
     coredns
+    cpva
     csi
     csi-secrets-store
     descheduler

--- a/k8s.gcr.io/images/k8s-staging-cpva/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-cpva/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS file documentation:
+#  https://github.com/kubernetes/kubernetes/blob/master/docs/devel/owners.md
+
+approvers:
+  - thockin
+  - dnardo
+  - MrHohn
+  - bowei

--- a/k8s.gcr.io/images/k8s-staging-cpva/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-cpva/images.yaml
@@ -1,0 +1,1 @@
+# No images yet

--- a/k8s.gcr.io/images/k8s-staging-cpva/promoter-manifest.yaml
+++ b/k8s.gcr.io/images/k8s-staging-cpva/promoter-manifest.yaml
@@ -1,0 +1,10 @@
+# google group for gcr.io/k8s-staging-cpva is k8s-infra-staging-cpva@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-cpva
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/cpva
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/cpva
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/cpva
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
I largely followed https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io#creating-staging-repos and https://github.com/kubernetes/k8s.io/pull/689.

This is to unblock a new release on CPVA: https://github.com/kubernetes-incubator/cluster-proportional-vertical-autoscaler/issues/33

/cc @bowei @thockin 