### PR TITLE
releng: Promote kubepkg:v0.1.0 images

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-releng/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-releng/images.yaml
@@ -1,0 +1,6 @@
+- name: kubepkg
+  dmap:
+    "sha256:caef826cde3d4cc884ccbac3a1805769ae59fe07f6f8234bf22dbfeb82312a99": ["v0.1.0", "v20201103-v0.5.0-63-ga247d79"]
+- name: kubepkg-rpm
+  dmap:
+    "sha256:f5fc791f5ef03c5fe3329fff3a40b80a44029a6e236981a2e5133ebf9597f9dd": ["v0.1.0", "v20201103-v0.5.0-63-ga247d79"]


### PR DESCRIPTION
`kubepkg` builds with every commit to k/release, so I'm choosing this image to promote as a test that the image promotion postsubmit works properly on `k8s-infra-prow-build-trusted` (ref: https://github.com/kubernetes/test-infra/pull/19810, https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/269, https://github.com/kubernetes/k8s.io/issues/157).

Staging run: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-release-push-image-kubepkg/1323591831455272960

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @hasheddan @saschagrunert 
cc: @kubernetes/release-engineering 