### PR TITLE
groups: support hierarchical groups.yaml files

### DIFF
--- a/groups/config.yaml
+++ b/groups/config.yaml
@@ -5,6 +5,3 @@ secret-version: projects/k8s-gsuite/secrets/gsuite-groups-manager_key/versions/l
 
 # Email id of the bot service account
 bot-id: wg-k8s-infra-api@kubernetes.io
-
-# Configuration file for the groups/members information
-groups-file: groups.yaml

--- a/groups/go.mod
+++ b/groups/go.mod
@@ -9,5 +9,8 @@ require (
 	google.golang.org/api v0.20.0
 	google.golang.org/genproto v0.0.0-20200429120912-1f37eeb960b2
 	gopkg.in/yaml.v2 v2.2.2
+	k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d
 	k8s.io/test-infra v0.0.0-20191024183346-202cefeb6ff5
 )
+
+replace k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d

--- a/groups/go.sum
+++ b/groups/go.sum
@@ -677,9 +677,6 @@ k8s.io/api v0.0.0-20180904230853-4e7be11eab3f/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j
 k8s.io/api v0.0.0-20181018013834-843ad2d9b9ae/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/api v0.0.0-20190918195907-bd6ac527cfd2/go.mod h1:AOxZTnaXR/xiarlQL0JUfwQPxjmKDvVYoRp58cA7lUo=
 k8s.io/apiextensions-apiserver v0.0.0-20190918201827-3de75813f604/go.mod h1:7H8sjDlWQu89yWB3FhZfsLyRCRLuoXoCoY5qtwW1q6I=
-k8s.io/apimachinery v0.0.0-20180904193909-def12e63c512/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
-k8s.io/apimachinery v0.0.0-20181015213631-60666be32c5d/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
-k8s.io/apimachinery v0.0.0-20190816221834-a9f1d8a9c101/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
 k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d h1:7Kns6qqhMAQWvGkxYOLSLRZ5hJO0/5pcE5lPGP2fxUw=
 k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d/go.mod h1:3jediapYqJ2w1BFw7lAZPCx7scubsTfosqHkhXCWJKw=
 k8s.io/apiserver v0.0.0-20190918200908-1e17798da8c1/go.mod h1:4FuDU+iKPjdsdQSN3GsEKZLB/feQsj1y9dhhBDVV2Ns=

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -112,29 +112,6 @@ groups:
       - ynli@google.com
       - zcorleissen@linuxfoundation.org
 
-  - email-id: community@kubernetes.io
-    name: community
-    description: |-
-
-    settings:
-      WhoCanPostMessage: "ANYONE_CAN_POST"
-      ReconcileMembers: "true"
-    owners:
-      - ihor@cncf.io
-      - jorgec@vmware.com
-      - killen.bob@gmail.com
-      - paris.pittman@gmail.com
-    managers:
-      - pal.nabarun95@gmail.com
-      - ameukam@gmail.com
-      - matthewbbroberg@gmail.com
-      - jrosland@vmware.com
-    members:
-      - dgiles@linuxfoundation.org
-      - jberkus@redhat.com
-      - chris@chrisshort.net
-      - samudralavamshi@gmail.com
-
   - email-id: conduct@kubernetes.io
     name: conduct
     description: |-

--- a/groups/sig-contributor-experience/OWNERS
+++ b/groups/sig-contributor-experience/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - castrojo
+  - cblecker
+  - idvoretskyi
+  - jdumars
+  - mrbobbytables
+  - nikhita
+  - parispittman

--- a/groups/sig-contributor-experience/groups.yaml
+++ b/groups/sig-contributor-experience/groups.yaml
@@ -1,0 +1,23 @@
+groups:
+  - email-id: community@kubernetes.io
+    name: community
+    description: |-
+
+    settings:
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      ReconcileMembers: "true"
+    owners:
+      - ihor@cncf.io
+      - jorgec@vmware.com
+      - killen.bob@gmail.com
+      - paris.pittman@gmail.com
+    managers:
+      - pal.nabarun95@gmail.com
+      - ameukam@gmail.com
+      - matthewbbroberg@gmail.com
+      - jrosland@vmware.com
+    members:
+      - dgiles@linuxfoundation.org
+      - jberkus@redhat.com
+      - chris@chrisshort.net
+      - samudralavamshi@gmail.com


### PR DESCRIPTION
For https://github.com/kubernetes/k8s.io/issues/460

Requiring all groups be added to a single `groups.yaml` can become
tedious to maintain. This commit allows splitting groups into
hierarchical `groups.yaml` files, akin to OWNERS files.

This commit contains the following changes:

- We now hardcode files containing groups config to have the file name
`groups.yaml`.

- We no longer allow the group config to be specified at an URL.

- The `groups-file` field in config.yaml is renamed to `groups-path`.
`groups-path` is the directory containing groups.yaml files. It must be
an absolute path. If not specified, it defaults to the directory
containing `config.yaml`.

- `readGroupsConfig` uses `groups-path` as the root dir and recursively
walks through all dirs and files. When it sees a `groups.yaml` file,
it reads the config and adds its groups to `config.Groups`.

- `config.Groups` finally contains the merged groups config from all
`groups.yaml` files.

---

This is WIP because:

- As https://github.com/kubernetes/k8s.io/issues/928#issuecomment-640993935 mentions, we probably need documented policies about how we'd split groups.yaml before enabling this. I just wanted to get this PR out to get the ball rolling.

- I moved `community@kubernetes.io` to the `sig-contributor-experience` dir and seeded OWNERS with the root OWNERS in k/community as an example, we'd probably need to tweak OWNERS/groups a bit more.

/hold
to ensure we have policies in place before enabling this

/assign @cblecker @dims @spiffxp 