### PR TITLE
Update SIG Release leadership and Release Managers (promotions, new members, retirement)

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -62,9 +62,9 @@ aliases:
     - derekwaynecarr
   sig-release-leads:
     - alejandrox1
+    - hasheddan
     - justaugustus
     - saschagrunert
-    - tpepper
   sig-scalability-leads:
     - mm4tt
     - shyamjvs
@@ -213,25 +213,23 @@ aliases:
   release-engineering-approvers:
     - alejandrox1 # SIG Technical Lead
     - cpanato # Release Manager
-    - dougm # Release Manager
     - feiskyer # Release Manager
-    - hasheddan # Release Manager
-    - hoegaarden # Release Manager
+    - hasheddan # subproject owner / Release Manager / SIG Technical Lead
     - idealhack # Release Manager
     - justaugustus # subproject owner / Release Manager / SIG Chair
-    - saschagrunert # SIG Technical Lead
-    - tpepper # subproject owner / Release Manager / SIG Chair
+    - puerco # Release Manager
+    - saschagrunert # subproject owner / Release Manager / SIG Chair
+    - tpepper # subproject owner
     - xmudrii # Release Manager
   release-engineering-reviewers:
     - alejandrox1 # SIG Technical Lead
     - cpanato # Release Manager
-    - dougm # Release Manager
     - feiskyer # Release Manager
-    - hasheddan # Release Manager
-    - hoegaarden # Release Manager
+    - hasheddan # subproject owner / Release Manager / SIG Technical Lead
     - idealhack # Release Manager
     - justaugustus # subproject owner / Release Manager / SIG Chair
-    - saschagrunert # SIG Technical Lead
-    - tpepper # subproject owner / Release Manager / SIG Chair
+    - puerco # Release Manager
+    - saschagrunert # subproject owner / Release Manager / SIG Chair
+    - tpepper # subproject owner
     - xmudrii # Release Manager
 ## END CUSTOM CONTENT

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -31,7 +31,6 @@ groups:
       - alarcj137@gmail.com
       - saschagrunert@gmail.com
       - stephen.k8s@agst.us
-      - tpepper@vmware.com
 
   - email-id: k8s-infra-release-editors@kubernetes.io
     name: k8s-infra-release-editors
@@ -44,15 +43,12 @@ groups:
       - k8s-infra-release-admins@kubernetes.io
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
-      - dmaceachern@vmware.com
       - feiskyer@gmail.com
       - georgedanielmangum@gmail.com
-      - hhorl@pivotal.io
       - idealhack@gmail.com
       - mudrinic.mare@gmail.com
       - saschagrunert@gmail.com
       - stephen.k8s@agst.us
-      - tpepper@vmware.com
 
   - email-id: k8s-infra-release-viewers@kubernetes.io
     name: k8s-infra-release-viewers
@@ -205,14 +201,11 @@ groups:
       - alarcj137@gmail.com
       - saschagrunert@gmail.com
       - stephen.k8s@agst.us
-      - tpepper@vmware.com
     members:
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
-      - dmaceachern@vmware.com
       - feiskyer@gmail.com
       - georgedanielmangum@gmail.com
-      - hhorl@pivotal.io
       - idealhack@gmail.com
       - mudrinic.mare@gmail.com
       - saugustus@vmware.com
@@ -231,20 +224,17 @@ groups:
       - saschagrunert@gmail.com
       - saugustus@vmware.com
       - stephen.k8s@agst.us
-      - tpepper@gmail.com
-      - tpepper@vmware.com
     members:
+      - release-managers-private@kubernetes.io
       - ameukam@gmail.com
       - amwat@google.com
       - bentheelder@google.com
       - ctadeu@gmail.com
-      - dmaceachern@vmware.com
       - feiskyer@gmail.com
       - georgedanielmangum@gmail.com
       - gianarb92@gmail.com
       - gmccloskey@google.com
       - gveronicalg@gmail.com
-      - hhorl@pivotal.io
       - idealhack@gmail.com
       - jameswangel@gmail.com
       - jeremy.r.rickard@gmail.com
@@ -254,7 +244,6 @@ groups:
       - mudrinic.mare@gmail.com
       - onlydole@gmail.com
       - pal.nabarun95@gmail.com
