### PR TITLE
Fix prow-build nodepool pool1 initial_count

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
@@ -105,7 +105,7 @@ module "prow_build_nodepool" {
   cluster_name    = module.prow_build_cluster.cluster.name
   location        = module.prow_build_cluster.cluster.location
   name            = "pool1"
-  initial_count   = 2
+  initial_count   = 6
   min_count       = 6
   max_count       = 30
   # kind-ipv6 jobs need an ipv6 stack; COS doesn't provide one, so we need to


### PR DESCRIPTION
I scaled this nodepool through the google cloud console when it became apparent that autoscaling wasn't going to scale up to initial_count until there was cause for an autoscaling event. (ref: https://github.com/kubernetes/k8s.io/pull/930#issuecomment-636539643)

It appears doing so set the nodepool's initial_count, so `terraform plan` showed terraform wanting to destroy and recreate the nodepool to get back down to an initial_count of 2.

Updating terraform resource definition to follow so `terraform plan` shows no diff

Discovered this while trying to run `terraform apply` for https://github.com/kubernetes/k8s.io/pull/857