### PR TITLE
Access to Triage Party for Verolop

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -13,6 +13,7 @@ groups:
       - bartek@smykla.com
       - dcampau1@gmail.com # 1.21 Bug Triage Lead
       - desponda@vmware.com # 1.21 Bug Triage Shadow
+      - gveronicalg@gmail.com
       - kcmartin2@mac.com # 1.21 Bug Triage Shadow
       - menna.elmasry@suse.com # 1.21 Bug Triage Shadow
 


### PR DESCRIPTION
Give TP access to @Verolop.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>

/assign @kubernetes/release-managers
/sig release
/area release-eng