### PR TITLE
releng: Promote debian-hyperkube-base:v1.1.1

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
@@ -26,25 +26,31 @@
   dmap:
     "sha256:8c8d854d868fb08352f73dda94f9e0b998c7318b48ddc587a355d0cbaf687f14": ["v1.0.0"]
     "sha256:ce7a6205a175f8eca8edc1bbff4c06516da523db6751085b6c7929d111fecb7f": ["v1.1.0"]
+    "sha256:f7f47c37bf6b0fc4b168912edbd45550240cecaf96fd53dccbe06c2a6bd268f2": ["v1.1.1"]
 - name: debian-hyperkube-base-amd64
   dmap:
     "sha256:5cab0f210e47d4e04fe06fa0a20d8c7fde3bcfe14fe73b3eab3c7070790c4927": ["v1.1.0"]
     "sha256:73a8cb2bfd6707c8ed70c252e97bdccad8bc265a9a585db12b8e3dac50d6cd2a": ["v1.0.0"]
+    "sha256:d0830921ae6c9636788ac89980bc8f77cb4a47fe53985f0b31b10d978a905a1a": ["v1.1.1"]
 - name: debian-hyperkube-base-arm
   dmap:
     "sha256:7321a64a58e942f0ba0fe5e2979b4ac22df2dcecedf7d118c4e643f5018b305a": ["v1.1.0"]
     "sha256:aee7c2958c6e0de896995e8b04c8173fd0a7bbb16cddb1f4668e3ae010b8c786": ["v1.0.0"]
+    "sha256:f06e07c95a11ead1d8a6929f8df5f6afe061943f970be9d3121b1bc58d25ba1b": ["v1.1.1"]
 - name: debian-hyperkube-base-arm64
   dmap:
     "sha256:06d0797613073328d86e1721d931b1e0b8026c8e70aeb753eadf5b0856d0aadb": ["v1.1.0"]
     "sha256:a74fc6d690e5c5e393fd509f50d7203fa5cd19bfbb127d4a3a996fd1ebcf35c4": ["v1.0.0"]
+    "sha256:c471afeec232448c2bafd52762a977470c85e4246ebca67bba544844f93b4b03": ["v1.1.1"]
 - name: debian-hyperkube-base-ppc64le
   dmap:
     "sha256:54afd9a85d6ecbe0792496f36012e7902601fb8084347cdc195c8b0561da39a3": ["v1.0.0"]
     "sha256:d51068e84f5113af53ca5a1f917f7705b15dd968a42a0dda049c2c7b3ba9ff0e": ["v1.1.0"]
+    "sha256:d62012612769d4d803ca8d78782a0b3643df362ddf338c9926738ea9dca9d624": ["v1.1.1"]
 - name: debian-hyperkube-base-s390x
   dmap:
     "sha256:405a94e6b82f2eb89c773e0e9f6105eb73cde5605d4508ae36a150d922fe1c66": ["v1.0.0"]
+    "sha256:504417278bd2935f8ed72ebcc1bba6ae4deae9959b07769280fda2948fe76dd4": ["v1.1.1"]
     "sha256:9251a1524956d960243ba42ee16274baa93942ee7514b1ef7a1c26f84e959dd8": ["v1.1.0"]
 - name: debian-iptables
   dmap:


### PR DESCRIPTION
Promotion for https://github.com/kubernetes/kubernetes/pull/92581.

Staging run: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-kubernetes-push-image-debian-hyperkube-base/1277719588221489154 / https://console.cloud.google.com/cloud-build/builds/7cd91949-3667-42e5-b779-a310afd6fd61?project=960211007710

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @dims @cblecker @BenTheElder @listx @liggitt 
cc: @kubernetes/release-engineering 

ref: https://github.com/kubernetes/kubernetes/issues/92272