### PR TITLE
releng: remove temporarily access for Verolop

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -513,7 +513,6 @@ groups:
       - dmaceachern@vmware.com
       - feiskyer@gmail.com
       - georgedanielmangum@gmail.com
-      - gveronicalg@gmail.com
       - hhorl@pivotal.io
       - idealhack@gmail.com
       - saschagrunert@gmail.com


### PR DESCRIPTION
remove temporary permission that was given in this [PR](https://github.com/kubernetes/k8s.io/pull/933) to cut K8s release `1.19.0-beta.1` 


/hold until `1.19.0-beta.1` is **released**
I will lift the hold when the release is out. thanks!


/assign @dims @cblecker
cc: @justaugustus @saschagrunert @hasheddan @Verolop @kubernetes/release-engineering

/priority important-soon
