### PR TITLE
Add new slack bot post-message resources to slack-infra

### DIFF
--- a/slack-infra/README.md
+++ b/slack-infra/README.md
@@ -5,6 +5,7 @@ Cluster resources to deploy the following apps from [kubernetes-sigs/slack-infra
 - slack-event-log
 - slack-moderator
 - slack-welcomer
+- slack-post-message
 - slackin
 
 Secrets are stored in Secret Manager in the `kubernetes-public` project, with

--- a/slack-infra/resources/ingress.yaml
+++ b/slack-infra/resources/ingress.yaml
@@ -25,3 +25,7 @@ spec:
             backend:
               serviceName: slack-welcomer
               servicePort: 80
+          - path: /infra/post-message/*
+            backend:
+              serviceName: slack-post-message
+              servicePort: 80

--- a/slack-infra/resources/slack-post-message/deployment.yaml
+++ b/slack-infra/resources/slack-post-message/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: slack-post-message
+  labels:
+    app: slack-post-message
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: slack-post-message
+  template:
+    metadata:
+      labels:
+        app: slack-post-message
+    spec:
+      containers:
+      - name: slack-post-message
+        image: gcr.io/k8s-staging-slack-infra/slack-post-message:v20200901-117c06f 
+        args:
+          - --config-path=/etc/slack-post-message/config.json
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        env:
+        - name: PATH_PREFIX
+          value: /infra/post-message
+        volumeMounts:
+        - mountPath: /etc/slack-post-message
+          name: config
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            scheme: HTTP
+            port: 8080
+      volumes:
+      - name: config
+        secret:
+          secretName: slack-post-message-config

--- a/slack-infra/resources/slack-post-message/service.yaml
+++ b/slack-infra/resources/slack-post-message/service.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: slack-post-message
+spec:
+  selector:
+    app: slack-post-message
+  type: NodePort
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080


### PR DESCRIPTION
This adds resources for the new slack bot [post-message](https://github.com/kubernetes-sigs/slack-infra/tree/master/slack-post-message) which allows authorized users to post a message in multiple channels together

Note: I haven't added a tag to the image value in `deployment.yaml` since the build hasn't happened yet from my knowledge. Please do add the appropriate tag before deploying

CC: @ameukam @mbbroberg 

