### PR TITLE
releng: dropping temporarily access for onlydole

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -49,7 +49,6 @@ groups:
       - hhorl@pivotal.io
       - idealhack@gmail.com
       - mudrinic.mare@gmail.com
-      - onlydole@gmail.com
       - saschagrunert@gmail.com
       - stephen.k8s@agst.us
       - tpepper@vmware.com


### PR DESCRIPTION
Dropping temporary access grant in #1430 to the RMA (@onlydole) to cut the v1.20.0-beta.2 release.

sig-release issue: kubernetes/sig-release#1339

/assign @dims @cblecker 
cc: @cpanato @justaugustus @kubernetes/release-engineering 

/priority important-soon