### PR TITLE
Remove inactive members from OWNERS

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -1000,7 +1000,6 @@ groups:
       ReconcileMembers: "true"
     members:
       - bowei@google.com
-      - dnardo@google.com
       - thockin@google.com
       - zihongz@google.com
 

--- a/k8s.gcr.io/images/k8s-staging-cpa/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-cpa/OWNERS
@@ -3,6 +3,5 @@
 
 approvers:
   - thockin
-  - dnardo
   - MrHohn
   - bowei


### PR DESCRIPTION
As a part of kubernetes/org#2013, we are cleaning up inactive members from OWNERS who haven't been active
since the release of v1.11. This commit removes dnardo from `k8s.gcr.io/images/k8s-staging-cpa/OWNERS` and `k8s-infra-staging-cpa@kubernetes.io`.

/assign @thockin 
cc @mrbobbytables @dnardo 