### PR TITLE
Allow k8s-staging-e2e-test-images GCB to access secrets

### DIFF
--- a/infra/gcp/clusters/modules/gke-project/main.tf
+++ b/infra/gcp/clusters/modules/gke-project/main.tf
@@ -68,6 +68,11 @@ resource "google_project_service" "stackdriver" {
   service = "stackdriver.googleapis.com"
   disable_dependent_services = true
 }
+resource "google_project_service" "secretmanager" {
+  project = google_project.project.project_id
+  service = "secretmanager.googleapis.com"
+  disable_dependent_services = true
+}
 
 
 // "Empower cluster admins" is what ensure-main-project.sh says

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -231,12 +231,12 @@ done
 
 # Special case: Empower GCB in k8s-staging-e2e-test-images to access secrets
 #               that were manually added to k8s-infra-prow-trusted
-color 6 "Configuring special cases for GCB access to windows-image-promoter-cert secrets"
+color 6 "Configuring special cases for GCB access to windows-img-promoter-cert secrets"
 for repo in "${WINDOWS_REMOTE_DOCKER_PROJECTS[@]}"; do
     (
         PROJECT="k8s-staging-${repo}"
         SECRET_PROJECT="k8s-infra-prow-build-trusted"
-        SECRET_GROUP="windows-image-promoter-cert"
+        SECRET_GROUP="windows-img-promoter-cert"
         for secret in $(gcloud secrets list \
                         --format="value(name)" \
                         --project="${SECRET_PROJECT}" \

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -94,6 +94,10 @@ RELEASE_STAGING_PROJECTS=(
     releng
 )
 
+WINDOWS_REMOTE_DOCKER_PROJECTS=(
+    e2e-test-images
+)
+
 if [ $# = 0 ]; then
     # default to all staging projects
     set -- "${STAGING_PROJECTS[@]}"
@@ -227,20 +231,22 @@ done
 
 # Special case: Empower GCB in k8s-staging-e2e-test-images to access secrets
 #               that were manually added to k8s-infra-prow-trusted
-color 6 "Configuring special case for k8s-staging-e2e-test-images"
-(
-    PROJECT="k8s-staging-e2e-test-images"
-    SECRET_PROJECT="k8s-infra-prow-build-trusted"
-    SECRET_GROUP="windows-image-promoter-cert"
-    for secret in $(gcloud secrets list \
-                    --format="value(name)" \
-                    --project="${SECRET_PROJECT}" \
-                    --filter="labels.secret-group=${SECRET_GROUP}"); do
-      color 6 "Empowering ${PROJECT}'s GCB service account to access secret ${secret} in ${SECRET_PROJECT}"
-      gcloud secrets add-iam-policy-binding \
-        "${secret}" \
-        --project="${SECRET_PROJECT}" \
-        --member="serviceAccount:$(gcb_service_account_email "k8s-staging-e2e-test-images")" \
-        --role="roles/secretmanager.secretAccessor"
-    done
-) 2>&1 | indent
+color 6 "Configuring special cases for GCB access to windows-image-promoter-cert secrets"
+for repo in "${WINDOWS_REMOTE_DOCKER_PROJECTS[@]}"; do
+    (
+        PROJECT="k8s-staging-${repo}"
+        SECRET_PROJECT="k8s-infra-prow-build-trusted"
+        SECRET_GROUP="windows-image-promoter-cert"
+        for secret in $(gcloud secrets list \
+                        --format="value(name)" \
+                        --project="${SECRET_PROJECT}" \
+                        --filter="labels.secret-group=${SECRET_GROUP}"); do
+          color 6 "Empowering ${PROJECT}'s GCB service account to access secret ${secret} in ${SECRET_PROJECT}"
+          gcloud secrets add-iam-policy-binding \
+            "${secret}" \
+            --project="${SECRET_PROJECT}" \
+            --member="serviceAccount:$(gcb_service_account_email "k8s-staging-e2e-test-images")" \
+            --role="roles/secretmanager.secretAccessor"
+        done
+    ) 2>&1 | indent
+done

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -178,6 +178,10 @@ for REPO; do
         color 6 "Enabling the KMS API"
         enable_api "${PROJECT}" cloudkms.googleapis.com
 
+        # Enable Secret Manager APIs
+        color 6 "Enabling the Secret Manager API"
+        enable_api "${PROJECT}" secretmanager.googleapis.com
+
         # Enable GCB and Prow to build and push images.
 
         # Enable GCB APIs
@@ -220,3 +224,5 @@ for repo in "${RELEASE_STAGING_PROJECTS[@]}"; do
         fi
     ) 2>&1 | indent
 done
+
+

--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -71,6 +71,22 @@ function svc_acct_email() {
     echo "${name}@${project}.iam.gserviceaccount.com"
 }
 
+# Get the cloud build service account email for a given project
+#   ref: https://cloud.google.com/cloud-build/docs/securing-builds/configure-access-control#service_account
+# $1 The GCP project
+function gcb_service_account_email() {
+    if [ $# != 1 -o -z "$1" ]; then
+        echo "gcb_service_account_email(project) requires 1 argument" >&2
+        return 1
+    fi
+    local project="$1"
+    gcloud projects get-iam-policy "${project}" \
+      --flatten="bindings[].members"\
+      --filter="bindings.role:roles/cloudbuild.builds.builder AND bindings.members ~ serviceAccount:[0-9]+@cloudbuild" \
+      --format="value(bindings.members)" |\
+      sed -e 's/^serviceAccount://'
+}
+
 # Ensure that a project exists in our org and has fundamental configurations as
 # we want them (e.g. billing).
 # $1: The GCP project


### PR DESCRIPTION
[This job](https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml) which uses [this cloudbuild.yaml](https://github.com/kubernetes/kubernetes/blob/master/test/images/cloudbuild.yaml) needs to be able to call out to a remote docker instance that can build windows images. We had originally been doing this by using kubernetes secrets, but now that the image build has been moved to GCB, we need to pass in secrets to GCB somehow.

This takes the approach of using Secret Manger, and enabling the secretAccessor role for the GCB service account as described here: https://cloud.google.com/cloud-build/docs/securing-builds/use-encrypted-secrets-credentials#store_credentials

~Note: I have only run `ensure-staging-storage.sh e2e-test-images`, and since our billing quota is maxed out, I had to comment out the `gclouc beta billing projects link` command in `lib.sh` to get it to work.~

~I'd like to hear whether folks think:~
~- we should tighten this down further and only allow secret access on a per-secret basis~
~- we should leave as-is; enable secretmanager for all projects, but special-case per-project secret access~
~- we should make this the default for all staging projects, and ensure each project's GCB can access secrets in that project~

EDIT: narrowed the use case down to https://github.com/kubernetes/k8s.io/pull/857#issuecomment-626838955

It's expected that N staging projects will need their GCB service account to access 3 secrets to talk to a remote windows docker instance.  The secrets are hosted in the k8s-infra-prow-build-trusted project, and IAM policies are added to each of those specific secrets for each of the GCB service accounts (currently N=1)

/cc @claudiubelu @dims