### PR TITLE
Move cs.k8s.io to a new host

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -108,10 +108,10 @@ code:
   type: CNAME
   value: redirect.k8s.io.
 # Code search (@dims)
-# TODO: Where does this run?
+# This service runs in a equinix host managed by @dims
 cs:
   type: A
-  value: 147.75.97.58
+  value: 139.178.84.205
 # sig-contributor-experience
 discuss:
   type: CNAME


### PR DESCRIPTION
Got a notification from the Equinix folks, so created a new server and moving the service to a new public IP

```
Due to a detected fault in one of our EWR1 facility blade-switch pairs, which cannot be replaced and jeopardizes network redundancy for the attached servers, we would like to take measures to prevent customer downtime should the second switch fail.

Please note that this issue only affects a subset of our t1.small.x86 instances. You are receiving this message because we determined that you have one or more servers attached to this switch, as listed below.

k8s-code

We recommend moving these instance(s) onto new t1.small.x86 server(s) to prevent the possibility of future downtime. If the server is reserved, we can transfer your reservation to new hardware. Otherwise, redeploying on-demand instances should be sufficient, as we have removed all servers connected to the affected switch from the public pool.
```