### PR TITLE
Add staging GCR repo for Kubernetes CI images

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -106,6 +106,17 @@ groups:
       - linusa@google.com
       - stephen.k8s@agst.us
 
+  - email-id: k8s-infra-staging-ci-images@kubernetes.io
+    name: k8s-infra-staging-ci-images
+    description: |-
+      ACL for staging CI images
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - k8s-infra-prow-oncall@kubernetes.io
+      - k8s-infra-release-editors@kubernetes.io
+      - ameukam@gmail.com
+
   - email-id: k8s-infra-staging-kubernetes@kubernetes.io
     name: k8s-infra-staging-kubernetes
     description: |-

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -61,6 +61,7 @@ STAGING_PROJECTS=(
     capi-kubeadm
     capi-docker
     capi-vsphere
+    ci-images
     coredns
     cpa
     csi

--- a/k8s.gcr.io/images/k8s-staging-ci-images/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-ci-images/OWNERS
@@ -1,0 +1,14 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+options:
+  no_parent_owners: true
+approvers:
+  - release-engineering-approvers
+  - sig-testing-leads
+  - wg-k8s-infra-leads
+reviewers:
+  - release-engineering-reviewers
+
+labels:
+  - sig/release
+  - area/release-eng

--- a/k8s.gcr.io/images/k8s-staging-ci-images/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ci-images/images.yaml
@@ -1,0 +1,1 @@
+# No images yet

--- a/k8s.gcr.io/manifests/k8s-staging-ci-images/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-ci-images/promoter-manifest.yaml
@@ -1,0 +1,12 @@
+# google group for gcr.io/k8s-staging-ci-images is k8s-infra-staging-ci-images@kubernetes.io
+
+registries:
+  - name: gcr.io/k8s-staging-ci-images
+    src: true
+  # Promotes to the following GCR locations:
+  - name: us.gcr.io/k8s-ci-images
+    service-account: k8s-infra-gcr-promoter@k8s-ci-images.iam.gserviceaccount.com
+  - name: eu.gcr.io/k8s-ci-images
+    service-account: k8s-infra-gcr-promoter@k8s-ci-images.iam.gserviceaccount.com
+  - name: asia.gcr.io/k8s-ci-images
+    service-account: k8s-infra-gcr-promoter@k8s-ci-images.iam.gserviceaccount.com


### PR DESCRIPTION
Add a GCR staging repo that will host images built by
ci-kubernetes-build jobs. It will help migrate those jobs
to k8s-infra-prow-build-cluster.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>