### PR TITLE
Move slack-infra to one namespace

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -144,10 +144,7 @@ groups:
       - k8s-infra-rbac-k8s-io-prod@kubernetes.io
       - k8s-infra-rbac-perfdash@kubernetes.io
       - k8s-infra-rbac-publishing-bot@kubernetes.io
-      - k8s-infra-rbac-slack-event-log@kubernetes.io
-      - k8s-infra-rbac-slack-moderator@kubernetes.io
-      - k8s-infra-rbac-slack-welcomer@kubernetes.io
-      - k8s-infra-rbac-slackin@kubernetes.io
+      - k8s-infra-rbac-slack-infra@kubernetes.io
 
   - email-id: k8s-infra-alerts@kubernetes.io
     name: k8s-infra-alerts
@@ -420,54 +417,13 @@ groups:
       - stefan.schimanski@gmail.com
       - thockin@google.com
 
-  - email-id: k8s-infra-rbac-slack-event-log@kubernetes.io
-    name: k8s-infra-rbac-slack-event-log
+  - email-id: k8s-infra-rbac-slack-infra@kubernetes.io
+    name: k8s-infra-rbac-slack-infra
     description: |-
-      ACL for Slack Event Log
+      ACL for Slack Infra
     settings:
       ReconcileMembers: "true"
       WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # required
-    members:
-      - k8s-infra-slack-infra-admins@kubernetes.io
-
-  - email-id: k8s-infra-rbac-slack-moderator@kubernetes.io
-    name: k8s-infra-rbac-slack-moderator
-    description: |-
-      ACL for Slack Moderator
-    settings:
-      ReconcileMembers: "true"
-      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # required
-    members:
-      - k8s-infra-slack-infra-admins@kubernetes.io
-
-  - email-id: k8s-infra-rbac-slack-welcomer@kubernetes.io
-    name: k8s-infra-rbac-slack-welcomer
-    description: |-
-      ACL for Slack Welcomer
-    settings:
-      ReconcileMembers: "true"
-      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # required
-    members:
-      - k8s-infra-slack-infra-admins@kubernetes.io
-
-  - email-id: k8s-infra-rbac-slackin@kubernetes.io
-    name: k8s-infra-rbac-slackin
-    description: |-
-      ACL for Slackin
-    settings:
-      ReconcileMembers: "true"
-      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # required
-    members:
-      - k8s-infra-slack-infra-admins@kubernetes.io
-
-  # Collective group for RBAC groups for slack infrastructure
-  # created to not duplicate members
-  - email-id: k8s-infra-slack-infra-admins@kubernetes.io
-    name: k8s-infra-slack-infra-admins
-    description: |-
-      ACL for Slack Infra Admins
-    settings:
-      ReconcileMembers: "true"
     members:
       - ameukam@gmail.com
       - bartek@smykla.com

--- a/infra/gcp/namespaces/ensure-namespaces.sh
+++ b/infra/gcp/namespaces/ensure-namespaces.sh
@@ -148,10 +148,7 @@ ALL_PROJECTS=(
     "k8s-io-prod"
     "k8s-io-canary"
     "perfdash"
-    "slack-event-log"
-    "slack-moderator"
-    "slack-welcomer"
-    "slackin"
+    "slack-infra"
 )
 
 for prj in "${ALL_PROJECTS[@]}"; do


### PR DESCRIPTION
/cc @spiffxp

Followin up: https://github.com/kubernetes/k8s.io/pull/757#issuecomment-614993485

Instead of having 4 separate namespaces (slack-even-log,
slack-moderator, slack-welcomer, slackin) put it in one,
called `slack-infra` which is much cleaner and more concise.

Signed-off-by: Bart Smykla <bsmykla@vmware.com>