### PR TITLE
releng: Temporarily grant access to Verolop

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -46,6 +46,7 @@ groups:
       - dmaceachern@vmware.com
       - feiskyer@gmail.com
       - georgedanielmangum@gmail.com
+      - gveronicalg@gmail.com
       - hhorl@pivotal.io
       - idealhack@gmail.com
       - mudrinic.mare@gmail.com


### PR DESCRIPTION
- temporary: Verónica (Verolop) is a Release Manager Associate being granted temporary elevated access to execute the Branch Management role. Access should be revoked after the `1.20.0-beta.0` release is cut.

sig-release issue: https://github.com/kubernetes/sig-release/issues/1302

/assign @dims @cblecker
cc: @justaugustus @saschagrunert @xmudrii @hasheddan  @kubernetes/release-engineering

/priority important-soon