### PR TITLE
Revert "prow: shrink gce-project pool for experiment"

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-resources-configmap.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/boskos-resources-configmap.yaml
@@ -113,18 +113,16 @@ data:
       - k8s-infra-e2e-boskos-108
       - k8s-infra-e2e-boskos-109
       - k8s-infra-e2e-boskos-110
-      # TODO(spiffxp): uncomment when done with experiment,
-      # ref: https://github.com/kubernetes-sigs/boskos/issues/20#issuecomment-788158669
-      # - k8s-infra-e2e-boskos-111
-      # - k8s-infra-e2e-boskos-112
-      # - k8s-infra-e2e-boskos-113
-      # - k8s-infra-e2e-boskos-114
-      # - k8s-infra-e2e-boskos-115
-      # - k8s-infra-e2e-boskos-116
-      # - k8s-infra-e2e-boskos-117
-      # - k8s-infra-e2e-boskos-118
-      # - k8s-infra-e2e-boskos-119
-      # - k8s-infra-e2e-boskos-120
+      - k8s-infra-e2e-boskos-111
+      - k8s-infra-e2e-boskos-112
+      - k8s-infra-e2e-boskos-113
+      - k8s-infra-e2e-boskos-114
+      - k8s-infra-e2e-boskos-115
+      - k8s-infra-e2e-boskos-116
+      - k8s-infra-e2e-boskos-117
+      - k8s-infra-e2e-boskos-118
+      - k8s-infra-e2e-boskos-119
+      - k8s-infra-e2e-boskos-120
       state: dirty
       type: gce-project
     - names:


### PR DESCRIPTION
This reverts commit 40a224fe019c2610f7c72c640c08048d44eedec6.

This reverts https://github.com/kubernetes/k8s.io/pull/1738 after successful completion of the experiment