### PR TITLE
releng: Promote debian-hyperkube-base:buster-v1.3.0 images

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
@@ -66,6 +66,7 @@
     "sha256:dac908eaa61d2034aec252576a470a7e4ab184c361f89170526f707a0c3c6082": ["v2.1.0"]
 - name: debian-hyperkube-base
   dmap:
+    "sha256:3f7c4a46fd7745144fe1bd701b3aaab4ae5767b468fd91809661b05028d5cf8d": ["buster-v1.3.0"]
     "sha256:41754f0f74447a1d0989c1e8ce9c804cee6239d84e45fdca5ee8d9c52320b6dc": ["buster-v1.1.4"]
     "sha256:685f2560a91e4adeeb16a8e61e70a7c2568cd68144591007aa24ee1dcc498d31": ["buster-v1.2.0"]
     "sha256:8c8d854d868fb08352f73dda94f9e0b998c7318b48ddc587a355d0cbaf687f14": ["v1.0.0"]
@@ -77,6 +78,7 @@
   dmap:
     "sha256:2726491fe7ec4ae8d263f4b76633c765b0a179f7106ee830b17e0d438e17d45d": ["buster-v1.1.4"]
     "sha256:5cab0f210e47d4e04fe06fa0a20d8c7fde3bcfe14fe73b3eab3c7070790c4927": ["v1.1.0"]
+    "sha256:6eeab2823353adbd549af945ec77fe19ff7aeddc2818b891c541001b646e13fb": ["buster-v1.3.0"]
     "sha256:73a8cb2bfd6707c8ed70c252e97bdccad8bc265a9a585db12b8e3dac50d6cd2a": ["v1.0.0"]
     "sha256:9f1f43babd36bfd2cce05a63b0331ed580c1fea876c833aae7036ffa5c6346c0": ["buster-v1.1.3", "v1.1.3"]
     "sha256:cac8683b5147a7827eed5294b86286c1cab0ae980daf19c4e9ad43805889d2c2": ["v1.1.2"]
@@ -90,10 +92,12 @@
     "sha256:7321a64a58e942f0ba0fe5e2979b4ac22df2dcecedf7d118c4e643f5018b305a": ["v1.1.0"]
     "sha256:aee7c2958c6e0de896995e8b04c8173fd0a7bbb16cddb1f4668e3ae010b8c786": ["v1.0.0"]
     "sha256:d4d0f188ee723c3f276922512ce2d335af4a54caf65b5df5e9105955d34a1d72": ["buster-v1.1.3", "v1.1.3"]
+    "sha256:d77aae188c6bda325799091dab2af7bf78e3851d643e75978c97570645c3dc7f": ["buster-v1.3.0"]
     "sha256:f06e07c95a11ead1d8a6929f8df5f6afe061943f970be9d3121b1bc58d25ba1b": ["v1.1.1"]
 - name: debian-hyperkube-base-arm64
   dmap:
     "sha256:06d0797613073328d86e1721d931b1e0b8026c8e70aeb753eadf5b0856d0aadb": ["v1.1.0"]
+    "sha256:60218736d6fa213e4469dd5a944fa575ca041c6e0ce9fc6d058258caf46178b5": ["buster-v1.3.0"]
     "sha256:9b98a76c8bca6d4b19adae1a20d475d959428a28530febba8c044ca0aabb471d": ["buster-v1.1.3", "v1.1.3"]
     "sha256:a74fc6d690e5c5e393fd509f50d7203fa5cd19bfbb127d4a3a996fd1ebcf35c4": ["v1.0.0"]
     "sha256:c471afeec232448c2bafd52762a977470c85e4246ebca67bba544844f93b4b03": ["v1.1.1"]
@@ -103,6 +107,7 @@
 - name: debian-hyperkube-base-ppc64le
   dmap:
     "sha256:0ba61ab0ec8b2ed9501e4e1245119fd8af1c211eab0cf3bfddb1dbd95ed7ef08": ["buster-v1.1.3", "v1.1.3"]
+    "sha256:1a70fab2f7251915344a3a2a0ea0d860325e8964f6d7c88bcf9d68ad6e2efdd9": ["buster-v1.3.0"]
     "sha256:54afd9a85d6ecbe0792496f36012e7902601fb8084347cdc195c8b0561da39a3": ["v1.0.0"]
     "sha256:5edc20fb8ffa3ea80880b3d45fe2cce4004e5784523eaebfd3086cac8c7452e3": ["v1.1.2"]
     "sha256:905bc5d4c721c7cd842a42208f5393b6685c221f61ef5c88bb9b4a9a21b426de": ["buster-v1.1.4"]
@@ -111,6 +116,7 @@
     "sha256:e4b9b9cbdf4f87d8141e6abb2c1566bd65b05de560991b5e81dde04b573cb56f": ["buster-v1.2.0"]
 - name: debian-hyperkube-base-s390x
   dmap:
+    "sha256:27bc7f0a3d74386fae0179d1f5f531b7005e687ddfc50a39f4a0bf1a240582aa": ["buster-v1.3.0"]
     "sha256:38670cf1b300b532685aa102e860ab14950bb1f57bc5d51760bf9d0bf246c563": ["v1.1.2"]
     "sha256:405a94e6b82f2eb89c773e0e9f6105eb73cde5605d4508ae36a150d922fe1c66": ["v1.0.0"]
     "sha256:504417278bd2935f8ed72ebcc1bba6ae4deae9959b07769280fda2948fe76dd4": ["v1.1.1"]


### PR DESCRIPTION
Promotion PR for https://github.com/kubernetes/release/pull/1861.

Addresses:
- [CVE-2020-29361](https://security-tracker.debian.org/tracker/CVE-2020-29361)
- [CVE-2020-29362](https://security-tracker.debian.org/tracker/CVE-2020-29362)
- [CVE-2020-29363](https://security-tracker.debian.org/tracker/CVE-2020-29363)

Continuation of #1555.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @hasheddan @saschagrunert @cpanato 
cc: @kubernetes/release-engineering @wespanther
/area security
/priority critical-urgent