### PR TITLE
Add a staging repo for addon-manager

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -713,6 +713,16 @@ groups:
   # Each group here governs access to one staging project.
   #
 
+  - email-id: k8s-infra-staging-addon-manager@kubernetes.io
+    name: k8s-infra-staging-addon-manager
+    description: |-
+      ACL for staging addon-manager images.
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - jsand@google.com
+      - zihongz@google.com
+
   - email-id: k8s-infra-staging-apisnoop@kubernetes.io
     name: k8s-infra-staging-apisnoop
     description: |-

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -41,6 +41,7 @@ PROD_PROJECT="k8s-artifacts-prod"
 
 # NB: Please keep this sorted.
 STAGING_PROJECTS=(
+    addon-manager
     apisnoop
     artifact-promoter
     autoscaling

--- a/k8s.gcr.io/images/k8s-staging-addon-manager/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-addon-manager/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS file documentation:
+#  https://github.com/kubernetes/kubernetes/blob/master/docs/devel/owners.md
+
+approvers:
+  - dekkagaijin
+  - MrHohn

--- a/k8s.gcr.io/images/k8s-staging-addon-manager/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-addon-manager/images.yaml
@@ -1,0 +1,1 @@
+# No images yet 

--- a/k8s.gcr.io/images/k8s-staging-addon-manager/promoter-manifest.yaml
+++ b/k8s.gcr.io/images/k8s-staging-addon-manager/promoter-manifest.yaml
@@ -1,0 +1,10 @@
+# google group for gcr.io/k8s-staging-addon-manager is k8s-infra-staging-addon-manager@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-addon-manager
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/addon-manager
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/addon-manager
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/addon-manager
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com 


### PR DESCRIPTION
This PR mostly followed https://github.com/kubernetes/k8s.io/blob/master/k8s.gcr.io/README.md.

This is to unblock a new release on addon-manager to pick up https://github.com/kubernetes/kubernetes/pull/93762.

(I put three of us that recently touched the addon-manager codes as the owner group to start with.)

/cc @spencer-p @dekkagaijin