### PR TITLE
Add gpu-project to boskos components

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-janitor.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-janitor.yaml
@@ -22,7 +22,7 @@ spec:
         image: gcr.io/k8s-prow/boskos/janitor:v20200422-8c8546d74
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
-        - --resource-type=gce-project,k8s-infra-gce-project,scalability-project
+        - --resource-type=gce-project,gpu-project,scalability-project
         - --pool-size=20
         - --
         - --hours=0

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-reaper-deployment.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-reaper-deployment.yaml
@@ -21,4 +21,4 @@ spec:
         image: gcr.io/k8s-prow/boskos/reaper:v20200422-8c8546d74
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
-        - --resource-type=gce-project,k8s-infra-gce-project,scalability-project
+        - --resource-type=gce-project,gpu-project,scalability-project


### PR DESCRIPTION
The gpu-project pool has been added, but since it defaults to dirty, and
nothing is configured to clean or reap it, boskos alerts are firing