### PR TITLE
Add repository for Nvidia GPU device plugin

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -1169,6 +1169,16 @@ groups:
       - lantaol@google.com
       - patrik@ptrk.io
       - zhenw@google.com
+  
+  - email-id: k8s-infra-staging-nvidia-gpu@kubernetes.io
+    name: k8s-infra-staging-nvidia-gpu
+    description: |-
+      ACL for Nvidia GPU device plugin
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - pradvenkat@google.com
+      - ruiwen@google.com
 
   - email-id: k8s-infra-staging-provider-azure@kubernetes.io
     name: k8s-infra-staging-provider-azure

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -84,6 +84,7 @@ STAGING_PROJECTS=(
     multitenancy
     nfd
     npd
+    nvidia-gpu
     provider-azure
     publishing-bot
     releng

--- a/k8s.gcr.io/images/k8s-staging-nvidia-gpu/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-nvidia-gpu/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- pradvenkat
+- ruiwen-zhao

--- a/k8s.gcr.io/images/k8s-staging-nvidia-gpu/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-nvidia-gpu/images.yaml
@@ -1,0 +1,1 @@
+# No images yet

--- a/k8s.gcr.io/manifests/k8s-staging-nvidia-gpu/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-nvidia-gpu/promoter-manifest.yaml
@@ -1,0 +1,10 @@
+# google group for gcr.io/k8s-staging-nvidia-gpu is k8s-infra-staging-nvidia-gpu@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-nvidia-gpu
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/nvidia-gpu
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/nvidia-gpu
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/nvidia-gpu
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
Add repository for Nvidia GPU device plugin. This repository will be used for [Kubernetes Device Plugin for NVIDIA GPUs](https://github.com/GoogleCloudPlatform/container-engine-accelerators/blob/master/cmd/nvidia_gpu/README.md), which is used by [addons/device-plugins/nvidia-gpu](https://github.com/kubernetes/kubernetes/blob/32dc42ed34eb5ca97bd8fa4544d9a91d6b05a310/cluster/addons/device-plugins/nvidia-gpu/daemonset.yaml#L39). The previous registry is read only now as part of the [Vanity Domain Flip](https://github.com/kubernetes/k8s.io/blob/master/k8s.gcr.io/Vanity-Domain-Flip.md).