### PR TITLE
Setup gcb-builder-releng-test SA for k8s-infra-prow-build

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/build-serviceaccounts.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/build-serviceaccounts.yaml
@@ -11,6 +11,6 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   annotations:
-    iam.gke.io/gcp-service-account: k8s-infra-staging-releng-test@k8s-infra-prow-build.iam.gserviceaccount.com
-  name: k8s-infra-staging-releng-test
+    iam.gke.io/gcp-service-account: gcb-builder-releng-test@k8s-staging-releng-test.iam.gserviceaccount.com
+  name: gcb-builder-releng-test
   namespace: test-pods

--- a/infra/gcp/ensure-main-project.sh
+++ b/infra/gcp/ensure-main-project.sh
@@ -154,19 +154,6 @@ empower_ksa_to_svcacct \
     "${PROJECT}" \
     "$(svc_acct_email "${PROJECT}" "k8s-infra-dns-updater")"
 
-color 6 "Ensuring the k8s-infra-staging-releng-test serviceaccount exists"
-ensure_service_account \
-    "${PROJECT}" \
-    "k8s-infra-staging-releng-test" \
-    "k8s-infra releng test"
-
-color 6 -n "Empowering k8s-infra-staging-releng-test serviceaccount to be used on"
-color 6 " build cluster"
-empower_ksa_to_svcacct \
-    "k8s-infra-prow-build.svc.id.goog[test-pods/k8s-infra-staging-releng-test]" \
-    "${PROJECT}" \
-    "$(svc_acct_email "${PROJECT}" "k8s-infra-staging-releng-test")"
-
 color 6 "Empowering ${DNS_GROUP}"
 gcloud projects add-iam-policy-binding "${PROJECT}" \
     --member "group:${DNS_GROUP}" \


### PR DESCRIPTION
This redoes https://github.com/kubernetes/k8s.io/pull/1620 to support https://github.com/kubernetes/release/issues/1850

Try to converge on a consistent naming pattern:
- k8s-infra-staging-foo@kubernetes.io group
- k8s-staging-foo project
- gcb-builder-foo service account in k8s-staging-foo project
- gcb-builder-foo service account usable by prow