### PR TITLE
Add support for MembersCanPostAsTheGroup setting

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -182,6 +182,7 @@ groups:
       Kubernetes elections committee
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
+      MembersCanPostAsTheGroup: "true"
       ReconcileMembers: "true"
     owners:
       - ihor@cncf.io

--- a/groups/reconcile.go
+++ b/groups/reconcile.go
@@ -274,6 +274,7 @@ func printGroupMembersAndSettings(srv *admin.Service, srv2 *groupssettings.Servi
 		group.Settings["WhoCanApproveMembers"] = g2.WhoCanApproveMembers
 		group.Settings["WhoCanModifyMembers"] = g2.WhoCanModifyMembers
 		group.Settings["WhoCanModerateMembers"] = g2.WhoCanModerateMembers
+		group.Settings["MembersCanPostAsTheGroup"] = g2.MembersCanPostAsTheGroup
 
 		l, err := srv.Members.List(g.Email).Do()
 		if err != nil {
@@ -439,6 +440,7 @@ func updateGroupSettings(srv *groupssettings.Service, groupEmailId string, group
 	wantSettings.WhoCanModerateContent = "OWNERS_AND_MANAGERS"
 	wantSettings.WhoCanPostMessage = "ALL_MEMBERS_CAN_POST"
 	wantSettings.MessageModerationLevel = "MODERATE_NONE"
+	wantSettings.MembersCanPostAsTheGroup = "false"
 
 	for key, value := range groupSettings {
 		switch key {
@@ -458,6 +460,8 @@ func updateGroupSettings(srv *groupssettings.Service, groupEmailId string, group
 			wantSettings.WhoCanPostMessage = value
 		case "MessageModerationLevel":
 			wantSettings.MessageModerationLevel = value
+		case "MembersCanPostAsTheGroup":
+			wantSettings.MembersCanPostAsTheGroup = value
 		}
 	}
 

--- a/groups/sig-contributor-experience/groups.yaml
+++ b/groups/sig-contributor-experience/groups.yaml
@@ -5,6 +5,7 @@ groups:
 
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
+      MembersCanPostAsTheGroup: "true"
       ReconcileMembers: "true"
     owners:
       - ihor@cncf.io


### PR DESCRIPTION
This will allow elections@ and community@ to send e-mail as the group itself