### PR TITLE
releng: Promote go-runner:buster-v2.3.1

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
@@ -212,6 +212,7 @@
     "sha256:536ab131b0d0e3b13eb83c985cc0ac9ba7e69e7dac9521e6cacd6a8b6019e0a6": ["v0.1.0"]
     "sha256:687c17db2f5cd4aea13faa7ae56bee639a5b11f380c431a9800205624f53541c": ["buster-v2.0.1"]
     "sha256:9123b097124dcc0e9232068052d749d5816aa5f2bf8129829df7d9033cb2cc74": ["buster-v2.3.0"]
+    "sha256:cd45714e4824eeff6f107d9e3b4f79be9ee0cf5071dc46caf755d3f324a36089": ["buster-v2.3.1"]
     "sha256:ff6e2f3683e7d284674ed18341fc898060204e8c43c9b477e13c6f7faf3e66d4": ["buster-v2.0.0"]
 - name: kube-cross
   dmap:


### PR DESCRIPTION
- `go-runner:buster-v2.3.1`: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-release-push-image-go-runner/1357628759489908736

Required for go1.15.8 updates: https://github.com/kubernetes/release/issues/1895

/assign @hasheddan @saschagrunert @xmudrii @puerco @ameukam 

cc: @kubernetes/release-engineering 