### PR TITLE
sig-release: List cleanup + Prow view access

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -642,7 +642,6 @@ groups:
       - jeremy.r.rickard@gmail.com
       - killen.bob@gmail.com
       - linusa@google.com
-      - marky.r.jackson@gmail.com
       - mudrinic.mare@gmail.com
       - onlydole@gmail.com
       - sethpmccombs@gmail.com
@@ -1455,7 +1454,6 @@ groups:
       - amwat@google.com
       - bentheelder@google.com
       - ctadeu@gmail.com
-      - daminisatya@gmail.com
       - dmaceachern@vmware.com
       - feiskyer@gmail.com
       - georgedanielmangum@gmail.com
@@ -1467,7 +1465,6 @@ groups:
       - jeremy.r.rickard@gmail.com
       - killen.bob@gmail.com
       - linusa@google.com
-      - marky.r.jackson@gmail.com
       - mudrinic.mare@gmail.com
       - onlydole@gmail.com
       - release-managers-private@kubernetes.io

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -410,7 +410,6 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
-      - k8s-infra-release-admins@kubernetes.io
       - k8s-infra-release-editors@kubernetes.io
       - brucema19901024@gmail.com
       - bryan@weave.works
@@ -428,7 +427,6 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
-      - k8s-infra-release-admins@kubernetes.io
       - k8s-infra-release-editors@kubernetes.io
       - dawnchen@google.com
       - decarr@redhat.com
@@ -619,7 +617,7 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
-      - alarcj137@gmail.com
+      - k8s-infra-release-admins@kubernetes.io
       - ctadeu@gmail.com
       - dmaceachern@vmware.com
       - feiskyer@gmail.com
@@ -638,16 +636,8 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
-      - alarcj137@gmail.com
-      - saschagrunert@gmail.com
-      - stephen.k8s@agst.us
-      - tpepper@gmail.com
-      - ctadeu@gmail.com
-      - dmaceachern@vmware.com
-      - feiskyer@gmail.com
+      - k8s-infra-release-editors@kubernetes.io
       - gveronicalg@gmail.com
-      - hhorl@pivotal.io
-      - idealhack@gmail.com
       - jameswangel@gmail.com
       - jeremy.r.rickard@gmail.com
       - killen.bob@gmail.com
@@ -1180,7 +1170,6 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
-      - k8s-infra-release-admins@kubernetes.io
       - k8s-infra-release-editors@kubernetes.io
 
   - email-id: k8s-infra-staging-kube-state-metrics@kubernetes.io
@@ -1282,7 +1271,6 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
-      - k8s-infra-release-admins@kubernetes.io
       - k8s-infra-release-editors@kubernetes.io
 
   - email-id: k8s-infra-staging-scl-image-builder@kubernetes.io

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -794,6 +794,7 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
+      - k8s-infra-release-editors@kubernetes.io
       - bentheelder@google.com
       - cblecker@gmail.com
       - davanum@gmail.com

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -1464,14 +1464,11 @@ groups:
       - jameswangel@gmail.com
       - jeremy.r.rickard@gmail.com
       - killen.bob@gmail.com
-      - linusa@google.com
       - mudrinic.mare@gmail.com
       - onlydole@gmail.com
       - release-managers-private@kubernetes.io
       - sethpmccombs@gmail.com
-      - simony@google.com
       - spiffxp@google.com
-      - sumitranr@google.com
 
   - email-id: security@kubernetes.io
     name: security

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -96,6 +96,7 @@ groups:
       - phil.wittrock@gmail.com
       - quinton@hoole.biz
       - saadali@google.com
+      - saschagrunert@gmail.com
       - saugustus@vmware.com
       - seans@google.com
       - stephen.k8s@agst.us
@@ -605,7 +606,8 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
-      - caselim@gmail.com
+      - alarcj137@gmail.com
+      - saschagrunert@gmail.com
       - stephen.k8s@agst.us
       - tpepper@gmail.com
 
@@ -617,7 +619,7 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
-      - caselim@gmail.com
+      - alarcj137@gmail.com
       - ctadeu@gmail.com
       - dmaceachern@vmware.com
       - feiskyer@gmail.com
@@ -636,7 +638,8 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
-      - caselim@gmail.com
+      - alarcj137@gmail.com
+      - saschagrunert@gmail.com
       - stephen.k8s@agst.us
       - tpepper@gmail.com
       - ctadeu@gmail.com
@@ -653,7 +656,6 @@ groups:
       - mudrinic.mare@gmail.com
       - onlydole@gmail.com
       - sethpmccombs@gmail.com
-      - saschagrunert@gmail.com
       - simony@google.com
       - sumitranr@google.com
 
@@ -1407,7 +1409,8 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
-      - cmiles@pivotal.io
+      - alarcj137@gmail.com
+      - saschagrunert@gmail.com
       - stephen.k8s@agst.us
       - tpepper@vmware.com
     members:
@@ -1430,7 +1433,8 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
-      - cmiles@pivotal.io
+      - alarcj137@gmail.com
+      - saschagrunert@gmail.com
       - stephen.k8s@agst.us
       - tpepper@vmware.com
     members:
@@ -1440,7 +1444,6 @@ groups:
       - georgedanielmangum@gmail.com
       - hhorl@pivotal.io
       - idealhack@gmail.com
-      - saschagrunert@gmail.com
       - saugustus@vmware.com
       - tpepper@gmail.com
 
@@ -1454,8 +1457,8 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
-      - caselim@gmail.com
-      - cmiles@pivotal.io
+      - alarcj137@gmail.com
+      - saschagrunert@gmail.com
       - saugustus@vmware.com
       - stephen.k8s@agst.us
       - tpepper@gmail.com
@@ -1481,7 +1484,6 @@ groups:
       - onlydole@gmail.com
       - release-managers-private@kubernetes.io
       - sethpmccombs@gmail.com
-      - saschagrunert@gmail.com
       - simony@google.com
       - spiffxp@google.com
       - sumitranr@google.com

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -675,6 +675,7 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
+      - k8s-infra-release-viewers@kubernetes.io
       - ameukam@gmail.com
       - bartek@smykla.com
       - georgedanielmangum@gmail.com


### PR DESCRIPTION
- Reconcile SIG Release Chair/TL list membership
- Full nesting of RelEng IAM groups
  - Nest -admins group in -editors group
  - Nest -editors group in -viewers group
  - Drop explicit membership for anyone already in a higher-privileged,
    already-nested group, unless they hold the target role for that group

    Example: A RelEng subproject owner should only need to be in the
                   -admins group, unless they are also a Release Manager.
  
  - Remove -admins from other non-release IAM groups, since their
    membership will already be covered by the -editors group
- Remove Marky and Damini from RelEng groups

  Marky has stepped down as a Release Manager Associate.
  Damini was a former RT Lead Shadow and no longer requires access.
- Remove former Google Build Admins from RelEng groups
- Grant Release Managers access to use build-image project
- Grant Release Managers access to inspect Prow

/assign @spiffxp @dims @cblecker 
/cc @tpepper @alejandrox1 @saschagrunert 
cc: @kubernetes/sig-release 

@kubernetes/ci-signal -- Please PR yourself into the Prow viewers group once this PR has merged.