### PR TITLE
Enable dns cache for k8s-infra-prow-build, cleanup gke-cluster module

### DIFF
--- a/infra/gcp/clusters/modules/gke-cluster/main.tf
+++ b/infra/gcp/clusters/modules/gke-cluster/main.tf
@@ -178,7 +178,7 @@ resource "google_container_cluster" "prod_cluster" {
       disabled = false
     }
     dns_cache_config {
-      enabled = var.enable_node_local_dns_cache
+      enabled = var.dns_cache_enabled
     }
   }
 
@@ -279,6 +279,9 @@ resource "google_container_cluster" "test_cluster" {
     }
     network_policy_config {
       disabled = false
+    }
+    dns_cache_config {
+      enabled = var.dns_cache_enabled
     }
   }
 

--- a/infra/gcp/clusters/modules/gke-cluster/main.tf
+++ b/infra/gcp/clusters/modules/gke-cluster/main.tf
@@ -186,11 +186,6 @@ resource "google_container_cluster" "prod_cluster" {
     channel = var.release_channel
   }
 
-  // Enable PodSecurityPolicy enforcement
-  pod_security_policy_config {
-    enabled = false // TODO: we should turn this on
-  }
-
   // Enable VPA
   vertical_pod_autoscaling {
     enabled = true
@@ -283,11 +278,6 @@ resource "google_container_cluster" "test_cluster" {
     dns_cache_config {
       enabled = var.dns_cache_enabled
     }
-  }
-
-  // Enable PodSecurityPolicy enforcement
-  pod_security_policy_config {
-    enabled = false // TODO: we should turn this on
   }
 
   // Enable VPA

--- a/infra/gcp/clusters/modules/gke-cluster/variables.tf
+++ b/infra/gcp/clusters/modules/gke-cluster/variables.tf
@@ -41,8 +41,6 @@ variable "is_prod_cluster" {
 }
 
 variable "release_channel" {
-  type        = string
-  default     = "UNSPECIFIED"
   description = <<EOF
   The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`.
 
@@ -50,10 +48,19 @@ variable "release_channel" {
 
   More information about release channels can be found here : https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels.
 EOF
+  type        = string
+  default     = "UNSPECIFIED"
 }
 
-variable "enable_node_local_dns_cache" {
-  description = "If this cluster should have NodeLocal DNSCache enabled"
+variable "dns_cache_enabled" {
+  description = <<EOF
+  Whether the cluster has the NodeLocal DNSCache add-on enabled
+
+  NOTE: changes to this value require node recreation to take effect (will happen during next maintenance window, or if gcloud command is used)
+
+  More information available here: https://cloud.google.com/kubernetes-engine/docs/how-to/nodelocal-dns-cache
+EOF
   type        = string
+  // TODO: default this true (and/or remove this option) once kubernetes-public/aaa uses this module
   default     = "false"
 }

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
@@ -31,7 +31,6 @@ locals {
   cluster_sa_name              = "prow-build-trusted"  // Name of the GSA and KSA that pods use by default
   gcb_builder_sa_name          = "gcb-builder"         // Name of the GSA and KSA that pods use to be allowed to run GCB builds and push to GCS buckets
   prow_deployer_sa_name        = "prow-deployer"       // Name of the GSA and KSA that pods use to be allowed to deploy to prow build clusters
-  enable_node_local_dns_cache  = "true"                // Enable NodeLocal DNSCache
 }
 
 module "project" {
@@ -132,7 +131,7 @@ module "prow_build_cluster" {
   bigquery_location = local.bigquery_location
   is_prod_cluster   = "true"
   release_channel   = "STABLE"
-  enable_node_local_dns_cache = local.enable_node_local_dns_cache
+  dns_cache_enabled = "true"
 }
 
 module "prow_build_nodepool" {

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
@@ -31,7 +31,6 @@ locals {
   pod_namespace                = "test-pods"            // MUST match whatever prow is configured to use when it schedules to this cluster
   cluster_sa_name              = "prow-build"           // Name of the GSA and KSA that pods use by default
   boskos_janitor_sa_name       = "boskos-janitor"       // Name of the GSA and KSA used by boskos-janitor
-  enable_node_local_dns_cache  = "true"                 // Enable NodeLocal DNSCache
 }
 
 module "project" {
@@ -107,7 +106,7 @@ module "prow_build_cluster" {
   bigquery_location = local.bigquery_location
   is_prod_cluster   = "true"
   release_channel   = "STABLE"
-  enable_node_local_dns_cache = local.enable_node_local_dns_cache
+  dns_cache_enabled = "true"
 }
 
 module "prow_build_nodepool_n1_highmem_8_maxiops" {


### PR DESCRIPTION
Followup to https://github.com/kubernetes/k8s.io/pull/1680 which added the dns cache option, and enabled for k8s-infra-prow-build-trusted

I did some cleanup while I was here, see commits for details