### PR TITLE
add generator script for image promotion

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-csi-secrets-store/generate.sh
+++ b/k8s.gcr.io/images/k8s-staging-csi-secrets-store/generate.sh
@@ -1,0 +1,11 @@
+#! /bin/sh
+
+repos="
+driver
+"
+
+for repo in $repos; do
+    echo "- name: $repo"
+    echo "  dmap:"
+    gcloud container images list-tags gcr.io/k8s-staging-csi-secrets-store/$repo --format='get(digest, tags)' --filter='tags~^v AND NOT tags~-amd64 AND NOT tags~v0.0.11' | sed -e 's/\([^ ]*\)\t\(.*\)/    "\1": [ "\2" ]/'
+done


### PR DESCRIPTION
Can be used to generate the promoter manifests for release

```yaml
- name: driver
  dmap:
    "sha256:384a5e90b409c16186a26152728ec265ed4dd15eae9d7e518962226aa2886b2b": [ "v0.0.12" ]
```