### PR TITLE
cluster-api-provider-digitalocean: Update OWNERS and group members

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -953,6 +953,7 @@ groups:
       - ctadeu@gmail.com
       - detiber@gmail.com
       - jeremylevanmorris@gmail.com
+      - ttr314@googlemail.com
 
   - email-id: k8s-infra-staging-cluster-api-azure@kubernetes.io
     name: k8s-infra-staging-cluster-api-azure

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -953,7 +953,6 @@ groups:
       - ctadeu@gmail.com
       - detiber@gmail.com
       - jeremylevanmorris@gmail.com
-      - mudrinic.mare@gmail.com
 
   - email-id: k8s-infra-staging-cluster-api-azure@kubernetes.io
     name: k8s-infra-staging-cluster-api-azure

--- a/k8s.gcr.io/images/k8s-staging-cluster-api-do/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api-do/OWNERS
@@ -5,3 +5,4 @@ approvers:
 - detiber
 - MorrisLaw
 - prksu
+- timoreimann

--- a/k8s.gcr.io/images/k8s-staging-cluster-api-do/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api-do/OWNERS
@@ -5,4 +5,3 @@ approvers:
 - detiber
 - MorrisLaw
 - prksu
-- xmudrii


### PR DESCRIPTION
As per https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/pull/234:

* Remove Marko Mudrinić (@xmudrii) from OWNERS and the group
* Add Timo Reimann (@timoreimann) to OWNERS and the group

/assign @cpanato @MorrisLaw @prksu @timoreimann 