### PR TITLE
releng: Grant Release Manager Admins artifact admin privileges

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -263,6 +263,7 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
+      - k8s-infra-release-admins@kubernetes.io
       - davanum@gmail.com
       - justinsb@google.com
       - linusa@google.com

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -825,34 +825,6 @@ groups:
       - jeewan@vmware.com
       - ytijani@vmware.com
 
-  - email-id: k8s-infra-staging-cip-test@kubernetes.io
-    name: k8s-infra-staging-cip-test
-    description: |-
-      ACL for staging cip-test buckets, also the test-only backup and auditing
-      jobs for the promoter. The associated test-only GCP Project IDs are:
-
-        - k8s-cip-test-prod: This is used for testing the promoter to see that
-          it can still promote things, as part of an E2E test.
-
-        - k8s-staging-cip-test: Also used for the promotion E2E test.
-
-        - k8s-gcr-backup-test-prod: Used for testing the backup script in
-          infra/gcr/backup_tools.
-
-        - k8s-gcr-backup-test-prod-bak: Same as above.
-
-        - k8s-gcr-audit-test-prod: Used for an E2E test for the cip-auditor
-          Cloud Run service.
-    settings:
-      ReconcileMembers: "true"
-    members:
-      - davanum@gmail.com
-      - ihor@cncf.io
-      - linusa@google.com
-      - spiffxp@google.com
-      - thockin@google.com
-      - rajib.jolite@gmail.com
-
   - email-id: k8s-infra-staging-provider-aws@kubernetes.io
     name: k8s-infra-staging-provider-aws
     description: |-

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -116,6 +116,34 @@ groups:
       - k8s-infra-release-editors@kubernetes.io
       - ameukam@gmail.com
 
+  - email-id: k8s-infra-staging-cip-test@kubernetes.io
+    name: k8s-infra-staging-cip-test
+    description: |-
+      ACL for staging cip-test buckets, also the test-only backup and auditing
+      jobs for the promoter. The associated test-only GCP Project IDs are:
+
+        - k8s-cip-test-prod: This is used for testing the promoter to see that
+          it can still promote things, as part of an E2E test.
+
+        - k8s-staging-cip-test: Also used for the promotion E2E test.
+
+        - k8s-gcr-backup-test-prod: Used for testing the backup script in
+          infra/gcr/backup_tools.
+
+        - k8s-gcr-backup-test-prod-bak: Same as above.
+
+        - k8s-gcr-audit-test-prod: Used for an E2E test for the cip-auditor
+          Cloud Run service.
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - davanum@gmail.com
+      - ihor@cncf.io
+      - linusa@google.com
+      - spiffxp@google.com
+      - thockin@google.com
+      - rajib.jolite@gmail.com
+
   - email-id: k8s-infra-staging-kubernetes@kubernetes.io
     name: k8s-infra-staging-kubernetes
     description: |-

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -137,6 +137,7 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
+      - k8s-infra-release-editors@kubernetes.io
       - davanum@gmail.com
       - ihor@cncf.io
       - linusa@google.com


### PR DESCRIPTION
The group of contributors defined in `k8s-infra-release-admins` (@kubernetes/sig-release-admins -- @justaugustus @tpepper @saschagrunert @alejandrox1) has extended admin privileges (including KMS access) over Release Engineering GCP projects, defined here: https://github.com/kubernetes/sig-release/blob/master/release-engineering/gcp.md

As part of extending the scope of personnel who can handle artifact promotion, auditing, and overall job/infra maintenance (ref: https://github.com/kubernetes/k8s.io/issues/157), this PR does the following:

- Move `k8s-staging-cip-test` staging project under SIG Release review
- Grants @kubernetes/release-managers access to the `k8s-staging-cip-test` staging project
- Grants @kubernetes/sig-release-admins artifact admin privileges by way of access to the following IAM groups:
  - k8s-infra-artifact-admins

/hold for any discussion
/assign @thockin @spiffxp @listx @dims 
cc: @kubernetes/k8s-infra-team @kubernetes/release-engineering 