### PR TITLE
sig-release: Onboard 1.20 RT Leads / offboard 1.19 RT Leads

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -67,6 +67,7 @@ groups:
       - fbongiovanni@google.com
       - fbranczyk@gmail.com
       - frapposelli@vmware.com
+      - georgedanielmangum@gmail.com
       - hankang@google.com
       - hpandey@pivotal.io
       - hweicdl@gmail.com
@@ -91,13 +92,14 @@ groups:
       - mwielgus@google.com
       - neolit123@gmail.com
       - nospam.wong@gmail.com
-      - onlydole@gmail.com
+      - pal.nabarun95@gmail.com
       - prydonius@gmail.com
       - phil.wittrock@gmail.com
       - quinton@hoole.biz
       - saadali@google.com
       - saschagrunert@gmail.com
       - saugustus@vmware.com
+      - saveetha13@gmail.com
       - seans@google.com
       - stephen.k8s@agst.us
       - szostok.mateusz@gmail.com

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -60,10 +60,11 @@ groups:
       - gveronicalg@gmail.com
       - jameswangel@gmail.com
       - jeremy.r.rickard@gmail.com
-      - killen.bob@gmail.com
       - linusa@google.com
       - mudrinic.mare@gmail.com
       - onlydole@gmail.com
+      - pal.nabarun95@gmail.com
+      - saveetha13@gmail.com
       - sethpmccombs@gmail.com
       - simony@google.com
       - sumitranr@google.com
@@ -184,11 +185,12 @@ groups:
       - idealhack@gmail.com
       - jameswangel@gmail.com
       - jeremy.r.rickard@gmail.com
-      - killen.bob@gmail.com
       - lauri.d.apple@gmail.com
       - mudrinic.mare@gmail.com
       - onlydole@gmail.com
+      - pal.nabarun95@gmail.com
       - release-managers-private@kubernetes.io
+      - saveetha13@gmail.com
       - sethpmccombs@gmail.com
       - spiffxp@google.com
 


### PR DESCRIPTION
Add 1.20 RT Leads (@jeremyrickard @savitharaghunathan @hasheddan @palnabarun) to the relevant groups:
- leads@
- k8s-infra-release-viewers@
- release-managers@

Closes: https://github.com/kubernetes/sig-release/issues/1201

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @dims @tpepper @saschagrunert @alejandrox1 