### PR TITLE
Update cluster-api-provider-azure OWNERS

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cluster-api-azure/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api-azure/OWNERS
@@ -2,10 +2,8 @@
 # Should always mirror the maintainers/reviewers in https://sigs.k8s.io/cluster-api-provider-azure/OWNERS_ALIASES
 
 approvers:
-- awesomenix
 - CecileRobertMichon
 - devigned
-- justaugustus
 - nader-ziada
 reviewers:
 - alexeldeib


### PR DESCRIPTION
update OWNERS to match updates made in CAPZ repo https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/master/OWNERS_ALIASES 

/assign @nader-ziada @devigned 