### PR TITLE
Added node-perf-dash-staging.k8s.io dns record

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -166,6 +166,9 @@ yt:
 node-perf-dash:
   type: A
   value: 130.211.155.47
+node-perf-dash-staging:
+  type: A
+  value: 35.227.254.215
 # sig-scalability
 perf-dash:
   type: A


### PR DESCRIPTION
Closes: https://github.com/kubernetes/k8s.io/issues/869

/cc @lorqor @ameukam 

ref. [#864#issuecomment-628601730](https://github.com/kubernetes/k8s.io/pull/864#issuecomment-628601730) and [#867#issuecomment-629006038](https://github.com/kubernetes/k8s.io/pull/867#issuecomment-629006038)

```shell
k8s.io(master#03fc79c) ❀ gcloud --project kubernetes-public compute addresses describe --global node-perf-dash-k8s-io-ingress-prod
address: 35.227.254.215
addressType: EXTERNAL
creationTimestamp: '2020-05-14T20:29:33.257-07:00'
description: IP for aaa cluster Ingress
id: '7035915040185365106'
ipVersion: IPV4
kind: compute#address
name: node-perf-dash-k8s-io-ingress-prod
networkTier: PREMIUM
selfLink: https://www.googleapis.com/compute/v1/projects/kubernetes-public/global/addresses/node-perf-dash-k8s-io-ingress-prod
status: RESERVED
```

Signed-off-by: Bart Smykla <bsmykla@vmware.com>