### PR TITLE
infra(k8s-infra-prow-build-trusted): Add promoter service accounts

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/build-serviceaccounts.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/build-serviceaccounts.yaml
@@ -47,6 +47,23 @@ metadata:
   name: prow-deployer
   namespace: test-pods
 ---
+# Image promotion service accounts
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  name: k8s-infra-gcr-promoter
+  namespace: test-pods
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod-bak.iam.gserviceaccount.com
+  name: k8s-infra-gcr-promoter-bak
+  namespace: test-pods
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -54,4 +71,3 @@ metadata:
     iam.gke.io/gcp-service-account: k8s-infra-gcr-vuln-dashboard@k8s-artifacts-prod.iam.gserviceaccount.com
   name: k8s-infra-gcr-vuln-dashboard
   namespace: test-pods
----


### PR DESCRIPTION
This is a step towards running the image promotion jobs on the
`k8s-infra-prow-build-trusted` instead of test-infra-trusted.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

ref: https://github.com/kubernetes/test-infra/pull/19789, https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/269, https://github.com/kubernetes/k8s.io/issues/157

/hold for review from @spiffxp, @thockin, or @dims, in case I've missed something
/assign @spiffxp @thockin @dims 
cc: @listx @kubernetes/release-engineering 