### PR TITLE
infra/gcp: only create known staging projects

### DIFF
--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -122,6 +122,12 @@ if [ $# = 0 ]; then
 fi
 
 for REPO; do
+
+    if ! (printf '%s\n' "${STAGING_PROJECTS[@]}" | grep -q "^${REPO}$"); then
+      color 2 "Skipping unrecognized staging project name: ${REPO}"
+      continue
+    fi
+
     color 3 "Configuring staging: ${REPO}"
 
     (


### PR DESCRIPTION
I should be able to run `ensure-staging-storage.sh monkeys` without fear
of a new k8s-staging-monkeys project accidentally showing up in the wild.

Fixes https://github.com/kubernetes/k8s.io/issues/1750