### PR TITLE
Enroll prow build clusters to a GKE release channel.

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
@@ -130,6 +130,7 @@ module "prow_build_cluster" {
   cluster_location  = local.cluster_location
   bigquery_location = local.bigquery_location
   is_prod_cluster   = "true"
+  release_channel = "STABLE"
 }
 
 module "prow_build_nodepool" {

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
@@ -130,7 +130,7 @@ module "prow_build_cluster" {
   cluster_location  = local.cluster_location
   bigquery_location = local.bigquery_location
   is_prod_cluster   = "true"
-  release_channel = "STABLE"
+  release_channel   = "STABLE"
 }
 
 module "prow_build_nodepool" {

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
@@ -105,6 +105,7 @@ module "prow_build_cluster" {
   cluster_location  = local.cluster_location
   bigquery_location = local.bigquery_location
   is_prod_cluster   = "true"
+  release_channel   = "STABLE"
 }
 
 module "prow_build_nodepool_n1_highmem_8_maxiops" {


### PR DESCRIPTION
Enrolling prow build clusters to the GKE release channel `STABLE`:
https://cloud.google.com/kubernetes-engine/docs/release-notes-stable.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>