### PR TITLE
releng: Promote vulndash:v0.4.3-1

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-artifact-promoter/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-artifact-promoter/images.yaml
@@ -29,4 +29,5 @@
 - name: vulndash
   dmap:
     "sha256:739b7d395aabed36c0a917eb59daf972eda4d3fa1a1162efcdfb7d9b6bebbd2b": ["v0.3.0-1"]
+    "sha256:9dce7e839f81e8f55533fcfe8e529e120f099018264084e9e21ca8e2e99d36fa": ["v0.4.3-1"]
     "sha256:c015bfcc07326924927521709ea04cf19b7ab98ee16d97793a39a038b11a0693": ["v0.3.0"]


### PR DESCRIPTION
The vulndash image is now built with go1.15.7

- `vulndash:v0.4.3-1`: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-release-push-image-vulndash/1351860030877470720

Required for go1.15.7 updates: https://github.com/kubernetes/release/issues/1851

/assign @hasheddan @saschagrunert @xmudrii @puerco 

cc: @kubernetes/release-engineering @ameukam 