### PR TITLE
Increase node capacity for k8s-infra-prow-build

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
@@ -117,7 +117,7 @@ module "prow_build_nodepool_n1_highmem_8_maxiops" {
   name            = "pool4"
   initial_count   = 1
   min_count       = 1
-  max_count       = 50
+  max_count       = 80
   # kind-ipv6 jobs need an ipv6 stack; COS doesn't provide one, so we need to
   # use an UBUNTU image instead. Keep parity with the existing google.com 
   # k8s-prow-builds/prow cluster by using the CONTAINERD variant


### PR DESCRIPTION
Over the last 6 weeks, capacity limit of the main pool(`pool4`) in
k8s-infra-prow-build has been reached more than once.
The new limit is based of the resource consumption seen in GCP
StackDriver:
https://console.cloud.google.com/monitoring/metrics-explorer?project=k8s-infra-prow-build&pageState=%7B%22xyChart%22:%7B%22dataSets%22:%5B%7B%22timeSeriesFilter%22:%7B%22filter%22:%22metric.type%3D%5C%22compute.googleapis.com%2Finstance_group%2Fsize%5C%22%20resource.type%3D%5C%22instance_group%5C%22%20resource.label.%5C%22project_id%5C%22%3D%5C%22k8s-infra-prow-build%5C%22%22,%22minAlignmentPeriod%22:%22300s%22,%22unitOverride%22:%221%22,%22aggregations%22:%5B%7B%22perSeriesAligner%22:%22ALIGN_MEAN%22,%22crossSeriesReducer%22:%22REDUCE_SUM%22,%22groupByFields%22:%5B%22resource.label.%5C%22project_id%5C%22%22%5D%7D,%7B%22crossSeriesReducer%22:%22REDUCE_NONE%22%7D%5D%7D,%22targetAxis%22:%22Y1%22,%22plotType%22:%22LINE%22%7D%5D,%22options%22:%7B%22mode%22:%22COLOR%22%7D,%22constantLines%22:%5B%5D,%22timeshiftDuration%22:%220s%22,%22y1Axis%22:%7B%22label%22:%22y1Axis%22,%22scale%22:%22LINEAR%22%7D%7D,%22isAutoRefresh%22:true,%22timeSelection%22:%7B%22timeRange%22:%226w%22%7D%7D

Ref: https://github.com/kubernetes/k8s.io/issues/1703

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>