### PR TITLE
Promote etcd 3.4.13-0 images

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-etcd/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-etcd/images.yaml
@@ -2,6 +2,7 @@
   dmap:
     "sha256:bcdd5657b1edc1a2eb27356f33dd66b9400d4a084209c33461c7a7da0a32ebb3": ["3.4.7-2"]
     "sha256:83c3e1f35b641e0cda53345f476c4c028fba697073bebafbaef19bcc1a9ce595": ["3.4.9-0"]
+    "sha256:4ad90a11b55313b182afc186b9876c8e891531b8db4c9bf1541953021618d0e2": ["3.4.13-0"]
 - name: etcd-empty-dir-cleanup
   dmap:
     "sha256:f805272b4422efa92e20789295c343ed26ff36ddc4f70eeb5d7890d6b758b0fc": ["3.4.7.0"]


### PR DESCRIPTION
Related: https://github.com/kubernetes/kubernetes/issues/94141

Images built by:
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-kubernetes-push-image-etcd/1298979413844561923

From the build log:
```
Created manifest list gcr.io/k8s-staging-etcd/etcd:3.4.13-0
docker manifest push --purge gcr.io/k8s-staging-etcd/etcd:3.4.13-0
Pushed ref gcr.io/k8s-staging-etcd/etcd@sha256:bd4d2c9a19be8a492bc79df53eee199fd04b415e9993eb69f7718052602a147a with digest: sha256:bd4d2c9a19be8a492bc79df53eee199fd04b415e9993eb69f7718052602a147a
Pushed ref gcr.io/k8s-staging-etcd/etcd@sha256:4cadaf5f37998d038861c66215809eee8316c7604934e03dd86015a0f6704cd3 with digest: sha256:4cadaf5f37998d038861c66215809eee8316c7604934e03dd86015a0f6704cd3
Pushed ref gcr.io/k8s-staging-etcd/etcd@sha256:cab4dc43598ed9b5c6a524dfea1abf4772a5e164c330451e5ca2635a95675aa8 with digest: sha256:cab4dc43598ed9b5c6a524dfea1abf4772a5e164c330451e5ca2635a95675aa8
Pushed ref gcr.io/k8s-staging-etcd/etcd@sha256:03d9db03b83a5991ede76dd53e19a1e46e6bf3c498ae8ace2e1be8f3d1d03ad6 with digest: sha256:03d9db03b83a5991ede76dd53e19a1e46e6bf3c498ae8ace2e1be8f3d1d03ad6
Pushed ref gcr.io/k8s-staging-etcd/etcd@sha256:dd9baad37b716232a737cd781cf65ceb9f7c541264cdde9ad3870d84e8644a49 with digest: sha256:dd9baad37b716232a737cd781cf65ceb9f7c541264cdde9ad3870d84e8644a49
sha256:4ad90a11b55313b182afc186b9876c8e891531b8db4c9bf1541953021618d0e2
```

cc @kubernetes/release-engineering @neolit123 @justaugustus @saschagrunert @BenTheElder @wojtek-t @wenjiaswe