### PR TITLE
Prepared service acount for dns automation

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -247,6 +247,7 @@ groups:
       - james@munnelly.eu
       - spiffxp@google.com
       - thockin@google.com
+      - k8s-infra-dns-updater@kubernetes-public.iam.gserviceaccount.com
 
   - email-id: k8s-infra-gcp-accounting@kubernetes.io
     name: k8s-infra-gcp-accounting

--- a/infra/gcp/ensure-main-project.sh
+++ b/infra/gcp/ensure-main-project.sh
@@ -136,6 +136,19 @@ empower_ksa_to_svcacct \
   "${PROJECT}" \
   $(svc_acct_email "${PROJECT}" "k8s-infra-gcp-auditor")
 
+color 6 "Ensuring the k8s-infra-dns-updater serviceaccount exists"
+ensure_service_account \
+    "${PROJECT}" \
+    "k8s-infra-dns-updater" \
+    "k8s-infra dns updater"
+
+color 6 -n "Empowering k8s-infra-dns-updater serviceaccount to be used on"
+color 6 " build cluster"
+empower_ksa_to_svcacct \
+    "k8s-infra-prow-build-trusted.svc.id.goog[test-pods/k8s-infra-dns-updater]" \
+    "${PROJECT}" \
+    "$(svc_acct_email "${PROJECT}" "k8s-infra-dns-updater")"
+
 color 6 "Empowering ${DNS_GROUP}"
 gcloud projects add-iam-policy-binding "${PROJECT}" \
     --member "group:${DNS_GROUP}" \


### PR DESCRIPTION
/cc @spiffxp @stp-ip 

- Ensuring the k8s-infra-dns-updater service account exists
  in kubernetes-public project
- Ensuring k8s-infra-dns-updater serviceaccount can be used
  by prow on build cluster
- As discussed at one of the last community calls added
  serviceaccount to k8s-infra-dns-admins@kubernetes.io group
  in groups.yaml file

(ref. #783)

Signed-off-by: Bart Smykla <bsmykla@vmware.com>