### PR TITLE
Updating the ingress-gce-404-server-with-metrics-amd64 with the correct

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-networking/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-networking/images.yaml
@@ -15,5 +15,5 @@
     "sha256:fd7449efcd712a85dbcdf6c1648f5f9bb674c208862f469c457ccd154d7d12bf": ["v2.6.0"]
 - name: ingress-gce-404-server-with-metrics-amd64
   dmap:
-    "sha256:96de528a8f05d77be966c0e17c51e0eb1de2be69ff2f62225b7be51c7c9e6fc3": ["v1.10.11"]
+    "sha256:7eb7b3cee4d33c10c49893ad3c386232b86d4067de5251294d4c620d6e072b93": ["v1.10.11"]
     


### PR DESCRIPTION
digest for the tag v1.10.11.
Updated digest:
sha256:7eb7b3cee4d33c10c49893ad3c386232b86d4067de5251294d4c620d6e072b93