### PR TITLE
Add new associate PSC members to the distributors-announce group

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -143,7 +143,9 @@ groups:
       - tallclair@google.com
     members:
       # Associate PSC members
+      - alextc@google.com
       - mok@vmware.com
+      - sfowler@redhat.com
       # Distributors
       - argoprod@us.ibm.com
       - aws-k8s-embargo-notification@amazon.com


### PR DESCRIPTION
We have recently added two new associate members of the PSC who should be
subscribed to the distributors-announce list

See https://github.com/kubernetes/security/pull/104 and https://github.com/kubernetes/security/pull/85