### PR TITLE
releng(etcd): Enable root-level promotion for etcd images

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-etcd/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-etcd/OWNERS
@@ -1,11 +1,15 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+options:
+  no_parent_owners: true
+approvers:
+  - release-engineering-approvers
 reviewers:
+  - release-engineering-reviewers
   - jpbetz
   - wenjiaswe
   - jingyih
-approvers:
-  - jpbetz
-  - jingyih
 labels:
-- sig/api-machinery
+  - sig/api-machinery
+  - sig/release
+  - area/release-eng

--- a/k8s.gcr.io/images/k8s-staging-etcd/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-etcd/images.yaml
@@ -1,6 +1,5 @@
 - name: etcd
   dmap:
-    "sha256:80d539b791923b37fb501166729307c987a237bf9a72cef3dbfca24744b5cb76": ["3.4.7-0", "3.4.7"]
     "sha256:bcdd5657b1edc1a2eb27356f33dd66b9400d4a084209c33461c7a7da0a32ebb3": ["3.4.7-2"]
 - name: etcd-empty-dir-cleanup
   dmap:

--- a/k8s.gcr.io/manifests/k8s-staging-etcd/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-etcd/promoter-manifest.yaml
@@ -1,10 +1,27 @@
+### ATTENTION ###
+# k8s-staging-etcd is a staging container registry that promotes ROOT level k8s.gcr.io images.
+# Image promotion for this project is restricted to Release Managers.
+#
 # google group for gcr.io/k8s-staging-etcd is k8s-infra-staging-etcd@kubernetes.io
+
 registries:
 - name: gcr.io/k8s-staging-etcd
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/etcd
+
+# Promotes to the following GCR locations:
+# - {us,eu,asia}.gcr.io/k8s-artifacts-prod --> k8s.gcr.io
+- name: us.gcr.io/k8s-artifacts-prod
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/etcd
+- name: eu.gcr.io/k8s-artifacts-prod
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/etcd
+- name: asia.gcr.io/k8s-artifacts-prod
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+
+# Promotes to the following GCR locations:
+# - {us,eu,asia}.gcr.io/k8s-artifacts-prod/kubernetes --> k8s.gcr.io/kubernetes
+- name: us.gcr.io/k8s-artifacts-prod/kubernetes
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/kubernetes
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/kubernetes
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
Following the [conversation in Slack](https://kubernetes.slack.com/archives/C2C40FMNF/p1589969478406600), we want to allow etcd images to promote to the root of *.gcr.io/k8s-artifacts-prod. This will eventually prevent breakages in downstream consumers that depend on all images living at a single endpoint/subdir.

We're doing a few things here:
- updating the promoter manifest to promote to `{us,eu,asia}.gcr.io/k8s-artifacts-prod/kubernetes` and `{us,eu,asia}.gcr.io/k8s-artifacts-prod` (instead of `{us,eu,asia}.gcr.io/k8s-artifacts-prod/etcd`)
- restricting etcd promotion approvals to @kubernetes/release-managers

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @dims @listx @jpbetz @wenjiaswe @jingyih
cc: @kubernetes/release-engineering 
/sig api-machinery release
/area release-eng