### PR TITLE
Update release-comms distribution mail address

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -1159,15 +1159,11 @@ groups:
       - stephen.k8s@agst.us
       - tpepper@vmware.com
     members:
-      - alarcj137@gmail.com
-      - chu.karen.h@gmail.com
       - jeremy.r.rickard@gmail.com
       - keroden@microsoft.com
       - killen.bob@gmail.com
-      - k8s@thatmightbe.com
       - max@koerbaecher.io
       - meenakshi.kaushik@gmail.com
-      - nadolny.claudia@gmail.com
       - onlydole@gmail.com
       - rcantw3ll@gmail.com
       - sandoval@adobe.com


### PR DESCRIPTION
Excluded old comms team, so new comms team can utilize this mail