### PR TITLE
Add prow-deployer service account

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/build-serviceaccounts.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/build-serviceaccounts.yaml
@@ -38,3 +38,11 @@ metadata:
     iam.gke.io/gcp-service-account: gsuite-groups-manager@k8s-gsuite.iam.gserviceaccount.com
   name: gsuite-groups-manager
   namespace: test-pods
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: prow-deployer@k8s-infra-prow-build-trusted.iam.gserviceaccount.com
+  name: prow-deployer
+  namespace: test-pods


### PR DESCRIPTION
I would like to be able to run prowjobs in k8s-infra-prow-build-trusted
that auto-deploy cluster resources to prow build clusters.

So I've setup an account named `prow-deployer` and given it
`roles/container.developer` access in the two projects containing prow
build clusters

part of https://github.com/kubernetes/k8s.io/issues/845