### PR TITLE
k8s.gcr.io/images/k8s-staging-cri-tools: Remove inactive OWNERS

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cri-tools/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-cri-tools/OWNERS
@@ -9,4 +9,6 @@ approvers:
   - tallclair
   - xlgao-zju
   - yujuhong
+emeritus_approvers:
   - runcom
+


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/2456

As a part of cleaning up inactive members (those with no activity within
the past 18 months) from OWNERS files, this commit moves runcom from an
approver to an emeritus_approver.

/assign @saschagrunert