### PR TITLE
releng: Drop temporary access granted to onlydole

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -61,7 +61,6 @@ groups:
       - idealhack@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
-      - onlydole@gmail.com
       - saschagrunert@gmail.com
 
   - email-id: k8s-infra-release-viewers@kubernetes.io


### PR DESCRIPTION
Dropping temporary access granted in #1689 to Taylor Dolezal to cut the `v1.20.1-beta.0` release

SIG Release issue: https://github.com/kubernetes/sig-release/issues/1474

/assign @dims @cblecker
cc: @kubernetes/release-engineering

/priority important-soon
/sig release

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>