### PR TITLE
Enable NAP in 'aaa' cluster

### DIFF
--- a/infra/gcp/clusters/projects/kubernetes-public/aaa/10-cluster-configuration.tf
+++ b/infra/gcp/clusters/projects/kubernetes-public/aaa/10-cluster-configuration.tf
@@ -148,6 +148,20 @@ resource "google_container_cluster" "cluster" {
     }
   }
 
+  // Enable NAP
+  cluster_autoscaling {
+    enabled = true
+    resource_limits {
+      resource_type = "cpu"
+      minimum = 2
+      maximum = 16
+    }
+    resource_limits {
+      resource_type = "memory"
+      maximum = 64
+    }
+  }
+
   // Enable PodSecurityPolicy enforcement
   pod_security_policy_config {
     enabled = false // TODO: we should turn this on


### PR DESCRIPTION
Context:

Currently perf-dash has cpu request/limit set to 3 cores and it still insufficient:
![image](https://user-images.githubusercontent.com/2559168/106723590-8d846380-6607-11eb-9d2c-577ef2ff16d9.png)

Also is being continuously OOMKilled with memory limit set to 8GiB.

The node pool added in https://github.com/kubernetes/k8s.io/pull/659 for perfdash is using n1-standard-4 which provides 4 cores and 12 GiB of allocatable memory.

I would like to increase perf-dash's requests to at least 6 cpus and 16 GiB (to give some room for growth), but I'm not able to do that due to the used machine type.

Instead of adding 'pool-3' node pool with larger machine type, I would like to propose enabling Node auto-provisioning on this cluster that will be adding such node pools as needed, reducing maintenance burden.