### PR TITLE
Remove references to k8s-staging-release-test

### DIFF
--- a/infra/gcp/ensure-release-projects.sh
+++ b/infra/gcp/ensure-release-projects.sh
@@ -28,13 +28,12 @@ function usage() {
     echo "usage: $0 [project...]" > /dev/stderr
     echo "example:" > /dev/stderr
     echo "  $0 # do all release projects" > /dev/stderr
-    echo "  $0 k8s-staging-release-test # just do one" > /dev/stderr
+    echo "  $0 k8s-release-test-prod # just do one" > /dev/stderr
     echo > /dev/stderr
 }
 
 # NB: Please keep this sorted.
 PROJECTS=(
-    k8s-staging-release-test
     k8s-release-test-prod
 )
 

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -80,7 +80,6 @@ STAGING_PROJECTS=(
     npd
     provider-azure
     publishing-bot
-    release-test
     releng
     scl-image-builder
     service-apis
@@ -91,7 +90,6 @@ STAGING_PROJECTS=(
 
 RELEASE_STAGING_PROJECTS=(
     kubernetes
-    release-test
     releng
 )
 
@@ -217,16 +215,6 @@ for repo in "${RELEASE_STAGING_PROJECTS[@]}"; do
         color 6 "Empowering ${RELEASE_VIEWERS} as project viewers in ${PROJECT}"
         empower_group_as_viewer "${PROJECT}" "${RELEASE_VIEWERS}"
 
-        # TODO(justaugustus): Remove once the k8s-releng-prod GCP project is
-        #                     configured to allow other release projects to decrypt
-        #                     KMS assets and existing KMS keys in the
-        #                     k8s-staging-release-test GCP project have been
-        #                     transferred over.
-        if [[ $PROJECT == "k8s-staging-release-test" ]]; then
-            # Let Release Admins administer KMS.
-            color 6 "Empowering ${RELEASE_ADMINS} as KMS admins in ${PROJECT}"
-            empower_group_for_kms "${PROJECT}" "${RELEASE_ADMINS}"
-        fi
     ) 2>&1 | indent
 done
 


### PR DESCRIPTION
Encountered while running `ensure-staging-storage.sh` for all projects (ref: https://github.com/kubernetes/k8s.io/pull/857#issuecomment-641692800).

The change that caused this (https://github.com/kubernetes/k8s.io/pull/742) landed 2020-04-13. Taking ~2 months to surface isn't great.

Per https://github.com/kubernetes/k8s.io/pull/857#issuecomment-641695063 I think this just about closes out https://github.com/kubernetes/release/issues/1161 but I'm avoiding using the "fixes" keyword to ensure we can verify.

/hold
We don't have automated deletion of projects so someone (probably me) will have to manually delete k8s-staging-release-test to finish this. I'm not about to do so off-hours.