### PR TITLE
releng: dropping temporarily access to gianarb

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -46,7 +46,6 @@ groups:
       - dmaceachern@vmware.com
       - feiskyer@gmail.com
       - georgedanielmangum@gmail.com
-      - gianarb92@gmail.com
       - hhorl@pivotal.io
       - idealhack@gmail.com
       - mudrinic.mare@gmail.com


### PR DESCRIPTION
Dropping temporary access grant in this PR https://github.com/kubernetes/k8s.io/pull/1342 to the RMA cut the v1.20.0-alpha.3

/hold until v1.20.0-alpha.3 is out

sig-release issue: https://github.com/kubernetes/sig-release/issues/1295

/assign @dims @cblecker
cc: @justaugustus @saschagrunert @xmudrii @hasheddan  @kubernetes/release-engineering

/priority important-soon