### PR TITLE
scale prow-build pool 3x

### DIFF
--- a/infra/gcp/clusters/modules/gke-nodepool/main.tf
+++ b/infra/gcp/clusters/modules/gke-nodepool/main.tf
@@ -32,7 +32,7 @@ resource "google_container_node_pool" "node_pool" {
   }
 
   // Autoscale the cluster as needed. Note if using a regional cluster these values will be multiplied by 3
-  initial_node_count = var.min_count
+  initial_node_count = var.initial_count
   autoscaling {
     min_node_count = var.min_count
     max_node_count = var.max_count

--- a/infra/gcp/clusters/modules/gke-nodepool/variables.tf
+++ b/infra/gcp/clusters/modules/gke-nodepool/variables.tf
@@ -33,6 +33,11 @@ variable "name" {
   type        = string
 }
 
+variable "initial_count" {
+  description = "The initial_node_count of this node_pool"
+  type        = string
+}
+
 variable "min_count" {
   description = "The min_node_count of this node_pool"
   type        = string

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
@@ -104,6 +104,7 @@ module "prow_build_nodepool" {
   cluster_name    = module.prow_build_cluster.cluster.name
   location        = module.prow_build_cluster.cluster.location
   name            = "trusted-pool1"
+  initial_count   = 1
   min_count       = 1
   max_count       = 3
   machine_type    = "n1-standard-8"
@@ -121,6 +122,7 @@ module "ghproxy_nodepool" {
   labels          = { dedicated = "ghproxy" }
   # NOTE: taints are only applied during creation and ignored after that, see module docs
   taints          = [{ key = "dedicated", value = "ghproxy", effect = "NO_SCHEDULE" }]
+  initial_count   = 1
   min_count       = 1
   max_count       = 1
   machine_type    = "n1-standard-8"

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
@@ -105,8 +105,9 @@ module "prow_build_nodepool" {
   cluster_name    = module.prow_build_cluster.cluster.name
   location        = module.prow_build_cluster.cluster.location
   name            = "pool1"
-  min_count       = 2
-  max_count       = 6
+  initial_count   = 2
+  min_count       = 6
+  max_count       = 30
   # kind-ipv6 jobs need an ipv6 stack; COS doesn't provide one, so we need to
   # use an UBUNTU image instead. Why the CONTAINERD variant? I don't know, but
   # it's what k8s-prow-builds/prow (prow.k8s.io's existing google.com build 
@@ -127,6 +128,7 @@ module "greenhouse_nodepool" {
   labels          = { dedicated = "greenhouse" }
   # NOTE: taints are only applied during creation and ignored after that, see module docs
   taints          = [{ key = "dedicated", value = "greenhouse", effect = "NO_SCHEDULE" }]
+  initial_count   = 1
   min_count       = 1
   max_count       = 1
   # choosing this image for parity with the build nodepool


### PR DESCRIPTION
this is in response to @BenTheElder suggesting the build cluster is
running out of resources (ref: https://github.com/kubernetes/kubernetes/issues/91548#issuecomment-636502815)

had to expose initial_count or terraform was going to delete/recreate
nodepools

autoscaling should be growing nodes for us if we're out of resources,
which leads me to believe prowjobs aren't declaring the resources they
actually need