### PR TITLE
serviceapi: update list of service-api image owners

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -1349,9 +1349,13 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
-      - thockin@google.com
-      - bowei@google.com
       - antonio.ojea.garcia@gmail.com
+      - bowei@google.com
+      - cmluciano@us.ibm.com
+      - daneyonhansen@gmail.com
+      - harrybagdi@gmail.com
+      - robertjscott@google.com
+      - thockin@google.com
 
   - email-id: k8s-infra-staging-slack-infra@kubernetes.io
     name: k8s-infra-staging-slack-infra

--- a/k8s.gcr.io/images/k8s-staging-service-apis/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-service-apis/OWNERS
@@ -2,8 +2,12 @@
 #  https://github.com/kubernetes/community/blob/master/contributors/devel/owners.md
 
 approvers:
-- thockin
 - bowei
+- cmluciano
+- danehans
+- hbagdi
+- robscott
+- thockin
 reviewers:
 - aojea
 labels:


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

I reorganized the list alphabetically and added all maintainer owners to the approver list. 

This repo will have it's first image once  https://github.com/kubernetes-sigs/service-apis/issues/487 is verified and approved. In order to push this image soon afterwards or before merge, I added myself to the OWNERS file.