### PR TITLE
enable vulnerability scanning api on all staging projects

### DIFF
--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -137,6 +137,10 @@ for REPO; do
         color 6 "Enabling the container registry API"
         enable_api "${PROJECT}" containerregistry.googleapis.com
 
+        # Enable vulnerability scanning on the staging project
+        color 6 "Enabling vulnerability scanning in staging projects"
+        enable_api "${PROJECT}" containerscanning.googleapis.com
+
         # Push an image to trigger the bucket to be created
         color 6 "Ensuring the registry exists and is readable"
         ensure_gcr_repo "${PROJECT}"


### PR DESCRIPTION
For the purposes of implementing a new vulnerability pre-submit check for the Container Image Promoter (https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/235), we need to enable the vulnerability scanning api on all image staging projects. Once vulnerability scanning is enabled, the new vulnerability check will be able to query the Container Analysis Service for any staged image before it is promoted.