### PR TITLE
releng: Drop temporary access to ameukam

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -55,7 +55,6 @@ groups:
     members:
       - k8s-infra-release-admins@kubernetes.io
       - adolfo.garcia@uservers.net
-      - ameukam@gmail.com
       - ctadeu@gmail.com
       - feiskyer@gmail.com
       - georgedanielmangum@gmail.com


### PR DESCRIPTION
Dropping temporary access granted in #1623 to Arnaud Meukam (@ameukam) to cut the v1.21.0-alpha.3 release

sig-release issue: https://github.com/kubernetes/sig-release/issues/1456

/assign @dims @cblecker
cc: @kubernetes/release-engineering

/priority important-soon
/sig release

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>