### PR TITLE
Raise prow-build max nodepool size to 50

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
@@ -115,7 +115,7 @@ module "prow_build_nodepool_n1_highmem_8_maxiops" {
   name            = "pool4"
   initial_count   = 1
   min_count       = 1
-  max_count       = 30
+  max_count       = 50
   # kind-ipv6 jobs need an ipv6 stack; COS doesn't provide one, so we need to
   # use an UBUNTU image instead. Keep parity with the existing google.com 
   # k8s-prow-builds/prow cluster by using the CONTAINERD variant


### PR DESCRIPTION
Instead of 3 x 30 = 90 nodes total, let's go up to 150 total

The build cluster we are migrating prow jobs from had a fixed size of
160 nodes.  We're starting to hit the limit of 90 nodes with increased
PR traffic.

Part of https://github.com/kubernetes/k8s.io/issues/1231