### PR TITLE
Bump terraform providers

### DIFF
--- a/infra/gcp/clusters/modules/gke-cluster/versions.tf
+++ b/infra/gcp/clusters/modules/gke-cluster/versions.tf
@@ -17,7 +17,7 @@
 terraform {
   required_version = "~> 0.12.20"
   required_providers {
-    google      = "~> 3.19.0"
-    google-beta = "~> 3.19.0"
+    google      = "~> 3.46.0"
+    google-beta = "~> 3.46.0"
   }
 }

--- a/infra/gcp/clusters/modules/gke-nodepool/versions.tf
+++ b/infra/gcp/clusters/modules/gke-nodepool/versions.tf
@@ -17,7 +17,7 @@
 terraform {
   required_version = "~> 0.12.20"
   required_providers {
-    google      = "~> 3.19.0"
-    google-beta = "~> 3.19.0"
+    google      = "~> 3.46.0"
+    google-beta = "~> 3.46.0"
   }
 }

--- a/infra/gcp/clusters/modules/gke-project/versions.tf
+++ b/infra/gcp/clusters/modules/gke-project/versions.tf
@@ -17,7 +17,7 @@
 terraform {
   required_version = "~> 0.12.20"
   required_providers {
-    google      = "~> 3.19.0"
-    google-beta = "~> 3.19.0"
+    google      = "~> 3.46.0"
+    google-beta = "~> 3.46.0"
   }
 }

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/00-provider.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/00-provider.tf
@@ -14,7 +14,7 @@ terraform {
   }
 
   required_providers {
-    google      = "~> 3.19.0"
-    google-beta = "~> 3.19.0"
+    google      = "~> 3.46.0"
+    google-beta = "~> 3.46.0"
   }
 }

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/00-provider.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/00-provider.tf
@@ -14,7 +14,7 @@ terraform {
   }
 
   required_providers {
-    google      = "~> 3.19.0"
-    google-beta = "~> 3.19.0"
+    google      = "~> 3.46.0"
+    google-beta = "~> 3.46.0"
   }
 }


### PR DESCRIPTION
Bump terraform provider version to 3.46.0 for projects:
- k8s-infra-prow-build
- k8s-infra-prow-build-trusted.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>