### PR TITLE
Allow admin access for ingresses

### DIFF
--- a/infra/gcp/namespaces/namespace-user-role.yml
+++ b/infra/gcp/namespaces/namespace-user-role.yml
@@ -24,7 +24,7 @@ rules:
     resources: ["leases"]
     verbs: ["*"]
   - apiGroups: ["networking.k8s.io"]
-    resources: ["networkpolicies"]
+    resources: ["networkpolicies","ingresses"]
     verbs: ["*"]
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]


### PR DESCRIPTION
Allow operators for the workloads hosted in `aaa` clusters to
operate ingresses in the API group `networking.k8s.io`.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>