### PR TITLE
Establish a staging repository for mirroring Docker Hub images

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -168,6 +168,11 @@ aliases:
     - nikhita
     - parispittman
 ## BEGIN CUSTOM CONTENT
+  build-admins:
+    - amwat
+    - BenTheElder
+    - MushuEE
+    - spiffxp
   build-image-approvers:
     - BenTheElder
     - cblecker

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -150,6 +150,23 @@ groups:
     members:
       - k8s-infra-release-editors@kubernetes.io
 
+  - email-id: k8s-infra-staging-mirror@kubernetes.io
+    name: k8s-infra-staging-mirror
+    description: |-
+      ACL for staging mirror images
+
+      This project is used to stage images mirrored from Docker Hub.
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - k8s-infra-release-editors@kubernetes.io
+      - bentheelder@google.com # SIG Testing Chair
+      # wg-k8s-infra-oncall
+      - cblecker@gmail.com
+      - davanum@gmail.com
+      - spiffxp@google.com
+      - thockin@google.com
+
   - email-id: k8s-infra-staging-releng@kubernetes.io
     name: k8s-infra-staging-releng
     description: |-

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -20,6 +20,22 @@ groups:
       - sayan.chowdhury2012@gmail.com # 1.20 Bug Triage Shadow
       - v@gor.io # 1.20 Bug Triage Lead
 
+  - email-id: k8s-infra-google-build-admins@kubernetes.io
+    name: k8s-infra-google-build-admins
+    description: |-
+      ACL for Google Build Admins (edit access to Docker Hub mirror, view
+      access to Release GCP projects)
+
+      https://git.k8s.io/sig-release/release-managers.md#build-admins
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - k8s-infra-release-editors@kubernetes.io
+      - amwat@google.com
+      - bentheelder@google.com
+      - mushuee@google.com
+      - spiffxp@google.com
+
   - email-id: k8s-infra-release-admins@kubernetes.io
     name: k8s-infra-release-admins
     description: |-
@@ -59,6 +75,7 @@ groups:
       ReconcileMembers: "true"
     members:
       - k8s-infra-release-editors@kubernetes.io
+      - k8s-infra-google-build-admins@kubernetes.io
       - ameukam@gmail.com
       - gianarb92@gmail.com
       - gveronicalg@gmail.com
@@ -160,12 +177,11 @@ groups:
       ReconcileMembers: "true"
     members:
       - k8s-infra-release-editors@kubernetes.io
-      - bentheelder@google.com # SIG Testing Chair
-      # wg-k8s-infra-oncall
-      - cblecker@gmail.com
-      - davanum@gmail.com
-      - spiffxp@google.com
-      - thockin@google.com
+      - k8s-infra-google-build-admins@kubernetes.io
+      - cblecker@gmail.com # wg-k8s-infra-oncall
+      - davanum@gmail.com # wg-k8s-infra-oncall
+      - spiffxp@google.com # wg-k8s-infra-oncall
+      - thockin@google.com # wg-k8s-infra-oncall
 
   - email-id: k8s-infra-staging-releng@kubernetes.io
     name: k8s-infra-staging-releng

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -86,6 +86,7 @@ STAGING_PROJECTS=(
     kubernetes
     kustomize
     metrics-server
+    mirror
     multitenancy
     networking
     nfd
@@ -106,6 +107,7 @@ STAGING_PROJECTS=(
 
 RELEASE_STAGING_PROJECTS=(
     kubernetes
+    mirror
     releng
 )
 

--- a/k8s.gcr.io/images/k8s-staging-mirror/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-mirror/OWNERS
@@ -1,0 +1,15 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+options:
+  no_parent_owners: true
+approvers:
+  - sig-release-leads
+  - sig-testing-leads
+  - release-engineering-approvers
+  - wg-k8s-infra-leads
+reviewers:
+  - release-engineering-reviewers
+
+labels:
+  - sig/release
+  - area/release-eng

--- a/k8s.gcr.io/images/k8s-staging-mirror/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-mirror/OWNERS
@@ -7,6 +7,7 @@ approvers:
   - sig-testing-leads
   - release-engineering-approvers
   - wg-k8s-infra-leads
+  - build-admins
 reviewers:
   - release-engineering-reviewers
 

--- a/k8s.gcr.io/images/k8s-staging-mirror/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-mirror/images.yaml
@@ -1,0 +1,1 @@
+# NO IMAGES YET

--- a/k8s.gcr.io/manifests/k8s-staging-mirror/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-mirror/promoter-manifest.yaml
@@ -1,0 +1,10 @@
+# google group for gcr.io/k8s-staging-mirror is k8s-infra-staging-mirror@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-mirror
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/mirror
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/mirror
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/mirror
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
Primary owners: @kubernetes/release-managers under the @kubernetes/release-engineering 
                subproject of SIG Release.

Shared ownership across:
- @kubernetes/sig-release 
- @kubernetes/sig-testing 
- @kubernetes/k8s-infra-team 

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @thockin @dims @BenTheElder @saschagrunert 
cc: @kubernetes/sig-release-leads 

ref: https://kubernetes.slack.com/archives/CCK68P2Q2/p1605906060178100, https://github.com/kubernetes/kubernetes/pull/95567, https://github.com/kubernetes/test-infra/issues/19477, https://www.docker.com/pricing/resource-consumption-updates, https://cloud.google.com/container-registry/docs/pulling-cached-images