### PR TITLE
Add staging repo for bootkube

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -677,6 +677,16 @@ groups:
       - justinsb@google.com
       - prignanov@vmware.com
 
+  - email-id: k8s-infra-staging-bootkube@kubernetes.io
+    name: k8s-infra-staging-bootkube
+    description: |-
+      ACL for staging bootkube image.
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - andrew@andrewrynhard.com
+      - rahul@rmenn.in
+
   - email-id: k8s-infra-staging-coredns@kubernetes.io
     name: k8s-infra-staging-coredns
     description: |-

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -42,6 +42,7 @@ STAGING_PROJECTS=(
     apisnoop
     artifact-promoter
     autoscaling
+    bootkube
     build-image
     cip-test
     cluster-api

--- a/k8s.gcr.io/images/k8s-staging-bootkube/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-bootkube/OWNERS
@@ -1,5 +1,5 @@
 # See the OWNERS file documentation:
-#  https://github.com/kubernetes/kubernetes/blob/master/docs/devel/owners.md
+#  https://go.k8s.io/owners
 
 approvers:
   - andrewrynhard

--- a/k8s.gcr.io/images/k8s-staging-bootkube/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-bootkube/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS file documentation:
+#  https://github.com/kubernetes/kubernetes/blob/master/docs/devel/owners.md
+
+approvers:
+  - andrewrynhard
+  - rmenn

--- a/k8s.gcr.io/images/k8s-staging-bootkube/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-bootkube/images.yaml
@@ -1,0 +1,1 @@
+# No images yet

--- a/k8s.gcr.io/images/k8s-staging-bootkube/promoter-manifest.yaml
+++ b/k8s.gcr.io/images/k8s-staging-bootkube/promoter-manifest.yaml
@@ -1,0 +1,10 @@
+ # google group for gcr.io/k8s-staging-bootkube is k8s-infra-staging-bootkube@kubernetes.io 
+registries:
+- name: gcr.io/k8s-staging-bootkube
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/bootkube
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/bootkube
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/bootkube
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
This is to move bootkube registry from quay.io/coreos to k8s.gcr.io. 

cc @dims @cblecker 