### PR TITLE
simplify indentation function to use sed

### DIFF
--- a/infra/gcp/lib_util.sh
+++ b/infra/gcp/lib_util.sh
@@ -35,15 +35,11 @@ function _nocolor() {
 function color() {
     _color "$1"
     shift
-    echo "$@"
-    _nocolor
+    echo "$@$(_nocolor)"
 }
 
 # Indent each line of stdin.
 # example: <command> | indent
 function indent() {
-    # Simple 'sed' messes up end-of-line when mixed with color codes,
-    # and I could not figure out why.
-    IFS=''
-    while read X; do echo "  ${X}"; done
+    sed 's/^/  /'
 }


### PR DESCRIPTION
    simplify indentation function to use sed

    This simplifies the indent function to just use sed, even with colors.
    Tested with some simple scripts, not with the actual scripts, because I
    don't have GCP permissions to run them.

    The reason why the line endings looked weird is because the "echo" in
    color() emits a newline after printing the message. E.g., `color 6
    hello` looks like this to sed:

        <color-code-6>hello\n<stop-color-code>

    So the "color off" code comes after the newline. Piping this to `sed
    's/^/  /'`, we get

        __<color-code-6>hello\n<stop-color-code>__

    (underscores used for illustrations). Notice the `<stop-color-code>`
    line will end with our indentation we inserted, but and will display as
    `%` in the terminal because it does not end with a newline. With the new
    approach, we print the termination of the color code on the same line as
    the contents we want to print, so it looks like this:

        __<color-code-6>hello<stop-color-code>\n

    so there is no extra line beyond what's already in the contents to
    `echo`, and we just get 1 indentation.
/cc @thockin 