### PR TITLE
infra: Disable retention policy on k8s-artifacts-prod-vuln-dashboard

### DIFF
--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -402,6 +402,14 @@ color 6 "Handling special cases"
     empower_service_account_for_cip_vuln_scanning \
         "$(svc_acct_email "${PROD_PROJECT}" "${VULN_DASHBOARD_SVCACCT}")" \
         "${PROD_PROJECT}"
+
+    # Special case: don't use retention on vulnerability dashboard bucket
+    #               'ci-release-vulndash-update' runs periodically in Prow and
+    #               requires access to overwrite the dashboard's html.
+    #               This should maybe one day be wired up as a Netlify site, but
+    #               one step at a time!
+    color 6 "Removing retention on the ${PROD_PROJECT}-vuln-dashboard bucket"
+    gsutil retention clear "gs://${PROD_PROJECT}-vuln-dashboard"
 ) 2>&1 | indent
 
 color 6 "Done"


### PR DESCRIPTION
Don't use retention on vulnerability dashboard bucket.

'ci-release-vulndash-update' runs periodically in Prow and requires
access to overwrite the dashboard's HTML.

Example [failure](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-release-vulndash-update/1323653481172570112):

```console
level=info msg="Updating the vulnerability dashboard..."
level=info msg="opening /home/prow/go/src/github.com/kubernetes/release/cmd/vulndash/dashboard.html"
level=info msg="parsing /home/prow/go/src/github.com/kubernetes/release/cmd/vulndash/dashboard.html"
level=info msg="uploading /home/prow/go/src/github.com/kubernetes/release/cmd/vulndash/dashboard.html to gcs"
level=fatal msg="updating vulnerability dashboard: Unable to upload latest version of dashboard HTML: Writer.Close: googleapi: Error 403: Object 'k8s-artifacts-prod-vuln-dashboard/dashboard.html' is subject to bucket's retention policy and cannot be deleted, overwritten or archived until 2030-10-31T10:08:40.300944987-07:00, forbidden"
```

This should maybe one day be wired up as a Netlify site, but one step
at a time!

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

ref: https://github.com/kubernetes/release/issues/1665#issuecomment-720697350
/assign @cpanato @spiffxp @dims 
cc: @kubernetes/release-engineering 