### PR TITLE
Fix SHA for go-runner manifest - bump to v0.1.1

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
@@ -100,5 +100,5 @@
     - v12.0.1
 - name: go-runner
   dmap:
-    sha256:536ab131b0d0e3b13eb83c985cc0ac9ba7e69e7dac9521e6cacd6a8b6019e0a6:
+    sha256:8ee20934e6c005a9ce8d6d8b7ed23698c3bb80e0b30a3d49e5aeca928cc69bf3:
     - v0.1.0


### PR DESCRIPTION
my bad, i used the SHA for amd64 image :(

Signed-off-by: Davanum Srinivas <davanum@gmail.com>