### PR TITLE
triage-party: Update triage/support -> kind/support labels

### DIFF
--- a/triage-party/release-team/configmap.yaml
+++ b/triage-party/release-team/configmap.yaml
@@ -151,11 +151,10 @@ data:
       # Issues missing initial feedback
       issue-needs-kind:
         name: "Unkinded Issues"
-        resolution: "Add a kind/ or triage/support label"
+        resolution: "Add a kind/ label"
         type: issue
         filters:
           - label: "!kind/.*"
-          - label: "!triage/support"
 
       issue-needs-priority:
         name: "Unprioritized Recent Issues"
@@ -280,7 +279,7 @@ data:
         resolution: "Close, or add to triage/long-term-support"
         type: issue
         filters:
-          - label: triage/support
+          - label: kind/support
           - label: "!long-term-support"
           - updated: +29d
 
@@ -361,7 +360,7 @@ data:
           - responded: +60d
           - label: "!kind/feature"
           - label: "!kind/bug"
-          - label: "!triage/support"
+          - label: "!kind/support"
 
       features-old:
         name: "Features that have not been commented on within 90 days"
@@ -391,7 +390,7 @@ data:
           - created: +90d
           - label: "!kind/feature"
           - label: "!kind/bug"
-          - label: "!triage/support"
+          - label: "!kind/support"
           - label: "!priority/awaiting-evidence"
 
       lifecycle-stale:


### PR DESCRIPTION
The label `triage/support` has been renamed to `kind/support`.

This updates the triage-party dashboards accordingly 👍 

/cc @justaugustus @LappleApple 