### PR TITLE
Add YoyinZyc to k8s-infra-staging-etcd group

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -780,6 +780,7 @@ groups:
       - jpbetz@google.com
       - wenjiazhang@google.com
       - jingyih@google.com
+      - yczhou@google.com
 
   - email-id: k8s-infra-staging-external-dns@kubernetes.io
     name: k8s-infra-staging-external-dns


### PR DESCRIPTION
@YoyinZyc is helping build and push new images to gcr.io/k8s-staging-etcd (https://github.com/kubernetes/kubernetes/pull/89895). She also helped build and push images for etcd during the last etcd version bump in kubernetes.