### PR TITLE
Grant kubernetes-release-test GCB GCR admin on k8s-staging-kubernetes

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -1161,9 +1161,6 @@ groups:
     members:
       - k8s-infra-release-admins@kubernetes.io
       - k8s-infra-release-editors@kubernetes.io
-      # This is the old kubernetes-release-test project. We need it until all
-      # the transitions to community ownership are done for release process.
-      - 648026197307@cloudbuild.gserviceaccount.com
 
   - email-id: k8s-infra-staging-kube-state-metrics@kubernetes.io
     name: k8s-infra-staging-kube-state-metrics

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -227,6 +227,17 @@ for repo in "${RELEASE_STAGING_PROJECTS[@]}"; do
         color 6 "Empowering ${RELEASE_VIEWERS} as project viewers in ${PROJECT}"
         empower_group_as_viewer "${PROJECT}" "${RELEASE_VIEWERS}"
 
+        # Grant the kubernete-release-test (old staging) GCB service account
+        # admin GCR access to the new staging project for Kubernetes releases.
+        # This is required for VDF as we need to continue running
+        # stages/releases from the old project while publishing container
+        # images to new project.
+        #
+        # ref: https://github.com/kubernetes/release/pull/1230
+        if [[ "${PROJECT}" == "k8s-staging-kubernetes" ]]; then
+            color 6 "Empowering kubernetes-release-test GCB service account to admin GCR"
+            empower_svcacct_to_admin_gcr "648026197307@cloudbuild.gserviceaccount.com" "${PROJECT}"
+        fi
     ) 2>&1 | indent
 done
 


### PR DESCRIPTION
This is required for VDF as we need to continue running stages/releases
from the old project while publishing container images to new project.

Also, we drop membership for that svc acct to the releng-editors group.
It was a previous experiment that didn't actually work (hence this
commit).

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @dims @thockin @listx 
cc: @kubernetes/release-engineering 

ref: https://github.com/kubernetes/release/pull/1230, https://github.com/kubernetes/release/issues/270, https://github.com/kubernetes/release/issues/911

Example failure: https://console.cloud.google.com/cloud-build/builds/e7beb8a7-f06b-4db9-aff5-00de05757dfb;step=2?project=kubernetes-release-test

```console
================================================================================
CHECK PREREQUISITES  (1/6)
================================================================================

Checking required system packages: OK
Checking required PIP packages: OK
Skipping security_layer::auth_check...
Checking Docker version: OK
Verifying Docker CLI Experimental status: OK
Checking write access to registry gcr.io/k8s-staging-kubernetes: FAILED
[2020-Jul-18 22:56:02 UTC] check_prerequisites in 5s
FAILED in check_prerequisites.

RELEASE INCOMPLETE! Exiting...


anago: DONE main on 9002e5d1184f Sat Jul 18 22:56:02 UTC 2020 in 5s
```