### PR TITLE
rename npd image name to node-problem-detector

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-npd/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-npd/images.yaml
@@ -1,3 +1,3 @@
-- name: npd
+- name: node-problem-detector
   dmap:
     "sha256:9343960c22c6033903413d032bdd6b903e34ff69862913aca31f3008a5800c51": ["0.8.3"]


### PR DESCRIPTION
According to the page https://console.cloud.google.com/gcr/images/k8s-staging-npd/GLOBAL/node-problem-detector?project=k8s-staging-npd&gcrImageListsize=30, the container name for npd should be `node-problem-detector`.

/cc @Random-Liu @wangzhen127