### PR TITLE
add manifests for initial deployment of sippy

### DIFF
--- a/sippy/OWNERS
+++ b/sippy/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - wg-reliability-leads
+reviewers:
+  - wg-reliability-leads
+
+labels:
+  - wg/reliability

--- a/sippy/README.md
+++ b/sippy/README.md
@@ -1,0 +1,17 @@
+# sippy
+
+`sippy` is a tool used to aid in transparency of stability metrics.
+
+[sippy](https://github.com/openshift/sippy) summarizes multiple test-grid dashboards with data slicing of related jobs, job runs,
+and tests.  Visit (placeholder for eventual URL) to see the kube instance. 
+
+
+## How to deploy sippy
+
+- Have [access](https://github.com/kubernetes/k8s.io/blob/master/running-in-community-clusters.md) to the GKE cluster `aaa`.
+
+- From the `sippy` directory run:
+
+```console
+kubectl apply -f sippy/
+```

--- a/sippy/sippy/certificate.yaml
+++ b/sippy/sippy/certificate.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: sippy-k8s-io
+  namespace: sippy
+  annotations:
+    acme.cert-manager.io/http01-override-ingress-name: "sippy"
+    cert-manager.io/issue-temporary-certificate: "true"
+spec:
+  secretName: sippy-k8s-io-tls
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-prod
+  dnsNames:
+    - sippy.k8s.io

--- a/sippy/sippy/deployment.yaml
+++ b/sippy/sippy/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: sippy
+  name: sippy
+  namespace: sippy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sippy
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: sippy
+    spec:
+      containers:
+        - image: quay.io/bparees/sippy:unstable
+          imagePullPolicy: Always
+          name: sippy
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          resources:
+            limits:
+              memory: 1500M
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          command:
+            - /tmp/src/sippy
+          args:
+            - --server
+            - --end-day
+            - "7"
+            - --local-data
+            - /data
+            - --dashboard
+            - kube-master=sig-release-master-blocking,sig-release-master-informing=
+            - --variant=kube
+          volumeMounts:
+            - mountPath: /data
+              name: data
+        - image: quay.io/bparees/sippy:unstable
+          imagePullPolicy: Always
+          name: fetchdata
+          resources:
+            limits:
+              memory: 500M
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          # This runs in a loop to collect data every hour or so.  We run it in the same pod so that both containers can mount
+          # and we don't need r/w many.
+          command:
+            - /tmp/src/scripts/fetchdata-kube.sh
+          volumeMounts:
+            - mountPath: /data
+              name: data
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: sippy

--- a/sippy/sippy/ingress.yaml
+++ b/sippy/sippy/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: sippy
+  namespace: sippy
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: "sippy-ingress-prod"
+  labels:
+    app: sippy
+spec:
+  defaultBackend:
+    service:
+      name: sippy
+      port:
+        number: 8080
+  tls:
+  - secretName : sippy-k8s-io-tls

--- a/sippy/sippy/pvc.yaml
+++ b/sippy/sippy/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: sippy
+  namespace: sippy
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+  storageClassName: standard

--- a/sippy/sippy/service.yaml
+++ b/sippy/sippy/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: sippy
+  name: sippy
+  namespace: sippy
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: sippy
+  sessionAffinity: None
+  type: ClusterIP
+


### PR DESCRIPTION
builds on https://github.com/kubernetes/k8s.io/pull/1614

This adds manifests to deploy and run sippy.  This is similar to what I have in my private toy cluster, but I need to do a little bit of alignment and work out ingresses instead of routes.

/assign @wojtek-t 

/hold

explicit hold until I'm able to test these locally.