### PR TITLE
Move prow-build-trusted to regular channel

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
@@ -130,7 +130,7 @@ module "prow_build_cluster" {
   cluster_location  = local.cluster_location
   bigquery_location = local.bigquery_location
   is_prod_cluster   = "true"
-  release_channel   = "STABLE"
+  release_channel   = "REGULAR"
   dns_cache_enabled = "true"
 }
 


### PR DESCRIPTION
This will mean upgrading from v1.17 to v1.18

Using this as our low-traffic canary cluster before trying to do the same for k8s-infra-prow-build (ref: https://github.com/kubernetes/k8s.io/issues/1541#issuecomment-784500765)