### PR TITLE
Add Rajula to sig-contributor-experience group as manager

### DIFF
--- a/groups/sig-contributor-experience/groups.yaml
+++ b/groups/sig-contributor-experience/groups.yaml
@@ -17,6 +17,7 @@ groups:
       - ameukam@gmail.com
       - matthewbbroberg@gmail.com
       - jrosland@vmware.com
+      - rajula96reddy@gmail.com
     members:
       - dgiles@linuxfoundation.org
       - jberkus@redhat.com


### PR DESCRIPTION
I am part of the Upstream marketing team and need these permissions to send out comms related to contributor survey for this year

CC: @mrbobbytables 