### PR TITLE
Strip out resource usage from audit files

### DIFF
--- a/audit/audit-gcp.sh
+++ b/audit/audit-gcp.sh
@@ -127,6 +127,7 @@ gcloud \
                     compute project-info describe \
                     --project="${PROJECT}" \
                     --format=json \
+                    | jq 'del(.quotas[].usage)' \
                     > "projects/${PROJECT}/services/${SVC}/project-info.json"
                 ;;
             container)

--- a/audit/projects/k8s-artifacts-prod-bak/services/compute/project-info.json
+++ b/audit/projects/k8s-artifacts-prod-bak/services/compute/project-info.json
@@ -11,174 +11,140 @@
   "name": "k8s-artifacts-prod-bak",
   "quotas": [
     {
-      "limit": 5000.0,
-      "metric": "SNAPSHOTS",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "SNAPSHOTS"
     },
     {
-      "limit": 15.0,
-      "metric": "NETWORKS",
-      "usage": 1.0
+      "limit": 15,
+      "metric": "NETWORKS"
     },
     {
-      "limit": 200.0,
-      "metric": "FIREWALLS",
-      "usage": 4.0
+      "limit": 200,
+      "metric": "FIREWALLS"
     },
     {
-      "limit": 2000.0,
-      "metric": "IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "IMAGES"
     },
     {
-      "limit": 21.0,
-      "metric": "STATIC_ADDRESSES",
-      "usage": 0.0
+      "limit": 21,
+      "metric": "STATIC_ADDRESSES"
     },
     {
-      "limit": 250.0,
-      "metric": "ROUTES",
-      "usage": 24.0
+      "limit": 250,
+      "metric": "ROUTES"
     },
     {
-      "limit": 45.0,
-      "metric": "FORWARDING_RULES",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "FORWARDING_RULES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_POOLS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_POOLS"
     },
     {
-      "limit": 150.0,
-      "metric": "HEALTH_CHECKS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "HEALTH_CHECKS"
     },
     {
-      "limit": 69.0,
-      "metric": "IN_USE_ADDRESSES",
-      "usage": 0.0
+      "limit": 69,
+      "metric": "IN_USE_ADDRESSES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_INSTANCES",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_INSTANCES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTP_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "URL_MAPS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "URL_MAPS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_SERVICES",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_SERVICES"
     },
     {
-      "limit": 300.0,
-      "metric": "INSTANCE_TEMPLATES",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "INSTANCE_TEMPLATES"
     },
     {
-      "limit": 15.0,
-      "metric": "TARGET_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "TARGET_VPN_GATEWAYS"
     },
     {
-      "limit": 30.0,
-      "metric": "VPN_TUNNELS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "VPN_TUNNELS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_BUCKETS",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_BUCKETS"
     },
     {
-      "limit": 10.0,
-      "metric": "ROUTERS",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "ROUTERS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_SSL_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_SSL_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTPS_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTPS_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "SSL_CERTIFICATES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "SSL_CERTIFICATES"
     },
     {
-      "limit": 175.0,
-      "metric": "SUBNETWORKS",
-      "usage": 23.0
+      "limit": 175,
+      "metric": "SUBNETWORKS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_TCP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_TCP_PROXIES"
     },
     {
-      "limit": 10.0,
-      "metric": "SECURITY_POLICIES",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "SECURITY_POLICIES"
     },
     {
-      "limit": 100.0,
-      "metric": "SECURITY_POLICY_RULES",
-      "usage": 0.0
+      "limit": 100,
+      "metric": "SECURITY_POLICY_RULES"
     },
     {
-      "limit": 45.0,
-      "metric": "PACKET_MIRRORINGS",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "PACKET_MIRRORINGS"
     },
     {
-      "limit": 300.0,
-      "metric": "NETWORK_ENDPOINT_GROUPS",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "NETWORK_ENDPOINT_GROUPS"
     },
     {
-      "limit": 6.0,
-      "metric": "INTERCONNECTS",
-      "usage": 0.0
+      "limit": 6,
+      "metric": "INTERCONNECTS"
     },
     {
-      "limit": 5000.0,
-      "metric": "GLOBAL_INTERNAL_ADDRESSES",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "GLOBAL_INTERNAL_ADDRESSES"
     },
     {
-      "limit": 15.0,
-      "metric": "VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "VPN_GATEWAYS"
     },
     {
-      "limit": 2000.0,
-      "metric": "MACHINE_IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "MACHINE_IMAGES"
     },
     {
-      "limit": 20.0,
-      "metric": "SECURITY_POLICY_CEVAL_RULES",
-      "usage": 0.0
+      "limit": 20,
+      "metric": "SECURITY_POLICY_CEVAL_RULES"
     },
     {
-      "limit": 15.0,
-      "metric": "EXTERNAL_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "EXTERNAL_VPN_GATEWAYS"
     }
   ],
   "selfLink": "https://www.googleapis.com/compute/v1/projects/k8s-artifacts-prod-bak",

--- a/audit/projects/k8s-artifacts-prod/services/compute/project-info.json
+++ b/audit/projects/k8s-artifacts-prod/services/compute/project-info.json
@@ -11,174 +11,140 @@
   "name": "k8s-artifacts-prod",
   "quotas": [
     {
-      "limit": 5000.0,
-      "metric": "SNAPSHOTS",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "SNAPSHOTS"
     },
     {
-      "limit": 15.0,
-      "metric": "NETWORKS",
-      "usage": 1.0
+      "limit": 15,
+      "metric": "NETWORKS"
     },
     {
-      "limit": 200.0,
-      "metric": "FIREWALLS",
-      "usage": 4.0
+      "limit": 200,
+      "metric": "FIREWALLS"
     },
     {
-      "limit": 2000.0,
-      "metric": "IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "IMAGES"
     },
     {
-      "limit": 21.0,
-      "metric": "STATIC_ADDRESSES",
-      "usage": 1.0
+      "limit": 21,
+      "metric": "STATIC_ADDRESSES"
     },
     {
-      "limit": 250.0,
-      "metric": "ROUTES",
-      "usage": 24.0
+      "limit": 250,
+      "metric": "ROUTES"
     },
     {
-      "limit": 45.0,
-      "metric": "FORWARDING_RULES",
-      "usage": 2.0
+      "limit": 45,
+      "metric": "FORWARDING_RULES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_POOLS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_POOLS"
     },
     {
-      "limit": 150.0,
-      "metric": "HEALTH_CHECKS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "HEALTH_CHECKS"
     },
     {
-      "limit": 69.0,
-      "metric": "IN_USE_ADDRESSES",
-      "usage": 2.0
+      "limit": 69,
+      "metric": "IN_USE_ADDRESSES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_INSTANCES",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_INSTANCES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTP_PROXIES",
-      "usage": 1.0
+      "limit": 30,
+      "metric": "TARGET_HTTP_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "URL_MAPS",
-      "usage": 1.0
+      "limit": 30,
+      "metric": "URL_MAPS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_SERVICES",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_SERVICES"
     },
     {
-      "limit": 300.0,
-      "metric": "INSTANCE_TEMPLATES",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "INSTANCE_TEMPLATES"
     },
     {
-      "limit": 15.0,
-      "metric": "TARGET_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "TARGET_VPN_GATEWAYS"
     },
     {
-      "limit": 30.0,
-      "metric": "VPN_TUNNELS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "VPN_TUNNELS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_BUCKETS",
-      "usage": 1.0
+      "limit": 9,
+      "metric": "BACKEND_BUCKETS"
     },
     {
-      "limit": 10.0,
-      "metric": "ROUTERS",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "ROUTERS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_SSL_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_SSL_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTPS_PROXIES",
-      "usage": 1.0
+      "limit": 30,
+      "metric": "TARGET_HTTPS_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "SSL_CERTIFICATES",
-      "usage": 1.0
+      "limit": 30,
+      "metric": "SSL_CERTIFICATES"
     },
     {
-      "limit": 175.0,
-      "metric": "SUBNETWORKS",
-      "usage": 23.0
+      "limit": 175,
+      "metric": "SUBNETWORKS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_TCP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_TCP_PROXIES"
     },
     {
-      "limit": 10.0,
-      "metric": "SECURITY_POLICIES",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "SECURITY_POLICIES"
     },
     {
-      "limit": 100.0,
-      "metric": "SECURITY_POLICY_RULES",
-      "usage": 0.0
+      "limit": 100,
+      "metric": "SECURITY_POLICY_RULES"
     },
     {
-      "limit": 45.0,
-      "metric": "PACKET_MIRRORINGS",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "PACKET_MIRRORINGS"
     },
     {
-      "limit": 300.0,
-      "metric": "NETWORK_ENDPOINT_GROUPS",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "NETWORK_ENDPOINT_GROUPS"
     },
     {
-      "limit": 6.0,
-      "metric": "INTERCONNECTS",
-      "usage": 0.0
+      "limit": 6,
+      "metric": "INTERCONNECTS"
     },
     {
-      "limit": 5000.0,
-      "metric": "GLOBAL_INTERNAL_ADDRESSES",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "GLOBAL_INTERNAL_ADDRESSES"
     },
     {
-      "limit": 15.0,
-      "metric": "VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "VPN_GATEWAYS"
     },
     {
-      "limit": 2000.0,
-      "metric": "MACHINE_IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "MACHINE_IMAGES"
     },
     {
-      "limit": 20.0,
-      "metric": "SECURITY_POLICY_CEVAL_RULES",
-      "usage": 0.0
+      "limit": 20,
+      "metric": "SECURITY_POLICY_CEVAL_RULES"
     },
     {
-      "limit": 15.0,
-      "metric": "EXTERNAL_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "EXTERNAL_VPN_GATEWAYS"
     }
   ],
   "selfLink": "https://www.googleapis.com/compute/v1/projects/k8s-artifacts-prod",

