### PR TITLE
Prepared slack-infra registry namespace

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -1053,6 +1053,18 @@ groups:
       - bowei@google.com
       - antonio.ojea.garcia@gmail.com
 
+  - email-id: k8s-infra-staging-slack-infra@kubernetes.io
+    name: k8s-infra-staging-slack-infra
+    description: |-
+      ACL for staging Slack Infra
+    settings:
+      ReconcileMembers: "true"
+    owners:
+      - ameukam@gmail.com
+      - bartek@smykla.com
+      - ktbry@google.com
+      - james@munnelly.eu
+
   - email-id: k8s-infra-staging-txtdirect@kubernetes.io
     name: k8s-infra-staging-txtdirect
     description: |-

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -79,6 +79,7 @@ STAGING_PROJECTS=(
     releng
     scl-image-builder
     service-apis
+    slack-infra
     txtdirect
 )
 

--- a/k8s.gcr.io/images/k8s-staging-slack-infra/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-slack-infra/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- ameukam
+- bartsmykla
+- Katharine
+- munnerz

--- a/k8s.gcr.io/images/k8s-staging-slack-infra/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-slack-infra/images.yaml
@@ -1,0 +1,1 @@
+# No images yet

--- a/k8s.gcr.io/manifests/k8s-staging-slack-infra/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-slack-infra/promoter-manifest.yaml
@@ -1,0 +1,10 @@
+# google group for gcr.io/k8s-staging-slack-infra is k8s-infra-staging-slack-infra@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-slack-infra
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/slack-infra
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/slack-infra
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/slack-infra
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
When deployed slack-infra to the `aaa` I realized we can't use existing slack-tools images:
```
Warning  Failed     16s (x2 over 30s)  kubelet, gke-aaa-pool2-20200316195138785800000-fafa121a-zhw5  Failed to pull image "gcr.io/kubernetes-tools/slackin-kubernetes@sha256:d1a9b02239e690d5cbd78c76475a112aedf279dbd8ef401de1b8394f817a23b3": rpc error: code = Unknown desc = Error response from daemon: pull access denied for gcr.io/kubernetes-tools/slackin-kubernetes, repository does not exist or may require 'docker login'
```
so this PR is intended to prepare "namespace" for slack tools which we'll use

ref. slack discussions: [#1](https://kubernetes.slack.com/archives/CCK68P2Q2/p1587698171114900?thread_ts=1587697208.113100&cid=CCK68P2Q2), [#2](https://kubernetes.slack.com/archives/C4M06S5HS/p1587698820067900)

/cc @Katharine @spiffxp @ameukam 

Signed-off-by: Bart Smykla <bsmykla@vmware.com>