### PR TITLE
k8s.gcr.io/../k8s-staging-kube-state-metrics: Promote v2.0.0-alpha.2

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-kube-state-metrics/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-kube-state-metrics/images.yaml
@@ -1,26 +1,26 @@
-# 2.0.0-alpha
 - name: kube-state-metrics
   dmap:
     "sha256:73867f9c84ef0ffb061b1bcb950b1947b1d60cb842ede63c0321a94b8cc6b6c8": ["2.0.0-alpha"]
+    "sha256:e3b9095a56b7d75b868c134089326566c545aa086360713647b1675c1a1738f3": ["2.0.0-alpha.1"]
+    "sha256:aa84c31d4ab935acbd7debdc23a18e87dc344727290d8313f0d7d14b96293482": ["2.0.0-alpha.2"]
 - name: kube-state-metrics-amd64
   dmap:
     "sha256:73867f9c84ef0ffb061b1bcb950b1947b1d60cb842ede63c0321a94b8cc6b6c8": ["2.0.0-alpha"]
-- name: kube-state-metrics-arm64
-  dmap:
-    "sha256:f18e7fff7b327511ca6ccd85b11b5cc14df9d99307baaab85ec7b4d18ca13a61": ["2.0.0-alpha"]
+    "sha256:e3b9095a56b7d75b868c134089326566c545aa086360713647b1675c1a1738f3": ["2.0.0-alpha.1"]
+    "sha256:5f7b131a12f14479235ac28deda05773f315606bf7bc3406b5055c192c0d1571": ["2.0.0-alpha.2"]
 - name: kube-state-metrics-arm
   dmap:
     "sha256:255894e01b3042564d8b5968abbc027dc7be816ba14c7d7426bd3ce54131219c": ["2.0.0-alpha"]
-# 2.0.0-alpha.1
-- name: kube-state-metrics
-  dmap:
-    "sha256:e3b9095a56b7d75b868c134089326566c545aa086360713647b1675c1a1738f3": ["2.0.0-alpha.1"]
-- name: kube-state-metrics-amd64
-  dmap:
-    "sha256:e3b9095a56b7d75b868c134089326566c545aa086360713647b1675c1a1738f3": ["2.0.0-alpha.1"]
+    "sha256:6f8a6c406ae8bab657f87338527afca0a35dcf43d6336e929c1d5c18a35dc7dc": ["2.0.0-alpha.1"]
+    "sha256:bfa5b7c9908b77b53ad6d0ca4007a4d43b86cb99915ee7229ea1e536540ab837": ["2.0.0-alpha.2"]
 - name: kube-state-metrics-arm64
   dmap:
+    "sha256:f18e7fff7b327511ca6ccd85b11b5cc14df9d99307baaab85ec7b4d18ca13a61": ["2.0.0-alpha"]
     "sha256:5dcbaec3e9fa314f34eb61083e293b0d12a8ca44181eb177280187b838d29460": ["2.0.0-alpha.1"]
-- name: kube-state-metrics-arm
+    "sha256:b53b10d9415a0b8ff2ad960707a1268b4d0917f704b65e4275d5832792a34b12": ["2.0.0-alpha.2"]
+- name: kube-state-metrics-ppc64le
   dmap:
-    "sha256:6f8a6c406ae8bab657f87338527afca0a35dcf43d6336e929c1d5c18a35dc7dc": ["2.0.0-alpha.1"]
+    "sha256:53a9f175e565896f17033fceddf3895fe3958469de4e5865f950685ad59baca7": ["2.0.0-alpha.2"]
+- name: kube-state-metrics-s390x
+  dmap:
+    "sha256:638b3efd875249877d822090aa6075485548173f3f32a3b6e15e816b23951800": ["2.0.0-alpha.2"]


