### PR TITLE
Fix DNS records for contrib site

### DIFF
--- a/dns/zone-configs/k8s.dev.yaml
+++ b/dns/zone-configs/k8s.dev.yaml
@@ -10,9 +10,9 @@ canary:
   - ns-cloud-a4.googledomains.com.
 
 '':
-  type: CNAME
-  value: kubernetes-contributor.netlify.app.
+  type: A
+  value: 104.198.14.52
 
 www:
   type: CNAME
-  value: k8s.dev.
+  value: kubernetes-contributor.netlify.app.

--- a/dns/zone-configs/kubernetes.dev.yaml
+++ b/dns/zone-configs/kubernetes.dev.yaml
@@ -10,9 +10,9 @@ canary:
   - ns-cloud-b4.googledomains.com.
 
 '':
-  type: CNAME
-  value: kubernetes-contributor.netlify.app.
+  type: A
+  value: 104.198.14.52
 
 www:
   type: CNAME
-  value: kubernetes.dev.
+  value: kubernetes-contributor.netlify.app.


### PR DESCRIPTION
Root level CNAME (CNAME flattening) is not supported.

The A record value was provided by netlify's documentation as an alternative.

/assign @cblecker 