### PR TITLE
releng: Temporarily grant Verolop access to cut 1.19.0-beta.1

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -509,15 +509,16 @@ groups:
       ReconcileMembers: "true"
     members:
       - caselim@gmail.com
-      - stephen.k8s@agst.us
-      - tpepper@gmail.com
-      - feiskyer@gmail.com
       - ctadeu@gmail.com
       - dmaceachern@vmware.com
+      - feiskyer@gmail.com
       - georgedanielmangum@gmail.com
+      - gveronicalg@gmail.com
       - hhorl@pivotal.io
       - idealhack@gmail.com
       - saschagrunert@gmail.com
+      - stephen.k8s@agst.us
+      - tpepper@gmail.com
 
   - email-id: k8s-infra-release-viewers@kubernetes.io
     name: k8s-infra-release-viewers


### PR DESCRIPTION
- Temporarily grant [Verolop ](https://github.com/Verolop ) access to cut v1.19.0-beta.1 (ref: https://github.com/kubernetes/sig-release/issues/1100 - pending cut release issue)

- order the list in alphabetical order using the initial letter of the email

/assign @cblecker
cc: @justaugustus @saschagrunert  @hasheddan @Verolop  @kubernetes/release-engineering

/priority important-soon