### PR TITLE
kubernetes-csi: promote first multi-arch mock-driver release

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-csi/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-csi/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# Current set of people in sig-storage-leads from
+# https://github.com/kubernetes/community/blob/master/OWNERS_ALIASES.
+approvers:
+- jsafrane
+- msau42
+- saad-ali
+- xing-yang

--- a/k8s.gcr.io/images/k8s-staging-csi/generate.sh
+++ b/k8s.gcr.io/images/k8s-staging-csi/generate.sh
@@ -16,6 +16,6 @@ snapshot-controller
 for repo in $repos; do
     echo "- name: $repo"
     echo "  dmap:"
-    gcloud container images list-tags gcr.io/k8s-staging-csi/$repo --format='get(digest, tags)' --filter='tags~v.* AND NOT tags~v2020.* AND NOT tags~.*rc.*' |
+    gcloud container images list-tags gcr.io/k8s-staging-csi/$repo --format='get(digest, tags)' --filter='tags~^v AND NOT tags~v2020 AND NOT tags~-rc' |
         sed -e 's/\([^ ]*\)\t\(.*\)/    "\1": [ "\2" ]/'
 done

--- a/k8s.gcr.io/images/k8s-staging-csi/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-csi/images.yaml
@@ -24,5 +24,6 @@
 - name: mock-driver
   dmap:
     "sha256:0b4273abac4c241fa3d70aaf52b0d79a133d2737081f4a5c5dea4949f6c45dc3": [ "v3.1.0" ]
+    "sha256:e7c5d268c1f83d423afc6e6d84aec6d3a93a864672ec441d6c66eb013e887972": [ "v3.1.1" ]
 - name: snapshot-controller
   dmap:


### PR DESCRIPTION
csi-test v3.1.1 produced the first multi-arch image. We probably want
to promote only the combined image (tag: v3.1.1) and not the
individual ones for each architecture (tags: amd64-linux-v3.1.1,
ppc64le-linux-v3.1.1, s390x-linux-v3.1.1).

This showed that the `tags~` regex matching does a sub-string match
and not a full match, so the script gets updated a bit to simplify
some terms and tighten the one that matches versions.

/cc @msau42