### PR TITLE
groups: Add Jeremy Rickard as a SIG Release Technical Lead

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -64,6 +64,7 @@ aliases:
   sig-release-leads:
     - alejandrox1
     - hasheddan
+    - jeremyrickard
     - justaugustus
     - saschagrunert
   sig-scalability-leads:
@@ -222,6 +223,7 @@ aliases:
     - feiskyer # Release Manager
     - hasheddan # subproject owner / Release Manager / SIG Technical Lead
     - idealhack # Release Manager
+    - jeremyrickard # SIG Technical Lead
     - justaugustus # subproject owner / Release Manager / SIG Chair
     - puerco # Release Manager
     - saschagrunert # subproject owner / Release Manager / SIG Chair
@@ -233,6 +235,7 @@ aliases:
     - feiskyer # Release Manager
     - hasheddan # subproject owner / Release Manager / SIG Technical Lead
     - idealhack # Release Manager
+    - jeremyrickard # SIG Technical Lead
     - justaugustus # subproject owner / Release Manager / SIG Chair
     - puerco # Release Manager
     - saschagrunert # subproject owner / Release Manager / SIG Chair

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -210,12 +210,12 @@ groups:
     owners:
       - alarcj137@gmail.com
       - georgedanielmangum@gmail.com
+      - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
       - saschagrunert@gmail.com
     managers:
       - tpepper@vmware.com # Release Team subproject owner
     members:
-      - jeremy.r.rickard@gmail.com
       - keroden@microsoft.com
       - killen.bob@gmail.com
       - lauri.d.apple@gmail.com
@@ -237,6 +237,7 @@ groups:
     owners:
       - alarcj137@gmail.com
       - georgedanielmangum@gmail.com
+      - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
       - saschagrunert@gmail.com
     members:
@@ -259,6 +260,7 @@ groups:
     owners:
       - alarcj137@gmail.com
       - georgedanielmangum@gmail.com
+      - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
       - saschagrunert@gmail.com
       - saugustus@vmware.com
@@ -274,7 +276,6 @@ groups:
       - gveronicalg@gmail.com
       - idealhack@gmail.com
       - jameswangel@gmail.com
-      - jeremy.r.rickard@gmail.com
       - kikis.github@gmail.com
       - lauri.d.apple@gmail.com
       - marky.r.jackson@gmail.com
@@ -311,6 +312,7 @@ groups:
     owners:
       - alarcj137@gmail.com
       - georgedanielmangum@gmail.com
+      - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
       - lauri.d.apple@gmail.com
       - saschagrunert@gmail.com


### PR DESCRIPTION
Adds @jeremyrickard to appropriate groups and OWNERS as part of sig technical lead onboarding.

(Note: Jeremy was already in the general `leads` group so he is not added in this PR)

xref: https://github.com/kubernetes/sig-release/issues/1421

/hold
/assign @justaugustus @saschagrunert 