### PR TITLE
add basic runbook for production image errors and disaster recovery

### DIFF
--- a/infra/gcp/backup_tools/restore_prod.sh
+++ b/infra/gcp/backup_tools/restore_prod.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# USAGE NOTES
+#
+# Backs up prod registries. This is a thin orchestrator as all the heavy lifting
+# is done by the gcrane binary.
+#
+# This script requires 1 environment variable to be defined:
+#
+# 1) GOPATH: toplevel path for checking out gcrane's source code.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+SCRIPT_ROOT="$(dirname "$(readlink -f "$0")")"
+
+export GCRANE_CHECKOUT_DIR="${GOPATH}/src/github.com/google/go-containerregistry"
+
+# shellcheck disable=SC1090
+source "${SCRIPT_ROOT}/backup_lib.sh"
+
+# Backup GCRs for prod.
+prod_repos=(
+    asia.gcr.io/k8s-artifacts-prod
+    eu.gcr.io/k8s-artifacts-prod
+    us.gcr.io/k8s-artifacts-prod
+)
+
+# Sanity check
+cred_sanity_check
+
+# Build gcrane first.
+build_gcrane
+
+# Copy each region to its backup.
+for repo in "${prod_repos[@]}"; do
+    gcrane_copy "${repo}-bak" "${repo}"
+done

--- a/infra/gcp/runbook.md
+++ b/infra/gcp/runbook.md
@@ -1,0 +1,55 @@
+# k8s-artifacts-prod Runbook for GCR Image issues
+
+## A bad image is detected by the auditor
+
+### Image deletions or overwrites
+
+Reinstate a known-good version of the image by re-running the [promoter][promoter] in
+non-dry-run mode. This can be done by manually running the `post-k8sio-cip` Prow
+job. Ask test-infra [oncall][oncall].
+
+Running the `post-k8sio-cip` job successfully will restore all deleted images.
+However, if an image tag is moved, the promoter cannot be used to overwrite the
+tag back to the original because tag overwrites are not supported by the
+promoter. Instead you have to use `gcrane` in order to restore the tag. If
+there are multiple images that need this treatment, it is most likely best to
+just run the `restore_prod.sh` script as below.
+
+If the manual promotion run above fails to reinstate all original images, then run:
+
+```
+$ <k8s.io_ROOT>/infra/gcp/backup_tools/restore_prod.sh
+```
+
+to restore production from the backups.
+
+### Validating image restorations
+
+Simply re-run the promoter in dry-run mode. Anyone can do this (no permissions
+are necessary in dry-drun mode). On a system without the promoter installed,
+you would have to do:
+
+```bash
+cd $GOPATH/src/sigs.k8s.io
+git clone https://github.com/kubernetes-sigs/k8s-container-image-promoter 2>/dev/null
+cd k8s-container-image-promoter
+make install # This makes "cip" available in your PATH.
+cip -dry-run -thin-manifest-dir=<k8s.io_ROOT>/k8s.gcr.io
+```
+
+This should result in a message "Nothing to promote." at the end.
+
+## Deploy a new auditor image
+
+```
+$ <k8s.io_ROOT>/infra/gcp/cip-auditor/deploy.sh <PROJECT_TO_RUN_IN> <SHA256_OF_IMAGE>
+# Example: $ ./deploy.sh k8s-artifacts-prod d7b5d70c641a21b46564aa76f4d46af0854689b22109d8055f6429a061c57496
+```
+
+Note: The image is sourced from the
+`us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip-auditor` repository.
+
+The auditor image runs on Cloud Run. It aggressively logs its findings (search for `VERIFIED` or `REJECTED`) into StackDriver logs.
+
+[oncall]: http://go.k8s.io/oncall
+[promoter]: https://github.com/kubernetes-sigs/k8s-container-image-promoter


### PR DESCRIPTION
Also add a production restoration script, which is the "inverse" of the
backup script.

/cc @thockin 