### PR TITLE
promote etcd 3.4.7-2

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-etcd/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-etcd/images.yaml
@@ -1,6 +1,7 @@
 - name: etcd
   dmap:
     "sha256:80d539b791923b37fb501166729307c987a237bf9a72cef3dbfca24744b5cb76": ["3.4.7-0", "3.4.7"]
+    "sha256:bcdd5657b1edc1a2eb27356f33dd66b9400d4a084209c33461c7a7da0a32ebb3": ["3.4.7-2"]
 - name: etcd-empty-dir-cleanup
   dmap:
     "sha256:f805272b4422efa92e20789295c343ed26ff36ddc4f70eeb5d7890d6b758b0fc": ["3.4.7.0"]


### PR DESCRIPTION
Image was built automatically:
https://testgrid.k8s.io/sig-release-image-pushes#post-kubernetes-push-image-etcd

CI job output: https://console.cloud.google.com/cloud-build/builds/c5068878-c89a-43de-9f45-f6660ccf8342?project=k8s-staging-etcd
```
docker manifest push --purge gcr.io/k8s-staging-etcd/etcd:3.4.7-2
Pushed ref gcr.io/k8s-staging-etcd/etcd@sha256:0873d877318546c6569e1abfafd75e0625c202d24435299c4d2e57eeebea52ee with digest: sha256:0873d877318546c6569e1abfafd75e0625c202d24435299c4d2e57eeebea52ee
Pushed ref gcr.io/k8s-staging-etcd/etcd@sha256:54654da17593ef5e930e57e6ff4e03c0139aeeb0e2f3a6f4f7de248a937369e7 with digest: sha256:54654da17593ef5e930e57e6ff4e03c0139aeeb0e2f3a6f4f7de248a937369e7
Pushed ref gcr.io/k8s-staging-etcd/etcd@sha256:18f3242ebdefb8c2cbb9da24bb1845001f031c222a06255a06a57b541f7b45ad with digest: sha256:18f3242ebdefb8c2cbb9da24bb1845001f031c222a06255a06a57b541f7b45ad
Pushed ref gcr.io/k8s-staging-etcd/etcd@sha256:2fb9a8348e5318142ea54c031bfc294c1042009d8f141e0e1d41c332386cc299 with digest: sha256:2fb9a8348e5318142ea54c031bfc294c1042009d8f141e0e1d41c332386cc299
Pushed ref gcr.io/k8s-staging-etcd/etcd@sha256:edc07fe4241d4d745fdd4aaf4bbef4a8568a427693ff7af9e6572335b45c272f with digest: sha256:edc07fe4241d4d745fdd4aaf4bbef4a8568a427693ff7af9e6572335b45c272f
sha256:bcdd5657b1edc1a2eb27356f33dd66b9400d4a084209c33461c7a7da0a32ebb3
```

Signed-off-by: Davanum Srinivas <davanum@gmail.com>