### PR TITLE
Add infra scripts/terraform for prow build cluster prototype

### DIFF
--- a/infra/gcp/clusters/kubernetes-public/prow-build-test/00-inputs.tf
+++ b/infra/gcp/clusters/kubernetes-public/prow-build-test/00-inputs.tf
@@ -1,0 +1,26 @@
+/*
+This file defines:
+- Required Terraform version
+- Required provider versions
+- Storage backend details
+- GCP project configuration
+*/
+
+terraform {
+  required_version = ">= 0.12.8"
+
+  backend "gcs" {
+    bucket = "k8s-infra-clusters-terraform"
+    prefix = "kubernetes-public/prow-build-test" // $project_name/$cluster_name
+  }
+
+  required_providers {
+    google      = "~> 2.14"
+    google-beta = "~> 2.14"
+  }
+}
+
+// This configures the source project where we should install the cluster
+data "google_project" "project" {
+  project_id = "kubernetes-public"
+}

--- a/infra/gcp/clusters/kubernetes-public/prow-build-test/10-cluster-configuration.tf
+++ b/infra/gcp/clusters/kubernetes-public/prow-build-test/10-cluster-configuration.tf
@@ -50,7 +50,7 @@ resource "google_bigquery_dataset" "usage_metering" {
   }
   access {
     role          = "WRITER"
-    user_by_email = "${google_service_account.cluster_node_sa.email}"
+    user_by_email = google_service_account.cluster_node_sa.email
   }
 
   // This restricts deletion of this dataset if there is data in it