--- a/audit/projects/k8s-cip-test-prod/services/compute/project-info.json
+++ b/audit/projects/k8s-cip-test-prod/services/compute/project-info.json
@@ -11,174 +11,140 @@
   "name": "k8s-cip-test-prod",
   "quotas": [
     {
-      "limit": 5000.0,
-      "metric": "SNAPSHOTS",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "SNAPSHOTS"
     },
     {
-      "limit": 15.0,
-      "metric": "NETWORKS",
-      "usage": 1.0
+      "limit": 15,
+      "metric": "NETWORKS"
     },
     {
-      "limit": 200.0,
-      "metric": "FIREWALLS",
-      "usage": 4.0
+      "limit": 200,
+      "metric": "FIREWALLS"
     },
     {
-      "limit": 2000.0,
-      "metric": "IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "IMAGES"
     },
     {
-      "limit": 21.0,
-      "metric": "STATIC_ADDRESSES",
-      "usage": 0.0
+      "limit": 21,
+      "metric": "STATIC_ADDRESSES"
     },
     {
-      "limit": 250.0,
-      "metric": "ROUTES",
-      "usage": 24.0
+      "limit": 250,
+      "metric": "ROUTES"
     },
     {
-      "limit": 45.0,
-      "metric": "FORWARDING_RULES",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "FORWARDING_RULES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_POOLS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_POOLS"
     },
     {
-      "limit": 150.0,
-      "metric": "HEALTH_CHECKS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "HEALTH_CHECKS"
     },
     {
-      "limit": 69.0,
-      "metric": "IN_USE_ADDRESSES",
-      "usage": 0.0
+      "limit": 69,
+      "metric": "IN_USE_ADDRESSES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_INSTANCES",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_INSTANCES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTP_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "URL_MAPS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "URL_MAPS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_SERVICES",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_SERVICES"
     },
     {
-      "limit": 300.0,
-      "metric": "INSTANCE_TEMPLATES",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "INSTANCE_TEMPLATES"
     },
     {
-      "limit": 15.0,
-      "metric": "TARGET_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "TARGET_VPN_GATEWAYS"
     },
     {
-      "limit": 30.0,
-      "metric": "VPN_TUNNELS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "VPN_TUNNELS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_BUCKETS",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_BUCKETS"
     },
     {
-      "limit": 10.0,
-      "metric": "ROUTERS",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "ROUTERS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_SSL_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_SSL_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTPS_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTPS_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "SSL_CERTIFICATES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "SSL_CERTIFICATES"
     },
     {
-      "limit": 175.0,
-      "metric": "SUBNETWORKS",
-      "usage": 23.0
+      "limit": 175,
+      "metric": "SUBNETWORKS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_TCP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_TCP_PROXIES"
     },
     {
-      "limit": 10.0,
-      "metric": "SECURITY_POLICIES",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "SECURITY_POLICIES"
     },
     {
-      "limit": 100.0,
-      "metric": "SECURITY_POLICY_RULES",
-      "usage": 0.0
+      "limit": 100,
+      "metric": "SECURITY_POLICY_RULES"
     },
     {
-      "limit": 45.0,
-      "metric": "PACKET_MIRRORINGS",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "PACKET_MIRRORINGS"
     },
     {
-      "limit": 300.0,
-      "metric": "NETWORK_ENDPOINT_GROUPS",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "NETWORK_ENDPOINT_GROUPS"
     },
     {
-      "limit": 6.0,
-      "metric": "INTERCONNECTS",
-      "usage": 0.0
+      "limit": 6,
+      "metric": "INTERCONNECTS"
     },
     {
-      "limit": 5000.0,
-      "metric": "GLOBAL_INTERNAL_ADDRESSES",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "GLOBAL_INTERNAL_ADDRESSES"
     },
     {
-      "limit": 15.0,
-      "metric": "VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "VPN_GATEWAYS"
     },
     {
-      "limit": 2000.0,
-      "metric": "MACHINE_IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "MACHINE_IMAGES"
     },
     {
-      "limit": 20.0,
-      "metric": "SECURITY_POLICY_CEVAL_RULES",
-      "usage": 0.0
+      "limit": 20,
+      "metric": "SECURITY_POLICY_CEVAL_RULES"
     },
     {
-      "limit": 15.0,
-      "metric": "EXTERNAL_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "EXTERNAL_VPN_GATEWAYS"
     }
   ],
   "selfLink": "https://www.googleapis.com/compute/v1/projects/k8s-cip-test-prod",

--- a/audit/projects/k8s-conform/services/compute/project-info.json
+++ b/audit/projects/k8s-conform/services/compute/project-info.json
@@ -11,174 +11,140 @@
   "name": "k8s-conform",
   "quotas": [
     {
-      "limit": 5000.0,
-      "metric": "SNAPSHOTS",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "SNAPSHOTS"
     },
     {
-      "limit": 15.0,
-      "metric": "NETWORKS",
-      "usage": 1.0
+      "limit": 15,
+      "metric": "NETWORKS"
     },
     {
-      "limit": 200.0,
-      "metric": "FIREWALLS",
-      "usage": 4.0
+      "limit": 200,
+      "metric": "FIREWALLS"
     },
     {
-      "limit": 2000.0,
-      "metric": "IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "IMAGES"
     },
     {
-      "limit": 21.0,
-      "metric": "STATIC_ADDRESSES",
-      "usage": 0.0
+      "limit": 21,
+      "metric": "STATIC_ADDRESSES"
     },
     {
-      "limit": 250.0,
-      "metric": "ROUTES",
-      "usage": 24.0
+      "limit": 250,
+      "metric": "ROUTES"
     },
     {
-      "limit": 45.0,
-      "metric": "FORWARDING_RULES",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "FORWARDING_RULES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_POOLS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_POOLS"
     },
     {
-      "limit": 150.0,
-      "metric": "HEALTH_CHECKS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "HEALTH_CHECKS"
     },
     {
-      "limit": 69.0,
-      "metric": "IN_USE_ADDRESSES",
-      "usage": 0.0
+      "limit": 69,
+      "metric": "IN_USE_ADDRESSES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_INSTANCES",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_INSTANCES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTP_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "URL_MAPS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "URL_MAPS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_SERVICES",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_SERVICES"
     },
     {
-      "limit": 300.0,
-      "metric": "INSTANCE_TEMPLATES",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "INSTANCE_TEMPLATES"
     },
     {
-      "limit": 15.0,
-      "metric": "TARGET_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "TARGET_VPN_GATEWAYS"
     },
     {
-      "limit": 30.0,
-      "metric": "VPN_TUNNELS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "VPN_TUNNELS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_BUCKETS",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_BUCKETS"
     },
     {
-      "limit": 10.0,
-      "metric": "ROUTERS",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "ROUTERS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_SSL_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_SSL_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTPS_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTPS_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "SSL_CERTIFICATES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "SSL_CERTIFICATES"
     },
     {
-      "limit": 175.0,
-      "metric": "SUBNETWORKS",
-      "usage": 23.0
+      "limit": 175,
+      "metric": "SUBNETWORKS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_TCP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_TCP_PROXIES"
     },
     {
-      "limit": 10.0,
-      "metric": "SECURITY_POLICIES",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "SECURITY_POLICIES"
     },
     {
-      "limit": 100.0,
-      "metric": "SECURITY_POLICY_RULES",
-      "usage": 0.0
+      "limit": 100,
+      "metric": "SECURITY_POLICY_RULES"
     },
     {
-      "limit": 45.0,
-      "metric": "PACKET_MIRRORINGS",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "PACKET_MIRRORINGS"
     },
     {
-      "limit": 300.0,
-      "metric": "NETWORK_ENDPOINT_GROUPS",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "NETWORK_ENDPOINT_GROUPS"
     },
     {
-      "limit": 6.0,
-      "metric": "INTERCONNECTS",
-      "usage": 0.0
+      "limit": 6,
+      "metric": "INTERCONNECTS"
     },
     {
-      "limit": 5000.0,
-      "metric": "GLOBAL_INTERNAL_ADDRESSES",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "GLOBAL_INTERNAL_ADDRESSES"
     },
     {
-      "limit": 15.0,
-      "metric": "VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "VPN_GATEWAYS"
     },
     {
-      "limit": 2000.0,
-      "metric": "MACHINE_IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "MACHINE_IMAGES"
     },
     {
-      "limit": 20.0,
-      "metric": "SECURITY_POLICY_CEVAL_RULES",
-      "usage": 0.0
+      "limit": 20,
+      "metric": "SECURITY_POLICY_CEVAL_RULES"
     },
     {
-      "limit": 15.0,
-      "metric": "EXTERNAL_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "EXTERNAL_VPN_GATEWAYS"
     }
   ],
   "selfLink": "https://www.googleapis.com/compute/v1/projects/k8s-conform",

