### PR TITLE
SIG Docs chair transition

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -39,12 +39,12 @@ aliases:
     - mrbobbytables
     - nikhita
   sig-docs-leads:
+    - irvifa
     - jimangel
     - kbarnard10
     - kbhawkey
     - onlydole
     - sftim
-    - zacharysarah
   sig-instrumentation-leads:
     - brancz
     - dashpole


### PR DESCRIPTION
ref: https://github.com/kubernetes/website/issues/23797

## 🟢 OK TO MERGE 🟢 

Don't merge this PR until all conditions are true:
- [x] all governance pieces of #23797 are approved
- [x] Date equal to or later than September 15th, 2020

## Description

This PR updates repo permissions and contacts for @irvifa becoming a chair and @zacharysarah transitioning to chair emeritus.

/assign @irvifa @jimangel @kbarnard10 