### PR TITLE
Allow bannai@google.com push images to network staging repository

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -1239,6 +1239,7 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
+      - bannai@google.com
       - bowei@google.com
       - jsand@google.com
       - mixia@google.com


### PR DESCRIPTION
Add bannai@google.com to k8s-infra-staging-networking@kubernetes.io so that they can push to gcr.io/k8s-staging-networking for pre-production ingress-gce images