### PR TITLE
k8s.gcr.io/images/k8s-staging-kube-state-metrics/: Add OWNERS file

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-kube-state-metrics/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-kube-state-metrics/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- brancz
+- lilic
+- tariq1890


### PR DESCRIPTION
We won't add a promotion image yet, only on next release.

cc @brancz @tariq1890 