-      - release-managers-private@kubernetes.io
       - saveetha13@gmail.com
       - sethpmccombs@gmail.com
       - spiffxp@google.com

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -67,15 +67,12 @@ groups:
       - gveronicalg@gmail.com
       - jameswangel@gmail.com
       - jeremy.r.rickard@gmail.com
-      - linusa@google.com
       - marky.r.jackson@gmail.com
       - max@koerbaecher.io
       - onlydole@gmail.com
       - pal.nabarun95@gmail.com
       - saveetha13@gmail.com
       - sethpmccombs@gmail.com
-      - simony@google.com
-      - sumitranr@google.com
 
   - email-id: k8s-infra-staging-artifact-promoter@kubernetes.io
     name: k8s-infra-staging-artifact-promoter

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -28,7 +28,6 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
-      - alarcj137@gmail.com
       - saschagrunert@gmail.com
       - stephen.k8s@agst.us
 

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -42,6 +42,7 @@ groups:
       ReconcileMembers: "true"
     members:
       - k8s-infra-release-admins@kubernetes.io
+      - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
       - dmaceachern@vmware.com
       - feiskyer@gmail.com
@@ -62,7 +63,6 @@ groups:
       ReconcileMembers: "true"
     members:
       - k8s-infra-release-editors@kubernetes.io
-      - adolfo.garcia@uservers.net
       - gianarb92@gmail.com
       - gveronicalg@gmail.com
       - jameswangel@gmail.com
@@ -206,6 +206,7 @@ groups:
       - stephen.k8s@agst.us
       - tpepper@vmware.com
     members:
+      - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
       - dmaceachern@vmware.com
       - feiskyer@gmail.com
@@ -232,7 +233,6 @@ groups:
       - tpepper@gmail.com
       - tpepper@vmware.com
     members:
-      - adolfo.garcia@uservers.net
       - amwat@google.com
       - bentheelder@google.com
       - ctadeu@gmail.com

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -63,6 +63,7 @@ groups:
       ReconcileMembers: "true"
     members:
       - k8s-infra-release-editors@kubernetes.io
+      - ameukam@gmail.com
       - gianarb92@gmail.com
       - gveronicalg@gmail.com
       - jameswangel@gmail.com
@@ -233,6 +234,7 @@ groups:
       - tpepper@gmail.com
       - tpepper@vmware.com
     members:
+      - ameukam@gmail.com
       - amwat@google.com
       - bentheelder@google.com
       - ctadeu@gmail.com

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -176,7 +176,8 @@ groups:
       - alarcj137@gmail.com
       - saschagrunert@gmail.com
       - stephen.k8s@agst.us
-      - tpepper@vmware.com
+    managers:
+      - tpepper@vmware.com # Release Team subproject owner
     members:
       - jeremy.r.rickard@gmail.com
       - keroden@microsoft.com
@@ -274,7 +275,6 @@ groups:
       - lauri.d.apple@gmail.com
       - saschagrunert@gmail.com
       - stephen.k8s@agst.us
-      - tpepper@vmware.com
 
   - email-id: release-team@kubernetes.io
     name: release-team
@@ -289,12 +289,12 @@ groups:
       - lauri.d.apple@gmail.com
       - saschagrunert@gmail.com
       - stephen.k8s@agst.us
-      - tpepper@vmware.com
     managers:
       - georgedanielmangum@gmail.com # 1.20 RT Lead Shadow
       - jeremy.r.rickard@gmail.com # 1.20 RT Lead
       - pal.nabarun95@gmail.com  # 1.20 RT Lead Shadow
       - saveetha13@gmail.com # 1.20 RT Lead Shadow
+      - tpepper@vmware.com # Release Team subproject owner
     members:
       - sig-release-leads@kubernetes.io
       - antheabjung@gmail.com # 1.20 Docs Lead
@@ -339,9 +339,9 @@ groups:
       - lauri.d.apple@gmail.com
       - saschagrunert@gmail.com
       - stephen.k8s@agst.us
-      - tpepper@vmware.com
     managers:
       - lachlan.evenson@gmail.com # 1.20 Emeritus Advisor
