### PR TITLE
promote csi-secrets-store driver:v0.0.14

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-csi-secrets-store/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-csi-secrets-store/images.yaml
@@ -1,4 +1,5 @@
 - name: driver
   dmap:
     "sha256:384a5e90b409c16186a26152728ec265ed4dd15eae9d7e518962226aa2886b2b": [ "v0.0.12" ]
+    "sha256:c263af27fd8ba4ec733e22849d916eff371b548c9b528c8e36bdf032aa376ae1": [ "v0.0.14" ]
     "sha256:27e40fbb130b7e0672c7506c48ba44760fef8dabf191bb0a72f55b66df99bd47": [ "v0.0.13" ]


### PR DESCRIPTION
```
++ docker manifest push --purge gcr.io/k8s-staging-csi-secrets-store/driver:v0.0.14
sha256:c263af27fd8ba4ec733e22849d916eff371b548c9b528c8e36bdf032aa376ae1
```

Build - https://console.cloud.google.com/cloud-build/builds/2ff0254a-55e4-493d-9d4a-47cff5fa4b6a?project=k8s-staging-csi-secrets-store

Generated by running -
```
➜ k8s.gcr.io/images/k8s-staging-csi-secrets-store/generate.sh > k8s.gcr.io/images/k8s-staging-csi-secrets-store/images.yaml
```

/assign @ritazh 