### PR TITLE
Add gke_cluster.cloud_shell_access

### DIFF
--- a/infra/gcp/clusters/modules/gke-cluster/main.tf
+++ b/infra/gcp/clusters/modules/gke-cluster/main.tf
@@ -94,7 +94,7 @@ resource "google_bigquery_dataset" "test_usage_metering" {
 //            Any changes in one MUST be reflected in the other.
 resource "google_container_cluster" "prod_cluster" {
   count     = var.is_prod_cluster == "true" ? 1 : 0
-  
+
   name     = var.cluster_name
   location = var.cluster_location
 
@@ -149,7 +149,10 @@ resource "google_container_cluster" "prod_cluster" {
   }
 
   // Restrict master to Google IP space; use Cloud Shell to access
-  master_authorized_networks_config {
+  dynamic "master_authorized_networks_config" {
+    for_each = var.cloud_shell_access ? [1] : []
+    content {
+    }
   }
 
   // Enable GKE Usage Metering
@@ -193,7 +196,7 @@ resource "google_container_cluster" "prod_cluster" {
 }
 resource "google_container_cluster" "test_cluster" {
   count     = var.is_prod_cluster == "true" ? 0 : 1
-  
+
   name     = var.cluster_name
   location = var.cluster_location
 
@@ -247,7 +250,10 @@ resource "google_container_cluster" "test_cluster" {
   }
 
   // Restrict master to Google IP space; use Cloud Shell to access
-  master_authorized_networks_config {
+  dynamic "master_authorized_networks_config" {
+    for_each = var.cloud_shell_access ? [1] : []
+    content {
+    }
   }
 
   // Enable GKE Usage Metering

--- a/infra/gcp/clusters/modules/gke-cluster/variables.tf
+++ b/infra/gcp/clusters/modules/gke-cluster/variables.tf
@@ -64,3 +64,9 @@ EOF
   // TODO: default this true (and/or remove this option) once kubernetes-public/aaa uses this module
   default     = "false"
 }
+
+variable "cloud_shell_access" {
+  description = "Control plane access restricted to Google Cloud Shell"
+  type        = bool
+  default     = true
+}

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
@@ -100,13 +100,14 @@ resource "google_service_account_iam_policy" "boskos_janitor_sa_iam" {
 
 module "prow_build_cluster" {
   source = "../../../modules/gke-cluster"
-  project_name      = local.project_id
-  cluster_name      = local.cluster_name
-  cluster_location  = local.cluster_location
-  bigquery_location = local.bigquery_location
-  is_prod_cluster   = "true"
-  release_channel   = "REGULAR"
-  dns_cache_enabled = "true"
+  project_name       = local.project_id
+  cluster_name       = local.cluster_name
+  cluster_location   = local.cluster_location
+  bigquery_location  = local.bigquery_location
+  is_prod_cluster    = "true"
+  release_channel    = "REGULAR"
+  dns_cache_enabled  = "true"
+  cloud_shell_access = false
 }
 
 module "prow_build_nodepool_n1_highmem_8_maxiops" {


### PR DESCRIPTION
Trying out a `dynamic` block pattern. This looks a lot nicer than what
I had to go through for `lifecycle` between a prod and test cluster.