### PR TITLE
Added k8s-infra-dns-updater svcacct as trusted

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/build-serviceaccounts.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/build-serviceaccounts.yaml
@@ -22,3 +22,11 @@ metadata:
     iam.gke.io/gcp-service-account: gcb-builder@k8s-infra-prow-build-trusted.iam.gserviceaccount.com
   name: gcb-builder
   namespace: test-pods
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: k8s-infra-dns-updater@kubernetes-public.iam.gserviceaccount.com
+  name: k8s-infra-dns-updater
+  namespace: test-pods


### PR DESCRIPTION
This service account will be used to run dns updates using octodns when the config files under `k/k8s.io/dns/zone-configs/*.yaml` will change

More informations about whole process of automating this efforts: #786

Initially I opened this PR in the wrong place (ref. [`k/test-infra#17739`](https://github.com/kubernetes/test-infra/pull/17739)) but via @spiffxp comment (ref. [`k/test-infra#17739#issuecomment-635627265`](https://github.com/kubernetes/test-infra/pull/17739#issuecomment-635627265)) I'm opening the PR here

/cc @spiffxp 

Signed-off-by: Bart Smykla <bsmykla@vmware.com>