### PR TITLE
Unsubscribe retired WG-SecurityAudit leads from leads@ mailing list.

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -45,7 +45,6 @@ groups:
       - paris.pittman@gmail.com
       - spiffxp@gmail.com
     members:
-      - aaron@smallnet.org
       - ahg@google.com
       - alarcj137@gmail.com
       - bartek@smykla.com
@@ -56,7 +55,6 @@ groups:
       - chiachenk@google.com
       - cncf-speakers@linuxfoundation.org
       - community@kubernetes.io
-      - cji@stripe.com
       - davanum@gmail.com
       - davidopp@google.com
       - dawnchen@google.com
@@ -80,7 +78,6 @@ groups:
       - ian@coldwater.io
       - irvi.fa@gmail.com
       - jameswangel@gmail.com
-      - jbeale@inguardians.com
       - jbelamaric@google.com
       - jeef111x@gmail.com
       - jeremy.r.rickard@gmail.com


### PR DESCRIPTION
I had unsubscribed from the leads@ mailing list multiple times, but I'm still getting the mail.  Two of the other former wg-securityaudit leads had the same experience. @mrbobbytables indicated that we can unsubscribe via PR on this file.

@aasmall 
@cji