### PR TITLE
Promote jessie-dnsutils 1.3

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-e2e-test-images/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-e2e-test-images/images.yaml
@@ -10,6 +10,7 @@
 - name: jessie-dnsutils
   dmap:
     "sha256:31183fd28aa9b4af81329e1886060492cfa67dd94e9d1132e00ed032ce685187": ["1.2"]
+    "sha256:8b03e4185ecd305bc9b410faac15d486a3b1ef1946196d429245cdd3c7b152eb": ["1.3"]
 - name: nonewprivs
   dmap:
     "sha256:553fcda2222ccea7cd534c8da34b709feb768d6389eb7333444b13f296bd168f": ["1.1"]


### PR DESCRIPTION
Promote jessie-dnsutils 1.3 from staging bucket to production as in multi-arch image tag 1.0 manifest for s390x is not available.