### PR TITLE
releng: create new gcp project k8s-infra-staging-releng-test to test images build

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -191,6 +191,17 @@ groups:
     members:
       - k8s-infra-release-editors@kubernetes.io
 
+  - email-id: k8s-infra-staging-releng-test@kubernetes.io
+    name: k8s-infra-staging-releng-test
+    description: |-
+      ACL for staging RelEng
+
+      This project is primarily used to validate Release Engineering images in presubmit.
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - k8s-infra-release-editors@kubernetes.io
+
   - email-id: release-comms@kubernetes.io
     name: release-comms
     description: |-

--- a/infra/gcp/ensure-release-projects.sh
+++ b/infra/gcp/ensure-release-projects.sh
@@ -159,7 +159,7 @@ for BUCKET in "${RELEASE_BUCKETS[@]}"; do
     empower_gcs_admins "k8s-release" "${BUCKET}"
 
     # Enable prow to write to the bucket
-    # TODO(spiffxp): I almost guarantee prow will need admin privileges but 
+    # TODO(spiffxp): I almost guarantee prow will need admin privileges but
     #                let's start restricted and find out
     empower_svcacct_to_write_gcs_bucket "${PROW_BUILD_SVCACCT}" "${BUCKET}"
 

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -95,6 +95,7 @@ STAGING_PROJECTS=(
     provider-azure
     publishing-bot
     releng
+    releng-test
     scheduler-plugins
     scl-image-builder
     service-apis


### PR DESCRIPTION
Part of https://github.com/kubernetes/release/issues/1850

Need to set up a GCP project to hold the images that we build for testing the process and don't overwrite others.

This is to improve our confidence when building the images we need for the whole project

/assign @justaugustus @dims @spiffxp 
cc @kubernetes/release-engineering 