--- a/audit/projects/k8s-gcr-audit-test-prod/services/compute/project-info.json
+++ b/audit/projects/k8s-gcr-audit-test-prod/services/compute/project-info.json
@@ -11,174 +11,140 @@
   "name": "k8s-gcr-audit-test-prod",
   "quotas": [
     {
-      "limit": 5000.0,
-      "metric": "SNAPSHOTS",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "SNAPSHOTS"
     },
     {
-      "limit": 15.0,
-      "metric": "NETWORKS",
-      "usage": 1.0
+      "limit": 15,
+      "metric": "NETWORKS"
     },
     {
-      "limit": 200.0,
-      "metric": "FIREWALLS",
-      "usage": 4.0
+      "limit": 200,
+      "metric": "FIREWALLS"
     },
     {
-      "limit": 2000.0,
-      "metric": "IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "IMAGES"
     },
     {
-      "limit": 21.0,
-      "metric": "STATIC_ADDRESSES",
-      "usage": 0.0
+      "limit": 21,
+      "metric": "STATIC_ADDRESSES"
     },
     {
-      "limit": 250.0,
-      "metric": "ROUTES",
-      "usage": 24.0
+      "limit": 250,
+      "metric": "ROUTES"
     },
     {
-      "limit": 45.0,
-      "metric": "FORWARDING_RULES",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "FORWARDING_RULES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_POOLS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_POOLS"
     },
     {
-      "limit": 150.0,
-      "metric": "HEALTH_CHECKS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "HEALTH_CHECKS"
     },
     {
-      "limit": 69.0,
-      "metric": "IN_USE_ADDRESSES",
-      "usage": 0.0
+      "limit": 69,
+      "metric": "IN_USE_ADDRESSES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_INSTANCES",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_INSTANCES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTP_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "URL_MAPS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "URL_MAPS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_SERVICES",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_SERVICES"
     },
     {
-      "limit": 300.0,
-      "metric": "INSTANCE_TEMPLATES",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "INSTANCE_TEMPLATES"
     },
     {
-      "limit": 15.0,
-      "metric": "TARGET_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "TARGET_VPN_GATEWAYS"
     },
     {
-      "limit": 30.0,
-      "metric": "VPN_TUNNELS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "VPN_TUNNELS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_BUCKETS",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_BUCKETS"
     },
     {
-      "limit": 10.0,
-      "metric": "ROUTERS",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "ROUTERS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_SSL_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_SSL_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTPS_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTPS_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "SSL_CERTIFICATES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "SSL_CERTIFICATES"
     },
     {
-      "limit": 175.0,
-      "metric": "SUBNETWORKS",
-      "usage": 23.0
+      "limit": 175,
+      "metric": "SUBNETWORKS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_TCP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_TCP_PROXIES"
     },
     {
-      "limit": 10.0,
-      "metric": "SECURITY_POLICIES",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "SECURITY_POLICIES"
     },
     {
-      "limit": 100.0,
-      "metric": "SECURITY_POLICY_RULES",
-      "usage": 0.0
+      "limit": 100,
+      "metric": "SECURITY_POLICY_RULES"
     },
     {
-      "limit": 45.0,
-      "metric": "PACKET_MIRRORINGS",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "PACKET_MIRRORINGS"
     },
     {
-      "limit": 300.0,
-      "metric": "NETWORK_ENDPOINT_GROUPS",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "NETWORK_ENDPOINT_GROUPS"
     },
     {
-      "limit": 6.0,
-      "metric": "INTERCONNECTS",
-      "usage": 0.0
+      "limit": 6,
+      "metric": "INTERCONNECTS"
     },
     {
-      "limit": 5000.0,
-      "metric": "GLOBAL_INTERNAL_ADDRESSES",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "GLOBAL_INTERNAL_ADDRESSES"
     },
     {
-      "limit": 15.0,
-      "metric": "VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "VPN_GATEWAYS"
     },
     {
-      "limit": 2000.0,
-      "metric": "MACHINE_IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "MACHINE_IMAGES"
     },
     {
-      "limit": 20.0,
-      "metric": "SECURITY_POLICY_CEVAL_RULES",
-      "usage": 0.0
+      "limit": 20,
+      "metric": "SECURITY_POLICY_CEVAL_RULES"
     },
     {
-      "limit": 15.0,
-      "metric": "EXTERNAL_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "EXTERNAL_VPN_GATEWAYS"
     }
   ],
   "selfLink": "https://www.googleapis.com/compute/v1/projects/k8s-gcr-audit-test-prod",

--- a/audit/projects/k8s-gcr-backup-test-prod-bak/services/compute/project-info.json
+++ b/audit/projects/k8s-gcr-backup-test-prod-bak/services/compute/project-info.json
@@ -11,174 +11,140 @@
   "name": "k8s-gcr-backup-test-prod-bak",
   "quotas": [
     {
-      "limit": 5000.0,
-      "metric": "SNAPSHOTS",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "SNAPSHOTS"
     },
     {
-      "limit": 15.0,
-      "metric": "NETWORKS",
-      "usage": 1.0
+      "limit": 15,
+      "metric": "NETWORKS"
     },
     {
-      "limit": 200.0,
-      "metric": "FIREWALLS",
-      "usage": 4.0
+      "limit": 200,
+      "metric": "FIREWALLS"
     },
     {
-      "limit": 2000.0,
-      "metric": "IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "IMAGES"
     },
     {
-      "limit": 21.0,
-      "metric": "STATIC_ADDRESSES",
-      "usage": 0.0
+      "limit": 21,
+      "metric": "STATIC_ADDRESSES"
     },
     {
-      "limit": 250.0,
-      "metric": "ROUTES",
-      "usage": 24.0
+      "limit": 250,
+      "metric": "ROUTES"
     },
     {
-      "limit": 45.0,
-      "metric": "FORWARDING_RULES",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "FORWARDING_RULES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_POOLS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_POOLS"
     },
     {
-      "limit": 150.0,
-      "metric": "HEALTH_CHECKS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "HEALTH_CHECKS"
     },
     {
-      "limit": 69.0,
-      "metric": "IN_USE_ADDRESSES",
-      "usage": 0.0
+      "limit": 69,
+      "metric": "IN_USE_ADDRESSES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_INSTANCES",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_INSTANCES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTP_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "URL_MAPS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "URL_MAPS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_SERVICES",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_SERVICES"
     },
     {
-      "limit": 300.0,
-      "metric": "INSTANCE_TEMPLATES",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "INSTANCE_TEMPLATES"
     },
     {
-      "limit": 15.0,
-      "metric": "TARGET_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "TARGET_VPN_GATEWAYS"
     },
     {
-      "limit": 30.0,
-      "metric": "VPN_TUNNELS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "VPN_TUNNELS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_BUCKETS",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_BUCKETS"
     },
     {
-      "limit": 10.0,
-      "metric": "ROUTERS",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "ROUTERS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_SSL_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_SSL_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTPS_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTPS_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "SSL_CERTIFICATES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "SSL_CERTIFICATES"
     },
     {
-      "limit": 175.0,
-      "metric": "SUBNETWORKS",
-      "usage": 23.0
+      "limit": 175,
+      "metric": "SUBNETWORKS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_TCP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_TCP_PROXIES"
     },
     {
-      "limit": 10.0,
-      "metric": "SECURITY_POLICIES",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "SECURITY_POLICIES"
     },
     {
-      "limit": 100.0,
-      "metric": "SECURITY_POLICY_RULES",
-      "usage": 0.0
+      "limit": 100,
+      "metric": "SECURITY_POLICY_RULES"
     },
     {
-      "limit": 45.0,
-      "metric": "PACKET_MIRRORINGS",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "PACKET_MIRRORINGS"
     },
     {
-      "limit": 300.0,
-      "metric": "NETWORK_ENDPOINT_GROUPS",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "NETWORK_ENDPOINT_GROUPS"
     },
     {
-      "limit": 6.0,
-      "metric": "INTERCONNECTS",
-      "usage": 0.0
+      "limit": 6,
+      "metric": "INTERCONNECTS"
     },
     {
-      "limit": 5000.0,
-      "metric": "GLOBAL_INTERNAL_ADDRESSES",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "GLOBAL_INTERNAL_ADDRESSES"
     },
     {
-      "limit": 15.0,
-      "metric": "VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "VPN_GATEWAYS"
     },
     {
-      "limit": 2000.0,
-      "metric": "MACHINE_IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "MACHINE_IMAGES"
     },
     {
-      "limit": 20.0,
-      "metric": "SECURITY_POLICY_CEVAL_RULES",
-      "usage": 0.0
+      "limit": 20,
+      "metric": "SECURITY_POLICY_CEVAL_RULES"
     },
     {
-      "limit": 15.0,
-      "metric": "EXTERNAL_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "EXTERNAL_VPN_GATEWAYS"
     }
   ],
   "selfLink": "https://www.googleapis.com/compute/v1/projects/k8s-gcr-backup-test-prod-bak",

