### PR TITLE
add e2e scale projects

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-janitor.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-janitor.yaml
@@ -22,7 +22,7 @@ spec:
         image: gcr.io/k8s-prow/boskos/janitor:v20200422-8c8546d74
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
-        - --resource-type=k8s-infra-gce-project
+        - --resource-type=k8s-infra-gce-project,scalability-project
         - --pool-size=20
         - --
         - --hours=0

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-reaper-deployment.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-reaper-deployment.yaml
@@ -21,4 +21,4 @@ spec:
         image: gcr.io/k8s-prow/boskos/reaper:v20200422-8c8546d74
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
-        - --resource-type=k8s-infra-gce-project
+        - --resource-type=k8s-infra-gce-project,scalability-project

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-resources.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-resources.yaml
@@ -42,3 +42,11 @@ resources:
   - k8s-infra-e2e-boskos-040
   state: dirty
   type: k8s-infra-gce-project
+- names:
+  - k8s-infra-e2e-boskos-scale-01
+  - k8s-infra-e2e-boskos-scale-02
+  - k8s-infra-e2e-boskos-scale-03
+  - k8s-infra-e2e-boskos-scale-04
+  - k8s-infra-e2e-boskos-scale-05
+  state: dirty
+  type: scalability-project

--- a/infra/gcp/ensure-e2e-projects.sh
+++ b/infra/gcp/ensure-e2e-projects.sh
@@ -50,16 +50,34 @@ ensure_regional_address \
 
 ## setup projects to be used by e2e tests for standing up clusters
 
-E2E_PROJECTS=(
+E2E_MANUAL_PROJECTS=(
   # for manual use during node-e2e job migration, eg: --gcp-project=k8s-infra-e2e-gce-project
   k8s-infra-e2e-gce-project
   # for manual use during job migration, eg: --gcp-project=k8s-infra-e2e-node-e2e-project
   k8s-infra-e2e-node-e2e-project
+  # for manual use during job migration, eg: --gcp-projec=k8s-infra-e2e-scale-project
+  k8s-infra-e2e-scale-project
 )
 
+# general purpose e2e projects, no quota changes
+E2E_BOSKOS_PROJECTS=()
 for i in $(seq 1 40); do
-  E2E_PROJECTS+=($(printf "k8s-infra-e2e-boskos-%03i" $i))
+  E2E_BOSKOS_PROJECTS+=($(printf "k8s-infra-e2e-boskos-%03i" $i))
 done
+
+# e2e projects for scalability jobs
+# - us-east1 cpu quota raised to 125
+# - us-east1 in-use addresses quota raised to 125
+E2E_SCALE_PROJECTS=()
+for i in $(seq 1 5); do
+  E2E_SCALE_PROJECTS+=($(printf "k8s-infra-e2e-boskos-scale-%02i" $i))
+done
+
+E2E_PROJECTS=(
+  "${E2E_MANUAL_PROJECTS[@]}"
+  "${E2E_BOSKOS_PROJECTS[@]}"
+  "${E2E_SCALE_PROJECTS[@]}"
+)
 
 if [ $# = 0 ]; then
     # default to all e2e projects


### PR DESCRIPTION
one manual project, and a pool of 5 projects

these are intended to match the projects that currently live in
prow.k8s.io's "scalability-project" boskos pool, e.g.
- us-east1 CPU quota raised to 125
- us-east1 in-use addresses quota raised to 125

ref: https://github.com/kubernetes/k8s.io/issues/851