### PR TITLE
Add OWNERS to triage-party.

### DIFF
--- a/triage-party/release-team/OWNERS
+++ b/triage-party/release-team/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - release-engineering-approvers
+reviewers:
+  - release-engineering-reviewers
+
+labels:
+  - sig/release
+  - area/release-eng


### PR DESCRIPTION
This PR adds sig-release leads so the they can review/approve changes
for triage-party.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>