### PR TITLE
Remove perf-dash-canary.k8s.io subdomain

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -170,9 +170,6 @@ node-perf-dash:
 perf-dash:
   type: A
   value: 34.102.200.94
-perf-dash-canary:
-  type: A
-  value: 34.102.200.94
 pr:
   type: CNAME
   value: redirect.k8s.io.

--- a/perf-dash.k8s.io/certificate.yaml
+++ b/perf-dash.k8s.io/certificate.yaml
@@ -12,4 +12,3 @@ spec:
     name: letsencrypt-prod
   dnsNames:
   - perf-dash.k8s.io
-  - perf-dash-canary.k8s.io


### PR DESCRIPTION
Waiting for confirmation from @mm4tt or @wojtek-t everything works and we can remove perf-dash-canary.k8s.io

/hold
/cc @mm4tt @wojtek-t 

ref. #549, #776 

+ removed subdomain from perf-dash certificate manifest

Signed-off-by: Bart Smykla <bsmykla@vmware.com>