### PR TITLE
Promote etcd 3.4.9-0

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-etcd/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-etcd/images.yaml
@@ -1,6 +1,7 @@
 - name: etcd
   dmap:
     "sha256:bcdd5657b1edc1a2eb27356f33dd66b9400d4a084209c33461c7a7da0a32ebb3": ["3.4.7-2"]
+    "sha256:83c3e1f35b641e0cda53345f476c4c028fba697073bebafbaef19bcc1a9ce595": ["3.4.9-0"]
 - name: etcd-empty-dir-cleanup
   dmap:
     "sha256:f805272b4422efa92e20789295c343ed26ff36ddc4f70eeb5d7890d6b758b0fc": ["3.4.7.0"]


### PR DESCRIPTION
Images built by:
https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-kubernetes-push-image-etcd/1273799163636617217

From build log:
```
docker manifest push --purge gcr.io/k8s-staging-etcd/etcd:3.4.9-0
Pushed ref gcr.io/k8s-staging-etcd/etcd@sha256:1bf63e04727684d902d13c29827c43865b38dcae23f8e740abd6d27a8e1c64ce with digest: sha256:1bf63e04727684d902d13c29827c43865b38dcae23f8e740abd6d27a8e1c64ce
Pushed ref gcr.io/k8s-staging-etcd/etcd@sha256:fab0598bcd89f13d52ca65576c4cd14e9fe83ddf4f0cddcf248df48a0f699fcb with digest: sha256:fab0598bcd89f13d52ca65576c4cd14e9fe83ddf4f0cddcf248df48a0f699fcb
Pushed ref gcr.io/k8s-staging-etcd/etcd@sha256:203609377848b73ed499f4133f1af89a22359b188ffe4928f265091ae52629ed with digest: sha256:203609377848b73ed499f4133f1af89a22359b188ffe4928f265091ae52629ed
Pushed ref gcr.io/k8s-staging-etcd/etcd@sha256:785aba7054cd7dd62785e03c1643d4cbea8c4509907e4f02e6fa42dca073e40e with digest: sha256:785aba7054cd7dd62785e03c1643d4cbea8c4509907e4f02e6fa42dca073e40e
Pushed ref gcr.io/k8s-staging-etcd/etcd@sha256:404197720b8d6460243c86bfb546d18ed848e3815ab61a5db8485f0d3cb5c8c4 with digest: sha256:404197720b8d6460243c86bfb546d18ed848e3815ab61a5db8485f0d3cb5c8c4
sha256:83c3e1f35b641e0cda53345f476c4c028fba697073bebafbaef19bcc1a9ce595
```