### PR TITLE
Reconcile security@kubernetes.io members

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -1310,7 +1310,7 @@ groups:
 
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
-      ReconcileMembers: "false"
+      ReconcileMembers: "true"
     owners:
       - cjcullen@google.com
       - joelsmith@redhat.com


### PR DESCRIPTION
We've removed opsgenie, so we can reconcile this list now.