### PR TITLE
Add wg-reliability-sippy namespace.

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -241,6 +241,7 @@ groups:
       - k8s-infra-rbac-triageparty-release@kubernetes.io
       - k8s-infra-rbac-slack-infra@kubernetes.io
       - k8s-infra-rbac-node-perf-dash@kubernetes.io
+      - k8s-infra-rbac-wg-reliability@kubernetes.io
 
   - email-id: k8s-infra-alerts@kubernetes.io
     name: k8s-infra-alerts
@@ -627,6 +628,18 @@ groups:
       - spiffxp@google.com
       - spiffxp@gmail.com
       - thockin@google.com
+
+  - email-id: k8s-infra-rbac-wg-reliability@kubernetes.io
+    name: k8s-infra-rbac-wg-reliability
+    description: |-
+      ACL for wg-reliability Infra
+    settings:
+      ReconcileMembers: "true"
+      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # required
+    members:
+      - deads@redhat.com
+      - wojtekt@google.com
+      - skuznets@redhat.com
 
   - email-id: k8s-infra-prow-oncall@kubernetes.io
     name: k8s-infra-prow-oncall

--- a/infra/gcp/namespaces/ensure-namespaces.sh
+++ b/infra/gcp/namespaces/ensure-namespaces.sh
@@ -152,6 +152,7 @@ ALL_PROJECTS=(
     "publishing-bot"
     "slack-infra"
     "triageparty-release"
+    "wg-reliability-sippy"
 )
 
 for prj in "${ALL_PROJECTS[@]}"; do


### PR DESCRIPTION
Sippy is a community tool will be used by wg-reliability to help produce
transparent metrics to assess overall stability and break down by
project area.

Additional details available in #wg-reliability and on the mailing list
at https://groups.google.com/g/kubernetes-sig-testing/c/BxnXXipU42M/m/bWyT-9gtAwAJ

@wojtek-t @stevekuznetsov 