### PR TITLE
Enable CIP owners to perform image promotion

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -39,20 +39,20 @@ aliases:
     - mrbobbytables
     - nikhita
   sig-docs-leads:
-    - irvifa
     - jimangel
     - kbarnard10
     - kbhawkey
     - onlydole
     - sftim
+    - zacharysarah
   sig-instrumentation-leads:
     - brancz
     - dashpole
     - ehashman
     - logicalhan
   sig-multicluster-leads:
+    - jeremyot
     - pmorie
-    - quinton-hoole
   sig-network-leads:
     - caseydavenport
     - dcbw
@@ -72,6 +72,9 @@ aliases:
   sig-scheduling-leads:
     - Huang-Wei
     - ahg-g
+  sig-security-leads:
+    - iancoldwater
+    - tabbysable
   sig-service-catalog-leads:
     - jberkhahn
     - mszostok
@@ -118,10 +121,6 @@ aliases:
     - quinton-hoole
     - tpepper
     - youngnick
-  wg-machine-learning-leads:
-    - k82cn
-    - kow3ns
-    - vishh
   wg-multitenancy-leads:
     - srampal
     - tashimi
@@ -133,11 +132,10 @@ aliases:
   wg-policy-leads:
     - ericavonb
     - hannibalhuang
-  wg-security-audit-leads:
-    - aasmall
-    - cji
-    - jaybeale
-    - joelsmith
+  wg-reliability-leads:
+    - deads2k
+    - stevekuznetsov
+    - wojtek-t
   ug-big-data-leads:
     - erikerlandson
     - foxish
@@ -165,10 +163,10 @@ aliases:
     - cblecker
     - derekwaynecarr
     - dims
-    - lachie83
+    - liggitt
+    - mrbobbytables
     - nikhita
     - parispittman
-    - spiffxp
 ## BEGIN CUSTOM CONTENT
   build-image-approvers:
     - BenTheElder

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -180,6 +180,16 @@ aliases:
     - dims
     - justaugustus
     - listx
+  cip-approvers:
+    - justaugustus
+    - justinsb
+    - listx
+    - thockin
+  cip-reviewers:
+    - justaugustus
+    - justinsb
+    - listx
+    - thockin
   provider-aws:
     - d-nishi
     - justinsb

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -202,21 +202,26 @@ aliases:
     - frapposelli
   release-engineering-approvers:
     - alejandrox1 # SIG Technical Lead
-    - dougm # Patch Release Team
-    - feiskyer # Patch Release Team
-    - hoegaarden # Patch Release Team
-    - idealhack # Patch Release Team
-    - justaugustus # subproject owner / Patch Release Team
+    - cpanato # Release Manager
+    - dougm # Release Manager
+    - feiskyer # Release Manager
+    - hasheddan # Release Manager
+    - hoegaarden # Release Manager
+    - idealhack # Release Manager
+    - justaugustus # subproject owner / Release Manager / SIG Chair
     - saschagrunert # SIG Technical Lead
-    - tpepper # subproject owner / Patch Release Team
+    - tpepper # subproject owner / Release Manager / SIG Chair
+    - xmudrii # Release Manager
   release-engineering-reviewers:
     - alejandrox1 # SIG Technical Lead
-    - cpanato # Branch Manager
-    - dougm # Patch Release Team
-    - feiskyer # Patch Release Team
-    - hoegaarden # Patch Release Team
-    - idealhack # Patch Release Team
-    - justaugustus # subproject owner / Patch Release Team
+    - cpanato # Release Manager
+    - dougm # Release Manager
+    - feiskyer # Release Manager
+    - hasheddan # Release Manager
+    - hoegaarden # Release Manager
+    - idealhack # Release Manager
+    - justaugustus # subproject owner / Release Manager / SIG Chair
     - saschagrunert # SIG Technical Lead
-    - tpepper # subproject owner / Patch Release Team
+    - tpepper # subproject owner / Release Manager / SIG Chair
+    - xmudrii # Release Manager
 ## END CUSTOM CONTENT

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -753,19 +753,6 @@ groups:
       - spiffxp@google.com
       - zz@ii.coop
 
-  - email-id: k8s-infra-staging-artifact-promoter@kubernetes.io
-    name: k8s-infra-staging-artifact-promoter
-    description: |-
-      ACL for staging artifact-promoter
-    settings:
-      ReconcileMembers: "true"
-    members:
-      - davanum@gmail.com
-      - ihor@cncf.io
-      - linusa@google.com
-      - spiffxp@google.com
-      - thockin@google.com
-
   - email-id: k8s-infra-staging-autoscaling@kubernetes.io
     name: k8s-infra-staging-autoscaling
     description: |-

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -84,6 +84,7 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
+      - k8s-infra-release-editors@kubernetes.io
       - davanum@gmail.com
       - ihor@cncf.io
       - linusa@google.com

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -77,6 +77,19 @@ groups:
       - simony@google.com
       - sumitranr@google.com
 
+  - email-id: k8s-infra-staging-artifact-promoter@kubernetes.io
+    name: k8s-infra-staging-artifact-promoter
+    description: |-
+      ACL for staging artifact-promoter
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - davanum@gmail.com
+      - ihor@cncf.io
+      - linusa@google.com
+      - spiffxp@google.com
+      - thockin@google.com
+
   - email-id: k8s-infra-staging-build-image@kubernetes.io
     name: k8s-infra-staging-build-image
     description: |-

--- a/k8s.gcr.io/images/k8s-staging-artifact-promoter/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-artifact-promoter/OWNERS
@@ -1,5 +1,15 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+options:
+  no_parent_owners: true
 approvers:
-- listx
-- thockin
+  - cip-approvers
+  - wg-k8s-infra-leads
+reviewers:
+  - cip-reviewers
+  - release-engineering-approvers
+  - release-engineering-reviewers
+
+labels:
+  - sig/release
+  - area/release-eng


### PR DESCRIPTION
- OWNERS: Sync aliases w/ k/community
- OWNERS(releng): Update RelEng reviewers/approvers
- OWNERS(releng): Add container-image-promoter reviewers/approvers
- OWNERS(releng): Use aliases, disallow root owners, add labels
- groups(releng): Move artifact-promoter staging IAM to SIG Release dir
- groups(releng): Grant RelManagers access to artifact-promoter staging

Part of CIP repo improvements: https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/266

/sig release
/area release-eng
cc: @kubernetes/release-engineering 
/assign @dims @bartsmykla @spiffxp 