### PR TITLE
Add custon kube-dns-autoscaler configmap to prow build clusters

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/kube-dns-autoscaler-configmap.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/kube-dns-autoscaler-configmap.yaml
@@ -1,0 +1,12 @@
+# This is to address a known issue with node local dns cache
+# https://cloud.google.com/kubernetes-engine/docs/how-to/nodelocal-dns-cache#known_issues
+# TODO: remove when cluster version is >= 1.19.7-gke.1500
+# NOTE: string containing structured data, was retrieved from v1.17.15-gke.800, may fail 
+#       silently in the future if the expected schema changes
+apiVersion: v1
+data:
+  linear: '{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}'
+kind: ConfigMap
+metadata:
+  name: kube-dns-autoscaler
+  namespace: kube-system

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/kube-dns-autoscaler-configmap.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/kube-dns-autoscaler-configmap.yaml
@@ -5,7 +5,7 @@
 #       silently in the future if the expected schema changes
 apiVersion: v1
 data:
-  linear: '{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}'
+  linear: '{"coresPerReplica":256,"nodesPerReplica":8,"min":4,"preventSinglePointFailure":true}'
 kind: ConfigMap
 metadata:
   name: kube-dns-autoscaler

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/kube-dns-autoscaler-configmap.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/kube-dns-autoscaler-configmap.yaml
@@ -1,0 +1,12 @@
+# This is to address a known issue with node local dns cache
+# https://cloud.google.com/kubernetes-engine/docs/how-to/nodelocal-dns-cache#known_issues
+# TODO: remove when cluster version is >= 1.19.7-gke.1500
+# NOTE: string containing structured data, was retrieved from v1.17.15-gke.800, may fail 
+#       silently in the future if the expected schema changes
+apiVersion: v1
+data:
+  linear: '{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}'
+kind: ConfigMap
+metadata:
+  name: kube-dns-autoscaler
+  namespace: kube-system

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/kube-dns-autoscaler-configmap.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/kube-dns-autoscaler-configmap.yaml
@@ -5,7 +5,7 @@
 #       silently in the future if the expected schema changes
 apiVersion: v1
 data:
-  linear: '{"coresPerReplica":256,"nodesPerReplica":16,"preventSinglePointFailure":true}'
+  linear: '{"coresPerReplica":256,"nodesPerReplica":8,"min":4,"preventSinglePointFailure":true}'
 kind: ConfigMap
 metadata:
   name: kube-dns-autoscaler


### PR DESCRIPTION
Now that node local dns cache is enabled for prow build clusters, we want to adjust the configmap used to autoscale dns servers.  This is as requested in https://github.com/kubernetes/test-infra/issues/20716#issuecomment-779942723

This should be the last bit of work related to enabling node local dns cache to prow build clusters:
- https://github.com/kubernetes/k8s.io/pull/1680 - enable for prow-build-trusted
- https://github.com/kubernetes/k8s.io/pull/1686 - enable for prow-build
- https://github.com/kubernetes/k8s.io/issues/1541#issuecomment-782264171 - upgrade clusters to v1.17 (to trigger rollout
- this PR - tune configmap values 

This should hopefully address:
- https://github.com/kubernetes/test-infra/issues/20716 - prowjobs failing with `could not resolve host: github.com`
- https://github.com/kubernetes/test-infra/issues/20816 - jobs erroring out wiht `Post \"https://oauth2.googleapis.com/token\": dial tcp: i/o timeout`