### PR TITLE
Add new group for conformance Inspur

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -681,7 +681,26 @@ groups:
   # Conformance groups: k8s-infra-conform-*
   #
   # Each group here governs access to one GCS bucket.
-  #
+
+  - email-id: k8s-infra-conform-inspur@kubernetes.io
+    name: k8s-infra-conform-inspur
+    description: |-
+      ACL for conformance Inspur
+    settings:
+      AllowExternalMembers: "true"
+      WhoCanJoin: "INVITED_CAN_JOIN"
+      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanDiscoverGroup: "ALL_MEMBERS_CAN_DISCOVER"
+      WhoCanInvite: "NONE_CAN_INVITE"
+      WhoCanAdd: "NONE_CAN_ADD"
+      WhoCanApproveMembers: "NONE_CAN_APPROVE"
+      WhoCanModifyMembers: "NONE"
+      WhoCanModerateMembers: "NONE"
+      ReconcileMembers: "true"
+    members:
+      - shiguangyin@inspur.com
+      - yindongchao@inspur.com
 
   - email-id: k8s-infra-conform-capi-openstack@kubernetes.io
     name: k8s-infra-conform-capi-openstack

--- a/infra/gcp/ensure-conformance-storage.sh
+++ b/infra/gcp/ensure-conformance-storage.sh
@@ -48,6 +48,7 @@ CONFORMANCE_BUCKETS=(
     capi-openstack
     cri-o
     huaweicloud
+    inspur
     s390x-k8s
 )
 if [ $# = 0 ]; then


### PR DESCRIPTION
This PR requests a group for Inspur as well as a GCS bucket.

The bucket used to store cloud provider conformance test results of [cloud-provider-inspur](https://github.com/OpenInspur/cloud-provider-inspur) and it'll report to TestGrid according to Contributing Test Results.