### PR TITLE
DNS Entry and TLS certificate for triage-party.

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -179,6 +179,10 @@ pr:
 pr-test:
   type: CNAME
   value: redirect.k8s.io.
+#sig-release
+release.triage:
+  type: A
+  value: 35.186.239.70
 # Running in a GKE cluster somewhere (@ixdy).
 prow:
   type: A

--- a/dns/zone-configs/kubernetes.io._0_base.yaml
+++ b/dns/zone-configs/kubernetes.io._0_base.yaml
@@ -150,6 +150,9 @@ prow:
 prs:
   type: CNAME
   value: prs.k8s.io.
+release.triage:
+  type: CNAME
+  value: release.triage.k8s.io.
 sigs:
   type: CNAME
   value: sigs.k8s.io.

--- a/triage-party/release-team/certificate.yaml
+++ b/triage-party/release-team/certificate.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: release-triage-k8s-io
+  namespace: triageparty-release
+  annotations:
+    acme.cert-manager.io/http01-override-ingress-name: "triage-party-release"
+    cert-manager.io/issue-temporary-certificate: "true"
+spec:
+  secretName: release-triage-k8s-io-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-prod
+  dnsNames:
+    - release.triage.k8s.io

--- a/triage-party/release-team/ingress.yaml
+++ b/triage-party/release-team/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: triage-party-release


### PR DESCRIPTION
Add DNS entry for triage-party
Add TLS certificate created by cert-manager
Switch the `apiVersion` of ingress allowed by current RBAC [role](https://github.com/kubernetes/k8s.io/blob/master/infra/gcp/namespaces/namespace-user-role.yml#L20-L21).

Closes #1023 

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>