### PR TITLE
Increase the memory limit for Triage Party.

### DIFF
--- a/triage-party/release-team/deployment.yaml
+++ b/triage-party/release-team/deployment.yaml
@@ -39,7 +39,7 @@ spec:
           resources:
             limits:
               cpu: 1
-              memory: 1Gi
+              memory: 4Gi
           volumeMounts:
             - name: config
               mountPath: /app/config


### PR DESCRIPTION
TP is sometimes OOMKilled:

```
Containers:
  triage-party:
    Container ID:   docker://c95c8a1a429a753949d650f2a6aebd4ac63886c77e90604a8516661d21769da8
    Image:          triageparty/triage-party:1.3.0
    Image ID:       docker-pullable://triageparty/triage-party@sha256:4aa57022c43ba5499b5e9eb0cb5d6ea4d31ca5b5a3c518212b3beddfdbc439de
    Port:           8080/TCP
    Host Port:      0/TCP
    State:          Running
      Started:      Tue, 26 Jan 2021 16:38:10 +0000
    Last State:     Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Tue, 26 Jan 2021 13:55:21 +0000
      Finished:     Tue, 26 Jan 2021 16:38:09 +0000
```

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>