@@ -74,10 +74,6 @@ resource "google_container_cluster" "cluster" {
 
   // Network config
   network = "default"
-  ip_allocation_policy {
-    use_ip_aliases    = true
-    create_subnetwork = true
-  }
 
   // Start with a single node, because we're going to delete the default pool
   initial_node_count = 1

--- a/infra/gcp/clusters/kubernetes-public/prow-build-test/10-cluster-configuration.tf
+++ b/infra/gcp/clusters/kubernetes-public/prow-build-test/10-cluster-configuration.tf
@@ -1,0 +1,160 @@
+/*
+This file defines:
+- GCP Service Account for nodes
+- Bigquery dataset for usage metering
+- GKE cluster configuration
+
+Note that it does not configure any node pools; this is done in a separate file.
+*/
+
+locals {
+  cluster_name      = "prow-build-test" // This is the name of the cluster defined in this file
+  cluster_location  = "us-central1"     // This is the GCP location (region or zone) where the cluster should be created
+  bigquery_location = "US"              // This is the bigquery specific location where the dataset should be created
+}
+
+// Create SA for nodes
+resource "google_service_account" "cluster_node_sa" {
+  project      = data.google_project.project.id
+  account_id   = "gke-nodes-${local.cluster_name}"
+  display_name = "Nodes in GKE cluster '${local.cluster_name}'"
+}
+
+// Add roles for SA
+resource "google_project_iam_member" "cluster_node_sa_logging" {
+  project = data.google_project.project.id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.cluster_node_sa.email}"
+}
+resource "google_project_iam_member" "cluster_node_sa_monitoring_viewer" {
+  project = data.google_project.project.id
+  role    = "roles/monitoring.viewer"
+  member  = "serviceAccount:${google_service_account.cluster_node_sa.email}"
+}
+resource "google_project_iam_member" "cluster_node_sa_monitoring_metricwriter" {
+  project = data.google_project.project.id
+  role    = "roles/monitoring.metricWriter"
+  member  = "serviceAccount:${google_service_account.cluster_node_sa.email}"
+}
+
+// BigQuery dataset for usage data
+resource "google_bigquery_dataset" "usage_metering" {
+  dataset_id  = replace("usage_metering_${local.cluster_name}", "-", "_")
+  project     = data.google_project.project.id
+  description = "GKE Usage Metering for cluster '${local.cluster_name}'"
+  location    = local.bigquery_location
+
+  access {
+    role          = "OWNER"
+    special_group = "projectOwners"
+  }
+  access {
+    role          = "WRITER"
+    user_by_email = "${google_service_account.cluster_node_sa.email}"
+  }
+
+  // This restricts deletion of this dataset if there is data in it
+  // IMPORTANT: Should be true on test clusters
+  delete_contents_on_destroy = true
+}
+
+// Create GKE cluster, but with no node pools. Node pools can be provisioned below
+resource "google_container_cluster" "cluster" {
+  name     = local.cluster_name
+  location = local.cluster_location
+
+  provider = google-beta
+  project  = data.google_project.project.id
+
+  // GKE clusters are critical objects and should not be destroyed
+  // IMPORTANT: should be false on test clusters
+  lifecycle {
+    prevent_destroy = false
+  }
+
+  // Network config
+  network = "default"
+  ip_allocation_policy {
+    use_ip_aliases    = true
+    create_subnetwork = true
+  }
+
+  // Start with a single node, because we're going to delete the default pool
+  initial_node_count = 1
+
+  // Removes the default node pool, so we can custom create them as separate
+  // objects
+  remove_default_node_pool = true
+
+  // Disable local and certificate auth
+  master_auth {
+    username = ""
+    password = ""
+
+    client_certificate_config {
+      issue_client_certificate = false
+    }
+  }
+
+  // Enable google-groups for RBAC
+  authenticator_groups_config {
+    security_group = "gke-security-groups@kubernetes.io"
+  }
+
+  // Enable workload identity for GCP IAM
+  workload_identity_config {
+    identity_namespace = "${data.google_project.project.id}.svc.id.goog"
+  }
+
+  // Enable Stackdriver Kubernetes Monitoring
+  logging_service    = "logging.googleapis.com/kubernetes"
+  monitoring_service = "monitoring.googleapis.com/kubernetes"
+
+  // Set maintenance time
+  maintenance_policy {
+    daily_maintenance_window {
+      start_time = "11:00" // (in UTC), 03:00 PST
+    }
+  }
+
+  // Restrict master to Google IP space; use Cloud Shell to access
+  master_authorized_networks_config {
+  }
+
+  // Enable GKE Usage Metering
+  resource_usage_export_config {
+    enable_network_egress_metering = true
+    bigquery_destination {
+      dataset_id = google_bigquery_dataset.usage_metering.dataset_id
+    }
+  }
+
+  // Enable GKE Network Policy
+  network_policy {
+    enabled  = true
+    provider = "CALICO"
+  }
+
+  // Configure cluster addons
+  addons_config {
+    horizontal_pod_autoscaling {
+      disabled = false
+    }
+    http_load_balancing {
+      disabled = false
+    }
+    network_policy_config {
+      disabled = false
+    }
+  }
+
+  // Enable PodSecurityPolicy enforcement
+  pod_security_policy_config {
+    enabled = false // TODO: we should turn this on
+  }
+
+  // Enable VPA
+  vertical_pod_autoscaling {
+    enabled = true
+  }
+}

