### PR TITLE
add domain cloud-provider-aws.sigs.k8s.io

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -257,6 +257,10 @@ release-0-2.cluster-api.sigs:
 master.cluster-api.sigs:
   type: CNAME
   value: master--kubernetes-sigs-cluster-api.netlify.app.
+# https://github.com/kubernetes/cloud-provider-aws docs (@andrewsykim, @justinsb, @nckturner)
+cloud-provider-aws.sigs:
+  type: CNAME
+  value: kubernetes-sigs-cloud-provider-aws.netlify.app.
 # https://github.com/kubernetes/cloud-provider-vsphere docs (@andrewsykim, @frapposelli)
 cloud-provider-vsphere.sigs:
   type: CNAME


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

Adds the domain `cloud-provider-aws.sigs.k8s.io` for the AWS Cloud Provider docs site. Content is still WIP but we would like the site up and running so we can check on the docs site as we iterate.  

ref: https://github.com/kubernetes/cloud-provider-aws/pull/94 https://github.com/kubernetes/cloud-provider-aws/issues/42 