### PR TITLE
Add nodepool for ghproxy

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
@@ -104,3 +104,20 @@ module "prow_build_nodepool" {
   disk_type       = "pd-standard"
   service_account = module.prow_build_cluster.cluster_node_sa.email
 }
+
+module "ghproxy_nodepool" {
+  source       = "../../modules/gke-nodepool"
+  project_name = local.project_id
+  cluster_name = module.prow_build_cluster.cluster.name
+  location     = module.prow_build_cluster.cluster.location
+  name         = "ghproxy"
+  labels       = { dedicated = "ghproxy" }
+  # NOTE: taints are only applied during creation and ignored after that, see module docs
+  taints          = [{ key = "dedicated", value = "ghproxy", effect = "NO_SCHEDULE" }]
+  min_count       = 1
+  max_count       = 1
+  machine_type    = "n1-standard-8"
+  disk_size_gb    = 100
+  disk_type       = "pd-ssd"
+  service_account = module.prow_build_cluster.cluster_node_sa.email
+}


### PR DESCRIPTION
Add a GKE nodepool to `prow-build-trusted` GKE cluster.

Ref: #843 

Similar work: https://github.com/kubernetes/test-infra/blob/master/config/clusters/k8s-prow/cluster-configuration.tf#L94-L136

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>