### PR TITLE
Add 1.21 CI Signal shadows to email groups

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -664,8 +664,12 @@ groups:
       - gmccloskey@google.com
       - helenfengzhi@gmail.com
       - liggitt@google.com
+      - max@koerbaecher.io # 1.21 CI Signal Shadow
       - mrfaizal@google.com
+      - priyankahariharan421@gmail.com # 1.21 CI Signal Shadow
       - rob.kielty@gmail.com
+      - saumya00@outlook.com # 1.21 CI Signal Shadow
+      - snichols@vmware.com # 1.21 CI Signal Shadow
       - spiffxp@gmail.com
       - thejoycekung@gmail.com
       - neolit123@gmail.com

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -357,22 +357,22 @@ groups:
       - kinarashah108@gmail.com # 1.20 RT Enhancements Shadow
       - lachlan.evenson@gmail.com # 1.20 Emeritus Advisor
       - leslie@eagleusb.com # 1.20 Docs Shadow
+      - max@koerbaecher.io # 1.21 CI Signal Shadow
       - meloncattiel@gmail.com # 1.21 Release Notes Shadow
       - mik.json@gmail.com # 1.20 RT Enhancements Shadow
       - mvortizr@gmail.com # 1.21 Docs Shadow
       - peeyushgupta91@gmail.com # 1.21 Comms Shadow
       - pmmalinov01@gmail.com # 1.21 Release Notes Shadow
+      - priyankahariharan421@gmail.com # 1.21 CI Signal Shadow
       - rlejano@gmail.com # 1.21 Docs Lead
+      - saumya00@outlook.com # 1.21 CI Signal Shadow
       - shubhamtatvamasi@gmail.com # 1.20 Comms Shadow
+      - snichols@vmware.com # 1.21 CI Signal Shadow
       - somtochionyekwere@gmail.com # 1.20 Docs Shadow
       - soniasingla.1812@gmail.com # 1.21 Release Notes Shadow
       - tengqim@cn.ibm.com # 1.21 Docs Shadow
       - tony@gosselin.it # 1.20 Comms Shadow
-      - rob.kielty@gmail.com # 1.20 CI Signal Lead
-      - hkamel.msft@gmail.com # 1.20 CI Signal Shadow
-      - thejoycekung@gmail.com # 1.20 CI Signal Shadow
-      - prashsh1@in.ibm.com # 1.20 CI Signal Shadow
-      - eddiezane@gmail.com # 1.20 CI Signal Shadow
+      - thejoycekung@gmail.com # 1.21 CI Signal Lead
       - victor@cloudflavor.io # 1.21 Docs Shadow
       - wilsonehusin@gmail.com # 1.21 Release Notes Lead
       - xander@grzy.dev # 1.21 Comms Shadow
@@ -412,22 +412,23 @@ groups:
       - kefroden@gmail.com # 1.21 RT Enhancements Shadow
       - kinarashah108@gmail.com # 1.20 RT Enhancements Shadow
       - leslie@eagleusb.com # 1.20 Docs Shadow
-      - max@koerbaecher.io # 1.20 Bug Triage Shadow
+      - max@koerbaecher.io # 1.21 CI Signal Shadow
       - meloncattiel@gmail.com # 1.21 Release Notes Shadow
       - mik.json@gmail.com # 1.20 RT Enhancements Shadow
       - monmonmsc@gmail.com # 1.20 Bug Triage Shadow
       - mvortizr@gmail.com # 1.21 Docs Shadow
       - pal.nabarun95@gmail.com  # 1.20 RT Lead Shadow
-      - pmmalinov01@gmail.com # 1.21 Release Notes Shadow
-      - prashsh1@in.ibm.com # 1.20 CI Signal Shadow
       - peeyushgupta91@gmail.com # 1.21 Comms Shadow
+      - pmmalinov01@gmail.com # 1.21 Release Notes Shadow
+      - priyankahariharan421@gmail.com # 1.21 CI Signal Shadow
+      - saumya00@outlook.com # 1.21 CI Signal Shadow
       - saveetha13@gmail.com # 1.20 RT Lead Shadow
       - sayan.chowdhury2012@gmail.com # 1.20 Bug Triage Shadow
       - shubhamtatvamasi@gmail.com # 1.20 Comms Shadow
+      - snichols@vmware.com # 1.21 CI Signal Shadow
       - somtochionyekwere@gmail.com # 1.20 Docs Shadow
       - soniasingla.1812@gmail.com # 1.21 Release Notes Shadow
       - tengqim@cn.ibm.com # 1.21 Docs Shadow
-      - thejoycekung@gmail.com # 1.20 CI Signal Shadow
       - tony@gosselin.it # 1.20 Comms Shadow
       - victor@cloudflavor.io # 1.21 Docs Shadow
       - xander@grzy.dev # 1.21 Comms Shadow


### PR DESCRIPTION
Adds 1.21 CI Signal shadows to:

- `release-team@`
- `release-team-shadows@`
- `k8s-infra-prow-viewers@`