### PR TITLE
Add new SIG-Windows TLs to leads group

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -78,12 +78,14 @@ groups:
       - ian@coldwater.io
       - irvi.fa@gmail.com
       - jameswangel@gmail.com
+      - jayunit100.apache@gmail.com
       - jbelamaric@google.com
       - jeef111x@gmail.com
       - jeremy.r.rickard@gmail.com
       - jeremyot@google.com
       - jonathan.berkhahn@gmail.com
       - jsafrane@redhat.com
+      - jsturtevant@gmail.com
       - justin@fathomdb.com
       - k8s@auggie.dev
       - kaitlynbarnard10@gmail.com


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

Related to https://github.com/kubernetes/org/pull/2415