### PR TITLE
Correct k8s.gcr.io post-k8sio-cip Testgrid link

### DIFF
--- a/k8s.gcr.io/README.md
+++ b/k8s.gcr.io/README.md
@@ -85,7 +85,7 @@ Essentially, in order to get images published to a production repo, you have to
 use the image promotion (PR creation) process defined above.
 
 [1]: https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md
-[2]: https://k8s-testgrid.appspot.com/sig-release-misc#post-k8sio-cip
+[2]: https://k8s-testgrid.appspot.com/sig-release-releng-blocking#post-k8sio-cip
 [ensure-staging-storage.sh]: /infra/gcp/ensure-staging-storage.sh
 [groups.yaml]: /groups/groups.yaml
 [vdf]:https://github.com/kubernetes/k8s.io/blob/master/k8s.gcr.io/Vanity-Domain-Flip.md


### PR DESCRIPTION
As of https://github.com/kubernetes/test-infra/commit/b925708ce2032ded46f309e4ea8ba91a3c63e9e3 the `post-k8sio-cip` tab no longer lives under the `sig-release-misc` dashboard so the existing link is dead.

This corrects it to (one) of its new homes under `sig-release-releng-blocking` (it also exists under `wg-k8s-infra-k8sio`)