### PR TITLE
Added dummy.k8s.io dns record to trigger prow job

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -22,6 +22,10 @@ www:
   type: CNAME
   value: k8s.io.
 
+dummy:
+  type: CNAME
+  value: k8s.io.
+
 # Our vanity redirector.  This is not just 'k8s.io', on the off chance this
 # becomes different from the main record. (@thockin)
 redirect:


### PR DESCRIPTION
As there is `k8sio-dns-update` job which should run dns updates in
dry-mode this temporary, dummy record is to check if the job will be
properly triggered and work as expected

/assign @spiffxp 

Signed-off-by: Bart Smykla <bsmykla@vmware.com>