### PR TITLE
Remove prow-build service account from group, grant permissions directly

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -115,7 +115,6 @@ groups:
       - k8s-infra-prow-oncall@kubernetes.io
       - k8s-infra-release-editors@kubernetes.io
       - ameukam@gmail.com
-      - prow-build@k8s-infra-prow-build.iam.gserviceaccount.com
 
   - email-id: k8s-infra-staging-cip-test@kubernetes.io
     name: k8s-infra-staging-cip-test

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -274,3 +274,15 @@ for repo in "${WINDOWS_REMOTE_DOCKER_PROJECTS[@]}"; do
         done
     ) 2>&1 | indent
 done
+
+# Special case: In order for ci-kubernetes-build to run on k8s-infra-prow-build,
+#               it needs write access to gcr.io/k8s-staging-ci-images. For now,
+#               we will grant the prow-build service account write access. Longer
+#               term we would prefer service accounts per project, and restrictions
+#               on which jobs can use which service accounts.
+color 6 "Configuring special case for k8s-staging-ci-images"
+(
+    PROJECT="k8s-staging-ci-images"
+    SERVICE_ACCOUNT=$(svc_acct_email "k8s-infra-prow-build" "prow-build")
+    empower_svcacct_to_write_gcr "${SERVICE_ACCOUNT}" "${PROJECT}"
+)


### PR DESCRIPTION
Followup to https://github.com/kubernetes/k8s.io/pull/1393. Looks like I was wrong about service accounts picking up permission from group membership (ref: https://github.com/kubernetes/k8s.io/pull/1393#issuecomment-723269683)

Instead of granting all permissions that k8s-infra-staging-ci-images@ has, grant only write access to gcr.io/k8s-staging-ci-images

This replicates what I did manually
```
gsutil iam ch serviceAccount:prow-build@k8s-infra-prow-build.iam.gserviceaccount.com:roles/storage.objectAdmin gs://artifacts.k8s-staging-ci-images.appspot.com
gsutil iam ch serviceAccount:prow-build@k8s-infra-prow-build.iam.gserviceaccount.com:roles/storage.legacyBucketWriter gs://artifacts.k8s-staging-ci-images.appspot.com
```