### PR TITLE
Allow read-only access to monitoring and logging of 'aaa' cluster

### DIFF
--- a/infra/gcp/clusters/projects/kubernetes-public/aaa/12-iam.tf
+++ b/infra/gcp/clusters/projects/kubernetes-public/aaa/12-iam.tf
@@ -1,0 +1,26 @@
+/*
+Ensure google groups defined in 'members' have read-only access to
+all monitoring data and configurations.
+Detailed list of permissions: https://cloud.google.com/monitoring/access-control#roles
+*/
+resource "google_project_iam_binding" "readonlymonitoringbinding" {
+  project = data.google_project.project.id
+  role    = "roles/monitoring.viewer"
+
+  members = [
+    "group:gke-security-groups@kubernetes.io",
+  ]
+}
+
+/*
+Ensure google groups defined in 'members' have read-only access to logs.
+Detailed list of permissions: https://cloud.google.com/logging/docs/access-control#permissions_and_roles
+*/
+resource "google_project_iam_binding" "readonlyloggingbinding" {
+  project = data.google_project.project.id
+  role    = "roles/logging.privateLogViewer"
+
+  members = [
+    "group:gke-security-groups@kubernetes.io",
+  ]
+}


### PR DESCRIPTION
Allow operators of the different workloads(except cert-manager) running on `aaa` to have
read-only access to Monitoring and Logging in the Google Cloud
Console and the APIs.

Detailed list of permissions :
- Monitoring : https://cloud.google.com/monitoring/access-control#roles
- Logging : https://cloud.google.com/logging/docs/access-control#permissions_and_roles

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>