### PR TITLE
Update boskos to v20210224-2728a7d and ghproxy as needed

### DIFF
--- a/hack/autobump-config.yaml
+++ b/hack/autobump-config.yaml
@@ -1,0 +1,30 @@
+---
+gitHubLogin: "TODO"
+gitHubToken: "TODO"
+gitName: "TODO"
+gitEmail: "TODO"
+skipPullRequest: false
+gitHubOrg: "kubernetes"
+gitHubRepo: "k8s.io"
+remoteName: "k8s.io"
+upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/k8s.io/main"
+includedConfigPaths:
+  - "infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources"
+  - "infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources"
+excludedConfigPaths:
+  - "k8s.gcr.io"
+extraFiles:
+  - "hack/verify-yamllint.sh"
+targetVersion: "latest"
+prefixes:
+  - name: "ghproxy"
+    prefix: "gcr.io/k8s-prow/ghproxy"
+    refConfigFile: "infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/ghproxy-deployment.yaml"
+    repo: "https://github.com/kubernetes/test-infra"
+    summarise: false
+  - name: "boskos"
+    prefix: "gcr.io/k8s-staging-boskos/"
+    refConfigFile: "infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos.yaml"
+    repo: "https://github.com/kubernetes-sigs/boskos"
+    summarise: false
+    consistentImages: true

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/ghproxy-deployment.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/ghproxy-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20200611-4c51f3fcb1
+          image: gcr.io/k8s-prow/ghproxy:v20210301-3ebd595eae
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-janitor.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-janitor.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: boskos-janitor
       containers:
       - name: boskos-janitor
-        image: gcr.io/k8s-staging-boskos/janitor:v20200819-984516e
+        image: gcr.io/k8s-staging-boskos/janitor:v20210224-2728a7d
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
         - --resource-type=gce-project,gpu-project,scalability-project

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-reaper-deployment.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-reaper-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos-reaper
-        image: gcr.io/k8s-staging-boskos/reaper:v20200819-984516e
+        image: gcr.io/k8s-staging-boskos/reaper:v20210224-2728a7d
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
         - --resource-type=gce-project,gpu-project,scalability-project

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos.yaml
@@ -125,7 +125,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos
-        image: gcr.io/k8s-staging-boskos/boskos:v20200819-984516e
+        image: gcr.io/k8s-staging-boskos/boskos:v20210224-2728a7d
         args:
         - --config=/etc/config/config
         - --namespace=test-pods


### PR DESCRIPTION
Multiple distinct ghproxy changes:

Commits | Dates | Images
--- | --- | ---
https://github.com/kubernetes/test-infra/compare/4c51f3fcb1...3ebd595eae | 2020&#x2011;06&#x2011;11&nbsp;&#x2192;&nbsp;2021&#x2011;03&#x2011;01 | ghproxy


Multiple distinct boskos changes:

Commits | Dates | Images
--- | --- | ---
https://github.com/kubernetes-sigs/boskos/compare/984516e...2728a7d | 2020&#x2011;08&#x2011;19&nbsp;&#x2192;&nbsp;2021&#x2011;02&#x2011;24 | boskos, janitor, reaper


/cc @fejta

---
EDIT: I was trying out `autobumper` locally, needed to add an option for base branch name (https://github.com/kubernetes/test-infra/pull/21101)

This also added `hack/autobump-config.yaml` which I wanted to happen, but forgot my personal login was in it.  Left as TODOs until we can decide who this should run as.

The reason for this change in the first place is https://github.com/kubernetes/k8s.io/pull/1738#issuecomment-788278587, trying to get a version of boskos that correctly shrinks resource pools