### PR TITLE
Add scheduler-plugins Staging Registry

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -1198,6 +1198,17 @@ groups:
       - nikitaraghunath@gmail.com
       - stefan.schimanski@gmail.com
 
+  - email-id: k8s-infra-staging-scheduler-plugins@kubernetes.io
+    name: k8s-infra-staging-scheduler-plugins
+    description: |-
+      ACL for staging scheduler-plugins
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - ahg@google.com
+      - hweicdl@gmail.com
+      - wangqingcan1990@gmail.com
+
   - email-id: k8s-infra-staging-scl-image-builder@kubernetes.io
     name: k8s-infra-staging-scl-image-builder
     description: |-

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -87,6 +87,7 @@ STAGING_PROJECTS=(
     provider-azure
     publishing-bot
     releng
+    scheduler-plugins
     seccomp-operator
     scl-image-builder
     service-apis

--- a/k8s.gcr.io/images/k8s-staging-scheduler-plugins/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-scheduler-plugins/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - ahg-g
+  - Huang-Wei
+reviewers:
+  - denkensk

--- a/k8s.gcr.io/images/k8s-staging-scheduler-plugins/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-scheduler-plugins/images.yaml
@@ -1,0 +1,1 @@
+# no images yet


### PR DESCRIPTION
Creates a new gcr.io staging container registry for the SIG Scheduling
scheduler-plugins project.

https://github.com/kubernetes-sigs/scheduler-plugins