### PR TITLE
Updated version of octodns in dns/Makefile

### DIFF
--- a/dns/Makefile
+++ b/dns/Makefile
@@ -19,7 +19,7 @@ ZONE_CONFIGS := zone-configs
 OCTODNS_CONFIG := octodns-config.yaml
 # TODO: This should just say "k8s.gcr.io/infra-tools/octodns:<tag>"
 # 		once the domain flip finishes.
-DOCKER_IMAGE ?= us.gcr.io/k8s-artifacts-prod/infra-tools/octodns:v20200501-36789b1
+DOCKER_IMAGE ?= us.gcr.io/k8s-artifacts-prod/infra-tools/octodns:v20200612-d4db040
 
 check-canary check-prod: TMPCFG := $(shell mktemp -d /tmp/octodns.XXXXXX)
 check-canary check-prod: TMP_OCTODNS_CFG := $(shell mktemp /tmp/octodns.XXXXXX)


### PR DESCRIPTION
The current one doesn't have bash inside so wouldn't work when used to
push or check-zone

Blocked by: #953 
/hold

/cc @ameukam 

Signed-off-by: Bart Smykla <bsmykla@vmware.com>