### PR TITLE
add domain capz.sigs.k8s.io

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -264,6 +264,10 @@ release-0-2.cluster-api.sigs:
 master.cluster-api.sigs:
   type: CNAME
   value: master--kubernetes-sigs-cluster-api.netlify.app.
+# https://github.com/kubernetes-sigs/cluster-api-provider-azure docs (@CecileRobertMichon, @nader-ziada, @devigned)
+capz.sigs:
+  type: CNAME
+  value: kubernetes-sigs-cluster-api-provider-azure.netlify.app.
 # https://github.com/kubernetes/cloud-provider-aws docs (@andrewsykim, @justinsb, @nckturner)
 cloud-provider-aws.sigs:
   type: CNAME


### PR DESCRIPTION
Adds the domain  `cluster-api-provider-azure.k8s.io` for the cluster-api-provider-azure

ref: #1182 

/cc @CecileRobertMichon 