### PR TITLE
Create staging project for boskos

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -429,7 +429,7 @@ groups:
       - karangoel@google.com
       - tangent@google.com
       - porterdavid@google.com
-      - hanfeil@google.com 
+      - hanfeil@google.com
 
   - email-id: k8s-infra-rbac-publishing-bot@kubernetes.io
     name: k8s-infra-rbac-publishing-bot
@@ -538,8 +538,8 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
-    - jichenjc@cn.ibm.com
-    - sbueringer@gmail.com
+      - jichenjc@cn.ibm.com
+      - sbueringer@gmail.com
 
   - email-id: k8s-infra-conform-cri-o@kubernetes.io
     name: k8s-infra-conform-cri-o
@@ -780,6 +780,17 @@ groups:
     members:
       - andrew@andrewrynhard.com
       - rahul@rmenn.in
+
+  - email-id: k8s-infra-staging-boskos@kubernetes.io
+    name: k8s-infra-staging-boskos
+    description: |-
+      ACL for staging kubernetes-sigs/boskos images.
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - aaleman@redhat.com
+      - jgrafton@google.com
+      - skuznets@redhat.com
 
   - email-id: k8s-infra-staging-coredns@kubernetes.io
     name: k8s-infra-staging-coredns
@@ -1195,7 +1206,6 @@ groups:
       - onlydole@gmail.com
       - rcantw3ll@gmail.com
       - sandoval@adobe.com
-
 
   - email-id: release-managers-private@kubernetes.io
     name: release-managers-private

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -43,6 +43,7 @@ STAGING_PROJECTS=(
     artifact-promoter
     autoscaling
     bootkube
+    boskos
     build-image
     cip-test
     cluster-api

--- a/k8s.gcr.io/images/k8s-staging-boskos/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-boskos/OWNERS
@@ -1,0 +1,15 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# These should match https://github.com/kubernetes-sigs/boskos/blob/master/OWNERS.
+reviewers:
+  - ixdy
+  - alvaroaleman
+  - stevekuznetsov
+
+approvers:
+  - ixdy
+  - alvaroaleman
+  - stevekuznetsov
+
+labels:
+  - sig/testing

--- a/k8s.gcr.io/images/k8s-staging-boskos/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-boskos/images.yaml
@@ -1,0 +1,1 @@
+# No images yet

--- a/k8s.gcr.io/manifests/k8s-staging-boskos/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-boskos/promoter-manifest.yaml
@@ -1,0 +1,10 @@
+# google group for gcr.io/k8s-staging-boskos is k8s-infra-staging-boskos@kubernetes.io
+registries:
+  - name: gcr.io/k8s-staging-boskos
+    src: true
+  - name: us.gcr.io/k8s-artifacts-prod/boskos
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: eu.gcr.io/k8s-artifacts-prod/boskos
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia.gcr.io/k8s-artifacts-prod/boskos
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
The boskos project is spinning out of kubernetes/test-infra (https://github.com/kubernetes/org/issues/1783, https://github.com/kubernetes/test-infra/issues/17614, https://github.com/kubernetes-sigs/boskos/issues/3).

I've created and tested a [cloudbuild.yaml](https://github.com/kubernetes-sigs/boskos/blob/master/images/cloudbuild.yaml) for the new repo, but I'll need a staging project to run builds and stage images.

Previously boskos used gcr.io/k8s-prow, but since it's now in a separate repo with a separate build system, we probably want to separate them.

cc @alvaroaleman @stevekuznetsov 