### PR TITLE
Update PSC associates

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -155,9 +155,10 @@ groups:
       - timallclair@gmail.com
     members:
       # Associate PSC members
-      - alextc@google.com
       - mok@vmware.com
       - sfowler@redhat.com
+      - taahm@google.com
+      - tabitha.c.sable@gmail.com
       # Distributors
       - argoprod@us.ibm.com
       - aws-k8s-embargo-notification@amazon.com


### PR DESCRIPTION
Update the distributors-announce list with the current PSC associates (found here: https://github.com/kubernetes/security#product-security-committee-psc)

/cc @tabbysable @ahmedtd