### PR TITLE
Upgrade triage-party to 1.2.0

### DIFF
--- a/triage-party/release-team/deployment.yaml
+++ b/triage-party/release-team/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: triage-party
-          image: triageparty/triage-party:1.1.0
+          image: triageparty/triage-party:1.2.0
           env:
             - name: GITHUB_TOKEN
               valueFrom:
@@ -27,6 +27,15 @@ spec:
               value: "disk"
             - name: PERSIST_PATH
               value: "/app/triage-party/cache"
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: 8080
+              scheme: HTTP
+            timeout: 5
           resources:
             limits:
               cpu: 1

--- a/triage-party/release-team/service.yaml
+++ b/triage-party/release-team/service.yaml
@@ -7,7 +7,7 @@ spec:
   type: NodePort
   ports:
     - port: 8080
-      nodePort: 32080
       protocol: TCP
+      targetPort: 8080
   selector:
     app: triage-party


### PR DESCRIPTION
New endpoints `health` and `healthz` were implemented to solve the issue
face with GKE ingress controller.

Changelog: https://github.com/google/triage-party/blob/master/CHANGELOG.md#version-120---2020-07-14.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>