### PR TITLE
Add pdb for pods created by prow

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/test-pods-poddisruptionbudget.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/test-pods-poddisruptionbudget.yaml
@@ -1,0 +1,31 @@
+# Copyright 2020 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The purpose of the PodDisruptionBudget here is to never allow evicting pods created by prow.
+# Eviction of pods can happen for one of two reasons:
+# * Cluster autoscaler downscaling
+# * Someome/Something using `kubectl drain`
+#
+# It is still possible to delete the pods via a normal delete call. See https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/#the-eviction-api
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: prow-pods
+  namespace: test-pods
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      created-by-prow: "true"


### PR DESCRIPTION
This should allow autoscaling/draining to avoid deleting nodes that
are still running pods scheduled by prow

Intended to make https://github.com/kubernetes/k8s.io/issues/1120 less disruptive