### PR TITLE
Promote CAPDO v0.3.1 image and update OWNERS

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cluster-api-do/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api-do/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+- cpanato
 - detiber
+- MorrisLaw
+- prksu
 - xmudrii

--- a/k8s.gcr.io/images/k8s-staging-cluster-api-do/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api-do/images.yaml
@@ -1,2 +1,3 @@
-#- name: cluster-api-do-controller
-#  dmap: {}
+- name: cluster-api-do-controller
+  dmap:
+    "sha256:5f28c3476244e846cabb932911b4095e868cdbe636565d5daaba172633df220b": ["v0.3.1"]


### PR DESCRIPTION
This PR promotes the CAPDO v0.3.1 image and updates the OWNERS file to add the [project maintainers](https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/blob/master/OWNERS_ALIASES).