### PR TITLE
prow: shrink gce-project pool for experiment

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-resources-configmap.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-resources-configmap.yaml
@@ -113,16 +113,18 @@ data:
       - k8s-infra-e2e-boskos-108
       - k8s-infra-e2e-boskos-109
       - k8s-infra-e2e-boskos-110
-      - k8s-infra-e2e-boskos-111
-      - k8s-infra-e2e-boskos-112
-      - k8s-infra-e2e-boskos-113
-      - k8s-infra-e2e-boskos-114
-      - k8s-infra-e2e-boskos-115
-      - k8s-infra-e2e-boskos-116
-      - k8s-infra-e2e-boskos-117
-      - k8s-infra-e2e-boskos-118
-      - k8s-infra-e2e-boskos-119
-      - k8s-infra-e2e-boskos-120
+      # TODO(spiffxp): uncomment when done with experiment,
+      # ref: https://github.com/kubernetes-sigs/boskos/issues/20#issuecomment-788158669
+      # - k8s-infra-e2e-boskos-111
+      # - k8s-infra-e2e-boskos-112
+      # - k8s-infra-e2e-boskos-113
+      # - k8s-infra-e2e-boskos-114
+      # - k8s-infra-e2e-boskos-115
+      # - k8s-infra-e2e-boskos-116
+      # - k8s-infra-e2e-boskos-117
+      # - k8s-infra-e2e-boskos-118
+      # - k8s-infra-e2e-boskos-119
+      # - k8s-infra-e2e-boskos-120
       state: dirty
       type: gce-project
     - names:


### PR DESCRIPTION
This is intended to confirm whether or not boskos does the right thing
when static resources are deleted from its config.

It should:
- tombstone free resources
- leave busy resources alone (tombstone once checked in)

I've chosen resources that are currently free and busy on purpose:
```
$ date -u +'%Y-%m-%dT%H:%M:%S'; k get resources -n test-pods | grep k8s-infra-e2e-boskos-1[12] | tail -n+2
2021-03-01T18:16:21
k8s-infra-e2e-boskos-110        gce-project           free                                                               19m
k8s-infra-e2e-boskos-111        gce-project           busy    ci-kubernetes-e2e-gci-gce-ingress                          75s
k8s-infra-e2e-boskos-112        gce-project           busy    ci-kubernetes-e2e-gci-gce-flaky-repro                      19s
k8s-infra-e2e-boskos-113        gce-project           free                                                               19m
k8s-infra-e2e-boskos-114        gce-project           free                                                               102m
k8s-infra-e2e-boskos-115        gce-project           free                                                               66m
k8s-infra-e2e-boskos-116        gce-project           free                                                               106m
k8s-infra-e2e-boskos-117        gce-project           free                                                               5m21s
k8s-infra-e2e-boskos-118        gce-project           free                                                               47m
k8s-infra-e2e-boskos-119        gce-project           busy    ci-kubernetes-e2e-gce-cos-k8sstable1-serial                3m19s
k8s-infra-e2e-boskos-120        gce-project           free                                                               115m
```

ref:  https://github.com/kubernetes-sigs/boskos/issues/20#issuecomment-788158669