### PR TITLE
use Prow trusted cluster for workload identity

### DIFF
--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -367,7 +367,7 @@ color 6 "Handling special cases"
 
     color 6 "Empowering promoter-scanning namespace to use prod promoter vuln-dashboard svcacct"
     empower_ksa_to_svcacct \
-        "k8s-prow-builds.svc.id.goog[test-pods/k8s-infra-gcr-vuln-dashboard]" \
+        "k8s-prow.svc.id.goog[test-pods/k8s-infra-gcr-vuln-dashboard]" \
         "${PROD_PROJECT}" \
         $(svc_acct_email "${PROD_PROJECT}" "${VULN_DASHBOARD_SVCACCT}")
     empower_ksa_to_svcacct \


### PR DESCRIPTION
This is a typo fix. The "-builds" suffix is for the regular non-trusted Prow
cluster. However, the Prow job that was created [1] is configured for the
trusted cluster -- hence this change.

[1]: https://github.com/kubernetes/test-infra/pull/19003