### PR TITLE
code of conduct committee update

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -149,10 +149,10 @@ aliases:
     - phenixblue
   committee-code-of-conduct:
     - AevaOnline
-    - Bradamant3
-    - carolynvs
-    - jdumars
+    - celestehorgan
+    - karenhchu
     - tashimi
+    - tpepper
   committee-product-security:
     - cjcullen
     - cji


### PR DESCRIPTION
Rotating out our emeriti members and adding the 2020 elected members.

Signed-off-by: Tim Pepper <tpepper@vmware.com>