### PR TITLE
Add maintainer to CAPA group

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -906,6 +906,7 @@ groups:
       - goldsteina@vmware.com
       - jeewan@vmware.com
       - prignanov@vmware.com
+      - richmcase@gmail.com
 
   - email-id: k8s-infra-staging-cluster-api-do@kubernetes.io
     name: k8s-infra-staging-cluster-api-do


### PR DESCRIPTION
Adding new CAPA maintainer to the `k8s-infra-staging-cluster-api-aws@kubernetes.io` group. For reference the list of current maintainers for CAPA is [here](https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/master/OWNERS_ALIASES#L22).

/cc @randomvariable 