### PR TITLE
remove premdeeps@ from groups

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -673,7 +673,6 @@ groups:
       - marky.r.jackson@gmail.com
       - mudrinic.mare@gmail.com
       - onlydole@gmail.com
-      - premdeeps@google.com
       - sethpmccombs@gmail.com
       - saschagrunert@gmail.com
       - simony@google.com
@@ -1474,7 +1473,6 @@ groups:
       - marky.r.jackson@gmail.com
       - mudrinic.mare@gmail.com
       - onlydole@gmail.com
-      - premdeeps@google.com
       - release-managers-private@kubernetes.io
       - sethpmccombs@gmail.com
       - saschagrunert@gmail.com


### PR DESCRIPTION
Premdeep Sharma (premdeeps@google.com) has recently switched teams and
is no longer on the OSS K8s rotation as he used to be.

/cc @ps882 