--- a/audit/projects/k8s-release-test-prod/services/compute/project-info.json
+++ b/audit/projects/k8s-release-test-prod/services/compute/project-info.json
@@ -11,174 +11,140 @@
   "name": "k8s-release-test-prod",
   "quotas": [
     {
-      "limit": 5000.0,
-      "metric": "SNAPSHOTS",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "SNAPSHOTS"
     },
     {
-      "limit": 15.0,
-      "metric": "NETWORKS",
-      "usage": 1.0
+      "limit": 15,
+      "metric": "NETWORKS"
     },
     {
-      "limit": 200.0,
-      "metric": "FIREWALLS",
-      "usage": 4.0
+      "limit": 200,
+      "metric": "FIREWALLS"
     },
     {
-      "limit": 2000.0,
-      "metric": "IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "IMAGES"
     },
     {
-      "limit": 21.0,
-      "metric": "STATIC_ADDRESSES",
-      "usage": 0.0
+      "limit": 21,
+      "metric": "STATIC_ADDRESSES"
     },
     {
-      "limit": 250.0,
-      "metric": "ROUTES",
-      "usage": 24.0
+      "limit": 250,
+      "metric": "ROUTES"
     },
     {
-      "limit": 45.0,
-      "metric": "FORWARDING_RULES",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "FORWARDING_RULES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_POOLS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_POOLS"
     },
     {
-      "limit": 150.0,
-      "metric": "HEALTH_CHECKS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "HEALTH_CHECKS"
     },
     {
-      "limit": 69.0,
-      "metric": "IN_USE_ADDRESSES",
-      "usage": 0.0
+      "limit": 69,
+      "metric": "IN_USE_ADDRESSES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_INSTANCES",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_INSTANCES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTP_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "URL_MAPS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "URL_MAPS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_SERVICES",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_SERVICES"
     },
     {
-      "limit": 300.0,
-      "metric": "INSTANCE_TEMPLATES",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "INSTANCE_TEMPLATES"
     },
     {
-      "limit": 15.0,
-      "metric": "TARGET_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "TARGET_VPN_GATEWAYS"
     },
     {
-      "limit": 30.0,
-      "metric": "VPN_TUNNELS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "VPN_TUNNELS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_BUCKETS",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_BUCKETS"
     },
     {
-      "limit": 10.0,
-      "metric": "ROUTERS",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "ROUTERS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_SSL_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_SSL_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTPS_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTPS_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "SSL_CERTIFICATES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "SSL_CERTIFICATES"
     },
     {
-      "limit": 175.0,
-      "metric": "SUBNETWORKS",
-      "usage": 23.0
+      "limit": 175,
+      "metric": "SUBNETWORKS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_TCP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_TCP_PROXIES"
     },
     {
-      "limit": 10.0,
-      "metric": "SECURITY_POLICIES",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "SECURITY_POLICIES"
     },
     {
-      "limit": 100.0,
-      "metric": "SECURITY_POLICY_RULES",
-      "usage": 0.0
+      "limit": 100,
+      "metric": "SECURITY_POLICY_RULES"
     },
     {
-      "limit": 45.0,
-      "metric": "PACKET_MIRRORINGS",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "PACKET_MIRRORINGS"
     },
     {
-      "limit": 300.0,
-      "metric": "NETWORK_ENDPOINT_GROUPS",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "NETWORK_ENDPOINT_GROUPS"
     },
     {
-      "limit": 6.0,
-      "metric": "INTERCONNECTS",
-      "usage": 0.0
+      "limit": 6,
+      "metric": "INTERCONNECTS"
     },
     {
-      "limit": 5000.0,
-      "metric": "GLOBAL_INTERNAL_ADDRESSES",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "GLOBAL_INTERNAL_ADDRESSES"
     },
     {
-      "limit": 15.0,
-      "metric": "VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "VPN_GATEWAYS"
     },
     {
-      "limit": 2000.0,
-      "metric": "MACHINE_IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "MACHINE_IMAGES"
     },
     {
-      "limit": 20.0,
-      "metric": "SECURITY_POLICY_CEVAL_RULES",
-      "usage": 0.0
+      "limit": 20,
+      "metric": "SECURITY_POLICY_CEVAL_RULES"
     },
     {
-      "limit": 15.0,
-      "metric": "EXTERNAL_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "EXTERNAL_VPN_GATEWAYS"
     }
   ],
   "selfLink": "https://www.googleapis.com/compute/v1/projects/k8s-release-test-prod",

--- a/audit/projects/k8s-sig-release-prototype/services/compute/project-info.json
+++ b/audit/projects/k8s-sig-release-prototype/services/compute/project-info.json
@@ -11,174 +11,140 @@
   "name": "k8s-sig-release-prototype",
   "quotas": [
     {
-      "limit": 5000.0,
-      "metric": "SNAPSHOTS",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "SNAPSHOTS"
     },
     {
-      "limit": 15.0,
-      "metric": "NETWORKS",
-      "usage": 1.0
+      "limit": 15,
+      "metric": "NETWORKS"
     },
     {
-      "limit": 200.0,
-      "metric": "FIREWALLS",
-      "usage": 4.0
+      "limit": 200,
+      "metric": "FIREWALLS"
     },
     {
-      "limit": 2000.0,
-      "metric": "IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "IMAGES"
     },
     {
-      "limit": 21.0,
-      "metric": "STATIC_ADDRESSES",
-      "usage": 0.0
+      "limit": 21,
+      "metric": "STATIC_ADDRESSES"
     },
     {
-      "limit": 250.0,
-      "metric": "ROUTES",
-      "usage": 24.0
+      "limit": 250,
+      "metric": "ROUTES"
     },
     {
-      "limit": 45.0,
-      "metric": "FORWARDING_RULES",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "FORWARDING_RULES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_POOLS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_POOLS"
     },
     {
-      "limit": 150.0,
-      "metric": "HEALTH_CHECKS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "HEALTH_CHECKS"
     },
     {
-      "limit": 69.0,
-      "metric": "IN_USE_ADDRESSES",
-      "usage": 0.0
+      "limit": 69,
+      "metric": "IN_USE_ADDRESSES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_INSTANCES",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_INSTANCES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTP_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "URL_MAPS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "URL_MAPS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_SERVICES",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_SERVICES"
     },
     {
-      "limit": 300.0,
-      "metric": "INSTANCE_TEMPLATES",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "INSTANCE_TEMPLATES"
     },
     {
-      "limit": 15.0,
-      "metric": "TARGET_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "TARGET_VPN_GATEWAYS"
     },
     {
-      "limit": 30.0,
-      "metric": "VPN_TUNNELS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "VPN_TUNNELS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_BUCKETS",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_BUCKETS"
     },
     {
-      "limit": 10.0,
-      "metric": "ROUTERS",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "ROUTERS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_SSL_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_SSL_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTPS_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTPS_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "SSL_CERTIFICATES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "SSL_CERTIFICATES"
     },
     {
-      "limit": 175.0,
-      "metric": "SUBNETWORKS",
-      "usage": 23.0
+      "limit": 175,
+      "metric": "SUBNETWORKS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_TCP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_TCP_PROXIES"
     },
     {
-      "limit": 10.0,
-      "metric": "SECURITY_POLICIES",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "SECURITY_POLICIES"
     },
     {
-      "limit": 100.0,
-      "metric": "SECURITY_POLICY_RULES",
-      "usage": 0.0
+      "limit": 100,
+      "metric": "SECURITY_POLICY_RULES"
     },
     {
-      "limit": 45.0,
-      "metric": "PACKET_MIRRORINGS",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "PACKET_MIRRORINGS"
     },
     {
-      "limit": 300.0,
-      "metric": "NETWORK_ENDPOINT_GROUPS",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "NETWORK_ENDPOINT_GROUPS"
     },
     {
-      "limit": 6.0,
-      "metric": "INTERCONNECTS",
-      "usage": 0.0
+      "limit": 6,
+      "metric": "INTERCONNECTS"
     },
     {
-      "limit": 5000.0,
-      "metric": "GLOBAL_INTERNAL_ADDRESSES",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "GLOBAL_INTERNAL_ADDRESSES"
     },
     {
-      "limit": 15.0,
-      "metric": "VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "VPN_GATEWAYS"
     },
     {
-      "limit": 2000.0,
-      "metric": "MACHINE_IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "MACHINE_IMAGES"
     },
     {
-      "limit": 20.0,
-      "metric": "SECURITY_POLICY_CEVAL_RULES",
-      "usage": 0.0
+      "limit": 20,
+      "metric": "SECURITY_POLICY_CEVAL_RULES"
     },
     {
-      "limit": 15.0,
-      "metric": "EXTERNAL_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "EXTERNAL_VPN_GATEWAYS"
     }
   ],
   "selfLink": "https://www.googleapis.com/compute/v1/projects/k8s-sig-release-prototype",

