### PR TITLE
promote csi sidecar images

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-sig-storage/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-sig-storage/images.yaml
@@ -1,5 +1,6 @@
 - name: csi-attacher
   dmap:
+    "sha256:a37e146d9743b87ba51eb4617489448174c513ee5deac0172cc4c802716e97b7": [ "v2.2.1" ]
     "sha256:2ffa647e8107cfd39e5f464e738dce014c9f5e51b108da36c3ab621048d0bbab": [ "v2.2.0" ]
     "sha256:7495d30800fb3ef22f3dc6d5fe9a0a6ec40ba32a2bdc0cf5e7fcaa507adc921e": [ "v3.0.1" ]
     "sha256:bc6d3ca87c62a2587470ba7adca84e9e5e7db61be1a35176084cc9ec3b4a87d5": [ "v3.0.0" ]
@@ -11,6 +12,7 @@
     "sha256:e07f914c32f0505e4c470a62a40ee43f84cbf8dc46ff861f31b14457ccbad108": [ "v2.0.1" ]
 - name: csi-provisioner
   dmap:
+    "sha256:3b9b5ae677fd74de3b1cde5d3606a970f615b598730aa003c0f52e755c78862e": [ "v1.6.1" ]
     "sha256:78e3393f5fd5ff6c1e5dada2478cfa456fb7164929e573cf9a87bf6532730679": [ "v1.6.0" ]
     "sha256:6fe39f4682c8677af7761948b196f27c45de566fb5f1612bb8114cd68bfe535e": [ "v1.5.0" ]
     "sha256:438c04395d03fa671f8656d6f951332516754e330d1ac4f9588df1ba2870a366": [ "v1.4.0" ]
@@ -20,12 +22,14 @@
     "sha256:95eb3a3aecc127cf632bdea2b48d676dbe28fe5fa8cf24bd11f26402ace8d888": [ "v2.0.1" ]
 - name: csi-resizer
   dmap:
+    "sha256:cc2ae1132e1ae7fd1e6ecbd656a73d0919812d4ff56f64f51843e1423eecde0f": [ "v0.5.1" ]
     "sha256:6c6a0332693a7c456378f6abd2bb40611826c1e1a733cadbdae2daab3125b71c": [ "v0.5.0" ]
     "sha256:43195976fb9f94d943f5dd9d58b8afa543be22d09a1165e8a489b7dfe22c657a": [ "v0.4.0" ]
     "sha256:5a8d85cdd1c80f43fb8fe6dcde1fae707a3177aaf0a786ff4b9f6f20247ec3ff": [ "v1.0.0" ]
     "sha256:ca160717df7f6b7964c936faf608b914f2277363e6d708ea2e2dbbf2c5f56a83": [ "v1.0.1" ]
 - name: csi-snapshotter
   dmap:
+    "sha256:f0673197110ba3c38a94b42fc0037d0c209b9d17c0b796072d26df72195a7ecd": [ "v2.1.2" ]
     "sha256:de94e695fc27ee421da8b9932c3d42699fe7b848bc34717f67f4350946bc46c9": [ "v2.1.1" ]
     "sha256:35ead85dd09aa8cc612fdb598d4e0e2f048bef816f1b74df5eeab67cd21b10aa": [ "v2.1.0" ]
     "sha256:1530db9fd380ecee86b48a7b3540568c46adb5a64b7fe718c51d9260c4834fd8": [ "v2.0.1" ]


### PR DESCRIPTION
This promotes the set of patch releases from 2 versions ago. Note that these images are mirrored from quay.io since we don't have cloudbuild setup in those release branches. Therefore, there is also no multiarch support.