### PR TITLE
nginx: disable to output the nginx version when show the exception pages

### DIFF
--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -12,6 +12,9 @@ data:
     }
 
     http {
+      # Disable to show the nginx version
+      server_tokens off;
+
       # This is the main site.
       server {
         server_name k8s.io;


### PR DESCRIPTION
/kind security

Disable the nginx version when showing the exception pages, this hides potential attacks to the server

/assign @dims 