### PR TITLE
Setup for groups reconciliation to happen via prow

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/build-serviceaccounts.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/build-serviceaccounts.yaml
@@ -30,3 +30,11 @@ metadata:
     iam.gke.io/gcp-service-account: k8s-infra-dns-updater@kubernetes-public.iam.gserviceaccount.com
   name: k8s-infra-dns-updater
   namespace: test-pods
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: gsuite-groups-manager@k8s-gsuite.iam.gserviceaccount.com
+  name: gsuite-groups-manager
+  namespace: test-pods

--- a/infra/gcp/ensure-gsuite.sh
+++ b/infra/gcp/ensure-gsuite.sh
@@ -69,6 +69,13 @@ ensure_service_account \
     "${GSUITE_SVCACCT}" \
     "Grants access to the googlegroups API in kubernetes.io GSuite"
 
+# Allow k8s-infra-prow-builds-trusted to run pods as this service account
+color 6 "Empowering ${GSUITE_SVCACCT} to be used on k8s-infra-prow-build-trusted"
+empower_ksa_to_svcacct \
+    "k8s-infra-prow-build-trusted.svc.id.goog[test-pods/${GSUITE_SVCACCT}]" \
+    "${PROJECT}" \
+    "$(svc_acct_email "${PROJECT}" "${GSUITE_SVCACCT}")"
+
 # Ensure the service account has a key in a secret accessible by the right people
 if ! gcloud --project="${PROJECT}" \
     secrets describe "${GSUITE_SVCACCT}_key" >/dev/null 2>&1; then


### PR DESCRIPTION
This just allows the service account to be used on k8s-infra-prow-build-trusted

Will modify groups in followup PR to allow running without a secret in config file