--- a/audit/projects/k8s-staging-capi-openstack/services/compute/project-info.json
+++ b/audit/projects/k8s-staging-capi-openstack/services/compute/project-info.json
@@ -11,174 +11,140 @@
   "name": "k8s-staging-capi-openstack",
   "quotas": [
     {
-      "limit": 5000.0,
-      "metric": "SNAPSHOTS",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "SNAPSHOTS"
     },
     {
-      "limit": 15.0,
-      "metric": "NETWORKS",
-      "usage": 1.0
+      "limit": 15,
+      "metric": "NETWORKS"
     },
     {
-      "limit": 200.0,
-      "metric": "FIREWALLS",
-      "usage": 4.0
+      "limit": 200,
+      "metric": "FIREWALLS"
     },
     {
-      "limit": 2000.0,
-      "metric": "IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "IMAGES"
     },
     {
-      "limit": 21.0,
-      "metric": "STATIC_ADDRESSES",
-      "usage": 0.0
+      "limit": 21,
+      "metric": "STATIC_ADDRESSES"
     },
     {
-      "limit": 250.0,
-      "metric": "ROUTES",
-      "usage": 24.0
+      "limit": 250,
+      "metric": "ROUTES"
     },
     {
-      "limit": 45.0,
-      "metric": "FORWARDING_RULES",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "FORWARDING_RULES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_POOLS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_POOLS"
     },
     {
-      "limit": 150.0,
-      "metric": "HEALTH_CHECKS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "HEALTH_CHECKS"
     },
     {
-      "limit": 69.0,
-      "metric": "IN_USE_ADDRESSES",
-      "usage": 0.0
+      "limit": 69,
+      "metric": "IN_USE_ADDRESSES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_INSTANCES",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_INSTANCES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTP_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "URL_MAPS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "URL_MAPS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_SERVICES",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_SERVICES"
     },
     {
-      "limit": 300.0,
-      "metric": "INSTANCE_TEMPLATES",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "INSTANCE_TEMPLATES"
     },
     {
-      "limit": 15.0,
-      "metric": "TARGET_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "TARGET_VPN_GATEWAYS"
     },
     {
-      "limit": 30.0,
-      "metric": "VPN_TUNNELS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "VPN_TUNNELS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_BUCKETS",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_BUCKETS"
     },
     {
-      "limit": 10.0,
-      "metric": "ROUTERS",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "ROUTERS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_SSL_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_SSL_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTPS_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTPS_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "SSL_CERTIFICATES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "SSL_CERTIFICATES"
     },
     {
-      "limit": 175.0,
-      "metric": "SUBNETWORKS",
-      "usage": 23.0
+      "limit": 175,
+      "metric": "SUBNETWORKS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_TCP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_TCP_PROXIES"
     },
     {
-      "limit": 10.0,
-      "metric": "SECURITY_POLICIES",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "SECURITY_POLICIES"
     },
     {
-      "limit": 100.0,
-      "metric": "SECURITY_POLICY_RULES",
-      "usage": 0.0
+      "limit": 100,
+      "metric": "SECURITY_POLICY_RULES"
     },
     {
-      "limit": 45.0,
-      "metric": "PACKET_MIRRORINGS",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "PACKET_MIRRORINGS"
     },
     {
-      "limit": 300.0,
-      "metric": "NETWORK_ENDPOINT_GROUPS",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "NETWORK_ENDPOINT_GROUPS"
     },
     {
-      "limit": 6.0,
-      "metric": "INTERCONNECTS",
-      "usage": 0.0
+      "limit": 6,
+      "metric": "INTERCONNECTS"
     },
     {
-      "limit": 5000.0,
-      "metric": "GLOBAL_INTERNAL_ADDRESSES",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "GLOBAL_INTERNAL_ADDRESSES"
     },
     {
-      "limit": 15.0,
-      "metric": "VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "VPN_GATEWAYS"
     },
     {
-      "limit": 2000.0,
-      "metric": "MACHINE_IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "MACHINE_IMAGES"
     },
     {
-      "limit": 20.0,
-      "metric": "SECURITY_POLICY_CEVAL_RULES",
-      "usage": 0.0
+      "limit": 20,
+      "metric": "SECURITY_POLICY_CEVAL_RULES"
     },
     {
-      "limit": 15.0,
-      "metric": "EXTERNAL_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "EXTERNAL_VPN_GATEWAYS"
     }
   ],
   "selfLink": "https://www.googleapis.com/compute/v1/projects/k8s-staging-capi-openstack",

--- a/audit/projects/k8s-staging-cip-test/services/compute/project-info.json
+++ b/audit/projects/k8s-staging-cip-test/services/compute/project-info.json
@@ -11,174 +11,140 @@
   "name": "k8s-staging-cip-test",
   "quotas": [
     {
-      "limit": 5000.0,
-      "metric": "SNAPSHOTS",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "SNAPSHOTS"
     },
     {
-      "limit": 15.0,
-      "metric": "NETWORKS",
-      "usage": 1.0
+      "limit": 15,
+      "metric": "NETWORKS"
     },
     {
-      "limit": 200.0,
-      "metric": "FIREWALLS",
-      "usage": 4.0
+      "limit": 200,
+      "metric": "FIREWALLS"
     },
     {
-      "limit": 2000.0,
-      "metric": "IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "IMAGES"
     },
     {
-      "limit": 21.0,
-      "metric": "STATIC_ADDRESSES",
-      "usage": 0.0
+      "limit": 21,
+      "metric": "STATIC_ADDRESSES"
     },
     {
-      "limit": 250.0,
-      "metric": "ROUTES",
-      "usage": 24.0
+      "limit": 250,
+      "metric": "ROUTES"
     },
     {
-      "limit": 45.0,
-      "metric": "FORWARDING_RULES",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "FORWARDING_RULES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_POOLS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_POOLS"
     },
     {
-      "limit": 150.0,
-      "metric": "HEALTH_CHECKS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "HEALTH_CHECKS"
     },
     {
-      "limit": 69.0,
-      "metric": "IN_USE_ADDRESSES",
-      "usage": 0.0
+      "limit": 69,
+      "metric": "IN_USE_ADDRESSES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_INSTANCES",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_INSTANCES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTP_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "URL_MAPS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "URL_MAPS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_SERVICES",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_SERVICES"
     },
     {
-      "limit": 300.0,
-      "metric": "INSTANCE_TEMPLATES",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "INSTANCE_TEMPLATES"
     },
     {
-      "limit": 15.0,
-      "metric": "TARGET_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "TARGET_VPN_GATEWAYS"
     },
     {
-      "limit": 30.0,
-      "metric": "VPN_TUNNELS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "VPN_TUNNELS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_BUCKETS",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_BUCKETS"
     },
     {
-      "limit": 10.0,
-      "metric": "ROUTERS",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "ROUTERS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_SSL_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_SSL_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTPS_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTPS_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "SSL_CERTIFICATES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "SSL_CERTIFICATES"
     },
     {
-      "limit": 175.0,
-      "metric": "SUBNETWORKS",
-      "usage": 23.0
+      "limit": 175,
+      "metric": "SUBNETWORKS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_TCP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_TCP_PROXIES"
     },
     {
-      "limit": 10.0,
-      "metric": "SECURITY_POLICIES",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "SECURITY_POLICIES"
     },
     {
-      "limit": 100.0,
-      "metric": "SECURITY_POLICY_RULES",
-      "usage": 0.0
+      "limit": 100,
+      "metric": "SECURITY_POLICY_RULES"
     },
     {
-      "limit": 45.0,
-      "metric": "PACKET_MIRRORINGS",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "PACKET_MIRRORINGS"
     },
     {
-      "limit": 300.0,
-      "metric": "NETWORK_ENDPOINT_GROUPS",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "NETWORK_ENDPOINT_GROUPS"
     },
     {
-      "limit": 6.0,
-      "metric": "INTERCONNECTS",
-      "usage": 0.0
+      "limit": 6,
+      "metric": "INTERCONNECTS"
     },
     {
-      "limit": 5000.0,
-      "metric": "GLOBAL_INTERNAL_ADDRESSES",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "GLOBAL_INTERNAL_ADDRESSES"
     },
     {
-      "limit": 15.0,
-      "metric": "VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "VPN_GATEWAYS"
     },
     {
-      "limit": 2000.0,
-      "metric": "MACHINE_IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "MACHINE_IMAGES"
     },
     {
-      "limit": 20.0,
-      "metric": "SECURITY_POLICY_CEVAL_RULES",
-      "usage": 0.0
+      "limit": 20,
+      "metric": "SECURITY_POLICY_CEVAL_RULES"
     },
     {
-      "limit": 15.0,
-      "metric": "EXTERNAL_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "EXTERNAL_VPN_GATEWAYS"
     }
   ],
   "selfLink": "https://www.googleapis.com/compute/v1/projects/k8s-staging-cip-test",

