### PR TITLE
Refactor for push buckets and kind

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -318,6 +318,15 @@ groups:
       - thockin@google.com
       - tpepper@gmail.com
 
+  - email-id: k8s-infra-push-kind@kubernetes.io
+    name: k8s-infra-push-kind
+    description: |-
+      ACL for pushing KinD artifacts
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - bentheelder@google.com
+
   #
   # RBAC groups: k8s-infra-rbac-*
   #

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -129,6 +129,7 @@ groups:
       - nikitaraghunath@gmail.com
       - killen.bob@gmail.com
 
+  # Every RBAC group should be added here.
   - email-id: gke-security-groups@kubernetes.io
     name: gke-security-groups
     description: |-
@@ -286,6 +287,12 @@ groups:
       - spiffxp@google.com
       - thockin@google.com
 
+  #
+  # Push groups: k8s-infra-push-*
+  #
+  # Each group here governs access to one GCS bucket.
+  #
+
   - email-id: k8s-infra-push-cni@kubernetes.io
     name: k8s-infra-push-cni
     description: |-
@@ -310,6 +317,12 @@ groups:
       - stephen.k8s@agst.us
       - thockin@google.com
       - tpepper@gmail.com
+
+  #
+  # RBAC groups: k8s-infra-rbac-*
+  #
+  # Each group here governs access to one k8s namespace.
+  #
 
   - email-id: k8s-infra-rbac-cert-manager@kubernetes.io
     name: k8s-infra-rbac-cert-manager
@@ -446,6 +459,12 @@ groups:
       - simony@google.com
       - sumitranr@google.com
 
+  #
+  # Conformance groups: k8s-infra-conform-*
+  #
+  # Each group here governs access to one GCS bucket.
+  #
+
   - email-id: k8s-infra-conform-capi-openstack@kubernetes.io
     name: k8s-infra-conform-capi-openstack
     description: |-
@@ -476,6 +495,12 @@ groups:
     members:
       - kevinwzf0126@gmail.com # Google account of wangzefeng@huawei.com
       - qdurenhongcai@gmail.com # Google account of renhongcai@huawei.com
+
+  #
+  # Staging groups: k8s-infra-staging-*
+  #
+  # Each group here governs access to one staging project.
+  #
 
   - email-id: k8s-infra-staging-apisnoop@kubernetes.io
     name: k8s-infra-staging-apisnoop

--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -77,6 +77,7 @@ ALL_PROD_PROJECTS=(
 #
 ALL_PROD_BUCKETS=(
     "cni"
+    "kind"
 )
 
 # Regions for prod GCR.

--- a/infra/gcp/lib_util.sh
+++ b/infra/gcp/lib_util.sh
@@ -38,3 +38,9 @@ function color() {
     echo "$@"
     _nocolor
 }
+
+# Indent each line of stdin.
+# example: <command> | indent
+function indent() {
+    sed 's/^/  /'
+}


### PR DESCRIPTION
Multiple steps - please review commit-by-commit.

Refactor prod-storage script to make it easy to add a new "push" bucket in prod.

Fix output to be legible (if this is good we can repeat for other scripts)

Add kind as a push bucket.

The new output looks something like this (debug left in here):

```
$ ./ensure-prod-storage.sh 
Ensuring all prod projects
  Ensuring project exists: k8s-artifacts-prod
  billingAccountName: billingAccounts/018801-93540E-22A20E
  billingEnabled: true
  name: projects/k8s-artifacts-prod/billingInfo
  projectId: k8s-artifacts-prod
  Enabling the container registry API: k8s-artifacts-prod
  Enabling the container analysis API: k8s-artifacts-prod
  Ensuring the GCR repository: k8s-artifacts-prod
  Ensuring the GCR exists and is readable
    region us
    TIM ensure_gcr_repo k8s-artifacts-prod us
    region eu
    TIM ensure_gcr_repo k8s-artifacts-prod eu
    region asia
    TIM ensure_gcr_repo k8s-artifacts-prod asia
  Empowering GCR admins
    region us
    TIM empower_gcr_admins k8s-artifacts-prod us
    region eu
    TIM empower_gcr_admins k8s-artifacts-prod eu
    region asia
    TIM empower_gcr_admins k8s-artifacts-prod asia
  Empowering image promoter
    region us
    TIM empower_artifact_promoter k8s-artifacts-prod us
    region eu
    TIM empower_artifact_promoter k8s-artifacts-prod eu
    region asia
    TIM empower_artifact_promoter k8s-artifacts-prod asia
  Enabling the GCS API: k8s-artifacts-prod
  Ensuring the GCS bucket: gs://k8s-artifacts-prod
    Ensuring the GCS bucket exists and is readable
    TIM ensure_public_gcs_bucket k8s-artifacts-prod gs://k8s-artifacts-prod
    Ensuring the bucket retention policy is set
    TIM ensure_gcs_bucket_retention gs://k8s-artifacts-prod 10y
    Empowering GCS admins
    TIM empower_gcs_admins k8s-artifacts-prod gs://k8s-artifacts-prod
  Ensuring project exists: k8s-artifacts-prod-bak
  billingAccountName: billingAccounts/018801-93540E-22A20E
  billingEnabled: true
  name: projects/k8s-artifacts-prod-bak/billingInfo
  projectId: k8s-artifacts-prod-bak
```