### PR TITLE
Add a release-team-shadows@kubernetes.io group for RT shadow comms

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -256,3 +256,24 @@ groups:
       - lachlan.evenson@gmail.com # 1.20 Emeritus Advisor
       - rob.kielty@gmail.com # 1.20 CI Signal Lead
       - v@gor.io # 1.20 Bug Triage Lead
+
+  - email-id: release-team-shadows@kubernetes.io
+    name: release-team-shadows
+    description: |-
+      Release Team Shadow Communications.
+      Includes SIG Release Leads, EA and Current Release Team Shadows.
+    settings:
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      ReconcileMembers: "true"
+    owners:
+      - alarcj137@gmail.com
+      - lauri.d.apple@gmail.com
+      - saschagrunert@gmail.com
+      - stephen.k8s@agst.us
+      - tpepper@vmware.com
+    managers:
+      - lachlan.evenson@gmail.com # 1.20 Emeritus Advisor
+    members:
+      - georgedanielmangum@gmail.com # 1.20 RT Lead Shadow
+      - pal.nabarun95@gmail.com  # 1.20 RT Lead Shadow
+      - saveetha13@gmail.com # 1.20 RT Lead Shadow


### PR DESCRIPTION
This PR creates a brand new release-team-shadows@kubernetes.io group to replace the existing non kubernetes.io Release Team Shadows google group. Adding this group will simplify on-boarding / off-boarding release team members and will move these activities to trackable activities and provide better insight into group membership.

Currently populated with:
* 1.20 RT Lead Shadows (members)
* 1.20 RT EA (manager)
* SIG-Release Leads (owners)

Once this is a thing, we can update all the onboarding/offboarding handbooks. 

/assign @dims @justaugustus@tpepper  @alejandrox1  @lachie83 

Currently populated with:
Signed-off-by: Jeremy Rickard <rickardj@vmware.com>