### PR TITLE
releng: Provision k8s-staging-experimental project

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -152,6 +152,18 @@ groups:
       - thockin@google.com
       - rajib.jolite@gmail.com
 
+  - email-id: k8s-infra-staging-experimental@kubernetes.io
+    name: k8s-infra-staging-experimental
+    description: |-
+      ACL for staging experimental images
+
+      This project is used to stage experimental images, for example, support
+      for new architectures.
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - k8s-infra-release-editors@kubernetes.io
+
   - email-id: k8s-infra-staging-kubernetes@kubernetes.io
     name: k8s-infra-staging-kubernetes
     description: |-

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -73,6 +73,7 @@ STAGING_PROJECTS=(
     etcd
     etcdadm
     examples
+    experimental
     external-dns
     git-sync
     infra-tools
@@ -107,6 +108,7 @@ STAGING_PROJECTS=(
 )
 
 RELEASE_STAGING_PROJECTS=(
+    experimental
     kubernetes
     mirror
     releng

--- a/k8s.gcr.io/images/k8s-staging-experimental/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-experimental/OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+options:
+  no_parent_owners: true
+approvers:
+  - release-engineering-approvers
+  - cblecker
+  - dims
+  - listx
+  - thockin
+reviewers:
+  - release-engineering-reviewers
+
+labels:
+  - sig/release
+  - area/release-eng

--- a/k8s.gcr.io/images/k8s-staging-experimental/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-experimental/images.yaml
@@ -1,0 +1,1 @@
+# No images yet

--- a/k8s.gcr.io/manifests/k8s-staging-experimental/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-experimental/promoter-manifest.yaml
@@ -1,0 +1,10 @@
+# google group for gcr.io/k8s-staging-experimental is k8s-infra-staging-experimental@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-experimental
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/experimental
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/experimental
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/experimental
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
To be used to stage experimental images, like support for new
architectures in an existing Tier 1 image.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @dims @hasheddan @saschagrunert 
cc: @kubernetes/release-engineering 

Part of https://github.com/kubernetes/sig-release/issues/1337.
Context (https://github.com/kubernetes/release/pull/1880#issuecomment-769074508):

> > ```
> > 1. We shouldn't add any new platforms to base images until there is clear path to at least `Tier 2` support in k/k. This would mean closing this PR and waiting until a functioning build of k/k can be demonstrated with this architecture.
> > ```
> 
> The counter to my feeling is: "How can a platform elevate their tier without supporting artifacts like this?".
> 
> > ```
> > 2. Adding support here allows for folks to more easily build k/k with that architecture to demonstrate its functionality as part of `Tier 3`. This would be accepting this PR and then having @houfangdong (or others) demonstrate ability to build k/k for this architecture, which would get them started on process to higher tiers.
> > ```
> > 
> > 
> > If we are comfortable with taking on the new platform from a maintenance perspective here, I don't think it necessarily needs to be gated on the criteria for tiers in k/k. In fact, I think our aim should be for base images like this to be as broadly useful as possible to the extent that we have bandwidth to maintain.
> 
> So my concern here would another tier impacting our ability to support our current artifacts.
> Example: @saschagrunert @cpanato saw image build errors recently with `s390x`, which cause our `amd64` pushes to fail.
> 
> I think if we can establish a playground variant of sorts, then I'd be open to this:
> 
> Example:
> 
>     * Tier 1: `debian-base:<tag>`
> 
>     * Anything else: `debian-base-experimental-arch:<tag>`
> 
> 
> Or even:
> 
>     * Tier 1: `k8s.gcr.io/build-image/debian-base:<tag>`
> 
>     * Anything else: `k8s.gcr.io/experimental-arch/debian-base:<tag>`
> 
> 
> They would build using the same Dockerfile/Makefiles, but run independently and (maybe) push to different staging projects.