### PR TITLE
Correct capitialisation of email address

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -259,7 +259,7 @@ groups:
       - celeste@cncf.io # 1.20 Release Notes Shadow
       - chris@chrisshort.net # 1.20 Comms Shadow
       - divya.mohan0209@gmail.com # 1.20 Comms Shadow
-      - jackytan@Outlook.com # 1.20 Release Notes Shadow
+      - jackytan@outlook.com # 1.20 Release Notes Shadow
       - james@jameslaverack.com # 1.20 Release Notes Lead
       - jeremylevanmorris@gmail.com # 1.20 RT Enhancements Shadow
       - joseph.r.sandoval@gmail.com # 1.20 Communications Lead
@@ -309,7 +309,7 @@ groups:
       - eddiezane@gmail.com # 1.20 CI Signal Shadow
       - georgedanielmangum@gmail.com # 1.20 RT Lead Shadow
       - hkamel.msft@gmail.com # 1.20 CI Signal Shadow
-      - jackytan@Outlook.com # 1.20 Release Notes Shadow
+      - jackytan@outlook.com # 1.20 Release Notes Shadow
       - jeremylevanmorris@gmail.com # 1.20 RT Enhancements Shadow
       - kcmartin2@mac.com # 1.20 Docs Shadow
       - kefroden@gmail.com # 1.20 RT Enhancements Shadow


### PR DESCRIPTION
Jacky is unable to access the mailing list, despite his email being in the groups.yaml file. We believe this is caused by a capitalisation difference between his email as presented for authentication (`@outlook.com`) and as written in the file (`@Outlook.com`).