### PR TITLE
Loic retired from slack moderatorship

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -1162,7 +1162,6 @@ groups:
       - jspeed@redhat.com
       - krajakavitha@gmail.com
       - lenferinkroy@gmail.com
-      - loic_le_dru@carrefour.com
       - manjunath.cse@gmail.com
       - nikitaraghunath@gmail.com
       - puja@giantswarm.io


### PR DESCRIPTION
As per https://github.com/kubernetes/community/pull/4765

/cc @castrojo @mrbobbytables 