### PR TITLE
releng: Temporarily grant access to sethmccombs

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -61,6 +61,7 @@ groups:
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
       - saschagrunert@gmail.com
+      - sethpmccombs@gmail.com
 
   - email-id: k8s-infra-release-viewers@kubernetes.io
     name: k8s-infra-release-viewers


### PR DESCRIPTION
* temporary: Seth (@sethmccombs) is a Release Manager Associate being granted temporary elevated access to cut the 1.21.0-alpha.2 release. Access should be revoked after the 1.21.0-alpha1.2 release is cut.
sig-release issue: https://github.com/kubernetes/sig-release/issues/1435

/assign @dims @cblecker
cc: @kubernetes/release-engineering

/priority important-soon

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>