### PR TITLE
Add docs for publishing-bot

### DIFF
--- a/k8s.io/README.md
+++ b/k8s.io/README.md
@@ -73,10 +73,3 @@ Use `make test` to run unit tests to verify the various endpoints on the server.
 Deploying
 ===
 Set kubectl to target the production cluster, then run `make deploy`.
-
-Publishing-bot
-===
-
-Details about running the [publishing-bot](https://git.k8s.io/publishing-bot)
-for the Kubernetes project can be found
-[here](https://git.k8s.io/publishing-bot/k8s-publishing-bot.md).

--- a/publishing-bot/README.md
+++ b/publishing-bot/README.md
@@ -1,0 +1,14 @@
+# Publishing Bot
+
+The [publishing-bot] runs in the`publishing-bot` namespace in the `aaa`
+cluster in the `kubernetes-public` project.
+
+The GitHub token is in the publishing-bot repo and is encrypted
+with git-crypt. The publishing-bot [OWNERS] have access to the token.
+
+For more details on deploying the bot, please see these [instructions].
+
+
+[publishing-bot]: https://github.com/kubernetes/publishing-bot
+[OWNERS]: https://github.com/kubernetes/publishing-bot/blob/master/OWNERS
+[instructions]: https://github.com/kubernetes/publishing-bot/blob/master/k8s-publishing-bot.md


### PR DESCRIPTION
For https://github.com/kubernetes/k8s.io/issues/503

Like https://github.com/kubernetes/k8s.io/pull/784, but for publishing-bot

Also see https://github.com/kubernetes/publishing-bot/pull/223 which adds more details to the existing publishing-bot docs.

/cc @dims @bartsmykla @ameukam 
/assign @bartsmykla 