### PR TITLE
Add new release-team@kubernetes.io list

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -220,3 +220,32 @@ groups:
       - saschagrunert@gmail.com
       - stephen.k8s@agst.us
       - tpepper@vmware.com
+
+  - email-id: release-team@kubernetes.io
+    name: release-team
+    description: |-
+      Release Team communications.
+      Includes SIG Release Leads and current release team.
+    settings:
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      ReconcileMembers: "true"
+    owners:
+      - alarcj137@gmail.com
+      - lauri.d.apple@gmail.com
+      - saschagrunert@gmail.com
+      - stephen.k8s@agst.us
+      - tpepper@vmware.com
+    managers:
+      - georgedanielmangum@gmail.com # 1.20 RT Lead Shadow
+      - jeremy.r.rickard@gmail.com # 1.20 RT Lead
+      - pal.nabarun95@gmail.com  # 1.20 RT Lead Shadow
+      - saveetha13@gmail.com # 1.20 RT Lead Shadow
+    members:
+      - sig-release-leads@kubernetes.io
+      - antheabjung@gmail.com # 1.20 Docs Lead
+      - james@jameslaverack.com # 1.20 Release Notes Lead
+      - joseph.r.sandoval@gmail.com # 1.20 Communications Lead
+      - kikis.github@gmail.com # 1.20 Enhancements Lead
+      - lachlan.evenson@gmail.com # 1.20 Emeritus Advisor
+      - rob.kielty@gmail.com # 1.20 CI Signal Lead
+      - v@gor.io # 1.20 Bug Triage Lead


### PR DESCRIPTION
This PR creates a brand new `release-team@kubernetes.io` group to replace the existing non kubernetes.io Release Team google group.  On-boarding / off-boarding release team members will become a trackable activity with the adoption of this group. 

Currently populated with:
* `sig-release-leads@kubernetes.io` 
* `1.20 Release Team` as members
* `1.20 Release Lead and Shadows` as managers
* SIG Release Leads as owners. 

Refs: kubernetes/sig-release#1185

/assign @dims @mrbobbytables @justaugustus @tpepper @saschagrunert @alejandrox1

/sig release

Signed-off-by: Jeremy Rickard <rickardj@vmware.com>