### PR TITLE
releng: setup service account to be used in prow build to access gcb

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/build-serviceaccounts.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/build-serviceaccounts.yaml
@@ -6,3 +6,11 @@ metadata:
     iam.gke.io/gcp-service-account: prow-build@k8s-infra-prow-build.iam.gserviceaccount.com
   name: prow-build
   namespace: test-pods
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: k8s-infra-staging-releng-test@k8s-infra-prow-build.iam.gserviceaccount.com
+  name: k8s-infra-staging-releng-test
+  namespace: test-pods

--- a/infra/gcp/ensure-main-project.sh
+++ b/infra/gcp/ensure-main-project.sh
@@ -154,6 +154,19 @@ empower_ksa_to_svcacct \
     "${PROJECT}" \
     "$(svc_acct_email "${PROJECT}" "k8s-infra-dns-updater")"
 
+color 6 "Ensuring the k8s-infra-staging-releng-test serviceaccount exists"
+ensure_service_account \
+    "${PROJECT}" \
+    "k8s-infra-staging-releng-test" \
+    "k8s-infra releng test"
+
+color 6 -n "Empowering k8s-infra-staging-releng-test serviceaccount to be used on"
+color 6 " build cluster"
+empower_ksa_to_svcacct \
+    "k8s-infra-prow-build.svc.id.goog[test-pods/k8s-infra-staging-releng-test]" \
+    "${PROJECT}" \
+    "$(svc_acct_email "${PROJECT}" "k8s-infra-staging-releng-test")"
+
 color 6 "Empowering ${DNS_GROUP}"
 gcloud projects add-iam-policy-binding "${PROJECT}" \
     --member "group:${DNS_GROUP}" \

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -293,3 +293,15 @@ color 6 "Configuring special case for k8s-staging-ci-images"
     SERVICE_ACCOUNT=$(svc_acct_email "k8s-infra-prow-build" "prow-build")
     empower_svcacct_to_write_gcr "${SERVICE_ACCOUNT}" "${PROJECT}"
 )
+
+# Special case: In order for pull-release-image-* to run on k8s-infra-prow-build,
+#               it needs write access to gcr.io/k8s-staging-releng-test. For now,
+#               we will grant the prow-build service account write access. Longer
+#               term we would prefer service accounts per project, and restrictions
+#               on which jobs can use which service accounts.
+color 6 "Configuring special case for k8s-staging-releng-test"
+(
+    PROJECT="k8s-staging-releng-test"
+    SERVICE_ACCOUNT=$(svc_acct_email "k8s-infra-prow-build" "k8s-infra-staging-releng-test")
+    empower_svcacct_to_write_gcr "${SERVICE_ACCOUNT}" "${PROJECT}"
+)


### PR DESCRIPTION
The PR tries to address the feedback https://github.com/kubernetes/test-infra/pull/20703#issuecomment-774224609 to be able to run pre-submits jobs to trigger GCB

To be honest I'm not sure if those changes are correct. Please let me know what we need to update/create.

Follow up
- create a check to add some enforcement around which jobs are allowed to use which service accounts via tests in `config/tests/jobs` in test-infra repo.

Related to https://github.com/kubernetes/release/issues/1850

/assign @spiffxp @hasheddan 