### PR TITLE
Fix typo in ensure-release-projects.sh

### DIFF
--- a/infra/gcp/ensure-release-projects.sh
+++ b/infra/gcp/ensure-release-projects.sh
@@ -147,7 +147,7 @@ RELEASE_BUCKETS=(
 )
 PROW_BUILD_SVCACCT=$(svc_acct_email "k8s-infra-prow-build" "prow-build")
 
-for BUCKET in "${ALL_BUCKETS[@]}"; do
+for BUCKET in "${RELEASE_BUCKETS[@]}"; do
     color 3 "Configuring bucket: ${BUCKET}"
 
     # Create the bucket


### PR DESCRIPTION
Turns out gs://k8s-release-dev didn't have the appropriate world-readable permissions applied, so gcsweb.k8s.io couldn't display its contents

Followup to https://github.com/kubernetes/k8s.io/pull/1110 and https://github.com/kubernetes/k8s.io/pull/1195
Part of https://github.com/kubernetes/k8s.io/issues/846