### PR TITLE
create and authorize service account for promoter vulnerability check

### DIFF
--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -342,6 +342,16 @@ color 6 "Handling special cases"
         "k8s-prow-builds.svc.id.goog[test-pods/k8s-infra-gcr-promoter-test]" \
         "${GCR_BACKUP_TEST_PRODBAK_PROJECT}" \
         $(svc_acct_email "${GCR_BACKUP_TEST_PRODBAK_PROJECT}" "${PROMOTER_SVCACCT}")
+
+    color 6 "Empowering promoter-scanning namespace to use prod promoter vuln scanning svcacct"
+    empower_ksa_to_svcacct \
+        "k8s-prow-builds.svc.id.goog[test-pods/k8s-infra-gcr-promoter-scanning]" \
+        "${PROD_PROJECT}" \
+        $(svc_acct_email "${PROD_PROJECT}" "${PROMOTER_VULN_SCANNING_SVCACCT}")
+    empower_ksa_to_svcacct \
+        "k8s-infra-prow-build-trusted.svc.id.goog[test-pods/k8s-infra-gcr-promoter-scanning]" \
+        "${PROD_PROJECT}" \
+        $(svc_acct_email "${PROD_PROJECT}" "${PROMOTER_VULN_SCANNING_SVCACCT}")
 ) 2>&1 | indent
 
 color 6 "Done"

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -140,6 +140,11 @@ for REPO; do
         # Enable vulnerability scanning on the staging project
         color 6 "Enabling vulnerability scanning in staging projects"
         enable_api "${PROJECT}" containerscanning.googleapis.com
+        
+        # Enable image promoter access to vulnerability scanning results
+        empower_service_account_for_cip_vuln_scanning \
+            "$(svc_acct_email "${PROD_PROJECT}" "${PROMOTER_VULN_SCANNING_SVCACCT}")" \
+            "${PROJECT}"
 
         # Push an image to trigger the bucket to be created
         color 6 "Ensuring the registry exists and is readable"

--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -30,6 +30,9 @@ GCS_ADMINS=$GCR_ADMINS
 # The service account name for the image promoter.
 PROMOTER_SVCACCT="k8s-infra-gcr-promoter"
 
+# The service account name for the image promoter's vulnerability check.
+PROMOTER_VULN_SCANNING_SVCACCT="k8s-infra-gcr-promoter-vuln-scanning"
+
 # The service account name for the GCR auditor (Cloud Run runtime service
 # account).
 AUDITOR_SVCACCT="k8s-infra-gcr-auditor"
@@ -178,6 +181,23 @@ function empower_service_account_for_cip_auditor_e2e_tester() {
             --member "serviceAccount:${acct}" \
             --role "${role}"
     done
+}
+
+# Grant roles for running pull-cip-vuln
+# $1: The service account
+# $2: The GCP Project
+function empower_service_account_for_cip_vuln_scanning() {
+    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+        echo "empower_service_account_for_cip_vuln_scanning(acct, project) requires 2 arguments" >&2
+        return 1
+    fi
+    local acct="$1"
+    local project="$2"
+
+    gcloud \
+        projects add-iam-policy-binding "${project}" \
+        --member "serviceAccount:${acct}" \
+        --role roles/containeranalysis.occurrences.viewer
 }
 
 # Grant GCB admin privileges to a principal


### PR DESCRIPTION
For the purpose of implementing a new vulnerability presubmit check for the image promoter (https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/235), a new service account needs to be created which is authorized to view the vulnerability scanning results for all of the staging projects. This service account will be used to authenticate a new Prow job - which runs the vulnerability check - via Workload Identity.