### PR TITLE
Added ssd storage class to aaa cluster conf

### DIFF
--- a/infra/gcp/clusters/kubernetes-public/aaa/00-inputs.tf
+++ b/infra/gcp/clusters/kubernetes-public/aaa/00-inputs.tf
@@ -17,6 +17,7 @@ terraform {
   required_providers {
     google      = "~> 2.14"
     google-beta = "~> 2.14"
+    kubernetes  = "~> 1.11"
   }
 }
 

--- a/infra/gcp/clusters/kubernetes-public/aaa/10-cluster-configuration.tf
+++ b/infra/gcp/clusters/kubernetes-public/aaa/10-cluster-configuration.tf
@@ -158,3 +158,26 @@ resource "google_container_cluster" "cluster" {
     enabled = true
   }
 }
+
+
+provider "kubernetes" {
+  host                   = "https://${google_container_cluster.cluster.endpoint}"
+  client_certificate     = base64decode(google_container_cluster.cluster[0].client_certificate)
+  client_key             = base64decode(google_container_cluster.cluster[0].client_key)
+  cluster_ca_certificate = base64decode(google_container_cluster.cluster[0].cluster_ca_certificate)
+  config_context         = "gke_kubernetes-public_us-central1_aaa"
+  load_config_file       = "true"
+}
+
+// Create ssd storage class (initialy for Publishing Bot)
+resource "kubernetes_storage_class" "ssd" {
+  metadata {
+    name = "ssd"
+  }
+
+  storage_provisioner = "kubernetes.io/gce-pd"
+
+  parameters = {
+    type = "pd-ssd"
+  }
+}


### PR DESCRIPTION
Applies to [discussion](https://github.com/kubernetes/k8s.io/pull/520/files#r379147033)

As we are close to deploy publishing bot at `aaa`
we need this storage class and it will be created
when provisioning `aaa` cluster via terraform now

/cc @ameukam @nikhita @sttts @thockin 

Signed-off-by: Bart Smykla <bsmykla@vmware.com>