### PR TITLE
Fixed certificate.yaml manifest for perfdash

### DIFF
--- a/perf-dash.k8s.io/certificate.yaml
+++ b/perf-dash.k8s.io/certificate.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: perfdash
   annotations:
     acme.cert-manager.io/http01-override-ingress-name: "perfdash"
+    cert-manager.io/issue-temporary-certificate: "true"
 spec:
   secretName: perfdash-k8s-io-tls
   issuerRef:
@@ -12,4 +13,3 @@ spec:
     name: letsencrypt-prod
   dnsNames:
   - perf-dash-canary.k8s.io
-  - perf-dash-canary.kubernetes.io


### PR DESCRIPTION
/cc @munnerz 

- Added missing annotation to issue temporary
  certificate. We didn't face the issue with it before
  because we were reusing already existing certificates.
- Removed perf-dash-canary.kubernetes.io dns name
  from certificate because we didn't put this subdomain
  in k/k8s.io/dns/zones-config manifests and it's actually
  unnecessary

Signed-off-by: Bart Smykla <bsmykla@vmware.com>