### PR TITLE
Migrate ingress for Triage Party

### DIFF
--- a/triage-party/release-team/ingress.yaml
+++ b/triage-party/release-team/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: triage-party-release


### PR DESCRIPTION
Switch the API version for Triage Party ingress.
Ref: https://github.com/kubernetes/k8s.io/issues/1031

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>