### PR TITLE
releng: Backfill most recent debian-base, debian-iptables, and pause

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
@@ -24,24 +24,34 @@
     - v2.0.0
 - name: debian-base-amd64
   dmap:
+    sha256:a67798e4746faaab3fde5b7407fa8bba75d8b1214d168dc7ad2b5364f6fc4319:
+    - v2.1.0
     sha256:d7be39e143d4e6677a28c81c0a84868b40800fc979dea1848bb19d526668a00c:
     - v2.0.0
 - name: debian-base-arm
   dmap:
+    sha256:3ab4332e481610acbcba7a801711e29506b4bd4ecb38f72590253674d914c449:
+    - v2.1.0
     sha256:fc731da13b0bc9013b85a86b583fc92e50869b5bc8e7aa6ca730ec0240954c7d:
     - v2.0.0
 - name: debian-base-arm64
   dmap:
     sha256:12502c3eed050fa9b6d5fe353a44bfc5f437dc325c8912b1a48dcc180df36f1e:
     - v2.0.0
+    sha256:8d53ac4da977eb20d6219ee49b9cdff8c066831ecab0e4294d0a02179d26b1d7:
+    - v2.1.0
 - name: debian-base-ppc64le
   dmap:
     sha256:4277aa59b63c5a1369e6d84a295ecc4ffa08985dcf114de9f7b6de1af4fcbc86:
     - v2.0.0
+    sha256:a631023e795fe18df7faa8fe1264e757a6c74a232b9a2659657bf65756f3f4aa:
+    - v2.1.0
 - name: debian-base-s390x
   dmap:
     sha256:78ef2a6b017539379c1654b4e52ba8519bfec821c62d0b3a1dbd15104b711e21:
     - v2.0.0
+    sha256:dac908eaa61d2034aec252576a470a7e4ab184c361f89170526f707a0c3c6082:
+    - v2.1.0
 - name: debian-iptables
   dmap:
     sha256:d1cd487e89fb4cba853cd3a948a6e9016faf66f2a7bb53cb1ac6b6c9cb58f5ed:

--- a/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
@@ -20,3 +20,49 @@
   dmap:
     sha256:b118abac0bcf633b9db4086584ee718526fe394cf1bd18aee036e6cc497860f6:
     - v2.1.0
+    sha256:ebda8587ec0f49eb88ee3a608ef018484908cbc5aa32556a0d78356088c185d4:
+    - v2.0.0
+- name: debian-base-amd64
+  dmap:
+    sha256:d7be39e143d4e6677a28c81c0a84868b40800fc979dea1848bb19d526668a00c:
+    - v2.0.0
+- name: debian-base-arm
+  dmap:
+    sha256:fc731da13b0bc9013b85a86b583fc92e50869b5bc8e7aa6ca730ec0240954c7d:
+    - v2.0.0
+- name: debian-base-arm64
+  dmap:
+    sha256:12502c3eed050fa9b6d5fe353a44bfc5f437dc325c8912b1a48dcc180df36f1e:
+    - v2.0.0
+- name: debian-base-ppc64le
+  dmap:
+    sha256:4277aa59b63c5a1369e6d84a295ecc4ffa08985dcf114de9f7b6de1af4fcbc86:
+    - v2.0.0
+- name: debian-base-s390x
+  dmap:
+    sha256:78ef2a6b017539379c1654b4e52ba8519bfec821c62d0b3a1dbd15104b711e21:
+    - v2.0.0
+- name: debian-iptables
+  dmap:
+    sha256:d1cd487e89fb4cba853cd3a948a6e9016faf66f2a7bb53cb1ac6b6c9cb58f5ed:
+    - v12.0.1
+- name: debian-iptables-amd64
+  dmap:
+    sha256:852d3c569932059bcab3a52cb6105c432d85b4b7bbd5fc93153b78010e34a783:
+    - v12.0.1
+- name: debian-iptables-arm
+  dmap:
+    sha256:c10f01b414a7cd4b2f3e26e152c90c64a1e781d99f83a6809764cf74ecbc46c3:
+    - v12.0.1
+- name: debian-iptables-arm64
+  dmap:
+    sha256:5725e6fde13a6405cf800e22846ebd2bde24b0860f1dc3f6f5f256f03cfa85bd:
+    - v12.0.1
+- name: debian-iptables-ppc64le
+  dmap:
+    sha256:b6d6e56a0c34c0393dcba0d5faaa531b92e5876114c5ab5a90e82e4889724c5a:
+    - v12.0.1
+- name: debian-iptables-s390x
+  dmap:
+    sha256:39e67e9bf25d67fe35bd9dcb25367277e5967368e02f2741e0efd4ce8874db14:
+    - v12.0.1

--- a/k8s.gcr.io/images/k8s-staging-kubernetes/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-kubernetes/images.yaml
@@ -13,5 +13,27 @@
 
 - name: pause
   dmap:
+    sha256:927d98197ec1141a368550822d18fa1c60bdae27b78b0c004f705f548c07814f:
+    - 3.2
     sha256:a319ac2280eb7e3a59e252e54b76327cb4a33cf8389053b0d78277f22bbca2fa:
     - 3.3
+- name: pause-amd64
+  dmap:
+    sha256:4a1c4b21597c1b4415bdbecb28a3296c6b5e23ca4f9feeb599860a1dac6a0108:
+    - 3.2
+- name: pause-arm
+  dmap:
+    sha256:bbb7780ca6592cfc98e601f2a5e94bbf748a232f9116518643905aa30fc01642:
+    - 3.2
+- name: pause-arm64
+  dmap:
+    sha256:31d3efd12022ffeffb3146bc10ae8beb890c80ed2f07363515580add7ed47636:
+    - 3.2
+- name: pause-ppc64le
+  dmap:
+    sha256:7f82fecd72730a6aeb70713476fb6f7545ed1bbf32cadd7414a77d25e235aaca:
+    - 3.2
+- name: pause-s390x
+  dmap:
+    sha256:1175fd4d728641115e2802be80abab108b8d9306442ce35425a4e8707ca60521:
+    - 3.2


### PR DESCRIPTION
- Backfill most recent `debian-base`, `debian-iptables`, and `pause`

  `pull-kubernetes-cross` expects `debian-base` and `debian-iptables` to be in
  the same registry. As we haven't promoted a new `debian-iptables` image
  yet, we need to backfill the most recent version into community infra.
  
  We do the same for the `debian-base` and pause images to support anyone
  who wants to move to the new image registry without changing image
  versions as well.

  Versions backfilled:
  - `debian-base` (all arches): v2.0.0
  - `debian-iptables` (all arches): v12.0.1
  - `pause` (all arches): 3.2

- Promote all arches for `debian-base-**:v2.1.0`
  
  `pull-kubernetes-cross` expects base images in the form:
  `image-<arch>:version`, which means we need to push all image names,
  despite the fat manifest.

  We can refactor the release libs at a later date, but for now, this
  should unblock build/promotion of `debian-iptables`.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/hold **until I actually backfill the images to staging**
/assign @dims @cblecker @BenTheElder @listx 
cc: @kubernetes/release-engineering 
/sig release
/area release-eng dependency security