### PR TITLE
Add an n1_highmem_8 nodepool to k8s-infra-prow-build to prep for migration

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
@@ -126,6 +126,25 @@ module "prow_build_nodepool_n1_highmem_16" {
   service_account = module.prow_build_cluster.cluster_node_sa.email
 }
 
+module "prow_build_nodepool_n1_highmem_8" {
+  source = "../../../modules/gke-nodepool"
+  project_name    = local.project_id
+  cluster_name    = module.prow_build_cluster.cluster.name
+  location        = module.prow_build_cluster.cluster.location
+  name            = "pool3"
+  initial_count   = 1
+  min_count       = 1
+  max_count       = 30
+  # kind-ipv6 jobs need an ipv6 stack; COS doesn't provide one, so we need to
+  # use an UBUNTU image instead. Keep parity with the existing google.com 
+  # k8s-prow-builds/prow cluster by using the CONTAINERD variant
+  image_type      = "UBUNTU_CONTAINERD"
+  machine_type    = "n1-highmem-16"
+  disk_size_gb    = 250
+  disk_type       = "pd-ssd"
+  service_account = module.prow_build_cluster.cluster_node_sa.email
+}
+
 module "greenhouse_nodepool" {
   source = "../../../modules/gke-nodepool"
   project_name    = local.project_id


### PR DESCRIPTION
There is a suspicion that switching to n1-highmem-16 nodes has caused more jobs-per-node to be scheduled, thus leading to more contention over resources that aren't accounted for by the scheduler (such as IOPS)

This PR is the first step in undoing that change, by moving us back to n1-highmem-8's.

I am concerned that moving back to more, smaller nodes will cause us to hit our quota of IP's, and we'll have to shift jobs off of this cluster until we can find some other way to mitigate (ref: https://github.com/kubernetes/k8s.io/issues/1132#issuecomment-678389503)