### PR TITLE
Enable serviceusage api in cluster projects

### DIFF
--- a/infra/gcp/clusters/modules/gke-project/main.tf
+++ b/infra/gcp/clusters/modules/gke-project/main.tf
@@ -73,6 +73,11 @@ resource "google_project_service" "secretmanager" {
   service = "secretmanager.googleapis.com"
   disable_dependent_services = true
 }
+resource "google_project_service" "serviceusage" {
+  project = google_project.project.project_id
+  service = "serviceusage.googleapis.com"
+  disable_dependent_services = true
+}
 
 
 // "Empower cluster admins" is what ensure-main-project.sh says


### PR DESCRIPTION
This is primarily for boskos' janitor's benefit, so I could see the
case being made that this should be done only for the one project
that is running boskos

This is ostensibly to allow a service account in project A to call
`gcloud services list --project=project-B`

Followup to https://github.com/kubernetes/k8s.io/pull/1160
ref: https://github.com/kubernetes/test-infra/issues/18897