### PR TITLE
Promote cluster-proportional-autoscaler 1.8.3 images

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cpa/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-cpa/images.yaml
@@ -1,18 +1,23 @@
 - name: cluster-proportional-autoscaler
   dmap:
     "sha256:762ef69b7093a8c4c83472aabdf79f4c5eb6743b122b2c06ca740f44cb00ca9d": ["1.8.2"]
+    "sha256:67640771ad9fc56f109d5b01e020f0c858e7c890bb0eb15ba0ebd325df3285e7": ["1.8.3"]
 - name: cluster-proportional-autoscaler-amd64
   dmap:
     "sha256:e310b7e60ed5dabcf9945fb86ee049bafde69b01ac0b9eb647c2b96c273e18d8": ["1.8.2"]
+    "sha256:dce43068853ad396b0fb5ace9a56cc14114e31979e241342d12d04526be1dfcc": ["1.8.3"]
 - name: cluster-proportional-autoscaler-arm
   dmap:
     "sha256:ba9d51870f9a718f91fb2a0df6366da36b2e5484a3331049b226310b5d59993d": ["1.8.2"]
+    "sha256:241ee3c88ee69c0362b1e9f20b288345b42f2a59645c1ea8b7d39fdec221af38": ["1.8.3"]
 - name: cluster-proportional-autoscaler-arm64
   dmap:
     "sha256:549b40bf6c29920f0f023fd97a6a9197f785f15799523c3486456a1bd24c840f": ["1.8.2"]
+    "sha256:a456b304377b79cba3290e9990003040941c0b3da18621a5ed734265287968c5": ["1.8.3"]
 - name: cluster-proportional-autoscaler-ppc64le
   dmap:
     "sha256:a9ba5e939a4f8f0ded4a6b222d01b6922fce231f7977098112d51e409fce81f0": ["1.8.2"]
+    "sha256:ac90f5dc759a917c2c98de81a9b5b77bf426b95e56caebaefcc0f2e01e2b8db9": ["1.8.3"]
 - name: cpvpa-amd64
   dmap:
     "sha256:8341c10f341fc7cacfefa4564088414b4eaef45142d76a83f80891544f18b632": ["v0.8.2"]


### PR DESCRIPTION
We are cutting a new release for cluster-proportional-autoscaler and need to release these images.

- https://pantheon.corp.google.com/gcr/images/k8s-staging-cpa/GLOBAL/cluster-proportional-autoscaler@sha256:67640771ad9fc56f109d5b01e020f0c858e7c890bb0eb15ba0ebd325df3285e7/details?tab=info&project=k8s-staging-cpa&folder&organizationId=758905017065
- https://pantheon.corp.google.com/gcr/images/k8s-staging-cpa/GLOBAL/cluster-proportional-autoscaler-amd64@sha256:dce43068853ad396b0fb5ace9a56cc14114e31979e241342d12d04526be1dfcc/details?tab=info&project=k8s-staging-cpa&folder&organizationId=758905017065
- https://pantheon.corp.google.com/gcr/images/k8s-staging-cpa/GLOBAL/cluster-proportional-autoscaler-arm@sha256:241ee3c88ee69c0362b1e9f20b288345b42f2a59645c1ea8b7d39fdec221af38/details?tab=info&project=k8s-staging-cpa&folder&organizationId=758905017065
- https://pantheon.corp.google.com/gcr/images/k8s-staging-cpa/GLOBAL/cluster-proportional-autoscaler-arm64@sha256:a456b304377b79cba3290e9990003040941c0b3da18621a5ed734265287968c5/details?tab=info&project=k8s-staging-cpa&folder&organizationId=758905017065
- https://pantheon.corp.google.com/gcr/images/k8s-staging-cpa/GLOBAL/cluster-proportional-autoscaler-ppc64le@sha256:ac90f5dc759a917c2c98de81a9b5b77bf426b95e56caebaefcc0f2e01e2b8db9/details?tab=info&project=k8s-staging-cpa&folder&organizationId=758905017065

Ref kubernetes-sigs/cluster-proportional-autoscaler#89.

cc @johngmyers @hakman 