### PR TITLE
New GCP audit - April 15, 2020

### DIFF
--- a/audit/projects/k8s-staging-kind/buckets/artifacts.k8s-staging-kind.appspot.com/bucketpolicyonly.txt
+++ b/audit/projects/k8s-staging-kind/buckets/artifacts.k8s-staging-kind.appspot.com/bucketpolicyonly.txt
@@ -1,0 +1,4 @@
+Bucket Policy Only setting for gs://artifacts.k8s-staging-kind.appspot.com:
+  Enabled: True
+  LockedTime: 2020-07-14 00:28:37.325000+00:00
+

--- a/audit/projects/k8s-staging-kind/buckets/artifacts.k8s-staging-kind.appspot.com/cors.txt
+++ b/audit/projects/k8s-staging-kind/buckets/artifacts.k8s-staging-kind.appspot.com/cors.txt
@@ -1,0 +1,1 @@
+gs://artifacts.k8s-staging-kind.appspot.com/ has no CORS configuration.

--- a/audit/projects/k8s-staging-kind/buckets/artifacts.k8s-staging-kind.appspot.com/iam.json
+++ b/audit/projects/k8s-staging-kind/buckets/artifacts.k8s-staging-kind.appspot.com/iam.json
@@ -1,0 +1,37 @@
+{
+  "bindings": [
+    {
+      "members": [
+        "group:k8s-infra-artifact-admins@kubernetes.io",
+        "projectEditor:k8s-staging-kind",
+        "projectOwner:k8s-staging-kind"
+      ],
+      "role": "roles/storage.legacyBucketOwner"
+    },
+    {
+      "members": [
+        "projectViewer:k8s-staging-kind"
+      ],
+      "role": "roles/storage.legacyBucketReader"
+    },
+    {
+      "members": [
+        "group:k8s-infra-staging-kind@kubernetes.io"
+      ],
+      "role": "roles/storage.legacyBucketWriter"
+    },
+    {
+      "members": [
+        "group:k8s-infra-artifact-admins@kubernetes.io",
+        "group:k8s-infra-staging-kind@kubernetes.io"
+      ],
+      "role": "roles/storage.objectAdmin"
+    },
+    {
+      "members": [
+        "allUsers"
+      ],
+      "role": "roles/storage.objectViewer"
+    }
+  ]
+}

--- a/audit/projects/k8s-staging-kind/buckets/artifacts.k8s-staging-kind.appspot.com/logging.txt
+++ b/audit/projects/k8s-staging-kind/buckets/artifacts.k8s-staging-kind.appspot.com/logging.txt
@@ -1,0 +1,1 @@
+gs://artifacts.k8s-staging-kind.appspot.com/ has no logging configuration.

--- a/audit/projects/k8s-staging-kind/buckets/k8s-staging-kind-gcb/bucketpolicyonly.txt
+++ b/audit/projects/k8s-staging-kind/buckets/k8s-staging-kind-gcb/bucketpolicyonly.txt
@@ -1,0 +1,4 @@
+Bucket Policy Only setting for gs://k8s-staging-kind-gcb:
+  Enabled: True
+  LockedTime: 2020-07-14 00:29:20.840000+00:00
+

--- a/audit/projects/k8s-staging-kind/buckets/k8s-staging-kind-gcb/cors.txt
+++ b/audit/projects/k8s-staging-kind/buckets/k8s-staging-kind-gcb/cors.txt
@@ -1,0 +1,1 @@
+gs://k8s-staging-kind-gcb/ has no CORS configuration.

--- a/audit/projects/k8s-staging-kind/buckets/k8s-staging-kind-gcb/iam.json
+++ b/audit/projects/k8s-staging-kind/buckets/k8s-staging-kind-gcb/iam.json
@@ -1,0 +1,44 @@
+{
+  "bindings": [
+    {
+      "members": [
+        "group:k8s-infra-artifact-admins@kubernetes.io",
+        "projectEditor:k8s-staging-kind",
+        "projectOwner:k8s-staging-kind"
+      ],
+      "role": "roles/storage.legacyBucketOwner"
+    },
+    {
+      "members": [
+        "projectViewer:k8s-staging-kind"
+      ],
+      "role": "roles/storage.legacyBucketReader"
+    },
+    {
+      "members": [
+        "group:k8s-infra-staging-kind@kubernetes.io"
+      ],
+      "role": "roles/storage.legacyBucketWriter"
+    },
+    {
+      "members": [
+        "group:k8s-infra-artifact-admins@kubernetes.io",
+        "group:k8s-infra-staging-kind@kubernetes.io"
+      ],
+      "role": "roles/storage.objectAdmin"
+    },
+    {
+      "members": [
+        "serviceAccount:deployer@k8s-prow.iam.gserviceaccount.com"
+      ],
+      "role": "roles/storage.objectCreator"
+    },
+    {
+      "members": [
+        "allUsers",
+        "serviceAccount:deployer@k8s-prow.iam.gserviceaccount.com"
+      ],
+      "role": "roles/storage.objectViewer"
+    }
+  ]
+}

--- a/audit/projects/k8s-staging-kind/buckets/k8s-staging-kind-gcb/logging.txt
+++ b/audit/projects/k8s-staging-kind/buckets/k8s-staging-kind-gcb/logging.txt
@@ -1,0 +1,1 @@
+gs://k8s-staging-kind-gcb/ has no logging configuration.

--- a/audit/projects/k8s-staging-kind/buckets/k8s-staging-kind/bucketpolicyonly.txt
+++ b/audit/projects/k8s-staging-kind/buckets/k8s-staging-kind/bucketpolicyonly.txt
@@ -1,0 +1,4 @@
+Bucket Policy Only setting for gs://k8s-staging-kind:
+  Enabled: True
+  LockedTime: 2020-07-14 00:29:00.126000+00:00
+

