### PR TITLE
slack-infra: grant access to mrbobbytables, jeefy and nikhita

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -620,7 +620,10 @@ groups:
       - bartek@smykla.com
       - cblecker@gmail.com
       - davanum@gmail.com
+      - jeef111x@gmail.com
+      - killen.bob@gmail.com
       - ktbry@google.com
+      - nikitaraghunath@gmail.com
       - rajula96reddy@gmail.com
       - spiffxp@google.com
       - spiffxp@gmail.com
@@ -1372,8 +1375,11 @@ groups:
     members:
       - ameukam@gmail.com
       - bartek@smykla.com
+      - jeef111x@gmail.com
+      - killen.bob@gmail.com
       - ktbry@google.com
       - james@munnelly.eu
+      - nikitaraghunath@gmail.com
       - rajula96reddy@gmail.com
 
   - email-id: k8s-infra-staging-txtdirect@kubernetes.io


### PR DESCRIPTION
Ref:
- https://github.com/kubernetes/k8s.io/pull/1696
- slack thread - https://kubernetes.slack.com/archives/CCK68P2Q2/p1614088645006800

Since slack admins can provision tokens, this PR grants @mrbobbytables and @jeefy ([slack admins](https://github.com/kubernetes/community/blob/master/communicatio/moderators.md#moderators)) access to slack-infra resources.

- @mrbobbytables is a sig-contribex lead
- @jeefy is a root approver for slack-infra
- @nikhita as contribex TL (Edit: also adding myself as contribex TL)

/assign @mrbobbytables @jeefy 
can you confirm if this okay for you?

/hold
for @mrbobbytables and @jeefy to ack

/assign @spiffxp 
for approval