### PR TITLE
Added key generation for k8s-conform service accounts

### DIFF
--- a/infra/gcp/ensure-conformance-storage.sh
+++ b/infra/gcp/ensure-conformance-storage.sh
@@ -62,6 +62,10 @@ ensure_project "${PROJECT}"
 color 6 "Enabling the GCS API"
 enable_api "${PROJECT}" storage-component.googleapis.com
 
+# Enable Secret Manager API
+color 6 "Enabling the Secret Manager API"
+enable_api "${PROJECT}" secretmanager.googleapis.com
+
 color 6 "Ensuring all conformance buckets"
 for REPO; do
     color 3 "Configuring conformance bucket for ${REPO}"
@@ -90,5 +94,51 @@ for REPO; do
     # Enable writers on the bucket
     color 6 "Empowering ${BUCKET_WRITERS} to GCS"
     empower_group_to_write_gcs_bucket "${BUCKET_WRITERS}" "${BUCKET}"
+
+    readonly SERVICE_ACCOUNT_NAME="service-${REPO}"
+    readonly SERVICE_ACCOUNT_EMAIL="$(svc_acct_email "${PROJECT}" \
+        "${SERVICE_ACCOUNT_NAME}")"
+    readonly SECRET_ID="${SERVICE_ACCOUNT_NAME}-key"
+    readonly TMP_DIR=$(mktemp -d "/tmp/${SERVICE_ACCOUNT_NAME}.XXXXXX")
+    readonly KEY_FILE="${TMP_DIR}/key.json"
+
+    # Clean tmp dir when exit
+    trap 'rm -rf "${TMP_DIR}"' EXIT
+
+    if ! gcloud iam service-accounts describe "${SERVICE_ACCOUNT_EMAIL}" \
+        --project "${PROJECT}" >/dev/null 2>&1
+    then
+        color 6 "Creating service account: ${SERVICE_ACCOUNT_NAME}"
+        ensure_service_account \
+            "${PROJECT}" \
+            "${SERVICE_ACCOUNT_NAME}" \
+            "${SERVICE_ACCOUNT_NAME}"
+
+        color 6 "Empowering service account: ${SERVICE_ACCOUNT_NAME} to GCS"
+        empower_svcacct_to_write_gcs_bucket \
+            "${SERVICE_ACCOUNT_EMAIL}" \
+            "${BUCKET}"
+
+        color 6 "Creating private key for service account: ${SERVICE_ACCOUNT_NAME}"
+        gcloud iam service-accounts keys create "${KEY_FILE}" \
+            --project "${PROJECT}" \
+            --iam-account "${SERVICE_ACCOUNT_EMAIL}"
+        
+        color 6 "Creating secret to store private key"
+        gcloud secrets create "${SECRET_ID}" \
+            --project "${PROJECT}" \
+            --replication-policy "automatic"
+
+        color 6 "Adding private key to secret"
+        gcloud secrets versions add "${SECRET_ID}" \
+            --project "${PROJECT}" \
+            --data-file "${KEY_FILE}"
+
+        color 6 "Empowering ${BUCKET_WRITERS} for read secret"
+        gcloud secrets add-iam-policy-binding "${SECRET_ID}" \
+            --project "${PROJECT}" \
+            --member "group:${BUCKET_WRITERS}" \
+            --role "roles/secretmanager.secretAccessor"
+    fi
 done 2>&1 | indent
 color 6 "Done"


### PR DESCRIPTION
My idea is to use GCP Secret Manager to store the keys, and I didn't want to implement in bash any complicated logic to check if there is already existing secret and/or key for the service account so I just make simple check if the service account already exist or not. It would also mean for current service accounts we would have to run script like:

```bash
#!/usr/bin/env bash

readonly PROJECT="k8s-conform"
readonly REPO="${1}"
readonly KEY_FILE="${2}"
readonly BUCKET_WRITERS="k8s-infra-conform-${REPO}@kubernetes.io"
readonly BUCKET="gs://${PROJECT}-${REPO}" 
readonly SECRET_ID="service-${REPO}-key"

gcloud --project "${PROJECT}" services enable secretmanager.googleapis.com

gcloud secrets create "${SECRET_ID}" \
    --project "${PROJECT}" \
    --replication-policy "automatic"

gcloud secrets versions add "${SECRET_ID}" \
    --project "${PROJECT}" \
    --data-file "${KEY_FILE}"

gcloud secrets add-iam-policy-binding "${SECRET_ID}" \
    --member "group:${BUCKET_WRITERS}" \
    --role "roles/secretmanager.secretAccessor"
```

For example:
```shell
~ ./script.sh capi-openstack ./path/to/the/key.json
~ ./script.sh cri-o ./path/to/the/key.json
~ ./script.sh huaweicloud ./path/to/the/key.json
```

/cc @dims @thockin @spiffxp 

Closes: #604

Signed-off-by: Bart Smykla <bsmykla@vmware.com>