### PR TITLE
build-image: Promote kube-cross:v1.14.4-2 and v1.13.12-2

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
@@ -26,6 +26,10 @@
     - v1.13.9-2
     sha256:97e77164ddc1f9ab56bcbab3e2895b882097b1eabd820497e894f41c0e4908fe:
     - v1.12.12-1
+    sha256:a297fddaaa8f8e88620de1f94c44dbbf26aaaf5f256266bf5c7eca5f0f68f56d:
+    - v1.14.4-2
+    sha256:b33ada5ba9b267ab9fc77b18aa9ceebc51ced6c57fb262eecb2d5ac35a3cfa52:
+    - v1.13.12-2
     sha256:dde2f519f19059cb5d2edfc177ea6ff316e2c50daa0af6c6a44d185858bc7b0d:
     - v1.14.4-1
     sha256:df0a50772214025040ea31144a731b5fa76944cbfc9c87db05af98e4aa39aa7f:


### PR DESCRIPTION
Promotion for https://github.com/kubernetes/release/pull/1372.
Needed for https://github.com/kubernetes/kubernetes/pull/88638.

Staging run: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-release-push-image-kube-cross/1274529745001779200, https://console.cloud.google.com/cloud-build/builds/6e562224-975b-4f68-b645-1f7131378ffe?project=k8s-staging-build-image, https://console.cloud.google.com/cloud-build/builds/b609681a-1f90-46d1-902d-f08841bada7c?folder=&organizationId=&project=k8s-staging-build-image

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @dims @cblecker @BenTheElder @listx 
cc: @kubernetes/release-engineering 