### PR TITLE
Switching perf-dash subdomain to the new place

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -169,7 +169,7 @@ node-perf-dash:
 # sig-scalability
 perf-dash:
   type: A
-  value: 35.188.102.189
+  value: 34.102.200.94
 perf-dash-canary:
   type: A
   value: 34.102.200.94

--- a/perf-dash.k8s.io/certificate.yaml
+++ b/perf-dash.k8s.io/certificate.yaml
@@ -11,4 +11,5 @@ spec:
     kind: ClusterIssuer
     name: letsencrypt-prod
   dnsNames:
+  - perf-dash.k8s.io
   - perf-dash-canary.k8s.io


### PR DESCRIPTION
/cc @mm4tt 

Holding till the update will populate (via. https://github.com/kubernetes/k8s.io/issues/772#issuecomment-617018974).
/hold

As we have confitrmation all issues with accessing our cluster
namespaces for members of rbac groups were resolved and
that the data between [perf-dash.k8s.io](https://perf-dash.k8s.io) and [perf-dash-canary.k8s.io](https://perf-dash-canary.k8s.io)
are consistent we can switch the DNS record of `perf-dash.k8s.io`
to point to the new place (inside the `aaa` cluster)

Signed-off-by: Bart Smykla <bsmykla@vmware.com>