### PR TITLE
Promote nonewprivs 1.3

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-e2e-test-images/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-e2e-test-images/images.yaml
@@ -15,6 +15,7 @@
 - name: nonewprivs
   dmap:
     "sha256:553fcda2222ccea7cd534c8da34b709feb768d6389eb7333444b13f296bd168f": ["1.1"]
+    "sha256:8ac1264691820febacf3aea5d152cbde6d10685731ec14966a9401c6f47a68ac": ["1.3"]
 - name: regression-issue-74839
   dmap:
     "sha256:b4f1d8d61bdad84bd50442d161d5460e4019d53e989b64220fdbc62fc87d76bf": ["1.2"]


### PR DESCRIPTION
Promote nonewprivs:1.3 which adds support for s390x arch [kubernetes/kubernetes#94876](https://github.com/kubernetes/kubernetes/pull/94876) [kubernetes/kubernetes#97346](https://github.com/kubernetes/kubernetes/pull/97346)
```
manifest-tool inspect --raw gcr.io/k8s-staging-e2e-test-images/nonewprivs:1.3 | jq '.["digest"]'
"sha256:8ac1264691820febacf3aea5d152cbde6d10685731ec14966a9401c6f47a68ac"
```