### PR TITLE
Add celestehorgan, jdumars to leads

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -51,6 +51,7 @@ groups:
       - bentheelder@google.com
       - caniszczyk@linuxfoundation.org
       - casey@tigera.io
+      - celeste@cncf.io
       - chiachenk@google.com
       - cncf-speakers@linuxfoundation.org
       - community@kubernetes.io
@@ -74,6 +75,7 @@ groups:
       - jameswangel@gmail.com
       - jbeale@inguardians.com
       - jbelamaric@google.com
+      - jdumars@gmail.com
       - jeef111x@gmail.com
       - jeremy.r.rickard@gmail.com
       - joelsmith@redhat.com


### PR DESCRIPTION
Signed-off-by: Celeste Horgan <celeste@cncf.io>

Add myself (@celestehorgan) and @jdumars to the leads mailing list, as leads for WG naming.