--- a/audit/projects/k8s-staging-cluster-api-aws/services/compute/project-info.json
+++ b/audit/projects/k8s-staging-cluster-api-aws/services/compute/project-info.json
@@ -11,174 +11,140 @@
   "name": "k8s-staging-cluster-api-aws",
   "quotas": [
     {
-      "limit": 5000.0,
-      "metric": "SNAPSHOTS",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "SNAPSHOTS"
     },
     {
-      "limit": 15.0,
-      "metric": "NETWORKS",
-      "usage": 1.0
+      "limit": 15,
+      "metric": "NETWORKS"
     },
     {
-      "limit": 200.0,
-      "metric": "FIREWALLS",
-      "usage": 4.0
+      "limit": 200,
+      "metric": "FIREWALLS"
     },
     {
-      "limit": 2000.0,
-      "metric": "IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "IMAGES"
     },
     {
-      "limit": 21.0,
-      "metric": "STATIC_ADDRESSES",
-      "usage": 0.0
+      "limit": 21,
+      "metric": "STATIC_ADDRESSES"
     },
     {
-      "limit": 250.0,
-      "metric": "ROUTES",
-      "usage": 24.0
+      "limit": 250,
+      "metric": "ROUTES"
     },
     {
-      "limit": 45.0,
-      "metric": "FORWARDING_RULES",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "FORWARDING_RULES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_POOLS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_POOLS"
     },
     {
-      "limit": 150.0,
-      "metric": "HEALTH_CHECKS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "HEALTH_CHECKS"
     },
     {
-      "limit": 69.0,
-      "metric": "IN_USE_ADDRESSES",
-      "usage": 0.0
+      "limit": 69,
+      "metric": "IN_USE_ADDRESSES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_INSTANCES",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_INSTANCES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTP_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "URL_MAPS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "URL_MAPS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_SERVICES",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_SERVICES"
     },
     {
-      "limit": 300.0,
-      "metric": "INSTANCE_TEMPLATES",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "INSTANCE_TEMPLATES"
     },
     {
-      "limit": 15.0,
-      "metric": "TARGET_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "TARGET_VPN_GATEWAYS"
     },
     {
-      "limit": 30.0,
-      "metric": "VPN_TUNNELS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "VPN_TUNNELS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_BUCKETS",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_BUCKETS"
     },
     {
-      "limit": 10.0,
-      "metric": "ROUTERS",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "ROUTERS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_SSL_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_SSL_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTPS_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTPS_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "SSL_CERTIFICATES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "SSL_CERTIFICATES"
     },
     {
-      "limit": 175.0,
-      "metric": "SUBNETWORKS",
-      "usage": 23.0
+      "limit": 175,
+      "metric": "SUBNETWORKS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_TCP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_TCP_PROXIES"
     },
     {
-      "limit": 10.0,
-      "metric": "SECURITY_POLICIES",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "SECURITY_POLICIES"
     },
     {
-      "limit": 100.0,
-      "metric": "SECURITY_POLICY_RULES",
-      "usage": 0.0
+      "limit": 100,
+      "metric": "SECURITY_POLICY_RULES"
     },
     {
-      "limit": 45.0,
-      "metric": "PACKET_MIRRORINGS",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "PACKET_MIRRORINGS"
     },
     {
-      "limit": 300.0,
-      "metric": "NETWORK_ENDPOINT_GROUPS",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "NETWORK_ENDPOINT_GROUPS"
     },
     {
-      "limit": 6.0,
-      "metric": "INTERCONNECTS",
-      "usage": 0.0
+      "limit": 6,
+      "metric": "INTERCONNECTS"
     },
     {
-      "limit": 5000.0,
-      "metric": "GLOBAL_INTERNAL_ADDRESSES",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "GLOBAL_INTERNAL_ADDRESSES"
     },
     {
-      "limit": 15.0,
-      "metric": "VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "VPN_GATEWAYS"
     },
     {
-      "limit": 2000.0,
-      "metric": "MACHINE_IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "MACHINE_IMAGES"
     },
     {
-      "limit": 20.0,
-      "metric": "SECURITY_POLICY_CEVAL_RULES",
-      "usage": 0.0
+      "limit": 20,
+      "metric": "SECURITY_POLICY_CEVAL_RULES"
     },
     {
-      "limit": 15.0,
-      "metric": "EXTERNAL_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "EXTERNAL_VPN_GATEWAYS"
     }
   ],
   "selfLink": "https://www.googleapis.com/compute/v1/projects/k8s-staging-cluster-api-aws",

--- a/audit/projects/k8s-staging-cluster-api/services/compute/project-info.json
+++ b/audit/projects/k8s-staging-cluster-api/services/compute/project-info.json
@@ -11,174 +11,140 @@
   "name": "k8s-staging-cluster-api",
   "quotas": [
     {
-      "limit": 5000.0,
-      "metric": "SNAPSHOTS",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "SNAPSHOTS"
     },
     {
-      "limit": 15.0,
-      "metric": "NETWORKS",
-      "usage": 1.0
+      "limit": 15,
+      "metric": "NETWORKS"
     },
     {
-      "limit": 200.0,
-      "metric": "FIREWALLS",
-      "usage": 4.0
+      "limit": 200,
+      "metric": "FIREWALLS"
     },
     {
-      "limit": 2000.0,
-      "metric": "IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "IMAGES"
     },
     {
-      "limit": 21.0,
-      "metric": "STATIC_ADDRESSES",
-      "usage": 0.0
+      "limit": 21,
+      "metric": "STATIC_ADDRESSES"
     },
     {
-      "limit": 250.0,
-      "metric": "ROUTES",
-      "usage": 24.0
+      "limit": 250,
+      "metric": "ROUTES"
     },
     {
-      "limit": 45.0,
-      "metric": "FORWARDING_RULES",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "FORWARDING_RULES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_POOLS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_POOLS"
     },
     {
-      "limit": 150.0,
-      "metric": "HEALTH_CHECKS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "HEALTH_CHECKS"
     },
     {
-      "limit": 69.0,
-      "metric": "IN_USE_ADDRESSES",
-      "usage": 0.0
+      "limit": 69,
+      "metric": "IN_USE_ADDRESSES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_INSTANCES",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_INSTANCES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTP_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "URL_MAPS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "URL_MAPS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_SERVICES",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_SERVICES"
     },
     {
-      "limit": 300.0,
-      "metric": "INSTANCE_TEMPLATES",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "INSTANCE_TEMPLATES"
     },
     {
-      "limit": 15.0,
-      "metric": "TARGET_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "TARGET_VPN_GATEWAYS"
     },
     {
-      "limit": 30.0,
-      "metric": "VPN_TUNNELS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "VPN_TUNNELS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_BUCKETS",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_BUCKETS"
     },
     {
-      "limit": 10.0,
-      "metric": "ROUTERS",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "ROUTERS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_SSL_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_SSL_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTPS_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTPS_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "SSL_CERTIFICATES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "SSL_CERTIFICATES"
     },
     {
-      "limit": 175.0,
-      "metric": "SUBNETWORKS",
-      "usage": 23.0
+      "limit": 175,
+      "metric": "SUBNETWORKS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_TCP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_TCP_PROXIES"
     },
     {
-      "limit": 10.0,
-      "metric": "SECURITY_POLICIES",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "SECURITY_POLICIES"
     },
     {
-      "limit": 100.0,
-      "metric": "SECURITY_POLICY_RULES",
-      "usage": 0.0
+      "limit": 100,
+      "metric": "SECURITY_POLICY_RULES"
     },
     {
-      "limit": 45.0,
-      "metric": "PACKET_MIRRORINGS",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "PACKET_MIRRORINGS"
     },
     {
-      "limit": 300.0,
-      "metric": "NETWORK_ENDPOINT_GROUPS",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "NETWORK_ENDPOINT_GROUPS"
     },
     {
-      "limit": 6.0,
-      "metric": "INTERCONNECTS",
-      "usage": 0.0
+      "limit": 6,
+      "metric": "INTERCONNECTS"
     },
     {
-      "limit": 5000.0,
-      "metric": "GLOBAL_INTERNAL_ADDRESSES",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "GLOBAL_INTERNAL_ADDRESSES"
     },
     {
-      "limit": 15.0,
-      "metric": "VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "VPN_GATEWAYS"
     },
     {
-      "limit": 2000.0,
-      "metric": "MACHINE_IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "MACHINE_IMAGES"
     },
     {
-      "limit": 20.0,
-      "metric": "SECURITY_POLICY_CEVAL_RULES",
-      "usage": 0.0
+      "limit": 20,
+      "metric": "SECURITY_POLICY_CEVAL_RULES"
     },
     {
-      "limit": 15.0,
-      "metric": "EXTERNAL_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "EXTERNAL_VPN_GATEWAYS"
     }
   ],
   "selfLink": "https://www.googleapis.com/compute/v1/projects/k8s-staging-cluster-api",

