### PR TITLE
Upgrade prow build clusters to Terraform 0.13

### DIFF
--- a/infra/gcp/clusters/modules/gke-cluster/versions.tf
+++ b/infra/gcp/clusters/modules/gke-cluster/versions.tf
@@ -15,9 +15,15 @@
  */
 
 terraform {
-  required_version = "~> 0.12.20"
+  required_version = ">= 0.13"
   required_providers {
-    google      = "~> 3.46.0"
-    google-beta = "~> 3.46.0"
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.46.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 3.46.0"
+    }
   }
 }

--- a/infra/gcp/clusters/modules/gke-nodepool/versions.tf
+++ b/infra/gcp/clusters/modules/gke-nodepool/versions.tf
@@ -15,9 +15,15 @@
  */
 
 terraform {
-  required_version = "~> 0.12.20"
+  required_version = ">= 0.13"
   required_providers {
-    google      = "~> 3.46.0"
-    google-beta = "~> 3.46.0"
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.46.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 3.46.0"
+    }
   }
 }

--- a/infra/gcp/clusters/modules/gke-project/versions.tf
+++ b/infra/gcp/clusters/modules/gke-project/versions.tf
@@ -15,9 +15,15 @@
  */
 
 terraform {
-  required_version = "~> 0.12.20"
+  required_version = ">= 0.13"
   required_providers {
-    google      = "~> 3.46.0"
-    google-beta = "~> 3.46.0"
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.46.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 3.46.0"
+    }
   }
 }

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/00-provider.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/00-provider.tf
@@ -6,7 +6,7 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 0.12.20"
+  required_version = "~> 0.13.6"
 
   backend "gcs" {
     bucket = "k8s-infra-clusters-terraform"
@@ -14,7 +14,13 @@ terraform {
   }
 
   required_providers {
-    google      = "~> 3.46.0"
-    google-beta = "~> 3.46.0"
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.46.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 3.46.0"
+    }
   }
 }

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/versions.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.13"
+}

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/00-provider.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/00-provider.tf
@@ -6,7 +6,7 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 0.12.20"
+  required_version = "~> 0.13.6"
 
   backend "gcs" {
     bucket = "k8s-infra-clusters-terraform"
@@ -14,7 +14,13 @@ terraform {
   }
 
   required_providers {
-    google      = "~> 3.46.0"
-    google-beta = "~> 3.46.0"
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.46.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 3.46.0"
+    }
   }
 }

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/versions.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
Upgrade the configuration of build clusters for support of
Terraform 0.13.
Command used with terraform binary (need at least 0.13.0 version):

```console
terraform 0.13upgrade -yes .
```

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>