### PR TITLE
releng: Enable root-level image promotion

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-kubernetes/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-kubernetes/images.yaml
@@ -10,6 +10,10 @@
 # - kube-proxy
 # - kube-scheduler
 # - pause
+#
+# Promotes to the following GCR locations:
+# - {us,eu,asia}.gcr.io/k8s-artifacts-prod --> k8s.gcr.io
+# - {us,eu,asia}.gcr.io/k8s-artifacts-prod/kubernetes --> k8s.gcr.io/kubernetes
 
 - name: pause
   dmap:

--- a/k8s.gcr.io/manifests/k8s-staging-kubernetes/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-kubernetes/promoter-manifest.yaml
@@ -12,9 +12,22 @@
 # - pause
 #
 # google group for gcr.io/k8s-staging-kubernetes is k8s-infra-staging-kubernetes@kubernetes.io
+
 registries:
 - name: gcr.io/k8s-staging-kubernetes
   src: true
+
+# Promotes to the following GCR locations:
+# - {us,eu,asia}.gcr.io/k8s-artifacts-prod --> k8s.gcr.io
+- name: us.gcr.io/k8s-artifacts-prod
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+
+# Promotes to the following GCR locations:
+# - {us,eu,asia}.gcr.io/k8s-artifacts-prod/kubernetes --> k8s.gcr.io/kubernetes
 - name: us.gcr.io/k8s-artifacts-prod/kubernetes
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: eu.gcr.io/k8s-artifacts-prod/kubernetes


### PR DESCRIPTION
- Add a promoter manifest for core Kubernetes images

  Ensures core images remain in sync between the 'kubernetes' subproject
  and the root level.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

Fixes: https://github.com/kubernetes/k8s.io/issues/716

/assign @tpepper @thockin @listx 
cc: @kubernetes/release-engineering 