### PR TITLE
Migrate ingress for slack-infra

### DIFF
--- a/slack-infra/resources/ingress.yaml
+++ b/slack-infra/resources/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: slack-infra


### PR DESCRIPTION
Switch the API version of the ingress for slack-infra.
Ref: https://github.com/kubernetes/k8s.io/issues/1031

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>