### PR TITLE
Create AWS test accounts using terraform

### DIFF
--- a/infra/aws/e2e/accounts/tf/.gitignore
+++ b/infra/aws/e2e/accounts/tf/.gitignore
@@ -1,0 +1,6 @@
+terraform.tfstate
+.terraform/
+terraform.tfstate.backup
+boskos/*.yaml
+gcs-encryption-key
+boskos/

--- a/infra/aws/e2e/accounts/tf/README.md
+++ b/infra/aws/e2e/accounts/tf/README.md
@@ -1,0 +1,35 @@
+# AWS account scripting
+
+* We create AWS accounts using terraform.
+
+* The state file is stored (encrypted) in GCS.
+
+* The encryption key is available only to those that should be running
+  this, as it contains the AWS account keys.
+
+* We additionally generate the boskos objects, and upload that also to
+  GCS, encrypted using the same key (as it broadly has the same data)
+
+
+## Applying to terraform
+
+Ensure that the key is written to `gcs-encryption-key`
+
+Ensure you are using the correct AWS profile, and then run tf-apply, for example:
+
+```
+export AWS_PROFILE=cncf
+./tf-apply
+```
+
+## Uploading to boskos
+
+Ensure that the encryption key is written to `gcs-encryption-key`
+
+Ensure you are using the correct k8s context, then run `apply-to-k8s`.  For example:
+
+
+```
+gcloud container clusters get-credentials ...
+./apply-to-k8s
+```

--- a/infra/aws/e2e/accounts/tf/accounts.tf
+++ b/infra/aws/e2e/accounts/tf/accounts.tf
@@ -1,0 +1,182 @@
+terraform {
+  required_version = "~> 0.13"
+  backend "gcs" {
+    bucket = "k8s-infra-clusters-terraform"
+    prefix = "aws/accounts"
+    # NOTE: Must specify encryption key
+  }
+}
+
+
+# Terraform doesn't work well with count in modules (even in 0.13)
+
+# Accounts for cluster-api-provider-aws project
+module "capa-user-00" {
+  source      = "./modules/account-and-user"
+  id          = "capa-2020-11-19-00"
+  email       = "k8s-infra-aws-admins+capa2020111900@kubernetes.io"
+  boskos-name = "capa-user-00"
+}
+
+module "capa-user-01" {
+  source      = "./modules/account-and-user"
+  id          = "capa-2020-11-19-01"
+  email       = "k8s-infra-aws-admins+capa2020111901@kubernetes.io"
+  boskos-name = "capa-user-01"
+}
+
+module "capa-user-02" {
+  source      = "./modules/account-and-user"
+  id          = "capa-2020-11-19-02"
+  email       = "k8s-infra-aws-admins+capa2020111902@kubernetes.io"
+  boskos-name = "capa-user-02"
+}
+
+module "capa-user-03" {
+  source      = "./modules/account-and-user"
+  id          = "capa-2020-11-19-03"
+  email       = "k8s-infra-aws-admins+capa2020111903@kubernetes.io"
+  boskos-name = "capa-user-03"
+}
+
+module "capa-user-04" {
+  source      = "./modules/account-and-user"
+  id          = "capa-2020-11-19-04"
+  email       = "k8s-infra-aws-admins+capa2020111904@kubernetes.io"
+  boskos-name = "capa-user-04"
+}
+
+module "capa-user-05" {
+  source      = "./modules/account-and-user"
+  id          = "capa-2020-11-19-05"
+  email       = "k8s-infra-aws-admins+capa2020111905@kubernetes.io"
+  boskos-name = "capa-user-05"
+}
+
+module "capa-user-06" {
+  source      = "./modules/account-and-user"
+  id          = "capa-2020-11-19-06"
+  email       = "k8s-infra-aws-admins+capa2020111906@kubernetes.io"
+  boskos-name = "capa-user-06"
+}
+
+module "capa-user-07" {
+  source      = "./modules/account-and-user"
+  id          = "capa-2020-11-19-07"
+  email       = "k8s-infra-aws-admins+capa2020111907@kubernetes.io"
+  boskos-name = "capa-user-07"
+}
+
+module "capa-user-08" {
+  source      = "./modules/account-and-user"
+  id          = "capa-2020-11-19-08"
+  email       = "k8s-infra-aws-admins+capa2020111908@kubernetes.io"
+  boskos-name = "capa-user-08"
+}
+
+module "capa-user-09" {
+  source      = "./modules/account-and-user"
+  id          = "capa-2020-11-19-09"
+  email       = "k8s-infra-aws-admins+capa2020111909@kubernetes.io"
+  boskos-name = "capa-user-09"
+}
+
+module "capa-user-10" {
+  source      = "./modules/account-and-user"
+  id          = "capa-2020-11-19-10"
+  email       = "k8s-infra-aws-admins+capa2020111910@kubernetes.io"
+  boskos-name = "capa-user-10"
+}
+
+module "capa-user-11" {
+  source      = "./modules/account-and-user"
+  id          = "capa-2020-11-19-11"
+  email       = "k8s-infra-aws-admins+capa2020111911@kubernetes.io"
+  boskos-name = "capa-user-11"
+}
+
+module "capa-user-12" {
+  source      = "./modules/account-and-user"
+  id          = "capa-2020-11-19-12"
+  email       = "k8s-infra-aws-admins+capa2020111912@kubernetes.io"
+  boskos-name = "capa-user-12"
+}
+
+module "capa-user-13" {
+  source      = "./modules/account-and-user"
+  id          = "capa-2020-11-19-13"
+  email       = "k8s-infra-aws-admins+capa2020111913@kubernetes.io"
+  boskos-name = "capa-user-13"
+}
+
+
+# Accounts for imagebuilder project
+module "image-builder-aws-1" {
+  source      = "./modules/account-and-user"
+  id          = "image-builder-aws-2020-11-19-00"                    # TODO: Switch to -01
+  email       = "k8s-infra-aws-admins+image2020111900@kubernetes.io" # TODO: Switch to 01
+  boskos-name = "image-builder-aws-1"
+}
+
+module "image-builder-aws-2" {
+  source      = "./modules/account-and-user"
+  id          = "image-builder-aws-2020-11-19-02"
+  email       = "k8s-infra-aws-admins+image2020111902@kubernetes.io"
+  boskos-name = "image-builder-aws-2"
+}
+
+module "image-builder-aws-3" {
+  source      = "./modules/account-and-user"
+  id          = "image-builder-aws-2020-11-19-03"
+  email       = "k8s-infra-aws-admins+image2020111903@kubernetes.io"
+  boskos-name = "image-builder-aws-3"
+}
+
+module "image-builder-aws-4" {
+  source      = "./modules/account-and-user"
+  id          = "image-builder-aws-2020-11-19-04"
+  email       = "k8s-infra-aws-admins+image2020111904@kubernetes.io"
+  boskos-name = "image-builder-aws-4"
+}
+
+module "image-builder-aws-5" {
+  source      = "./modules/account-and-user"
+  id          = "image-builder-aws-2020-11-19-05"
+  email       = "k8s-infra-aws-admins+image2020111905@kubernetes.io"
+  boskos-name = "image-builder-aws-5"
+}
+
+module "image-builder-aws-6" {
+  source      = "./modules/account-and-user"
+  id          = "image-builder-aws-2020-11-19-06"
+  email       = "k8s-infra-aws-admins+image2020111906@kubernetes.io"
+  boskos-name = "image-builder-aws-6"
+}
+
+module "image-builder-aws-7" {
+  source      = "./modules/account-and-user"
+  id          = "image-builder-aws-2020-11-19-07"
+  email       = "k8s-infra-aws-admins+image2020111907@kubernetes.io"
+  boskos-name = "image-builder-aws-7"
+}
+
+module "image-builder-aws-8" {
+  source      = "./modules/account-and-user"
+  id          = "image-builder-aws-2020-11-19-08"
+  email       = "k8s-infra-aws-admins+image2020111908@kubernetes.io"
+  boskos-name = "image-builder-aws-8"
+}
+
+module "image-builder-aws-9" {
+  source      = "./modules/account-and-user"
+  id          = "image-builder-aws-2020-11-19-09"
+  email       = "k8s-infra-aws-admins+image2020111909@kubernetes.io"
+  boskos-name = "image-builder-aws-9"
+}
+
+module "image-builder-aws-10" {
+  source      = "./modules/account-and-user"
+  id          = "image-builder-aws-2020-11-19-10"
+  email       = "k8s-infra-aws-admins+image2020111910@kubernetes.io"
+  boskos-name = "image-builder-aws-10"
+}

--- a/infra/aws/e2e/accounts/tf/apply-to-k8s
+++ b/infra/aws/e2e/accounts/tf/apply-to-k8s
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+KEY=$(cat gcs-encryption-key)
+
+gsutil -o "GSUtil:decryption_key1=${KEY}" cat gs://k8s-infra-clusters-terraform/aws/k8s/accounts-boskos.yaml | kubectl apply -f - --dry-run

--- a/infra/aws/e2e/accounts/tf/modules/account-and-user/main.tf
+++ b/infra/aws/e2e/accounts/tf/modules/account-and-user/main.tf
@@ -1,0 +1,40 @@
+# Intermediate module; workaround for terraform being bad at multiple providers
+module "account" {
+  source = "../account"
+  id     = var.id
+  email  = var.email
+}
+
+module "user" {
+  source = "../user"
+  id     = var.id
+  orgid  = module.account.orgid
+}
+
+
+# Create the boskos yaml file
+# Workaround for terraform bugs around showing state/variables; we have to write from here
+resource "local_file" "boskos" {
+  filename          = "boskos/${var.boskos-name}.yaml"
+  sensitive_content = <<EOF
+apiVersion: boskos.k8s.io/v1
+kind: ResourceObject
+metadata:
+  name: ${var.boskos-name}
+  namespace: test-pods
+  labels:
+    terraform-id: ${var.id}
+    terraform-email: ${var.email}
+spec:
+  type: aws-account
+status:
+  #owner: ""
+  #state: free
+  userData:
+    access-key-id: "${module.user.aws_access_key_id}"
+    secret-access-key: "${module.user.aws_secret_access_key}"
+
+---
+
+EOF
+}

--- a/infra/aws/e2e/accounts/tf/modules/account-and-user/variables.tf
+++ b/infra/aws/e2e/accounts/tf/modules/account-and-user/variables.tf
@@ -1,0 +1,8 @@
+variable "id" {
+}
+
+variable "email" {
+}
+
+variable "boskos-name" {
+}

--- a/infra/aws/e2e/accounts/tf/modules/account/main.tf
+++ b/infra/aws/e2e/accounts/tf/modules/account/main.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  version             = "~> 2.0"
+  region              = "us-east-1"
+  allowed_account_ids = ["768319786644"] # Create in the main CNCF account
+}
+
+resource "aws_organizations_account" "main" {
+  name  = var.id
+  email = var.email
+}
+
+

--- a/infra/aws/e2e/accounts/tf/modules/account/outputs.tf
+++ b/infra/aws/e2e/accounts/tf/modules/account/outputs.tf
@@ -1,0 +1,3 @@
+output "orgid" {
+  value = aws_organizations_account.main.id
+}

--- a/infra/aws/e2e/accounts/tf/modules/account/variables.tf
+++ b/infra/aws/e2e/accounts/tf/modules/account/variables.tf
@@ -1,0 +1,5 @@
+variable "id" {
+}
+
+variable "email" {
+}

--- a/infra/aws/e2e/accounts/tf/modules/user/main.tf
+++ b/infra/aws/e2e/accounts/tf/modules/user/main.tf
@@ -1,0 +1,45 @@
+provider "aws" {
+  version = "~> 2.0"
+  region  = "us-east-1"
+  assume_role {
+    role_arn = "arn:aws:iam::${var.orgid}:role/OrganizationAccountAccessRole"
+  }
+}
+
+resource "aws_iam_user" "main" {
+  name = var.id
+
+  tags = {
+  }
+}
+
+
+resource "aws_iam_access_key" "main" {
+  user = aws_iam_user.main.name
+  # TODO: encrypt with pgp_key?
+}
+
+
+# Grant permissions needed by CAPA / Test Accounts
+# TODO: More precise permissions?
+
+resource "aws_iam_user_policy_attachment" "main-ec2" {
+  user       = aws_iam_user.main.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2FullAccess"
+}
+
+resource "aws_iam_user_policy_attachment" "main-iam" {
+  user       = aws_iam_user.main.name
+  policy_arn = "arn:aws:iam::aws:policy/IAMFullAccess"
+}
+
+resource "aws_iam_user_policy_attachment" "main-cloudformation" {
+  user       = aws_iam_user.main.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSDeepRacerCloudFormationAccessPolicy"
+}
+
+# Per https://github.com/kubernetes/k8s.io/issues/984
+resource "aws_iam_user_policy_attachment" "main-ssm" {
+  user       = aws_iam_user.main.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMFullAccess"
+}

--- a/infra/aws/e2e/accounts/tf/modules/user/outputs.tf
+++ b/infra/aws/e2e/accounts/tf/modules/user/outputs.tf
@@ -1,0 +1,7 @@
+output "aws_access_key_id" {
+  value = aws_iam_access_key.main.id
+}
+
+output "aws_secret_access_key" {
+  value = aws_iam_access_key.main.secret
+}

--- a/infra/aws/e2e/accounts/tf/modules/user/variables.tf
+++ b/infra/aws/e2e/accounts/tf/modules/user/variables.tf
@@ -1,0 +1,5 @@
+variable "id" {
+}
+
+variable "orgid" {
+}

--- a/infra/aws/e2e/accounts/tf/tf-apply
+++ b/infra/aws/e2e/accounts/tf/tf-apply
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+KEY=$(cat gcs-encryption-key)
+
+terraform init -backend-config="encryption_key=${KEY}"
+
+terraform apply
+
+# To view the encrypted state file
+#gsutil -o "GSUtil:decryption_key1=${KEY}" cat gs://k8s-infra-clusters-terraform/aws/accounts/default.tfstate
+
+find boskos/ -name "*.yaml" | sort | xargs cat > boskos/joined
+gsutil -o "GSUtil:encryption_key=${KEY}" cp boskos/joined gs://k8s-infra-clusters-terraform/aws/k8s/accounts-boskos.yaml


### PR DESCRIPTION
This brings them under declarative management.  We use a date to
enable rotation of old accounts, as these are limited.  Pre-created 14
accounts, next step is to get these into boskos.

A lot of workarounds for terraform shortcomings, hence the slightly
odd structure.