### PR TITLE
Update Triage-Party rules for 1.20 milestone

### DIFF
--- a/triage-party/release-team/configmap.yaml
+++ b/triage-party/release-team/configmap.yaml
@@ -26,11 +26,11 @@ data:
 
 
     collections:
-      - id: daily
-        name: Daily Triage
+      - id: bug-triage
+        name: Bug Triage
         dedup: true
         description: >
-          queue to be emptied once a day
+          Dashboard tracking the current status of all issues and PRs targeting the current release (1.20).
         rules:
           - milestone-issues
           - urgent-issues
@@ -39,11 +39,11 @@ data:
     rules:
       ### Milestone ###
       milestone-issues:
-        name: "v1.19 Issues"
+        name: "v1.20 Issues"
         resolution: "Add a milestone/ label"
         type: issue
         filters:
-        - milestone: "v1.19"
+        - milestone: "v1.20"
 
       ### Daily Triage ####
       issue-needs-priority-overdue:


### PR DESCRIPTION
Adjust rules for Triage-Party so that it's easier for bug triage team to track issues and
PRs for 1.20 milestone.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>