### PR TITLE
add staging project for kind

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -793,6 +793,18 @@ groups:
       - wfender@google.com
       - ygui@google.com
 
+  - email-id: k8s-infra-staging-kind@kubernetes.io
+    name: k8s-infra-staging-kind
+    description: |-
+      ACL for staging kind artifacts.
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - amwat@google.com
+      - antonio.ojea.garcia@gmail.com 
+      - bentheelder@google.com
+      - james@munnelly.eu
+
   - email-id: k8s-infra-staging-kops@kubernetes.io
     name: k8s-infra-staging-kops
     description: |-

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -63,6 +63,7 @@ STAGING_PROJECTS=(
     etcd
     external-dns
     kas-network-proxy
+    kind
     kops
     kube-state-metrics
     kubeadm

--- a/k8s.gcr.io/images/k8s-image-staging-kind/OWNERS
+++ b/k8s.gcr.io/images/k8s-image-staging-kind/OWNERS
@@ -1,0 +1,14 @@
+# See the OWNERS file documentation:
+#  https://github.com/kubernetes/kubernetes/blob/master/docs/devel/owners.md
+
+reviewers:
+- amwat
+- aojea
+- BenTheElder
+- munnerz
+
+approvers:
+- amwat
+- aojea
+- BenTheElder
+- munnerz

--- a/k8s.gcr.io/images/k8s-image-staging-kind/images.yaml
+++ b/k8s.gcr.io/images/k8s-image-staging-kind/images.yaml
@@ -1,0 +1,1 @@
+# No images yet

--- a/k8s.gcr.io/manifests/k8s-image-staging-kind/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-image-staging-kind/promoter-manifest.yaml
@@ -1,0 +1,10 @@
+# google group for gcr.io/k8s-staging-kind is k8s-infra-staging-kind@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-kind
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/kind
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/kind
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/kind
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
to start we'll be using this to move our existing CI binary build (consumed by kubernetes CI) over to community infra with GCB + GCS

ref: https://github.com/kubernetes/k8s.io/issues/654

this PR is constructed per https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io#creating-staging-repos

fellow owners: @amwat @aojea @munnerz 

cc @bartsmykla @dims @spiffxp 