### PR TITLE
Add a k8s-infra-gcp-auditor service account

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -276,6 +276,7 @@ groups:
       - thockin@google.com
       - adolfo.garcia@uservers.net
       - bartek@smykla.com
+      - k8s-infra-gcp-auditor@kubernetes-public.iam.gserviceaccount.com
 
   - email-id: k8s-infra-gcp-org-admins@kubernetes.io
     name: Organization Administrators for kubernetes.io

--- a/infra/gcp/ensure-main-project.sh
+++ b/infra/gcp/ensure-main-project.sh
@@ -121,6 +121,18 @@ gcloud projects add-iam-policy-binding "${PROJECT}" \
     --member "group:${ACCOUNTING_GROUP}" \
     --role roles/bigquery.jobUser
 
+color 6 "Ensuring the k8s-infra-gcp-auditor serviceaccount exists"
+ensure_service_account \
+  "${PROJECT}" \
+  "k8s-infra-gcp-auditor" \
+  "Grants readonly access to org resources"
+
+color 6 "Empowering k8s-infra-gcp-auditor serviceaccount to be used on build cluster"
+empower_ksa_to_svcacct \
+  "kubernetes-public.svc.id.goog[test-pods/k8s-infra-gcp-auditor]" \
+  "${PROJECT}" \
+  $(svc_acct_email "${PROJECT}" "k8s-infra-gcp-auditor")
+
 color 6 "Empowering ${DNS_GROUP}"
 gcloud projects add-iam-policy-binding "${PROJECT}" \
     --member "group:${DNS_GROUP}" \

--- a/infra/gcp/ensure-main-project.sh
+++ b/infra/gcp/ensure-main-project.sh
@@ -137,8 +137,8 @@ ensure_dns_zone "${PROJECT}" "canary-x-k8s-io" "canary.x-k8s.io"
 ensure_dns_zone "${PROJECT}" "canary-k8s-e2e-com" "canary.k8s-e2e.com"
 
 color 6 "Creating the BigQuery dataset for billing data"
-if ! bq --project "${PROJECT}" ls "${BQ_BILLING_DATASET}" >/dev/null 2>&1; then
-    bq --project "${PROJECT}" mk "${BQ_BILLING_DATASET}"
+if ! bq --project_id "${PROJECT}" ls "${BQ_BILLING_DATASET}" >/dev/null 2>&1; then
+    bq --project_id "${PROJECT}" mk "${BQ_BILLING_DATASET}"
 fi
 
 color 6 "Setting BigQuery permissions"


### PR DESCRIPTION
I'm trying to get an audit prowjob running. I want to use workload identity to bind it to a service account that has all of the appropriate read permissions.

Rather than directly assign it to org iam roles, add it to a group that already has those roles assigned.

Since changes to the group could roll this back, I'd like to get this merged.  This rest is still work in progress