### PR TITLE
releng: Drop temporary access granted to sethmccombs

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -61,7 +61,6 @@ groups:
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
       - saschagrunert@gmail.com
-      - sethpmccombs@gmail.com
 
   - email-id: k8s-infra-release-viewers@kubernetes.io
     name: k8s-infra-release-viewers


### PR DESCRIPTION
Dropping temporary access granted in #1574 to Seth McCombs to cut the v1.20.1-alpha.2 release

sig-release issue: https://github.com/kubernetes/sig-release/issues/1435

/assign @dims @cblecker
cc: @kubernetes/release-engineering

/priority important-soon
/sig release

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>