### PR TITLE
Merge k8s-infra-gce-project pool into gce-project pool

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-resources-configmap.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-resources-configmap.yaml
@@ -43,9 +43,6 @@ data:
       - k8s-infra-e2e-boskos-038
       - k8s-infra-e2e-boskos-039
       - k8s-infra-e2e-boskos-040
-      state: dirty
-      type: k8s-infra-gce-project
-    - names:
       - k8s-infra-e2e-boskos-041
       - k8s-infra-e2e-boskos-042
       - k8s-infra-e2e-boskos-043


### PR DESCRIPTION
Instead of 2 40 project pools, we'll now have one 80 project pool

ref: https://github.com/kubernetes/test-infra/issues/18552#issuecomment-667213622