### PR TITLE
Enable Secret Manager API for kubernetes-public

### DIFF
--- a/infra/gcp/ensure-main-project.sh
+++ b/infra/gcp/ensure-main-project.sh
@@ -77,6 +77,9 @@ color 6 "Enabling the OSLogin API"
 enable_api "${PROJECT}" oslogin.googleapis.com
 color 6 "Enabling the DNS API"
 enable_api "${PROJECT}" dns.googleapis.com
+color 6 "Enabling the Secret Manager API"
+enable_api "${PROJECT}" secretmanager.googleapis.com
+
 
 color 6 "Ensuring the cluster terraform-state bucket exists"
 ensure_private_gcs_bucket "${PROJECT}" "gs://${CLUSTER_TERRAFORM_BUCKET}"


### PR DESCRIPTION
I would like to move the git-crypt secrets we have in
slack-infra/secrets into secret manager. The kubernetes-public project
seemed like the most appropriate place since slack-infra runs in aaa
which is hosted in kubernetes-public