### PR TITLE
create a vuln dashboard svcacct and bucket

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/build-serviceaccounts.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/build-serviceaccounts.yaml
@@ -46,3 +46,12 @@ metadata:
     iam.gke.io/gcp-service-account: prow-deployer@k8s-infra-prow-build-trusted.iam.gserviceaccount.com
   name: prow-deployer
   namespace: test-pods
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: k8s-infra-gcr-vuln-dashboard@kubernetes-public.iam.gserviceaccount.com
+  name: k8s-infra-gcr-vuln-dashboard
+  namespace: test-pods
+---

--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -33,6 +33,9 @@ PROMOTER_SVCACCT="k8s-infra-gcr-promoter"
 # The service account name for the image promoter's vulnerability check.
 PROMOTER_VULN_SCANNING_SVCACCT="k8s-infra-gcr-vuln-scanning"
 
+# The service account name for the k8s vulnerability dashboard.
+VULN_DASHBOARD_SVCACCT = "k8s-infra-gcr-vuln-dashboard"
+
 # The service account name for the GCR auditor (Cloud Run runtime service
 # account).
 AUDITOR_SVCACCT="k8s-infra-gcr-auditor"


### PR DESCRIPTION
In order to create a vulnerability dashboard (talked about in more detail [here](https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/253), we need to set up a gcs bucket to host the vulnerability dashboard's static html page. We also need a vulnerability dashboard service account that can access the Container Analysis Service information for the k8s-artificats-prod project and can write to the new gcs bucket (so it can update the static page). 

In this PR, the gcs bucket created and used is gs://k8s-artifacts-prod-vuln-dashboard. A new service account is created with write access to this gcs bucket and read access to the k8s-artifacts-prod container analysis results.