### PR TITLE
Moved creation of iam roles to separate function

### DIFF
--- a/infra/gcp/ensure-main-project.sh
+++ b/infra/gcp/ensure-main-project.sh
@@ -96,14 +96,11 @@ gcloud projects add-iam-policy-binding "${PROJECT}" \
 gcloud projects add-iam-policy-binding "${PROJECT}" \
     --member "group:${CLUSTER_ADMINS_GROUP}" \
     --role roles/compute.loadBalancerAdmin
-if ! gcloud --project "${PROJECT}" iam roles describe ServiceAccountLister >/dev/null 2>&1; then
-    gcloud --project "${PROJECT}" --quiet \
-        iam roles create ServiceAccountLister \
-        --title "Service Account Lister" \
-        --description "Can list ServiceAccounts." \
-        --stage GA \
-        --permissions iam.serviceAccounts.list
-fi
+ensure_custom_iam_role "${PROJECT}" \
+    ServiceAccountLister \
+    "Service Account Lister" \
+    "Can list ServiceAccounts." \
+    iam.serviceAccounts.list
 gcloud projects add-iam-policy-binding "${PROJECT}" \
     --member "group:${CLUSTER_ADMINS_GROUP}" \
     --role "projects/${PROJECT}/roles/ServiceAccountLister"

--- a/infra/gcp/lib_util.sh
+++ b/infra/gcp/lib_util.sh
@@ -67,3 +67,21 @@ fi
 function indent() {
     ${SED} -u 's/^/  /'
 }
+
+# Join things with separator
+# Arguments:
+#   $1:  Separator (has to be single character)
+#   $2+: The things to join
+# Example usage:
+#   join_by , foo bar baz
+function join_by() {
+  if [ $# -lt 2 ] || [ -z "${1}" ] || [ -z "${2}" ]; then
+      echo "join_by(separator, string...) requires at least 2 arguments" >&2
+      return 1
+  fi
+
+  local IFS="${1}"; shift
+  # Using $* and not $@ is not a mistake, as $* returns string and respect IFS
+  # and $@ returns array which doesn't respect IFS
+  echo "$*"
+}


### PR DESCRIPTION
As there was multiple times discussion about possibility of
creating custom iam roles with more granular permissions,
and there is ongoing work to automate some of our scripts
which will probably need custom roles it's good time
to move out the logic to the separate function

Also created one more helper function `join_by` to joing strings
together with the provided separator

/cc @thockin @spiffxp @munnerz 

Signed-off-by: Bart Smykla <bsmykla@vmware.com>