### PR TITLE
releng: Promote arch-specific digests for debian-hyperkube-base:v1.1.0

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
@@ -28,19 +28,24 @@
     "sha256:ce7a6205a175f8eca8edc1bbff4c06516da523db6751085b6c7929d111fecb7f": ["v1.1.0"]
 - name: debian-hyperkube-base-amd64
   dmap:
+    "sha256:5cab0f210e47d4e04fe06fa0a20d8c7fde3bcfe14fe73b3eab3c7070790c4927": ["v1.1.0"]
     "sha256:73a8cb2bfd6707c8ed70c252e97bdccad8bc265a9a585db12b8e3dac50d6cd2a": ["v1.0.0"]
 - name: debian-hyperkube-base-arm
   dmap:
+    "sha256:7321a64a58e942f0ba0fe5e2979b4ac22df2dcecedf7d118c4e643f5018b305a": ["v1.1.0"]
     "sha256:aee7c2958c6e0de896995e8b04c8173fd0a7bbb16cddb1f4668e3ae010b8c786": ["v1.0.0"]
 - name: debian-hyperkube-base-arm64
   dmap:
+    "sha256:06d0797613073328d86e1721d931b1e0b8026c8e70aeb753eadf5b0856d0aadb": ["v1.1.0"]
     "sha256:a74fc6d690e5c5e393fd509f50d7203fa5cd19bfbb127d4a3a996fd1ebcf35c4": ["v1.0.0"]
 - name: debian-hyperkube-base-ppc64le
   dmap:
     "sha256:54afd9a85d6ecbe0792496f36012e7902601fb8084347cdc195c8b0561da39a3": ["v1.0.0"]
+    "sha256:d51068e84f5113af53ca5a1f917f7705b15dd968a42a0dda049c2c7b3ba9ff0e": ["v1.1.0"]
 - name: debian-hyperkube-base-s390x
   dmap:
     "sha256:405a94e6b82f2eb89c773e0e9f6105eb73cde5605d4508ae36a150d922fe1c66": ["v1.0.0"]
+    "sha256:9251a1524956d960243ba42ee16274baa93942ee7514b1ef7a1c26f84e959dd8": ["v1.1.0"]
 - name: debian-iptables
   dmap:
     "sha256:1ae6d76dea462973759ff1c4e02263867da1f85db9aa10462a030ca421cbf0e9": ["v12.1.0"]


### PR DESCRIPTION
(Continuation of promotion for https://github.com/kubernetes/kubernetes/pull/92354.)

There are certain scripts that expect the arch-specific image names
e.g., `debian-hyperkube-base-amd64`, so we need to promote the individual
image manifests as well.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @dims @cblecker @BenTheElder @listx @liggitt 
cc: @kubernetes/release-engineering 

/priority critical-urgent
ref: https://github.com/kubernetes/kubernetes/issues/92275, https://github.com/kubernetes/kubernetes/issues/92272, https://github.com/kubernetes/kubernetes/issues/92250