### PR TITLE
Remove staging slack dns and update certificate

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -203,9 +203,6 @@ sigs:
 slack:
   type: A
   value: 34.107.195.71
-slack-staging:
-  type: A
-  value: 34.107.195.71
 # Prow (@ixdy).
 submit-queue:
   type: CNAME

--- a/slack-infra/resources/certificate.yaml
+++ b/slack-infra/resources/certificate.yaml
@@ -11,4 +11,5 @@ spec:
     kind: ClusterIssuer
     name: letsencrypt-prod
   dnsNames:
-  - slack-staging.k8s.io
+  - slack.k8s.io
+  - slack.kubernetes.io


### PR DESCRIPTION
Closes: #816

Removing unnecessary anymore dns record for slack-staging.k8s.io
as we switched slack.k8s.io and slack.kubernetes.io to point to
the `aaa` cluster.

Also updated slack-infra's certificates to reflect these changes

Signed-off-by: Bart Smykla <bsmykla@vmware.com>