### PR TITLE
Allow namespace-use-role access to secrets

### DIFF
--- a/infra/gcp/namespaces/namespace-user-role.yml
+++ b/infra/gcp/namespaces/namespace-user-role.yml
@@ -40,7 +40,7 @@ rules:
     verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["list"]
+    verbs: ["*"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["list"]


### PR DESCRIPTION
Putting this up to ask the question: why are cluster admins the only
people allowed to create secrets?  I personally would rather delegate
control of a namespace's resource, including its secrets, to the rbac
group.

Bumped into this while helping @ameukam setup triage-party here: https://github.com/kubernetes/k8s.io/pull/967/files#r445789688

/cc @cblecker @thockin @dims