### PR TITLE
Added cloudbuild.yaml file for octodns-docker

### DIFF
--- a/dns/octodns-docker/cloudbuild.yaml
+++ b/dns/octodns-docker/cloudbuild.yaml
@@ -1,0 +1,11 @@
+steps:
+- name: gcr.io/cloud-builders/docker
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/octodns:$_GIT_TAG',
+          '--build-arg', 'IMAGE_ARG=gcr.io/$PROJECT_ID/octodns:$_GIT_TAG',
+          '.']
+substitutions:
+  _GIT_TAG: "12345"
+images:
+- "gcr.io/$PROJECT_ID/octodns:$_GIT_TAG"
+options:
+  substitution_option: "ALLOW_LOOSE"


### PR DESCRIPTION
As we discussed at our yesterday's k8s-infra-wg community call, we came to the consensus we'll be building our octodns image and storing it under the `infra-tools` registry. This is followuping PR with cloudbuild.yaml file for automated builds using prow.

I used [cncf/apisnoop](https://github.com/cncf/apisnoop/blob/master/apps/webapp/app/cloudbuild.yaml) as an example for that file and followed the instructions from: https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md

Signed-off-by: Bart Smykla <bsmykla@vmware.com>