### PR TITLE
Upgrade triage-party to 1.3.0

### DIFF
--- a/triage-party/release-team/deployment.yaml
+++ b/triage-party/release-team/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: triage-party
-          image: triageparty/triage-party:1.2.1
+          image: triageparty/triage-party:1.3.0
           env:
             - name: GITHUB_TOKEN
               valueFrom:
@@ -35,7 +35,7 @@ spec:
               path: /health
               port: 8080
               scheme: HTTP
-            timeout: 5
+            timeoutSeconds: 5
           resources:
             limits:
               cpu: 1


### PR DESCRIPTION
Update triage-party to 1.3.0 
CHANGELOG: https://github.com/google/triage-party/blob/master/CHANGELOG.md#version-130---2020-08-24

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>