### PR TITLE
Added AllowWebPosting option to groups reconciler

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -27,6 +27,7 @@ groups:
     description: |-
       SIG/WG/UG Leads
     settings:
+      AllowWebPosting: "true"
       WhoCanViewGroup: "ANYONE_CAN_VIEW"
       WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
       WhoCanPostMessage: "ANYONE_CAN_POST"

--- a/groups/groups_test.go
+++ b/groups/groups_test.go
@@ -265,3 +265,43 @@ func TestHardcodedGroupsForParanoia(t *testing.T) {
 		}
 	}
 }
+
+// Setting AllowWebPosting should be set for every group which should support
+// access to the group not only via gmail but also via web (you can see the list
+// and history of threads and also use web interface to operate the group)
+// More info:
+// 	https://developers.google.com/admin-sdk/groups-settings/v1/reference/groups#allowWebPosting
+func TestGroupsWhichShouldSupportHistory(t *testing.T) {
+	groups := map[string]struct{}{
+		"leads@kubernetes.io": {},
+	}
+
+	found := make(map[string]struct{})
+
+	for _, group := range cfg.Groups {
+		emailId := group.EmailId
+		found[emailId] = struct{}{}
+		if _, ok := groups[emailId]; ok {
+			allowedWebPosting, ok := group.Settings["AllowWebPosting"]
+			if !ok {
+				t.Errorf(
+					"group '%s': must have 'settings.allowedWebPosting = true'",
+					group.Name,
+				)
+			} else if allowedWebPosting != "true" {
+				t.Errorf(
+					"group '%s': must have 'settings.allowedWebPosting = true'" +
+						" but have 'settings.allowedWebPosting = %s' instead",
+					group.Name,
+					allowedWebPosting,
+				)
+			}
+		}
+	}
+
+	for email := range groups {
+		if _, ok := found[email]; !ok {
+			t.Errorf("group '%s' is missing, should be present", email)
+		}
+	}
+}

--- a/groups/reconcile.go
+++ b/groups/reconcile.go
@@ -446,6 +446,8 @@ func updateGroupSettings(srv *groupssettings.Service, groupEmailId string, group
 		switch key {
 		case "AllowExternalMembers":
 			wantSettings.AllowExternalMembers = value
+		case "AllowWebPosting":
+			wantSettings.AllowWebPosting = value
 		case "WhoCanJoin":
 			wantSettings.WhoCanJoin = value
 		case "WhoCanViewMembership":


### PR DESCRIPTION
Closes: https://github.com/kubernetes/k8s.io/issues/1171

As currently if you want the group to be accessible not only via gmail
vut also via web interface you would have to set the option "Group
Settings -> Posting Policies -> Conversation: ON" manually, this change
is adding option `AllowWebPosting` to the groups configuration, so
reconciler will set it automatically when your group will have setting
`AllowWebPosting: "true"`.

I also added test to check if groups which should have this option set
(at this point as via #1171 I only added `leads@kubernetes.io` to the
list of groups to validate), and if not, or the value of this option is
not equal `true` it will fail.

As there is already a lot of groups and I didn't want to imperatively
change this setting by default to `false` for them I have not introduced
the default value for that option, but we can change it if we'll decide
that should be the case.

/cc @spiffxp 
/assign @spiffxp @dims 

Signed-off-by: Bart Smykla <bsmykla@vmware.com>