### PR TITLE
Fix boskos gce-project deployment

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-janitor.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-janitor.yaml
@@ -22,7 +22,7 @@ spec:
         image: gcr.io/k8s-prow/boskos/janitor:v20200422-8c8546d74
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
-        - --resource-type=k8s-infra-gce-project,scalability-project
+        - --resource-type=gce-project,k8s-infra-gce-project,scalability-project
         - --pool-size=20
         - --
         - --hours=0

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-reaper-deployment.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-reaper-deployment.yaml
@@ -21,4 +21,4 @@ spec:
         image: gcr.io/k8s-prow/boskos/reaper:v20200422-8c8546d74
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
-        - --resource-type=k8s-infra-gce-project,scalability-project
+        - --resource-type=gce-project,k8s-infra-gce-project,scalability-project

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-resources-configmap.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-resources-configmap.yaml
@@ -99,4 +99,5 @@ data:
 kind: ConfigMap
 metadata:
   creationTimestamp: null
-  name: boskos-resources.yaml
+  name: resources
+  namespace: test-pods


### PR DESCRIPTION
The configmap should be named resources, not boskos-configmap.yaml. Little too fast with kubectl today

The gce-project pool needs to be explicitly referenced by boskos components or it would be appropriately managed

fix/followup to https://github.com/kubernetes/k8s.io/pull/1083

ref: https://github.com/kubernetes/k8s.io/issues/1078