### PR TITLE
slack-infra: add slack-moderator-words config

### DIFF
--- a/slack-infra/README.md
+++ b/slack-infra/README.md
@@ -4,6 +4,7 @@ Cluster resources to deploy the following apps from [kubernetes-sigs/slack-infra
 
 - slack-event-log
 - slack-moderator
+- slack-moderator-words
 - slack-welcomer
 - slack-post-message
 - slackin

--- a/slack-infra/resources/ingress.yaml
+++ b/slack-infra/resources/ingress.yaml
@@ -29,3 +29,7 @@ spec:
             backend:
               serviceName: slack-post-message
               servicePort: 80
+          - path: /infra/moderator-words/*
+            backend:
+              serviceName: slack-moderator-words
+              servicePort: 80

--- a/slack-infra/resources/slack-event-log/deployment.yaml
+++ b/slack-infra/resources/slack-event-log/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-event-log
-        image: gcr.io/k8s-staging-slack-infra/slack-event-log:v20200612-1c5d751
+        image: gcr.io/k8s-staging-slack-infra/slack-event-log:v20210223-8525eb3
         args:
           - --config-path=/etc/slack-event-log/config.json
         ports:

--- a/slack-infra/resources/slack-moderator-words/deployment.yaml
+++ b/slack-infra/resources/slack-moderator-words/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: slack-moderator-words
+  labels:
+    app: slack-moderator-words
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: slack-moderator-words
+  template:
+    metadata:
+      labels:
+        app: slack-moderator-words
+    spec:
+      containers:
+      - name: slack-moderator-words
+        image: gcr.io/k8s-staging-slack-infra/slack-moderator-words:latest
+        imagePullPolicy: Always
+        args:
+          - --config-path=/etc/slack-moderator-words/config.json
+          - --filter-config-path=/etc/filters/filters.yaml
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        env:
+        - name: PATH_PREFIX
+          value: /infra/moderator-words
+        volumeMounts:
+        - mountPath: /etc/slack-moderator-words
+          name: config
+        - mountPath: /etc/filters
+          name: filters
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            scheme: HTTP
+            port: 8080
+      volumes:
+      - name: config
+        secret:
+          secretName: slack-moderator-words-config
+      - name: filters
+        configMap:
+          name: slack-moderator-words-filters

--- a/slack-infra/resources/slack-moderator-words/deployment.yaml
+++ b/slack-infra/resources/slack-moderator-words/deployment.yaml
@@ -16,8 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-moderator-words
-        image: gcr.io/k8s-staging-slack-infra/slack-moderator-words:latest
-        imagePullPolicy: Always
+        image: gcr.io/k8s-staging-slack-infra/slack-moderator-words:v20210223-8525eb3
         args:
           - --config-path=/etc/slack-moderator-words/config.json
           - --filter-config-path=/etc/filters/filters.yaml

--- a/slack-infra/resources/slack-moderator-words/filters.yaml
+++ b/slack-infra/resources/slack-moderator-words/filters.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: slack-moderator-words-filters
+data:
+  filters.yaml: |-
+    - triggers:
+      - guys
+      action: chat.postEphemeral
+      message: "May I suggest \"all\" instead of \"guys\" when addessing a group of people? Thank you. :slightly_smiling_face:"

--- a/slack-infra/resources/slack-moderator-words/service.yaml
+++ b/slack-infra/resources/slack-moderator-words/service.yaml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: slack-moderator-words
+spec:
+  selector:
+    app: slack-moderator-words
+  type: NodePort
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080

--- a/slack-infra/resources/slack-moderator/deployment.yaml
+++ b/slack-infra/resources/slack-moderator/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-moderator
-        image: gcr.io/k8s-staging-slack-infra/slack-moderator:v20200612-1c5d751
+        image: gcr.io/k8s-staging-slack-infra/slack-moderator:v20210223-8525eb3
         args:
           - --config-path=/etc/slack-moderator/config.json
         ports:

--- a/slack-infra/resources/slack-post-message/deployment.yaml
+++ b/slack-infra/resources/slack-post-message/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-post-message
-        image: gcr.io/k8s-staging-slack-infra/slack-post-message:v20200901-117c06f 
+        image: gcr.io/k8s-staging-slack-infra/slack-post-message:v20210223-8525eb3
         args:
           - --config-path=/etc/slack-post-message/config.json
         ports:

--- a/slack-infra/resources/slack-welcomer/deployment.yaml
+++ b/slack-infra/resources/slack-welcomer/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-moderator
-        image: gcr.io/k8s-staging-slack-infra/slack-welcomer:v20200612-1c5d751
+        image: gcr.io/k8s-staging-slack-infra/slack-welcomer:v20210223-8525eb3
         args:
           - --config-path=/etc/slack-welcomer/config.json
           - --message-path=/etc/welcome-message/welcome.md


### PR DESCRIPTION
ref:
- PR adding slack-moderator-words - https://github.com/kubernetes-sigs/slack-infra/pull/41
- updates to slack-moderator-words to push the image - https://github.com/kubernetes-sigs/slack-infra/pull/43

This PR adds config for `slack-moderator-words`  to slack-infra.

/hold
Need to do a few thing before we can merge this.

- [x] Push the `slack-moderator-words` image - https://github.com/kubernetes-sigs/slack-infra/pull/43 needs to merge
- [x] Update the config in this PR to the versioned image (ref: [postsubmit job](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-slack-infra-push-images/1364209929354743808))
- [ ] Add the `slack-moderator-words-config` secret

/cc @ameukam @jeefy @mrbobbytables @cpanato 

/assign @ameukam 
Arnaud -- since you've done most of the work for setting up slack-infra, can you help with this PR? :pray: 