### PR DESCRIPTION
cc @brancz PTAL, here is the verification:
> ➜ git:(dev-4.7) ✗ docker run gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics@sha256:aa84c31d4ab935acbd7debdc23a18e87dc344727290d8313f0d7d14b96293482 --version
Unable to find image 'gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics@sha256:aa84c31d4ab935acbd7debdc23a18e87dc344727290d8313f0d7d14b96293482' locally
sha256:aa84c31d4ab935acbd7debdc23a18e87dc344727290d8313f0d7d14b96293482: Pulling from k8s-staging-kube-state-metrics/kube-state-metrics
Digest: sha256:aa84c31d4ab935acbd7debdc23a18e87dc344727290d8313f0d7d14b96293482
Status: Downloaded newer image for gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics@sha256:aa84c31d4ab935acbd7debdc23a18e87dc344727290d8313f0d7d14b96293482
version.Version{GitCommit:"", BuildDate:"2020-10-28T09:46:10Z", Release:"v2.0.0-alpha.2", GoVersion:"go1.15.3", Compiler:"gc", Platform:"linux/amd64"}
➜   git:(dev-4.7) ✗ docker run gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics@sha256:5f7b131a12f14479235ac28deda05773f315606bf7bc3406b5055c192c0d1571 --version
Unable to find image 'gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics@sha256:5f7b131a12f14479235ac28deda05773f315606bf7bc3406b5055c192c0d1571' locally
sha256:5f7b131a12f14479235ac28deda05773f315606bf7bc3406b5055c192c0d1571: Pulling from k8s-staging-kube-state-metrics/kube-state-metrics
Digest: sha256:5f7b131a12f14479235ac28deda05773f315606bf7bc3406b5055c192c0d1571
Status: Downloaded newer image for gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics@sha256:5f7b131a12f14479235ac28deda05773f315606bf7bc3406b5055c192c0d1571
version.Version{GitCommit:"", BuildDate:"2020-10-28T09:46:10Z", Release:"v2.0.0-alpha.2", GoVersion:"go1.15.3", Compiler:"gc", Platform:"linux/amd64"}
➜   git:(dev-4.7) ✗ docker run gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics@sha256:bfa5b7c9908b77b53ad6d0ca4007a4d43b86cb99915ee7229ea1e536540ab837 --version
Unable to find image 'gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics@sha256:bfa5b7c9908b77b53ad6d0ca4007a4d43b86cb99915ee7229ea1e536540ab837' locally
sha256:bfa5b7c9908b77b53ad6d0ca4007a4d43b86cb99915ee7229ea1e536540ab837: Pulling from k8s-staging-kube-state-metrics/kube-state-metrics
Digest: sha256:bfa5b7c9908b77b53ad6d0ca4007a4d43b86cb99915ee7229ea1e536540ab837
Status: Downloaded newer image for gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics@sha256:bfa5b7c9908b77b53ad6d0ca4007a4d43b86cb99915ee7229ea1e536540ab837
version.Version{GitCommit:"", BuildDate:"2020-10-28T09:47:49Z", Release:"v2.0.0-alpha.2", GoVersion:"go1.15.3", Compiler:"gc", Platform:"linux/arm"}
➜  git:(dev-4.7) ✗ docker run gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics@sha256:b53b10d9415a0b8ff2ad960707a1268b4d0917f704b65e4275d5832792a34b12 --version
Unable to find image 'gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics@sha256:b53b10d9415a0b8ff2ad960707a1268b4d0917f704b65e4275d5832792a34b12' locally
sha256:b53b10d9415a0b8ff2ad960707a1268b4d0917f704b65e4275d5832792a34b12: Pulling from k8s-staging-kube-state-metrics/kube-state-metrics
Digest: sha256:b53b10d9415a0b8ff2ad960707a1268b4d0917f704b65e4275d5832792a34b12
Status: Downloaded newer image for gcr.io/k8s-staging-kube-state-metrics/kube-state-metrics@sha256:b53b10d9415a0b8ff2ad960707a1268b4d0917f704b65e4275d5832792a34b12
version.Version{GitCommit:"", BuildDate:"2020-10-28T09:49:41Z", Release:"v2.0.0-alpha.2", GoVersion:"go1.15.3", Compiler:"gc", Platform:"linux/arm64"}

Thanks to @paulfantom for testing arm images and the manifest generation help!