### PR TITLE
Migrate deployments to apps/v1

### DIFF
--- a/gcsweb.k8s.io/deployment.yaml
+++ b/gcsweb.k8s.io/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: gcsweb
@@ -6,7 +6,9 @@ metadata:
     app: gcsweb
 spec:
   replicas: 2
-  # selector defaults from template labels
+  selector:
+    matchLabels:
+      app: gcsweb
   strategy:
     rollingUpdate:
       maxSurge: 1

--- a/k8s.io/deployment.yaml
+++ b/k8s.io/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: k8s-io
@@ -7,7 +7,10 @@ metadata:
     version: v1
 spec:
   replicas: 2
-  # selector defaults to template's labels
+  selector:
+    matchLabels:
+      app: k8s-io
+      version: v1
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/node-perf-dash.k8s.io/deployment.yaml
+++ b/node-perf-dash.k8s.io/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: node-perf-dash
@@ -8,6 +8,9 @@ metadata:
     version: "0.3"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: node-perf-dash
   template:
     metadata:
       labels:


### PR DESCRIPTION
The `aaa` cluster is in version v1.15 (`v1.15.12-gke.20`) which is the last
version serving deployment resource under extensions/v1beta1.
See: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#deprecations-and-removals. 

~Adding a new deployment resource under apps/v1.~
EDIT: Migrate all the _Deployments_ to apps/v1.


Signed-off-by: Arnaud Meukam <ameukam@gmail.com>