--- a/audit/projects/k8s-staging-kind/buckets/k8s-staging-kind/cors.txt
+++ b/audit/projects/k8s-staging-kind/buckets/k8s-staging-kind/cors.txt
@@ -1,0 +1,1 @@
+gs://k8s-staging-kind/ has no CORS configuration.

--- a/audit/projects/k8s-staging-kind/buckets/k8s-staging-kind/iam.json
+++ b/audit/projects/k8s-staging-kind/buckets/k8s-staging-kind/iam.json
@@ -1,0 +1,37 @@
+{
+  "bindings": [
+    {
+      "members": [
+        "group:k8s-infra-artifact-admins@kubernetes.io",
+        "projectEditor:k8s-staging-kind",
+        "projectOwner:k8s-staging-kind"
+      ],
+      "role": "roles/storage.legacyBucketOwner"
+    },
+    {
+      "members": [
+        "projectViewer:k8s-staging-kind"
+      ],
+      "role": "roles/storage.legacyBucketReader"
+    },
+    {
+      "members": [
+        "group:k8s-infra-staging-kind@kubernetes.io"
+      ],
+      "role": "roles/storage.legacyBucketWriter"
+    },
+    {
+      "members": [
+        "group:k8s-infra-artifact-admins@kubernetes.io",
+        "group:k8s-infra-staging-kind@kubernetes.io"
+      ],
+      "role": "roles/storage.objectAdmin"
+    },
+    {
+      "members": [
+        "allUsers"
+      ],
+      "role": "roles/storage.objectViewer"
+    }
+  ]
+}

--- a/audit/projects/k8s-staging-kind/buckets/k8s-staging-kind/logging.txt
+++ b/audit/projects/k8s-staging-kind/buckets/k8s-staging-kind/logging.txt
@@ -1,0 +1,1 @@
+gs://k8s-staging-kind/ has no logging configuration.

--- a/audit/projects/k8s-staging-kind/description.json
+++ b/audit/projects/k8s-staging-kind/description.json
@@ -1,0 +1,11 @@
+{
+  "createTime": "2020-04-15T00:27:38.298Z",
+  "lifecycleState": "ACTIVE",
+  "name": "k8s-staging-kind",
+  "parent": {
+    "id": "758905017065",
+    "type": "organization"
+  },
+  "projectId": "k8s-staging-kind",
+  "projectNumber": "220811308229"
+}

--- a/audit/projects/k8s-staging-kind/iam.json
+++ b/audit/projects/k8s-staging-kind/iam.json
@@ -1,0 +1,50 @@
+{
+  "bindings": [
+    {
+      "members": [
+        "serviceAccount:220811308229@cloudbuild.gserviceaccount.com",
+        "serviceAccount:deployer@k8s-prow.iam.gserviceaccount.com"
+      ],
+      "role": "roles/cloudbuild.builds.builder"
+    },
+    {
+      "members": [
+        "group:k8s-infra-staging-kind@kubernetes.io"
+      ],
+      "role": "roles/cloudbuild.builds.editor"
+    },
+    {
+      "members": [
+        "serviceAccount:service-220811308229@gcp-sa-cloudbuild.iam.gserviceaccount.com"
+      ],
+      "role": "roles/cloudbuild.serviceAgent"
+    },
+    {
+      "members": [
+        "serviceAccount:service-220811308229@containerregistry.iam.gserviceaccount.com"
+      ],
+      "role": "roles/editor"
+    },
+    {
+      "members": [
+        "user:spiffxp@google.com"
+      ],
+      "role": "roles/owner"
+    },
+    {
+      "members": [
+        "group:k8s-infra-staging-kind@kubernetes.io"
+      ],
+      "role": "roles/serviceusage.serviceUsageConsumer"
+    },
+    {
+      "members": [
+        "group:k8s-infra-artifact-admins@kubernetes.io",
+        "group:k8s-infra-release-viewers@kubernetes.io",
+        "group:k8s-infra-staging-kind@kubernetes.io"
+      ],
+      "role": "roles/viewer"
+    }
+  ],
+  "version": 1
+}

--- a/audit/projects/k8s-staging-kind/services/enabled.txt
+++ b/audit/projects/k8s-staging-kind/services/enabled.txt
@@ -1,0 +1,8 @@
+NAME                              TITLE
+cloudbuild.googleapis.com         Cloud Build API
+cloudkms.googleapis.com           Cloud Key Management Service (KMS) API
+containerregistry.googleapis.com  Container Registry API
+logging.googleapis.com            Cloud Logging API
+pubsub.googleapis.com             Cloud Pub/Sub API
+storage-api.googleapis.com        Google Cloud Storage JSON API
+storage-component.googleapis.com  Cloud Storage

--- a/audit/projects/kubernetes-public/iam.json
+++ b/audit/projects/kubernetes-public/iam.json
@@ -115,6 +115,18 @@
     },
     {
       "members": [
+        "group:k8s-infra-cluster-admins@kubernetes.io"
+      ],
+      "role": "roles/stackdriver.accounts.editor"
+    },
+    {
+      "members": [
+        "group:k8s-infra-cluster-admins@kubernetes.io"
+      ],
+      "role": "roles/stackdriver.accounts.viewer"
+    },
+    {
+      "members": [
         "user:thockin@gmail.com"
       ],
       "role": "roles/viewer"


### PR DESCRIPTION
Contains resources for KIND and IAM change which gives
more permissions for k8s-infra-cluster-admins@kubernetes.io
in relation to StackDriver. It's needed to get POC of monitoring

Signed-off-by: Bart Smykla <bsmykla@vmware.com>