### PR TITLE
Fixed ensure-static-ips.sh

### DIFF
--- a/infra/gcp/ensure-static-ips.sh
+++ b/infra/gcp/ensure-static-ips.sh
@@ -47,5 +47,5 @@ ADDRESSES=(
 
 for address in "${ADDRESSES[@]}"; do
     color 6 "Ensure address: $address"
-    ensure_global_address "$address" "$PROJECT_NAME" "IP for aaa cluster Ingress"
+    ensure_global_address "$PROJECT_NAME" "$address" "IP for aaa cluster Ingress"
 done


### PR DESCRIPTION
The scripts wasn't working as the arguments were passed in the
wrong order (ref: [`infra/gcp/lib.sh`](https://github.com/kubernetes/k8s.io/blob/8afbcc153f5f877f050cb97b5d2cbad1281fc362/infra/gcp/lib.sh#L483-L485))

/cc @spiffxp @ameukam @munnerz 

Signed-off-by: Bart Smykla <bsmykla@vmware.com>