### PR TITLE
Remove n1-highmem-16 pool from k8s-infra-prow-build

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
@@ -107,25 +107,6 @@ module "prow_build_cluster" {
   is_prod_cluster   = "true"
 }
 
-module "prow_build_nodepool_n1_highmem_16" {
-  source = "../../../modules/gke-nodepool"
-  project_name    = local.project_id
-  cluster_name    = module.prow_build_cluster.cluster.name
-  location        = module.prow_build_cluster.cluster.location
-  name            = "pool2"
-  initial_count   = 1
-  min_count       = 1
-  max_count       = 30
-  # kind-ipv6 jobs need an ipv6 stack; COS doesn't provide one, so we need to
-  # use an UBUNTU image instead. Keep parity with the existing google.com 
-  # k8s-prow-builds/prow cluster by using the CONTAINERD variant
-  image_type      = "UBUNTU_CONTAINERD"
-  machine_type    = "n1-highmem-16"
-  disk_size_gb    = 250
-  disk_type       = "pd-ssd"
-  service_account = module.prow_build_cluster.cluster_node_sa.email
-}
-
 module "prow_build_nodepool_n1_highmem_8" {
   source = "../../../modules/gke-nodepool"
   project_name    = local.project_id


### PR DESCRIPTION
Part of https://github.com/kubernetes/k8s.io/issues/1173
Followup to https://github.com/kubernetes/k8s.io/pull/1172