### PR TITLE
Switch slack-infra to community hosted images

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-slack-infra/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-slack-infra/images.yaml
@@ -1,1 +1,15 @@
-# No images yet
+- name: slack-event-log
+  dmap:
+    "sha256:a56c29108faf779b6ebd84e90a71a62d457cb290841508f69624efe298f4b403": ["v20200612-1c5d751"]
+- name: slack-moderator
+  dmap:
+    "sha256:8212fd9ae215d9974801b8c3e8d8b14156c93353bddb897d9be27c84a586db16": ["v20200612-1c5d751"]
+- name: slack-report-message
+  dmap:
+    "sha256:41e6c94a4b6c9a29d2742689bf515a7750f3cfdb3a9b1e36b3aa02ac21ab93cf": ["v20200612-1c5d751"]
+- name: slack-welcomer
+  dmap:
+    "sha256:5b80002652416013af7331d882fadf32e46c39c8ed034b5b8af5a3906422c9da": ["v20200612-1c5d751"]
+- name: tempelis
+  dmap:
+    "sha256:abafcc2fe91bd63202c7dc81d03a15c7dd878f232deecf795274422483616bf2": ["v20200612-1c5d751"]

--- a/slack-infra/resources/slack-event-log/deployment.yaml
+++ b/slack-infra/resources/slack-event-log/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-event-log
-        image: gcr.io/kubernetes-tools/slack-event-log:v20190415-bdf772f89
+        image: gcr.io/k8s-staging-slack-infra/slack-event-log:v20200612-1c5d751
         args:
           - --config-path=/etc/slack-event-log/config.json
         ports:

--- a/slack-infra/resources/slack-moderator/deployment.yaml
+++ b/slack-infra/resources/slack-moderator/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-moderator
-        image: gcr.io/kubernetes-tools/slack-moderator:v20190415-bdf772f89
+        image: gcr.io/k8s-staging-slack-infra/slack-moderator:v20200612-1c5d751
         args:
           - --config-path=/etc/slack-moderator/config.json
         ports:

--- a/slack-infra/resources/slack-welcomer/deployment.yaml
+++ b/slack-infra/resources/slack-welcomer/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-moderator
-        image: gcr.io/kubernetes-tools/slack-welcomer:v20190618-a9e322536
+        image: gcr.io/k8s-staging-slack-infra/slack-welcomer:v20200612-1c5d751
         args:
           - --config-path=/etc/slack-welcomer/config.json
           - --message-path=/etc/welcome-message/welcome.md


### PR DESCRIPTION
Use staging images for slack-infra. 

Ref: #905

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>