### PR TITLE
Extend permissions to Replicasets and Statefulsets

### DIFF
--- a/infra/gcp/namespaces/namespace-user-role.yml
+++ b/infra/gcp/namespaces/namespace-user-role.yml
@@ -12,7 +12,7 @@ rules:
     resources: ["horizontalpodautoscalers"]
     verbs: ["*"]
   - apiGroups: ["apps"]
-    resources: ["deployments"]
+    resources: ["deployments", "replicasets", "statefulsets"]
     verbs: ["*"]
   - apiGroups: ["batch"]
     resources: ["cronjobs", "jobs"]


### PR DESCRIPTION
Include Replicasets & Statefulsets in the list of resources of the "apps"
API group.

Will be required for publishing-bot : https://github.com/kubernetes/publishing-bot/blob/master/Makefile#L71

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>

cc @bartsmykla @thockin @spiffxp