### PR TITLE
releng: dropping temporarily access to puerco/mkorbi/markyjackson-taulia/jimangel

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -42,16 +42,12 @@ groups:
       ReconcileMembers: "true"
     members:
       - k8s-infra-release-admins@kubernetes.io
-      - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
       - dmaceachern@vmware.com
       - feiskyer@gmail.com
       - georgedanielmangum@gmail.com
       - hhorl@pivotal.io
       - idealhack@gmail.com
-      - jameswangel@gmail.com
-      - marky.r.jackson@gmail.com
-      - max@koerbaecher.io
       - mudrinic.mare@gmail.com
       - saschagrunert@gmail.com
       - stephen.k8s@agst.us


### PR DESCRIPTION
Dropping temporary access grant in this PR https://github.com/kubernetes/k8s.io/pull/1322 to the RMA cut the releases
thanks for all work you all did, was amazing!

/hold until all releases are out!

sig-release issue: https://github.com/kubernetes/sig-release/issues/1278

/assign @dims @cblecker
cc: @justaugustus @saschagrunert @xmudrii @hasheddan  @kubernetes/release-engineering

/priority important-soon