### PR TITLE
Stripped out fingerprint properties from audit

### DIFF
--- a/audit/audit-gcp.sh
+++ b/audit/audit-gcp.sh
@@ -127,7 +127,7 @@ gcloud \
                     compute project-info describe \
                     --project="${PROJECT}" \
                     --format=json \
-                    | jq 'del(.quotas[].usage)' \
+                    | jq 'del(.quotas[].usage, .commonInstanceMetadata.fingerprint)' \
                     > "projects/${PROJECT}/services/${SVC}/project-info.json"
                 ;;
             container)


### PR DESCRIPTION
Closes: #809

Added logic to remove .commonInstanceMetadata.fingerptint
property from audit/projects/*/services/compute/project-info.json

As #807 is not yer merged I haven't included audit files after this change as it would cause conflicts. We can followup after this PR will be merged or if @spiffxp he can redo audit (I don't think it's necessary though as followup PR should make less effort).

/cc @spiffxp @thockin 

Signed-off-by: Bart Smykla <bsmykla@vmware.com>