### PR TITLE
Grant GCR write privileges to prow-build Service Account

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -115,6 +115,7 @@ groups:
       - k8s-infra-prow-oncall@kubernetes.io
       - k8s-infra-release-editors@kubernetes.io
       - ameukam@gmail.com
+      - prow-build@k8s-infra-prow-build.iam.gserviceaccount.com
 
   - email-id: k8s-infra-staging-cip-test@kubernetes.io
     name: k8s-infra-staging-cip-test


### PR DESCRIPTION
Grant prow-build Service Account privileges to write to GCR registries
for the staging projects.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>