### PR TITLE
Update Release Engineering lists

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -427,20 +427,18 @@ groups:
       - stephen.k8s@agst.us
       - tpepper@gmail.com
     members:
-      - alarcj137@gmail.com
-      - alexeldeib@gmail.com
       - ctadeu@gmail.com
       - dmaceachern@vmware.com
       - feiskyer@gmail.com
+      - gveronicalg@gmail.com
       - hhorl@pivotal.io
       - idealhack@gmail.com
       - jameswangel@gmail.com
-      - kendrickcoleman@gmail.com
       - killen.bob@gmail.com
       - linusa@google.com
+      - marky.r.jackson@gmail.com
       - mudrinic.mare@gmail.com
       - onlydole@gmail.com
-      - paul.bouwer@gmail.com
       - premdeeps@google.com
       - sethpmccombs@gmail.com
       - saschagrunert@gmail.com
@@ -1120,22 +1118,20 @@ groups:
       - tpepper@gmail.com
       - tpepper@vmware.com
     members:
-      - alarcj137@gmail.com
-      - alexeldeib@gmail.com
       - ctadeu@gmail.com
       - daminisatya@gmail.com
       - dmaceachern@vmware.com
       - feiskyer@gmail.com
       - georgedanielmangum@gmail.com
+      - gveronicalg@gmail.com
       - hhorl@pivotal.io
       - idealhack@gmail.com
       - jameswangel@gmail.com
-      - kendrickcoleman@gmail.com
       - killen.bob@gmail.com
       - linusa@google.com
+      - marky.r.jackson@gmail.com
       - mudrinic.mare@gmail.com
       - onlydole@gmail.com
-      - paul.bouwer@gmail.com
       - premdeeps@google.com
       - release-managers-private@kubernetes.io
       - sethpmccombs@gmail.com

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -445,21 +445,6 @@ groups:
       - simony@google.com
       - sumitranr@google.com
 
-  - email-id: k8s-infra-sig-release-prototype@kubernetes.io
-    name: k8s-infra-sig-release-prototype
-    description: |-
-      ACL for sig-release prototype
-    settings:
-      ReconcileMembers: "true"
-    members:
-      - bartek@smykla.com
-      - davanum@gmail.com
-      - hh@ii.coop
-      - ihor@cncf.io
-      - spiffxp@google.com
-      - thockin@google.com
-      - tpepper@gmail.com
-
   - email-id: k8s-infra-conform-capi-openstack@kubernetes.io
     name: k8s-infra-conform-capi-openstack
     description: |-
@@ -840,10 +825,10 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
-      # TODO(justaugustus): Add editors group after k8s.gcr.io domain flip
       - k8s-infra-release-admins@kubernetes.io
-      # This is the old kubernetes-release-test project.  We need it until all
-      # the transitions to community-ownership are done for release process.
+      - k8s-infra-release-editors@kubernetes.io
+      # This is the old kubernetes-release-test project. We need it until all
+      # the transitions to community ownership are done for release process.
       - 648026197307@cloudbuild.gserviceaccount.com
 
   - email-id: k8s-infra-staging-kube-state-metrics@kubernetes.io
@@ -935,20 +920,6 @@ groups:
       - davanum@gmail.com
       - nikitaraghunath@gmail.com
       - stefan.schimanski@gmail.com
-
-  - email-id: k8s-infra-staging-release-test@kubernetes.io
-    name: k8s-infra-staging-release-test
-    description: |-
-      ACL for staging release-test
-    settings:
-      ReconcileMembers: "true"
-    members:
-      - k8s-infra-release-admins@kubernetes.io
-      - k8s-infra-release-editors@kubernetes.io
-      - davanum@gmail.com
-      - ihor@cncf.io
-      - spiffxp@google.com
-      - thockin@google.com
 
   - email-id: k8s-infra-staging-releng@kubernetes.io
     name: k8s-infra-staging-releng

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -434,6 +434,7 @@ groups:
       - hhorl@pivotal.io
       - idealhack@gmail.com
       - jameswangel@gmail.com
+      - jeremy.r.rickard@gmail.com
       - killen.bob@gmail.com
       - linusa@google.com
       - marky.r.jackson@gmail.com
@@ -1098,6 +1099,7 @@ groups:
       - hhorl@pivotal.io
       - idealhack@gmail.com
       - jameswangel@gmail.com
+      - jeremy.r.rickard@gmail.com
       - killen.bob@gmail.com
       - linusa@google.com
       - marky.r.jackson@gmail.com


### PR DESCRIPTION
- Update Release Manager groups
  - Remove Jorge Alarcon Ochoa (@alejandrox1) (previous RT Lead (1.18)) (ref: https://github.com/kubernetes/sig-release/issues/933)
  - Update Release Manager Associates:
    - Add (ref: https://github.com/kubernetes/sig-release/issues/1047):
      - Marky Jackson (@markyjackson-taulia)
      - Verónica López (@Verolop)
    - Remove (ref: https://github.com/kubernetes/sig-release/pull/1046):
      - Ace Eldeib (@alexeldeib)
      - Kendrick Coleman (@kacole2)
      - Paul Bouwer (@paulbouwer)
      - Taylor Dolezal (@onlydole)
- Update access to Release Manager GCP projects
  - Add editors to `k8s-infra-staging-kubernetes`
  - Deprecate IAM groups for (ref: https://github.com/kubernetes/release/issues/1161):
    - `k8s-infra-sig-release-prototype`
    - `k8s-infra-staging-release-test`
- Grant new RT Lead Shadows (@jeremyrickard) view access to Releng projects (ref: https://github.com/kubernetes/sig-release/issues/1031)

/assign @tpepper @dims @cblecker 
cc: @onlydole @kubernetes/release-managers @kubernetes/release-engineering 