### PR TITLE
Update k8s-infra-staging-cluster-api-do membership

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -726,7 +726,10 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
+      - ahmadnurus.sh@gmail.com
+      - ctadeu@gmail.com
       - detiber@gmail.com
+      - jeremylevanmorris@gmail.com
       - mudrinic.mare@gmail.com
 
   - email-id: k8s-infra-staging-cluster-api-azure@kubernetes.io


### PR DESCRIPTION
This PR updates the `k8s-infra-staging-cluster-api-do` group membership to add the [project maintainers](https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/blob/master/OWNERS_ALIASES).

/cc @cpanato @prksu @MorrisLaw 