### PR TITLE
Complete config for scl-image-builder gcr staging

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-scl-image-builder/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-scl-image-builder/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# https://github.com/kubernetes/community/blob/master/OWNERS_ALIASES.
+approvers:
+- CecileRobertMichon
+- codenrhoden
+- detiber
+- moshloop
+
+reviewers:
+- justinsb

--- a/k8s.gcr.io/images/k8s-staging-scl-image-builder/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-scl-image-builder/images.yaml
@@ -1,0 +1,1 @@
+# No images yet

--- a/k8s.gcr.io/manifests/k8s-staging-scl-image-builder/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-scl-image-builder/promoter-manifest.yaml
@@ -1,0 +1,10 @@
+# google group for gcr.io/k8s-staging-scl-image-builder is k8s-infra-staging-scl-image-builder@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-scl-image-builder
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/scl-image-builder
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/scl-image-builder
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/scl-image-builder
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
Entries for "scl-image-builder" were added to `groups.yaml` and
`ensure-staging-storage.sh` 5+ months ago, but the configuration was never
completed and the Google Group was never created. This PR completes the
config according to the latest documentation. Afterwards, the Google
Group can be created and the gcr.io repo can start to be used.

/cc @dims @CecileRobertMichon @detiber 