### PR TITLE
Add namespaces for prow staging

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/staging-test-pods-namespace.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/staging-test-pods-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+spec:
+  name: staging-test-pods

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/staging-test-pods-namespace.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/staging-test-pods-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+spec:
+  name: staging-test-pods


### PR DESCRIPTION
Add namespaces to prow build clusters that will be used by the prow
staging instance.

We are experimenting with the possibility that more than one prow
instance can run against the same build cluster.

Ref: https://github.com/kubernetes/k8s.io/issues/1475

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>