+      - tpepper@vmware.com # Release Team subproject owner
     members:
       - celeste@cncf.io # 1.20 Release Notes Shadow
       - chris@chrisshort.net # 1.20 Comms Shadow

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -28,6 +28,7 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
+      - georgedanielmangum@gmail.com
       - saschagrunert@gmail.com
       - stephen.k8s@agst.us
 
@@ -173,6 +174,7 @@ groups:
       ReconcileMembers: "true"
     owners:
       - alarcj137@gmail.com
+      - georgedanielmangum@gmail.com
       - saschagrunert@gmail.com
       - stephen.k8s@agst.us
     managers:
@@ -199,13 +201,13 @@ groups:
       ReconcileMembers: "true"
     owners:
       - alarcj137@gmail.com
+      - georgedanielmangum@gmail.com
       - saschagrunert@gmail.com
       - stephen.k8s@agst.us
     members:
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
       - feiskyer@gmail.com
-      - georgedanielmangum@gmail.com
       - idealhack@gmail.com
       - mudrinic.mare@gmail.com
       - saugustus@vmware.com
@@ -221,6 +223,7 @@ groups:
       ReconcileMembers: "true"
     owners:
       - alarcj137@gmail.com
+      - georgedanielmangum@gmail.com
       - saschagrunert@gmail.com
       - saugustus@vmware.com
       - stephen.k8s@agst.us
@@ -231,7 +234,6 @@ groups:
       - bentheelder@google.com
       - ctadeu@gmail.com
       - feiskyer@gmail.com
-      - georgedanielmangum@gmail.com
       - gianarb92@gmail.com
       - gmccloskey@google.com
       - gveronicalg@gmail.com
@@ -271,6 +273,7 @@ groups:
       ReconcileMembers: "true"
     owners:
       - alarcj137@gmail.com
+      - georgedanielmangum@gmail.com
       - lauri.d.apple@gmail.com
       - saschagrunert@gmail.com
       - stephen.k8s@agst.us
@@ -285,11 +288,11 @@ groups:
       ReconcileMembers: "true"
     owners:
       - alarcj137@gmail.com
+      - georgedanielmangum@gmail.com
       - lauri.d.apple@gmail.com
       - saschagrunert@gmail.com
       - stephen.k8s@agst.us
     managers:
-      - georgedanielmangum@gmail.com # 1.20 RT Lead Shadow
       - jeremy.r.rickard@gmail.com # 1.20 RT Lead
       - pal.nabarun95@gmail.com  # 1.20 RT Lead Shadow
       - saveetha13@gmail.com # 1.20 RT Lead Shadow
@@ -335,6 +338,7 @@ groups:
       ReconcileMembers: "true"
     owners:
       - alarcj137@gmail.com
+      - georgedanielmangum@gmail.com
       - lauri.d.apple@gmail.com
       - saschagrunert@gmail.com
       - stephen.k8s@agst.us
@@ -348,7 +352,6 @@ groups:
       - divya.mohan0209@gmail.com # 1.20 Comms Shadow
       - droslean@gmail.com # 1.20 Bug Triage Shadow
       - eddiezane@gmail.com # 1.20 CI Signal Shadow
-      - georgedanielmangum@gmail.com # 1.20 RT Lead Shadow
       - hkamel.msft@gmail.com # 1.20 CI Signal Shadow
       - jackytan@outlook.com # 1.20 Release Notes Shadow
       - jeremylevanmorris@gmail.com # 1.20 RT Enhancements Shadow


### PR DESCRIPTION
The access portion of: https://github.com/kubernetes/sig-release/pull/1331

- Prune previous Build Admins
- Promote @puerco to full-fledged Release Manager
- Add @ameukam as Release Manager Associate
- Tim, @hoegaarden, and @dougm retire as Release Managers
- @tpepper is now Emeritus Chair
  ...but remains as subproject owner for a few things!
- Drop @alejandrox1 from release-admins IAM
  This group now has GCS/GCR admin access and should be restricted to
  senior Release Managers.
- @hasheddan joins as SIG TL and Senior Release Manager
- Corresponding OWNERS_ALIASES update

/assign @dims @cblecker 
/cc @saschagrunert @hasheddan 
cc: @kubernetes/release-engineering 