### PR TITLE
Remove leads of the retired wg-security-audit from the leads ML

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -45,7 +45,6 @@ groups:
       - paris.pittman@gmail.com
       - spiffxp@gmail.com
     members:
-      - aaron@smallnet.org
       - ahg@google.com
       - alarcj137@gmail.com
       - bartek@smykla.com
@@ -56,7 +55,6 @@ groups:
       - chiachenk@google.com
       - cncf-speakers@linuxfoundation.org
       - community@kubernetes.io
-      - cji@stripe.com
       - davanum@gmail.com
       - davidopp@google.com
       - dawnchen@google.com
@@ -80,12 +78,10 @@ groups:
       - ian@coldwater.io
       - irvi.fa@gmail.com
       - jameswangel@gmail.com
-      - jbeale@inguardians.com
       - jbelamaric@google.com
       - jeef111x@gmail.com
       - jeremy.r.rickard@gmail.com
       - jeremyot@google.com
-      - joelsmith@redhat.com
       - jonathan.berkhahn@gmail.com
       - jsafrane@redhat.com
       - justin@fathomdb.com


### PR DESCRIPTION
I had unsubscribed from the leads mailing list multiple times, but the automation resubscribes me. The other three former wg-security-audit leads (mentioned here to allow their LGTM) had the same experience. @mrbobbytables shared that we can unsubscribe via PR on this file.

@aasmall
@cji
@joelsmith 