### PR TITLE
Added dns records for slack-infra staging

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -204,6 +204,9 @@ sigs:
 slack:
   type: A
   value: 130.211.42.98
+slack-staging:
+  type: A
+  value: 34.107.195.71
 # Prow (@ixdy).
 submit-queue:
   type: CNAME


### PR DESCRIPTION
- slack-staging.k8s.io

IP address can be confirmed [here](https://console.cloud.google.com/networking/addresses/list?authuser=0&organizationId=758905017065&project=kubernetes-public) under the name `k8s-fw-slack-infra-slack-infra--ea949c440a044527` which will be changed to `slack-infra-ingress-prod` (ref. #793)

Closes: #795

Signed-off-by: Bart Smykla <bsmykla@vmware.com>