### PR TITLE
Promote aws-ebs-csi-driver v0.8.1

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-provider-aws/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-provider-aws/images.yaml
@@ -1,4 +1,6 @@
 - name: aws-ebs-csi-driver
   dmap:
-    "sha256:a8ed0a90b49c16301f3ca934b75db63b8d5c8d68c377a865bce15c9af4a12ff5": ["v0.8.0", "latest"]
-    "sha256:f0a70741879930df4c70ae855c5dfc106e83c9678d956f80e965f71a57ac89c1": ["v0.8.0-amazonlinux", "latest-amazonlinux"]
+    "sha256:a8ed0a90b49c16301f3ca934b75db63b8d5c8d68c377a865bce15c9af4a12ff5": ["v0.8.0"]
+    "sha256:f0a70741879930df4c70ae855c5dfc106e83c9678d956f80e965f71a57ac89c1": ["v0.8.0-amazonlinux"]
+    "sha256:3801d90c7cfb438b308166681c59aa6576d1e614223e1d17eee9997287bac17e": ["v0.8.1", "latest"]
+    "sha256:89870880dc6c09ae7141874c4234a3af9d871edc61e7302802bfbd095c4826f9": ["v0.8.1-amazonlinux", "latest-amazonlinux"]


### PR DESCRIPTION
```
$ gcloud container images list-tags gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver --format='get(tags, digest)' --filter='tags:v0.8.1 AND tags!~rc\.\d'
latest;v20210106-v0.8.1	sha256:3801d90c7cfb438b308166681c59aa6576d1e614223e1d17eee9997287bac17e
latest-amazonlinux;v20210106-v0.8.1-amazonlinux	sha256:89870880dc6c09ae7141874c4234a3af9d871edc61e7302802bfbd095c4826f9
```