### PR TITLE
Provision 10 gpu GCP projects

### DIFF
--- a/infra/gcp/ensure-e2e-projects.sh
+++ b/infra/gcp/ensure-e2e-projects.sh
@@ -92,10 +92,18 @@ for i in $(seq 1 5); do
   E2E_SCALE_PROJECTS+=($(printf "k8s-infra-e2e-boskos-scale-%02i" $i))
 done
 
+# e2e projects for gpu jobs
+# - us-west1 Committed NVIDIA K80 GPUs raised to 2
+E2E_GPU_PROJECTS=()
+for i in $(seq 1 10); do
+  E2E_GPU_PROJECTS+=($(printf "k8s-infra-e2e-boskos-gpu-%02i" $i))
+done
+
 E2E_PROJECTS=(
   "${E2E_MANUAL_PROJECTS[@]}"
   "${E2E_BOSKOS_PROJECTS[@]}"
   "${E2E_SCALE_PROJECTS[@]}"
+  "${E2E_GPU_PROJECTS[@]}"
 )
 
 if [ $# = 0 ]; then


### PR DESCRIPTION
This is to account for:
- the [~5 projects of peak usage k8s-prow-builds' gpu-project pool currently sees](https://monitoring.prow.k8s.io/d/wSrfvNxWz/boskos-resource-usage?orgId=1&from=now-30d&to=now&fullscreen&panelId=6)
- the [`max_concurrency: 15` pull-kubernetes-e2e-gce-device-plugin-gpu presubmit job](https://github.com/kubernetes/test-infra/blob/f33224993b51b111050b865a83686cc810677c49/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml#L12-L20)  that is all currently pinned to a single gcp project 

The actual raising of quota for these projects is going to need to be done by hand, unfortunately. So before I do this big ugly manual thing, I wanted to make sure I'm not missing something simpler / more obvious.

We could make a single gcp project to hold all of the presubmits, with a much higher gpu quota.  This is equivalent to what is done now.  But I feel like sticking to pools of projects means we're less likely to develop pets instead of cattle.

ref: https://github.com/kubernetes/k8s.io/issues/1095

/hold
for comment