### PR TITLE
Allow override of the release channel of the terraform module gke-cluster

### DIFF
--- a/infra/gcp/clusters/modules/gke-cluster/main.tf
+++ b/infra/gcp/clusters/modules/gke-cluster/main.tf
@@ -179,6 +179,10 @@ resource "google_container_cluster" "prod_cluster" {
     }
   }
 
+  release_channel {
+    channel = var.release_channel
+  }
+
   // Enable PodSecurityPolicy enforcement
   pod_security_policy_config {
     enabled = false // TODO: we should turn this on

--- a/infra/gcp/clusters/modules/gke-cluster/variables.tf
+++ b/infra/gcp/clusters/modules/gke-cluster/variables.tf
@@ -39,3 +39,15 @@ variable "is_prod_cluster" {
   type        = string
   default     = "false"
 }
+
+variable "release_channel" {
+  type        = string
+  default     = "UNSPECIFIED"
+  description = <<EOF
+  The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`.
+
+  Setting a release channel overrides the 'min_master_version' option.
+
+  More information about release channels can be found here : https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels.
+EOF
+}


### PR DESCRIPTION
Introduce a variable in the gke-cluster terraform module allowing to override the
release channel.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>