### PR TITLE
Add staging project to publish k-sigs/seccomp-operator images

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -1581,3 +1581,14 @@ groups:
       - wfender@google.com
       - mattcary@google.com
       - saikatroyc@google.com
+
+  - email-id: k8s-staging-seccomp-operator@kubernetes.io
+    name: k8s-staging-seccomp-operator
+    description: |-
+      ACL for seccomp operator artifacts
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - georgedanielmangum@gmail.com
+      - pjbgf@linux.com
+      - saschagrunert@gmail.com

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -84,6 +84,7 @@ STAGING_PROJECTS=(
     provider-azure
     publishing-bot
     releng
+    seccomp-operator
     scl-image-builder
     service-apis
     slack-infra

--- a/k8s.gcr.io/images/k8s-staging-seccomp-operator/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-seccomp-operator/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - hasheddan
+  - pjbgf
+  - saschagrunert

--- a/k8s.gcr.io/manifests/k8s-staging-seccomp-operator/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-seccomp-operator/promoter-manifest.yaml
@@ -1,0 +1,11 @@
+# google group for gcr.io/k8s-staging-seccomp-operator is
+# k8s-staging-seccomp-operator@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-seccomp-operator
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/seccomp-operator
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/seccomp-operator
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/seccomp-operator
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
This allows us to publish to push built images into gcr.io via Google
Cloud Build.

Required by https://github.com/kubernetes/k8s.io/pull/1017