### PR TITLE
Add n1-highmem-16 nodepool to k8s-infra-prow-build

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
@@ -127,6 +127,26 @@ module "prow_build_nodepool" {
   service_account = module.prow_build_cluster.cluster_node_sa.email
 }
 
+module "prow_build_nodepool_n1_highmem_16" {
+  source = "../../../modules/gke-nodepool"
+  project_name    = local.project_id
+  cluster_name    = module.prow_build_cluster.cluster.name
+  location        = module.prow_build_cluster.cluster.location
+  name            = "pool2"
+  initial_count   = 1
+  min_count       = 1
+  max_count       = 30
+  # kind-ipv6 jobs need an ipv6 stack; COS doesn't provide one, so we need to
+  # use an UBUNTU image instead. Why the CONTAINERD variant? I don't know, but
+  # it's what k8s-prow-builds/prow (prow.k8s.io's existing google.com build 
+  # cluster) is using today, so we're just going to follow that
+  image_type      = "UBUNTU_CONTAINERD"
+  machine_type    = "n1-highmem-16"
+  disk_size_gb    = 250
+  disk_type       = "pd-ssd"
+  service_account = module.prow_build_cluster.cluster_node_sa.email
+}
+
 module "greenhouse_nodepool" {
   source = "../../../modules/gke-nodepool"
   project_name    = local.project_id


### PR DESCRIPTION
The intent is to cordon off the n1-highmem-8 nodepool, and shift jobs to 
 this node pool.

 We're doing this to mitigate the fact that the cluster is configured to use
 an external IP for each new node, and we don't have enough IP quota to
 scale as large as PR traffic is requiring us to

This is one of the suggested workarounds from https://github.com/kubernetes/k8s.io/issues/1132#issuecomment-678389503