### PR TITLE
Enable GCR for e2e projects

### DIFF
--- a/infra/gcp/ensure-e2e-projects.sh
+++ b/infra/gcp/ensure-e2e-projects.sh
@@ -122,6 +122,7 @@ for prj; do
     enable_api "${prj}" logging.googleapis.com
     enable_api "${prj}" monitoring.googleapis.com
     enable_api "${prj}" storage-component.googleapis.com
+    enable_api "${prj}" containerregistry.googleapis.com
 
     color 6 "Empower prow-build service account to edit e2e project: ${prj}"
     # TODO: this is what prow.k8s.io uses today, but it is likely over-permissioned, we could


### PR DESCRIPTION
This is needed specifically by the scale projects to be able to run kubemark, but I would like the "push to GCR repo in the project boskos gave to my job, with no expectation the image will live beyond the job" pattern to be possible for all e2e projects.

ref: https://github.com/kubernetes/k8s.io/issues/1535