### PR TITLE
Promote scheduler-plugins image v0.18.9 to k8s.gcr.io

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-scheduler-plugins/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-scheduler-plugins/images.yaml
@@ -1,1 +1,3 @@
-# no images yet
+- name: kube-scheduler
+  dmap:
+    "sha256:01d1b53bce3c2477ab403b54914ff9229e073d99e9b711f161b796cec73176be": ["v0.18.9"]


### PR DESCRIPTION
Following https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io#image-promoter, this PR tries to promote the staging image (gcr.io/k8s-staging-scheduler-plugins/kube-scheduler:v20201017-v0.18.9) to k8s.gcr.io.

cc/ @seanmalloy 