### PR TITLE
Add oncall groups and bind to projective primitive roles

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -549,6 +549,51 @@ groups:
       - simony@google.com
       - sumitranr@google.com
 
+  - email-id: k8s-infra-prow-oncall@kubernetes.io
+    name: k8s-infra-prow-oncall
+    description: |-
+      ACL for oncall/break-glass access to resources used by prow.k8s.io
+    settings:
+      ReconcileMembers: "true"
+    members:
+      # test-infra-oncall
+      - amerai@google.com
+      - bentheelder@google.com
+      - clarketm@google.com
+      - colew@google.com
+      - fejta@google.com
+      - slchase@google.com
+      # wg-k8s-infra-oncall
+      - cblecker@gmail.com
+      - davanum@gmail.com
+      - spiffxp@google.com
+      - thockin@google.com
+
+  - email-id: k8s-infra-prow-viewers@kubernetes.io
+    name: k8s-infra-prow-viewers
+    description: |-
+      ACL for view access to resources used by prow.k8s.io, including build clusters and e2e projects
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - spiffxp@gmail.com
+
+  - email-id: k8s-infra-sig-scalability-oncall@kubernetes.io
+    name: k8s-infra-sig-scalability-oncall
+    description: |-
+      ACL for oncall/break-glass access to projects used by sig-scalability tests (k8s-infra-e2e-boskos-scale-*)
+    settings:
+      ReconcileMembers: "true"
+    members:
+      # scalability-oncall
+      - jkaniuk@google.com
+      - jprzychodzen@google.com
+      - maciejborsz@google.com
+      # sig-scalability leads
+      - jeedigv@amazon.com
+      - mmatejczyk@google.com
+      - wojtekt@google.com
+
   #
   # Conformance groups: k8s-infra-conform-*
   #

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
@@ -38,6 +38,13 @@ module "project" {
   project_name          = local.project_id
 }
 
+// Ensure k8s-infra-prow-oncall@kuberentes.io has owner access to this project
+resource "google_project_iam_member" "k8s_infra_prow_oncall" {
+  project = local.project_id
+  role    = "roles/owner"
+  member  = "group:k8s-infra-prow-oncall@kubernetes.io"
+}
+
 // Create GCP SA for pods
 resource "google_service_account" "prow_build_cluster_sa" {
   project      = local.project_id

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
@@ -39,6 +39,13 @@ module "project" {
   project_name          = local.project_id
 }
 
+// Ensure k8s-infra-prow-oncall@kuberentes.io has owner access to this project
+resource "google_project_iam_member" "k8s_infra_prow_oncall" {
+  project = local.project_id
+  role    = "roles/owner"
+  member  = "group:k8s-infra-prow-oncall@kubernetes.io"
+}
+
 // Create GCP SA for pods
 resource "google_service_account" "prow_build_cluster_sa" {
   project      = local.project_id


### PR DESCRIPTION
This mirrors what is done today for the google.com-equivalent projects
- test-infra-oncall has owner access to the prow projects, and all e2e projects
- scalability-oncall has owner access to all scalability e2e projects

I also added a k8s-infra-prow-viewer group to see if that would give sufficient
access for troubleshooting

I anticipate dialing these down to custom roles to be done as followup

ACLs ref: https://github.com/kubernetes/k8s.io/issues/844
scalability ref: https://github.com/kubernetes/test-infra/pull/17725