### PR TITLE
Correct k8s-infra-gcr-vuln-dashboard SA

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/build-serviceaccounts.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/build-serviceaccounts.yaml
@@ -51,7 +51,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    iam.gke.io/gcp-service-account: k8s-infra-gcr-vuln-dashboard@kubernetes-public.iam.gserviceaccount.com
+    iam.gke.io/gcp-service-account: k8s-infra-gcr-vuln-dashboard@k8s-artifacts-prod.iam.gserviceaccount.com
   name: k8s-infra-gcr-vuln-dashboard
   namespace: test-pods
 ---

--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -377,7 +377,7 @@ color 6 "Handling special cases"
     ensure_service_account \
         "${PROD_PROJECT}" \
         "${VULN_DASHBOARD_SVCACCT}" \
-        "k8s-infra container image vuln scanning"
+        "k8s-infra container image vuln dashboard"
 
     color 6 "Empowering promoter-scanning namespace to use prod promoter vuln-dashboard svcacct"
     for project in "${PROW_TRUSTED_BUILD_CLUSTER_PROJECTS[@]}"; do


### PR DESCRIPTION
The kubernetes service account in k8s-infra-prow-build-trusted was bound
to a non-existing service account (wrong project name). Typo fixed.

The description for the account was incorrect, manually updated via:

    gcloud iam service-accounts update \
      --display-name "k8s-infra container image vuln dashboard" \
      --project=k8s-artifacts-prod
      k8s-infra-gcr-vuln-dashboard@k8s-artifacts-prod.iam.gserviceaccount.com

ref: https://github.com/kubernetes/release/issues/1665#issuecomment-718739469

/area release-eng