--- a/audit/projects/k8s-staging-coredns/services/compute/project-info.json
+++ b/audit/projects/k8s-staging-coredns/services/compute/project-info.json
@@ -11,174 +11,140 @@
   "name": "k8s-staging-coredns",
   "quotas": [
     {
-      "limit": 5000.0,
-      "metric": "SNAPSHOTS",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "SNAPSHOTS"
     },
     {
-      "limit": 15.0,
-      "metric": "NETWORKS",
-      "usage": 1.0
+      "limit": 15,
+      "metric": "NETWORKS"
     },
     {
-      "limit": 200.0,
-      "metric": "FIREWALLS",
-      "usage": 4.0
+      "limit": 200,
+      "metric": "FIREWALLS"
     },
     {
-      "limit": 2000.0,
-      "metric": "IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "IMAGES"
     },
     {
-      "limit": 21.0,
-      "metric": "STATIC_ADDRESSES",
-      "usage": 0.0
+      "limit": 21,
+      "metric": "STATIC_ADDRESSES"
     },
     {
-      "limit": 250.0,
-      "metric": "ROUTES",
-      "usage": 24.0
+      "limit": 250,
+      "metric": "ROUTES"
     },
     {
-      "limit": 45.0,
-      "metric": "FORWARDING_RULES",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "FORWARDING_RULES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_POOLS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_POOLS"
     },
     {
-      "limit": 150.0,
-      "metric": "HEALTH_CHECKS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "HEALTH_CHECKS"
     },
     {
-      "limit": 69.0,
-      "metric": "IN_USE_ADDRESSES",
-      "usage": 0.0
+      "limit": 69,
+      "metric": "IN_USE_ADDRESSES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_INSTANCES",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_INSTANCES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTP_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "URL_MAPS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "URL_MAPS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_SERVICES",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_SERVICES"
     },
     {
-      "limit": 300.0,
-      "metric": "INSTANCE_TEMPLATES",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "INSTANCE_TEMPLATES"
     },
     {
-      "limit": 15.0,
-      "metric": "TARGET_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "TARGET_VPN_GATEWAYS"
     },
     {
-      "limit": 30.0,
-      "metric": "VPN_TUNNELS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "VPN_TUNNELS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_BUCKETS",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_BUCKETS"
     },
     {
-      "limit": 10.0,
-      "metric": "ROUTERS",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "ROUTERS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_SSL_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_SSL_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTPS_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTPS_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "SSL_CERTIFICATES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "SSL_CERTIFICATES"
     },
     {
-      "limit": 175.0,
-      "metric": "SUBNETWORKS",
-      "usage": 23.0
+      "limit": 175,
+      "metric": "SUBNETWORKS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_TCP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_TCP_PROXIES"
     },
     {
-      "limit": 10.0,
-      "metric": "SECURITY_POLICIES",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "SECURITY_POLICIES"
     },
     {
-      "limit": 100.0,
-      "metric": "SECURITY_POLICY_RULES",
-      "usage": 0.0
+      "limit": 100,
+      "metric": "SECURITY_POLICY_RULES"
     },
     {
-      "limit": 45.0,
-      "metric": "PACKET_MIRRORINGS",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "PACKET_MIRRORINGS"
     },
     {
-      "limit": 300.0,
-      "metric": "NETWORK_ENDPOINT_GROUPS",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "NETWORK_ENDPOINT_GROUPS"
     },
     {
-      "limit": 6.0,
-      "metric": "INTERCONNECTS",
-      "usage": 0.0
+      "limit": 6,
+      "metric": "INTERCONNECTS"
     },
     {
-      "limit": 5000.0,
-      "metric": "GLOBAL_INTERNAL_ADDRESSES",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "GLOBAL_INTERNAL_ADDRESSES"
     },
     {
-      "limit": 15.0,
-      "metric": "VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "VPN_GATEWAYS"
     },
     {
-      "limit": 2000.0,
-      "metric": "MACHINE_IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "MACHINE_IMAGES"
     },
     {
-      "limit": 20.0,
-      "metric": "SECURITY_POLICY_CEVAL_RULES",
-      "usage": 0.0
+      "limit": 20,
+      "metric": "SECURITY_POLICY_CEVAL_RULES"
     },
     {
-      "limit": 15.0,
-      "metric": "EXTERNAL_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "EXTERNAL_VPN_GATEWAYS"
     }
   ],
   "selfLink": "https://www.googleapis.com/compute/v1/projects/k8s-staging-coredns",

--- a/audit/projects/k8s-staging-csi/services/compute/project-info.json
+++ b/audit/projects/k8s-staging-csi/services/compute/project-info.json
@@ -11,174 +11,140 @@
   "name": "k8s-staging-csi",
   "quotas": [
     {
-      "limit": 5000.0,
-      "metric": "SNAPSHOTS",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "SNAPSHOTS"
     },
     {
-      "limit": 15.0,
-      "metric": "NETWORKS",
-      "usage": 1.0
+      "limit": 15,
+      "metric": "NETWORKS"
     },
     {
-      "limit": 200.0,
-      "metric": "FIREWALLS",
-      "usage": 4.0
+      "limit": 200,
+      "metric": "FIREWALLS"
     },
     {
-      "limit": 2000.0,
-      "metric": "IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "IMAGES"
     },
     {
-      "limit": 21.0,
-      "metric": "STATIC_ADDRESSES",
-      "usage": 0.0
+      "limit": 21,
+      "metric": "STATIC_ADDRESSES"
     },
     {
-      "limit": 250.0,
-      "metric": "ROUTES",
-      "usage": 24.0
+      "limit": 250,
+      "metric": "ROUTES"
     },
     {
-      "limit": 45.0,
-      "metric": "FORWARDING_RULES",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "FORWARDING_RULES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_POOLS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_POOLS"
     },
     {
-      "limit": 150.0,
-      "metric": "HEALTH_CHECKS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "HEALTH_CHECKS"
     },
     {
-      "limit": 69.0,
-      "metric": "IN_USE_ADDRESSES",
-      "usage": 0.0
+      "limit": 69,
+      "metric": "IN_USE_ADDRESSES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_INSTANCES",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_INSTANCES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTP_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "URL_MAPS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "URL_MAPS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_SERVICES",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_SERVICES"
     },
     {
-      "limit": 300.0,
-      "metric": "INSTANCE_TEMPLATES",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "INSTANCE_TEMPLATES"
     },
     {
-      "limit": 15.0,
-      "metric": "TARGET_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "TARGET_VPN_GATEWAYS"
     },
     {
-      "limit": 30.0,
-      "metric": "VPN_TUNNELS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "VPN_TUNNELS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_BUCKETS",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_BUCKETS"
     },
     {
-      "limit": 10.0,
-      "metric": "ROUTERS",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "ROUTERS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_SSL_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_SSL_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTPS_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTPS_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "SSL_CERTIFICATES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "SSL_CERTIFICATES"
     },
     {
-      "limit": 175.0,
-      "metric": "SUBNETWORKS",
-      "usage": 23.0
+      "limit": 175,
+      "metric": "SUBNETWORKS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_TCP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_TCP_PROXIES"
     },
     {
-      "limit": 10.0,
-      "metric": "SECURITY_POLICIES",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "SECURITY_POLICIES"
     },
     {
-      "limit": 100.0,
-      "metric": "SECURITY_POLICY_RULES",
-      "usage": 0.0
+      "limit": 100,
+      "metric": "SECURITY_POLICY_RULES"
     },
     {
-      "limit": 45.0,
-      "metric": "PACKET_MIRRORINGS",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "PACKET_MIRRORINGS"
     },
     {
-      "limit": 300.0,
-      "metric": "NETWORK_ENDPOINT_GROUPS",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "NETWORK_ENDPOINT_GROUPS"
     },
     {
-      "limit": 6.0,
-      "metric": "INTERCONNECTS",
-      "usage": 0.0
+      "limit": 6,
+      "metric": "INTERCONNECTS"
     },
     {
-      "limit": 5000.0,
-      "metric": "GLOBAL_INTERNAL_ADDRESSES",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "GLOBAL_INTERNAL_ADDRESSES"
     },
     {
-      "limit": 15.0,
-      "metric": "VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "VPN_GATEWAYS"
     },
     {
-      "limit": 2000.0,
-      "metric": "MACHINE_IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "MACHINE_IMAGES"
     },
     {
-      "limit": 20.0,
-      "metric": "SECURITY_POLICY_CEVAL_RULES",
-      "usage": 0.0
+      "limit": 20,
+      "metric": "SECURITY_POLICY_CEVAL_RULES"
     },
     {
-      "limit": 15.0,
-      "metric": "EXTERNAL_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "EXTERNAL_VPN_GATEWAYS"
     }
   ],
   "selfLink": "https://www.googleapis.com/compute/v1/projects/k8s-staging-csi",

--- a/audit/projects/k8s-staging-release-test/services/compute/project-info.json
+++ b/audit/projects/k8s-staging-release-test/services/compute/project-info.json
@@ -11,174 +11,140 @@
   "name": "k8s-staging-release-test",
   "quotas": [
     {
-      "limit": 5000.0,
-      "metric": "SNAPSHOTS",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "SNAPSHOTS"
     },
     {
-      "limit": 15.0,
-      "metric": "NETWORKS",
-      "usage": 1.0
+      "limit": 15,
+      "metric": "NETWORKS"
     },
     {
-      "limit": 200.0,
-      "metric": "FIREWALLS",
-      "usage": 4.0
+      "limit": 200,
+      "metric": "FIREWALLS"
     },
     {
-      "limit": 2000.0,
-      "metric": "IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "IMAGES"
     },
     {
-      "limit": 21.0,
-      "metric": "STATIC_ADDRESSES",
-      "usage": 0.0
+      "limit": 21,
+      "metric": "STATIC_ADDRESSES"
     },
     {
-      "limit": 250.0,
-      "metric": "ROUTES",
-      "usage": 24.0
+      "limit": 250,
+      "metric": "ROUTES"
     },
     {
-      "limit": 45.0,
-      "metric": "FORWARDING_RULES",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "FORWARDING_RULES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_POOLS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_POOLS"
     },
     {
-      "limit": 150.0,
-      "metric": "HEALTH_CHECKS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "HEALTH_CHECKS"
     },
     {
-      "limit": 69.0,
-      "metric": "IN_USE_ADDRESSES",
-      "usage": 0.0
+      "limit": 69,
+      "metric": "IN_USE_ADDRESSES"
     },
     {
-      "limit": 150.0,
-      "metric": "TARGET_INSTANCES",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "TARGET_INSTANCES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTP_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "URL_MAPS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "URL_MAPS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_SERVICES",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_SERVICES"
     },
     {
-      "limit": 300.0,
-      "metric": "INSTANCE_TEMPLATES",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "INSTANCE_TEMPLATES"
     },
     {
-      "limit": 15.0,
-      "metric": "TARGET_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "TARGET_VPN_GATEWAYS"
     },
     {
-      "limit": 30.0,
-      "metric": "VPN_TUNNELS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "VPN_TUNNELS"
     },
     {
-      "limit": 9.0,
-      "metric": "BACKEND_BUCKETS",
-      "usage": 0.0
+      "limit": 9,
+      "metric": "BACKEND_BUCKETS"
     },
     {
-      "limit": 10.0,
-      "metric": "ROUTERS",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "ROUTERS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_SSL_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_SSL_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_HTTPS_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_HTTPS_PROXIES"
     },
     {
-      "limit": 30.0,
-      "metric": "SSL_CERTIFICATES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "SSL_CERTIFICATES"
     },
     {
-      "limit": 175.0,
-      "metric": "SUBNETWORKS",
-      "usage": 23.0
+      "limit": 175,
+      "metric": "SUBNETWORKS"
     },
     {
-      "limit": 30.0,
-      "metric": "TARGET_TCP_PROXIES",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "TARGET_TCP_PROXIES"
     },
     {
-      "limit": 10.0,
-      "metric": "SECURITY_POLICIES",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "SECURITY_POLICIES"
     },
     {
-      "limit": 100.0,
-      "metric": "SECURITY_POLICY_RULES",
-      "usage": 0.0
+      "limit": 100,
+      "metric": "SECURITY_POLICY_RULES"
     },
     {
-      "limit": 45.0,
-      "metric": "PACKET_MIRRORINGS",
-      "usage": 0.0
+      "limit": 45,
+      "metric": "PACKET_MIRRORINGS"
     },
     {
-      "limit": 300.0,
-      "metric": "NETWORK_ENDPOINT_GROUPS",
-      "usage": 0.0
+      "limit": 300,
+      "metric": "NETWORK_ENDPOINT_GROUPS"
     },
     {
-      "limit": 6.0,
-      "metric": "INTERCONNECTS",
-      "usage": 0.0
+      "limit": 6,
+      "metric": "INTERCONNECTS"
     },
     {
-      "limit": 5000.0,
-      "metric": "GLOBAL_INTERNAL_ADDRESSES",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "GLOBAL_INTERNAL_ADDRESSES"
     },
     {
-      "limit": 15.0,
-      "metric": "VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "VPN_GATEWAYS"
     },
     {
-      "limit": 2000.0,
-      "metric": "MACHINE_IMAGES",
-      "usage": 0.0
+      "limit": 2000,
+      "metric": "MACHINE_IMAGES"
     },
     {
-      "limit": 20.0,
-      "metric": "SECURITY_POLICY_CEVAL_RULES",
-      "usage": 0.0
+      "limit": 20,
+      "metric": "SECURITY_POLICY_CEVAL_RULES"
     },
     {
-      "limit": 15.0,
-      "metric": "EXTERNAL_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 15,
+      "metric": "EXTERNAL_VPN_GATEWAYS"
     }
   ],
   "selfLink": "https://www.googleapis.com/compute/v1/projects/k8s-staging-release-test",

