### PR TITLE
Added staging repository for infra-tools

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -850,6 +850,20 @@ groups:
       - difazio.raffaele@gmail.com
       - nick@juni.io
 
+  - email-id: k8s-infra-staging-infra-tools@kubernetes.io
+    name: k8s-infra-staging-infra-tools
+    description: |-
+      ACL for staging Infra Tools
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - bartek@smykla.com
+      - cblecker@gmail.com
+      - davanum@gmail.com
+      - james@munnelly.eu
+      - thockin@google.com
+      - spiffxp@google.com
+
   - email-id: k8s-infra-staging-kas-network-proxy@kubernetes.io
     name: k8s-infra-staging-kas-network-proxy
     description: |-

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -62,6 +62,7 @@ STAGING_PROJECTS=(
     e2e-test-images
     etcd
     external-dns
+    infra-tools
     kas-network-proxy
     kind
     kops

--- a/k8s.gcr.io/images/k8s-staging-infra-tools/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-infra-tools/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - bartsmykla
+  - munnerz

--- a/k8s.gcr.io/images/k8s-staging-infra-tools/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-infra-tools/images.yaml
@@ -1,0 +1,1 @@
+# No images yet

--- a/k8s.gcr.io/manifests/k8s-staging-infra-tools/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-infra-tools/promoter-manifest.yaml
@@ -1,0 +1,10 @@
+# google group for gcr.io/k8s-staging-infra-tools is k8s-infra-staging-infra-tools@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-infra-tools
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/infra-tools
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/infra-tools
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/infra-tools
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
Following step no. 1 at #783 I want to prepare the staging registry for our instance of `octodns` from [k/k8s.io/dns/octodns-docker](https://github.com/kubernetes/k8s.io/tree/master/dns/octodns-docker) which will be used to automate dns updates.

As I didn't get the consensus yet I'm asking you guys to lgtm it
/cc @dims @spiffxp @thockin 

I asked @munnerz if he would like to help me with the infra-tools if there will be need in the future so I've put our names in the `OWNERS` file.

Signed-off-by: Bart Smykla <bsmykla@vmware.com>