--- a/infra/gcp/clusters/kubernetes-public/prow-build-test/11-pool1-configuration.tf
+++ b/infra/gcp/clusters/kubernetes-public/prow-build-test/11-pool1-configuration.tf
@@ -1,0 +1,59 @@
+/*
+This file defines:
+- Node pool for pool1
+
+Note: If you wish to create additional node pools, please duplicate this file
+and change the resource name, name_prefix, and any other cluster specific settings.
+*/
+
+resource "google_container_node_pool" "pool1" {
+  name_prefix = "pool1-"
+  location    = google_container_cluster.cluster.location
+  cluster     = google_container_cluster.cluster.name
+
+  provider = google-beta
+  project  = data.google_project.project.id
+
+  // Start with a single node
+  initial_node_count = 1
+
+  // Auto repair, and auto upgrade nodes to match the master version
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  // Autoscale the cluster as needed. Note that these values will be multiplied
+  // by 3, as the cluster will exist in three zones
+  autoscaling {
+    min_node_count = 1
+    max_node_count = 3
+  }
+
+  // Set machine type, and enable all oauth scopes tied to the service account
+  node_config {
+    // k8s-prow-builds uses n1-highmem-8
+    machine_type = "n1-highmem-2"
+    // k8s-prow-builds uses 250
+    disk_size_gb = 100
+    // k8s-prow-builds uses pd-ssd
+    disk_type    = "pd-ssd"
+
+    service_account = google_service_account.cluster_node_sa.email
+    oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
+
+    // Needed for workload identity
+    workload_metadata_config {
+      node_metadata = "GKE_METADATA_SERVER"
+    }
+    metadata = {
+      disable-legacy-endpoints = "true"
+    }
+  }
+
+  // If we need to destroy the node pool, create the new one before destroying
+  // the old one
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/infra/gcp/ensure-e2e-projects.sh
+++ b/infra/gcp/ensure-e2e-projects.sh
@@ -40,6 +40,9 @@ ensure_service_account \
   "kubernetes-public" \
   "prow-build-test" \
   "used by prowjobs that run in prow-build-test cluster"
+# the namespace "test-pods" here must match the namespace defined in prow's config.yaml
+# to launch pods defined by prowjobs
+# eg: https://github.com/kubernetes/test-infra/blob/master/config/prow/config.yaml#L73
 empower_ksa_to_svcacct \
   "kubernetes-public.svc.id.goog[test-pods/prow-build]" \
   "kubernetes-public" \
@@ -56,6 +59,11 @@ ensure_service_account \
   "kubernetes-public" \
   "boskos-janitor-test" \
   "used by boskos-janitor in prow-build-test cluster"
+# the namespace "test-pods" here must match the namespace defined in prows config.yaml
+# to launch pods defined by prowjobs because most prowjobs as-written assume they can
+# talk to either http://boskos (kubetest or bootstrap.py jobs) or 
+# https://boskos.svc.test-pods.cluster.local (some of the cluster-api jobs), and so
+# all boskos components are deployed to this namespace
 empower_ksa_to_svcacct \
   "kubernetes-public.svc.id.goog[test-pods/boskos-janitor]" \
   "kubernetes-public" \
@@ -107,9 +115,6 @@ for prj; do
     --role roles/editor
 
   # empower prowjobs in build cluster to ssh to nodes within projects
-  # TODO: the proper way to do this would be via WI + OS Login, prow doesn't do this yet
-  #       but I think this can be tied to workload identity with no prow changes?
-  # this key was manually generated, and is stored as a secret inside the build cluster
   prow_build_ssh_pubkey="prow:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCmYxHh/wwcV0P1aChuFLpl28w6DFyc7G5Xrw1F8wH1Re9AdxyemM2bTZ/PhsP3u9VDnNbyOw3UN00VFdumkFLjLf1WQ7Q6rZDlPjlw7urBIvAMqUecY6ae1znqsZ0dMBxOuPXHznlnjLjM5b7O7q5WsQMCA9Szbmz6DsuSyCuX0It2osBTN+8P/Fa6BNh3W8AF60M7L8/aUzLfbXVS2LIQKAHHD8CWqvXhLPuTJ03iSwFvgtAK1/J2XJwUP+OzAFrxj6A9LW5ZZgk3R3kRKr0xT/L7hga41rB1qy8Uz+Xr/PTVMNGW+nmU4bPgFchCK0JBK7B12ZcdVVFUEdpaAiKZ prow"
 
   # append to project-wide ssh-keys metadata if not present

--- a/infra/gcp/ensure-e2e-projects.sh
+++ b/infra/gcp/ensure-e2e-projects.sh
@@ -70,8 +70,11 @@ ensure_regional_address \
 
 # TODO: replace spiffxp- projects with actual projects
 E2E_PROJECTS=(
+  # for manual use during node-e2e job migration, eg: --gcp-project=spiffxp-node-e2e-project
   spiffxp-node-e2e-project
+  # for manual use during job migration, eg: --gcp-project=spiffxp-gce-project
   spiffxp-gce-project
+  # managed by boskos, part of the gce-project pool, eg: --gcp-project-type=gce-project
   spiffxp-boskos-project-01
   spiffxp-boskos-project-02
   spiffxp-boskos-project-03

--- a/infra/gcp/ensure-e2e-projects.sh
+++ b/infra/gcp/ensure-e2e-projects.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script creates & configures projects intended to be used for e2e
+# testing of kubernetes and managed by boskos
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+. "${SCRIPT_DIR}/lib.sh"
+
+function usage() {
+    echo "usage: $0 [repo...]" > /dev/stderr
+    echo "example:" > /dev/stderr
+    echo "  $0 # do all projects" > /dev/stderr
+    echo "  $0 k8s-infra-node-e2e-project # just do one" > /dev/stderr
+    echo > /dev/stderr
+}
+
+## setup service accounts and ips for the prow build cluster
+
+# TODO: replace prow-build-test with actual service account
+PROW_BUILD_SVCACCT=$(svc_acct_email "kubernetes-public" "prow-build-test")
+ensure_service_account \
+  "kubernetes-public" \
+  "prow-build-test" \
+  "used by prowjobs that run in prow-build-test cluster"
+empower_ksa_to_svcacct \
+  "kubernetes-public.svc.id.goog[test-pods/prow-build]" \
+  "kubernetes-public" \
+  "${PROW_BUILD_SVCACCT}"
+
+# manual parts: 
+# - create key, add to prow-build-test as service-account secret
+# - gsutil iam ch serviceAccount:$PROW_BUILD_SVCACCT:objectAdmin gs://bashfire-prow
+# - gsutil iam ch serviceAccount:$PROW_BUILD_SVCACCT:objectCreator gs://bashfire-prow
+
+# TODO: replace boskos-janitor-test with actual service account
+BOSKOS_JANITOR_SVCACCT=$(svc_acct_email "kubernetes-public" "boskos-janitor-test")
+ensure_service_account \
+  "kubernetes-public" \
+  "boskos-janitor-test" \
+  "used by boskos-janitor in prow-build-test cluster"
+empower_ksa_to_svcacct \
+  "kubernetes-public.svc.id.goog[test-pods/boskos-janitor]" \
+  "kubernetes-public" \
+  "${BOSKOS_JANITOR_SVCACCT}"
+ensure_regional_address \
+  "kubernetes-public" \
+  "us-central1" \
+  "boskos-metrics" \
+  "to allow monitoring.k8s.prow.io to scrape boskos metrics"
+
+## setup projects to be used by e2e tests for standing up clusters
+
+# TODO: replace spiffxp- projects with actual projects
+E2E_PROJECTS=(
+  spiffxp-node-e2e-project
+  spiffxp-gce-project
+  spiffxp-boskos-project-01
+  spiffxp-boskos-project-02
+  spiffxp-boskos-project-03
+)
+
+if [ $# = 0 ]; then
+    # default to all e2e projects
+    set -- "${E2E_PROJECTS[@]}"
+fi
+
+for prj; do
+  # create the project
+  ensure_project "${prj}"
+
+  # enable the necessary apis
+  enable_api "${prj}" compute.googleapis.com
+  enable_api "${prj}" storage-component.googleapis.com
+
+  # empower prow to do what it needs within the project
+  gcloud \
+    projects add-iam-policy-binding "${prj}" \
+    --member "serviceAccount:${PROW_BUILD_SVCACCT}" \
+    --role roles/editor
+
+  # empower boskos-janitor to clean projects
+  gcloud \
+    projects add-iam-policy-binding "${prj}" \
+    --member "serviceAccount:${BOSKOS_JANITOR_SVCACCT}" \
+    --role roles/editor
+
+  # empower prowjobs in build cluster to ssh to nodes within projects
+  # TODO: the proper way to do this would be via WI + OS Login, prow doesn't do this yet
+  #       but I think this can be tied to workload identity with no prow changes?
+  # this key was manually generated, and is stored as a secret inside the build cluster
+  prow_build_ssh_pubkey="prow:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCmYxHh/wwcV0P1aChuFLpl28w6DFyc7G5Xrw1F8wH1Re9AdxyemM2bTZ/PhsP3u9VDnNbyOw3UN00VFdumkFLjLf1WQ7Q6rZDlPjlw7urBIvAMqUecY6ae1znqsZ0dMBxOuPXHznlnjLjM5b7O7q5WsQMCA9Szbmz6DsuSyCuX0It2osBTN+8P/Fa6BNh3W8AF60M7L8/aUzLfbXVS2LIQKAHHD8CWqvXhLPuTJ03iSwFvgtAK1/J2XJwUP+OzAFrxj6A9LW5ZZgk3R3kRKr0xT/L7hga41rB1qy8Uz+Xr/PTVMNGW+nmU4bPgFchCK0JBK7B12ZcdVVFUEdpaAiKZ prow"
+
+  # append to project-wide ssh-keys metadata if not present
+  ssh_pubkeys=$(mktemp "/tmp/${prj}-ssh-keys-XXXX")
+  gcloud compute project-info describe --project="${prj}" --format=json | \
+    jq -r '(.commonInstanceMetadata.items//[])[]|select(.key=="ssh-keys").value' > "${ssh_pubkeys}"
+  if ! grep -q "${prow_build_ssh_pubkey}" "${ssh_pubkeys}"; then
+    echo "${prow_build_ssh_pubkey}" >> "${ssh_pubkeys}"
+    gcloud compute project-info add-metadata --project="${prj}" \
+      --metadata-from-file ssh-keys="${ssh_pubkeys}"
+  fi
+done

--- a/infra/gcp/ensure-e2e-projects.sh
+++ b/infra/gcp/ensure-e2e-projects.sh
@@ -88,6 +88,7 @@ for prj; do
 
   # enable the necessary apis
   enable_api "${prj}" compute.googleapis.com
+  enable_api "${prj}" logging.googleapis.com
   enable_api "${prj}" storage-component.googleapis.com
 
   # empower prow to do what it needs within the project

--- a/infra/gcp/ensure-e2e-projects.sh
+++ b/infra/gcp/ensure-e2e-projects.sh
@@ -37,6 +37,8 @@ function usage() {
 # TODO: replace prow-build-test with actual service account
 PROW_BUILD_SVCACCT=$(svc_acct_email "kubernetes-public" "prow-build-test")
 
+color 6 "Ensuring prow build cluster is empowered"
+(
 color 6 "Ensuring prow build cluster service-account exists"
 ensure_service_account \
   "kubernetes-public" \
@@ -56,10 +58,13 @@ empower_ksa_to_svcacct \
 # - create key, add to prow-build-test as service-account secret
 # - gsutil iam ch serviceAccount:$PROW_BUILD_SVCACCT:objectAdmin gs://bashfire-prow
 # - gsutil iam ch serviceAccount:$PROW_BUILD_SVCACCT:objectCreator gs://bashfire-prow
+) 2>&1 | indent
 
 # TODO: replace boskos-janitor-test with actual service account
 BOSKOS_JANITOR_SVCACCT=$(svc_acct_email "kubernetes-public" "boskos-janitor-test")
 
+color 6 "Ensuring boskos-janitor is empowered"
+(
 color 6 "Ensuring boskos-janitor service account exists"
 ensure_service_account \
   "kubernetes-public" \
@@ -78,12 +83,14 @@ empower_ksa_to_svcacct \
   "${BOSKOS_JANITOR_SVCACCT}"
 
 color 6 "Ensuring external ip address exists for boskos-metrics service in prow build cluster"
+# this is so monitoring.prow.k8s.io is able to scrape metrics from boskos
 # TODO: replace this with a global address used by an ingress
 ensure_regional_address \
   "kubernetes-public" \
   "us-central1" \
   "boskos-metrics" \
   "to allow monitoring.k8s.prow.io to scrape boskos metrics"
+) 2>&1 | indent
 
 ## setup projects to be used by e2e tests for standing up clusters
 
@@ -104,42 +111,45 @@ if [ $# = 0 ]; then
     set -- "${E2E_PROJECTS[@]}"
 fi
 
+color 6 "Ensuring e2e projects exist and are appropriately configured"
 for prj; do
-  color 6 "Ensuring e2e project exists: ${prj}"
-  ensure_project "${prj}"
+  color 6 "Ensuring e2e project exists and is appropriately configured: ${prj}"
+  (
+    ensure_project "${prj}"
 
-  color 6 "Enabling APIs necessary for kubernetes e2e jobs to use e2e project: ${prj}"
-  enable_api "${prj}" compute.googleapis.com
-  enable_api "${prj}" logging.googleapis.com
-  enable_api "${prj}" storage-component.googleapis.com
+    color 6 "Enabling APIs necessary for kubernetes e2e jobs to use e2e project: ${prj}"
+    enable_api "${prj}" compute.googleapis.com
+    enable_api "${prj}" logging.googleapis.com
+    enable_api "${prj}" storage-component.googleapis.com
 
-  color 6 "Empower prow-build service account to edit e2e project: ${prj}"
-  # TODO: this is what prow.k8s.io uses today, but it is likely over-permissioned, we could
-  #       look into creating a more constrained IAM role and using that instead
-  gcloud \
-    projects add-iam-policy-binding "${prj}" \
-    --member "serviceAccount:${PROW_BUILD_SVCACCT}" \
-    --role roles/editor
+    color 6 "Empower prow-build service account to edit e2e project: ${prj}"
+    # TODO: this is what prow.k8s.io uses today, but it is likely over-permissioned, we could
+    #       look into creating a more constrained IAM role and using that instead
+    gcloud \
+      projects add-iam-policy-binding "${prj}" \
+      --member "serviceAccount:${PROW_BUILD_SVCACCT}" \
+      --role roles/editor
 
-  color 6 "Empower boskos-janitor service account to clean e2e project: ${prj}"
-  # TODO: this is what prow.k8s.io uses today, but it is likely over-permissioned, we could
-  #       look into creating a more constrained IAM role and using that instead
-  gcloud \
-    projects add-iam-policy-binding "${prj}" \
-    --member "serviceAccount:${BOSKOS_JANITOR_SVCACCT}" \
-    --role roles/editor
+    color 6 "Empower boskos-janitor service account to clean e2e project: ${prj}"
+    # TODO: this is what prow.k8s.io uses today, but it is likely over-permissioned, we could
+    #       look into creating a more constrained IAM role and using that instead
+    gcloud \
+      projects add-iam-policy-binding "${prj}" \
+      --member "serviceAccount:${BOSKOS_JANITOR_SVCACCT}" \
+      --role roles/editor
 
-  color 6 "Ensure prow-build prowjobs are able to ssh to instances in e2e project: ${prj}"
-  # TODO: this is what prow.k8s.io does today, we could look into use OS Login instead
-  prow_build_ssh_pubkey="prow:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCmYxHh/wwcV0P1aChuFLpl28w6DFyc7G5Xrw1F8wH1Re9AdxyemM2bTZ/PhsP3u9VDnNbyOw3UN00VFdumkFLjLf1WQ7Q6rZDlPjlw7urBIvAMqUecY6ae1znqsZ0dMBxOuPXHznlnjLjM5b7O7q5WsQMCA9Szbmz6DsuSyCuX0It2osBTN+8P/Fa6BNh3W8AF60M7L8/aUzLfbXVS2LIQKAHHD8CWqvXhLPuTJ03iSwFvgtAK1/J2XJwUP+OzAFrxj6A9LW5ZZgk3R3kRKr0xT/L7hga41rB1qy8Uz+Xr/PTVMNGW+nmU4bPgFchCK0JBK7B12ZcdVVFUEdpaAiKZ prow"
+    color 6 "Ensure prow-build prowjobs are able to ssh to instances in e2e project: ${prj}"
+    # TODO: this is what prow.k8s.io does today, we could look into use OS Login instead
+    prow_build_ssh_pubkey="prow:ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCmYxHh/wwcV0P1aChuFLpl28w6DFyc7G5Xrw1F8wH1Re9AdxyemM2bTZ/PhsP3u9VDnNbyOw3UN00VFdumkFLjLf1WQ7Q6rZDlPjlw7urBIvAMqUecY6ae1znqsZ0dMBxOuPXHznlnjLjM5b7O7q5WsQMCA9Szbmz6DsuSyCuX0It2osBTN+8P/Fa6BNh3W8AF60M7L8/aUzLfbXVS2LIQKAHHD8CWqvXhLPuTJ03iSwFvgtAK1/J2XJwUP+OzAFrxj6A9LW5ZZgk3R3kRKr0xT/L7hga41rB1qy8Uz+Xr/PTVMNGW+nmU4bPgFchCK0JBK7B12ZcdVVFUEdpaAiKZ prow"
 
-  # append to project-wide ssh-keys metadata if not present
-  ssh_pubkeys=$(mktemp "/tmp/${prj}-ssh-keys-XXXX")
-  gcloud compute project-info describe --project="${prj}" --format=json | \
-    jq -r '(.commonInstanceMetadata.items//[])[]|select(.key=="ssh-keys").value' > "${ssh_pubkeys}"
-  if ! grep -q "${prow_build_ssh_pubkey}" "${ssh_pubkeys}"; then
-    echo "${prow_build_ssh_pubkey}" >> "${ssh_pubkeys}"
-    gcloud compute project-info add-metadata --project="${prj}" \
-      --metadata-from-file ssh-keys="${ssh_pubkeys}"
-  fi
-done
+    # append to project-wide ssh-keys metadata if not present
+    ssh_pubkeys=$(mktemp "/tmp/${prj}-ssh-keys-XXXX")
+    gcloud compute project-info describe --project="${prj}" --format=json | \
+      jq -r '(.commonInstanceMetadata.items//[])[]|select(.key=="ssh-keys").value' > "${ssh_pubkeys}"
+    if ! grep -q "${prow_build_ssh_pubkey}" "${ssh_pubkeys}"; then
+      echo "${prow_build_ssh_pubkey}" >> "${ssh_pubkeys}"
+      gcloud compute project-info add-metadata --project="${prj}" \
+        --metadata-from-file ssh-keys="${ssh_pubkeys}"
+    fi
+  ) 2>&1 | indent
+done 2>&1 | indent

--- a/infra/gcp/ensure-prod-storage-gclb.sh
+++ b/infra/gcp/ensure-prod-storage-gclb.sh
@@ -53,9 +53,7 @@ color 6 "Enabling the compute API: ${PROD_PROJECT}"
 enable_api "${PROD_PROJECT}" compute.googleapis.com
 
 color 6 "Reconciling Global Address"
-if ! gcloud --project "${PROD_PROJECT}" compute addresses describe "${NAME}" --global >/dev/null 2>&1; then
-  gcloud --project "${PROD_PROJECT}" compute addresses create "${NAME}" --global --description="IP Address for GCLB for binary artifacts"
-fi
+ensure_global_address "${PROD_PROJECT}" "${NAME}" "IP Address for GCLB for binary artifacts"
 ip_addr=$(gcloud --project "${PROD_PROJECT}" compute addresses describe "${NAME}" --global --format='value(address)')
 echo "Address: ${ip_addr}"
 

--- a/infra/gcp/ensure-static-ips.sh
+++ b/infra/gcp/ensure-static-ips.sh
@@ -46,5 +46,5 @@ ADDRESSES=(
 
 for address in "${ADDRESSES[@]}"; do
     color 6 "Ensure address: $address"
-    ensure_global_ip "$address" "$PROJECT_NAME"
+    ensure_global_address "$address" "$PROJECT_NAME" "IP for aaa cluster Ingress"
 done

--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -470,22 +470,25 @@ function empower_ksa_to_svcacct() {
         --project="${gcp_project}"
 }
 
-# Ensure that global IP address exists, creating one if need.
-# $1 The IP name (e.g. k8s-io-ingress-prod)
-# $2 The GCP project
-function ensure_global_ip() {
-    if [ $# != 2 -o -z "$1" -o -z "$2" ]; then
-        echo "ensure_global_ip(name, project) requires 2 arguments" >&2
+# Ensure that a global ip address exists, creating one if needed
+# $1 The GCP project
+# $2 The address name (e.g. foo-ingress)
+# $3 The address description (e.g. "IP address for the foo GCLB")
+function ensure_global_address() {
+    if [ ! $# -eq 3 -o -z "$1" -o -z "$2" -o -z "$3" ]; then
+        echo "ensure_global_address(gcp_project, name, description) requires 3 arguments" >&2
         return 1
     fi
 
-    local name="$1"
-    local project="$2"
+    local gcp_project="$1"
+    local name="$2"
+    local description="$3"
 
-    # Create IP if it doesn't exist
-    if ! gcloud compute addresses describe "$name" --global \
-        --project "$project" > /dev/null 2>&1; then
-        gcloud compute addresses create "$name" --global \
-            --project "$project"
+    if ! gcloud --project "${gcp_project}" compute addresses describe "${name}" --global >/dev/null 2>&1; then
+      gcloud --project "${gcp_project}" \
+        compute addresses create \
+        "${name}" \
+        --description="${description}" \
+        --global
     fi
 }

--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -492,3 +492,28 @@ function ensure_global_address() {
         --global
     fi
 }
+
+# Ensure that a regional ip address exists, creating one if needed
+# $1 The GCP project
+# $2 The region (e.g. us-central1)
+# $3 The address name (e.g. foo-ingress)
+# $4 The address description (e.g. "IP address for the foo GCLB")
+function ensure_regional_address() {
+    if [ ! $# -eq 4 -o -z "$1" -o -z "$2" -o -z "$3" -o -z "$4" ]; then
+        echo "ensure_regional_address(gcp_project, region, name, description) requires 4 arguments" >&2
+        return 1
+    fi
+
+    local gcp_project="$1"
+    local region="$2"
+    local name="$3"
+    local description="$4"
+
+    if ! gcloud --project "${gcp_project}" compute addresses describe "${name}" --region="${region}" >/dev/null 2>&1; then
+      gcloud --project "${gcp_project}" \
+        compute addresses create \
+        "${name}" \
+        --description="${description}" \
+        --region="${region}"
+    fi
+}

--- a/infra/gcp/lib_util.sh
+++ b/infra/gcp/lib_util.sh
@@ -38,8 +38,32 @@ function color() {
     echo "$@$(_nocolor)"
 }
 
+# ensure_gnu_sed
+# Determines which sed binary is gnu-sed on linux/darwin
+#
+# Sets:
+#  SED: The name of the gnu-sed binary
+#
+function ensure_gnu_sed() {
+  sed_help="$(LANG=C sed --help 2>&1 || true)"
+  if echo "${sed_help}" | grep -q "GNU\|BusyBox"; then
+    SED="sed"
+  elif command -v gsed &>/dev/null; then
+    SED="gsed"
+  else
+    >&2 echo "Failed to find GNU sed as sed or gsed. If you are on Mac: brew install gnu-sed"
+    return 1
+  fi
+  export SED
+}
+
+# indent relies on sed -u which isn't available in macOS's sed
+if ! ensure_gnu_sed; then
+  exit 1
+fi
+
 # Indent each line of stdin.
 # example: <command> | indent
 function indent() {
-    sed -u 's/^/  /'
+    ${SED} -u 's/^/  /'
 }


### PR DESCRIPTION
Add a kubernetes/prow-build-test cluster provisioned via terraform
- uses n1-highmem-2 nodes; e2e jobs were evicted from n1-standard-1

Add two service accounts:
- prow-build-test - given edit access to e2e projects, and write access to gs:// bucket for prow
- boskos-janitor-test - given edit access to e2e projects

Add five gcp projects:
- spiffxp-node-e2e-project - to pin node-e2e jobs to
- spiffxp-gce-project - to pin e2e or other jobs to
- spiffxp-boskos-project-0[1-3]: for boskos' gce-project pool
- minimal set of changes from default project creation to get node-e2e and e2e jobs to pass

While I was here I needed to script creation of ip addresses so I refactored/added to lib.sh, if need be I can pull those commits into a separate PR

I hooked this build cluster up to my own prow instance so I could iterate on getting things working.

eg:
- https://prow.bashfire.dev/view/gcs/bashfire-prow/logs/ci-kubernetes-e2e-gci-gce/1254462708674203648 - pinned to spiffxp-e2e-project
- https://prow.bashfire.dev/view/gcs/bashfire-prow/logs/ci-kubernetes-e2e-gci-gce/1254484503276032000 - using a boskos-managed project
- https://prow.bashfire.dev/view/gcs/bashfire-prow/logs/ci-kubernetes-node-kubelet/1254456039659540480 - pinned to spiffxp-node-e2e-project
- https://prow.bashfire.dev/view/gcs/bashfire-prow/logs/ci-kubernetes-node-kubelet/1254484503280226304 - using a boskos-managed project