### PR TITLE
Add 40 more e2e projects

### DIFF
--- a/infra/gcp/ensure-e2e-projects.sh
+++ b/infra/gcp/ensure-e2e-projects.sh
@@ -76,7 +76,7 @@ E2E_MANUAL_PROJECTS=(
 
 # general purpose e2e projects, no quota changes
 E2E_BOSKOS_PROJECTS=()
-for i in $(seq 1 40); do
+for i in $(seq 1 80); do
   E2E_BOSKOS_PROJECTS+=($(printf "k8s-infra-e2e-boskos-%03i" $i))
 done
 


### PR DESCRIPTION
This isn't enough to fully meet the forecast load of
kubernetes/kubernetes presubmits, but it's enough to start provisioning
away from k8s-infra-gce-project

ref: https://github.com/kubernetes/k8s.io/issues/1078