### PR TITLE
Rename seccomp-operator to security-profiles-operator

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -135,7 +135,7 @@ groups:
       - tasha.drew@gmail.com
       - celeste@cncf.io
       - tpepper@vmware.com
-      - chu.karen.h@gmail.com 
+      - chu.karen.h@gmail.com
 
   - email-id: distributors-announce@kubernetes.io
     name: distributors-announce
@@ -1492,10 +1492,10 @@ groups:
       - saikatroyc@google.com
       - jinxu@google.com
 
-  - email-id: k8s-infra-staging-seccomp-operator@kubernetes.io
-    name: k8s-infra-staging-seccomp-operator
+  - email-id: k8s-infra-staging-sp-operator@kubernetes.io
+    name: k8s-infra-staging-sp-operator
     description: |-
-      ACL for seccomp operator artifacts
+      ACL for security-profiles-operator artifacts
     settings:
       ReconcileMembers: "true"
     members:

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -90,12 +90,12 @@ STAGING_PROJECTS=(
     publishing-bot
     releng
     scheduler-plugins
-    seccomp-operator
     scl-image-builder
     service-apis
     slack-infra
     sig-docs
     sig-storage
+    sp-operator
     storage-migrator
     txtdirect
 )

--- a/k8s.gcr.io/images/k8s-staging-seccomp-operator/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-seccomp-operator/images.yaml
@@ -1,3 +1,3 @@
-- name: seccomp-operator
+- name: security-profiles-operator
   dmap:
     "sha256:67c97995264f949ab2d2e028cc6fb981cf5fe4646442abb8b422e9559c6a5732": ["v0.1.0"]

--- a/k8s.gcr.io/manifests/k8s-staging-seccomp-operator/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-seccomp-operator/promoter-manifest.yaml
@@ -1,11 +1,11 @@
-# google group for gcr.io/k8s-staging-seccomp-operator is
-# k8s-infra-staging-seccomp-operator@kubernetes.io
+# google group for gcr.io/k8s-staging-sp-operator is
+# k8s-infra-staging-sp-operator@kubernetes.io
 registries:
-- name: gcr.io/k8s-staging-seccomp-operator
+- name: gcr.io/k8s-staging-sp-operator
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/seccomp-operator
+- name: us.gcr.io/k8s-artifacts-prod/security-profiles-operator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/seccomp-operator
+- name: eu.gcr.io/k8s-artifacts-prod/security-profiles-operator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/seccomp-operator
+- name: asia.gcr.io/k8s-artifacts-prod/security-profiles-operator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
Renaming the operator to it's new proposed name.

Refers to https://github.com/kubernetes/org/issues/2177