--- a/audit/projects/kubernetes-public/services/compute/project-info.json
+++ b/audit/projects/kubernetes-public/services/compute/project-info.json
@@ -29,174 +29,140 @@
   "name": "kubernetes-public",
   "quotas": [
     {
-      "limit": 10000.0,
-      "metric": "SNAPSHOTS",
-      "usage": 0.0
+      "limit": 10000,
+      "metric": "SNAPSHOTS"
     },
     {
-      "limit": 30.0,
-      "metric": "NETWORKS",
-      "usage": 1.0
+      "limit": 30,
+      "metric": "NETWORKS"
     },
     {
-      "limit": 500.0,
-      "metric": "FIREWALLS",
-      "usage": 11.0
+      "limit": 500,
+      "metric": "FIREWALLS"
     },
     {
-      "limit": 5000.0,
-      "metric": "IMAGES",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "IMAGES"
     },
     {
-      "limit": 175.0,
-      "metric": "STATIC_ADDRESSES",
-      "usage": 4.0
+      "limit": 175,
+      "metric": "STATIC_ADDRESSES"
     },
     {
-      "limit": 300.0,
-      "metric": "ROUTES",
-      "usage": 28.0
+      "limit": 300,
+      "metric": "ROUTES"
     },
     {
-      "limit": 150.0,
-      "metric": "FORWARDING_RULES",
-      "usage": 8.0
+      "limit": 150,
+      "metric": "FORWARDING_RULES"
     },
     {
-      "limit": 500.0,
-      "metric": "TARGET_POOLS",
-      "usage": 0.0
+      "limit": 500,
+      "metric": "TARGET_POOLS"
     },
     {
-      "limit": 500.0,
-      "metric": "HEALTH_CHECKS",
-      "usage": 4.0
+      "limit": 500,
+      "metric": "HEALTH_CHECKS"
     },
     {
-      "limit": 575.0,
-      "metric": "IN_USE_ADDRESSES",
-      "usage": 8.0
+      "limit": 575,
+      "metric": "IN_USE_ADDRESSES"
     },
     {
-      "limit": 500.0,
-      "metric": "TARGET_INSTANCES",
-      "usage": 0.0
+      "limit": 500,
+      "metric": "TARGET_INSTANCES"
     },
     {
-      "limit": 100.0,
-      "metric": "TARGET_HTTP_PROXIES",
-      "usage": 4.0
+      "limit": 100,
+      "metric": "TARGET_HTTP_PROXIES"
     },
     {
-      "limit": 100.0,
-      "metric": "URL_MAPS",
-      "usage": 4.0
+      "limit": 100,
+      "metric": "URL_MAPS"
     },
     {
-      "limit": 60.0,
-      "metric": "BACKEND_SERVICES",
-      "usage": 4.0
+      "limit": 60,
+      "metric": "BACKEND_SERVICES"
     },
     {
-      "limit": 1000.0,
-      "metric": "INSTANCE_TEMPLATES",
-      "usage": 7.0
+      "limit": 1000,
+      "metric": "INSTANCE_TEMPLATES"
     },
     {
-      "limit": 50.0,
-      "metric": "TARGET_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 50,
+      "metric": "TARGET_VPN_GATEWAYS"
     },
     {
-      "limit": 100.0,
-      "metric": "VPN_TUNNELS",
-      "usage": 0.0
+      "limit": 100,
+      "metric": "VPN_TUNNELS"
     },
     {
-      "limit": 30.0,
-      "metric": "BACKEND_BUCKETS",
-      "usage": 0.0
+      "limit": 30,
+      "metric": "BACKEND_BUCKETS"
     },
     {
-      "limit": 20.0,
-      "metric": "ROUTERS",
-      "usage": 0.0
+      "limit": 20,
+      "metric": "ROUTERS"
     },
     {
-      "limit": 100.0,
-      "metric": "TARGET_SSL_PROXIES",
-      "usage": 0.0
+      "limit": 100,
+      "metric": "TARGET_SSL_PROXIES"
     },
     {
-      "limit": 100.0,
-      "metric": "TARGET_HTTPS_PROXIES",
-      "usage": 4.0
+      "limit": 100,
+      "metric": "TARGET_HTTPS_PROXIES"
     },
     {
-      "limit": 100.0,
-      "metric": "SSL_CERTIFICATES",
-      "usage": 4.0
+      "limit": 100,
+      "metric": "SSL_CERTIFICATES"
     },
     {
-      "limit": 275.0,
-      "metric": "SUBNETWORKS",
-      "usage": 24.0
+      "limit": 275,
+      "metric": "SUBNETWORKS"
     },
     {
-      "limit": 100.0,
-      "metric": "TARGET_TCP_PROXIES",
-      "usage": 0.0
+      "limit": 100,
+      "metric": "TARGET_TCP_PROXIES"
     },
     {
-      "limit": 10.0,
-      "metric": "SECURITY_POLICIES",
-      "usage": 0.0
+      "limit": 10,
+      "metric": "SECURITY_POLICIES"
     },
     {
-      "limit": 200.0,
-      "metric": "SECURITY_POLICY_RULES",
-      "usage": 0.0
+      "limit": 200,
+      "metric": "SECURITY_POLICY_RULES"
     },
     {
-      "limit": 150.0,
-      "metric": "PACKET_MIRRORINGS",
-      "usage": 0.0
+      "limit": 150,
+      "metric": "PACKET_MIRRORINGS"
     },
     {
-      "limit": 1000.0,
-      "metric": "NETWORK_ENDPOINT_GROUPS",
-      "usage": 0.0
+      "limit": 1000,
+      "metric": "NETWORK_ENDPOINT_GROUPS"
     },
     {
-      "limit": 6.0,
-      "metric": "INTERCONNECTS",
-      "usage": 0.0
+      "limit": 6,
+      "metric": "INTERCONNECTS"
     },
     {
-      "limit": 5000.0,
-      "metric": "GLOBAL_INTERNAL_ADDRESSES",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "GLOBAL_INTERNAL_ADDRESSES"
     },
     {
-      "limit": 50.0,
-      "metric": "VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 50,
+      "metric": "VPN_GATEWAYS"
     },
     {
-      "limit": 5000.0,
-      "metric": "MACHINE_IMAGES",
-      "usage": 0.0
+      "limit": 5000,
+      "metric": "MACHINE_IMAGES"
     },
     {
-      "limit": 20.0,
-      "metric": "SECURITY_POLICY_CEVAL_RULES",
-      "usage": 0.0
+      "limit": 20,
+      "metric": "SECURITY_POLICY_CEVAL_RULES"
     },
     {
-      "limit": 50.0,
-      "metric": "EXTERNAL_VPN_GATEWAYS",
-      "usage": 0.0
+      "limit": 50,
+      "metric": "EXTERNAL_VPN_GATEWAYS"
     }
   ],
   "selfLink": "https://www.googleapis.com/compute/v1/projects/kubernetes-public",


### PR DESCRIPTION
Closes: #726 

Stripping out resource usage from `project-info.json` files with audit reflecting the changes.

/cc @thockin @spiffxp @puerco 