### PR TITLE
Allow a user to see logs of a pod.

### DIFF
--- a/infra/gcp/namespaces/namespace-user-role.yml
+++ b/infra/gcp/namespaces/namespace-user-role.yml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{namespace}}
 rules:
   - apiGroups: [""]
-    resources: ["configmaps", "endpoints", "persistentvolumeclaims", "pods", "resourcequotas", "services"]
+    resources: ["configmaps", "endpoints", "persistentvolumeclaims", "pods", "pods/log", "pods/status", "resourcequotas", "services"]
     verbs: ["*"]
   - apiGroups: ["autoscaling"]
     resources: ["horizontalpodautoscalers"]


### PR DESCRIPTION
Getting this error : 
```console
kubectl -n slack-infra logs slack-event-log-77965d767d-4bkql
Error from server (Forbidden): pods "slack-event-log-77965d767d-4bkql" is forbidden: User "ameukam@gmail.com" cannot get resource "pods/log" in API group "" in the namespace "slack-infra": Required "container.pods.getLogs" permission.
```

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>

/assign @thockin @spiffxp @bartsmykla 