### PR TITLE
Add manual gpu-project and ingress-project

### DIFF
--- a/infra/gcp/ensure-e2e-projects.sh
+++ b/infra/gcp/ensure-e2e-projects.sh
@@ -66,12 +66,16 @@ ensure_regional_address \
 ## setup projects to be used by e2e tests for standing up clusters
 
 E2E_MANUAL_PROJECTS=(
-  # for manual use during node-e2e job migration, eg: --gcp-project=k8s-infra-e2e-gce-project
+  # for manual use during node-e2e job migration, eg: --gcp-project=gce-project
   k8s-infra-e2e-gce-project
-  # for manual use during job migration, eg: --gcp-project=k8s-infra-e2e-node-e2e-project
+  # for manual use during job migration, eg: --gcp-project=node-e2e-project
   k8s-infra-e2e-node-e2e-project
-  # for manual use during job migration, eg: --gcp-projec=k8s-infra-e2e-scale-project
+  # for manual use during job migration, eg: --gcp-project=scale-project
   k8s-infra-e2e-scale-project
+  # for manual use during job migration, eg: --gcp-project=gpu-project
+  k8s-infra-e2e-gpu-project
+  # for manual use during job migration, eg: --gcp-project=ingress-project
+  k8s-infra-e2e-ingress-project
 )
 
 # general purpose e2e projects, no quota changes


### PR DESCRIPTION
This follows the previous pattern of "create a non-boskos managed
project that contributors could use as humans", and sets the stage for
me to work on figuring out what gpu-project and ingress-project will
need from a quota perspective

part of https://github.com/kubernetes/k8s.io/issues/1093
part of https://github.com/kubernetes/k8s.io/issues/1095