### PR TITLE
Add tests for data validation

### DIFF
--- a/policies/README.md
+++ b/policies/README.md
@@ -1,0 +1,9 @@
+# Rego policies
+
+[Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) policies collection.
+
+## Kubernetes policies
+
+These policies warn about deprecated resources that will be removed in 1.20.x and 1.22.x Kubernetes releases.
+
+These policies should be executed by [conftest](https://www.conftest.dev/install/).

--- a/policies/deprecations.rego
+++ b/policies/deprecations.rego
@@ -1,0 +1,36 @@
+package main
+
+warn[msg] {
+  input.apiVersion != "v1"
+  input.kind != "List"
+  msg := _warn
+}
+
+# All resources will no longer be served from rbac.authorization.k8s.io/v1alpha1 and rbac.authorization.k8s.io/v1beta1 in 1.20. Migrate to use rbac.authorization.k8s.io/v1 instead
+_warn = msg {
+  apis := ["rbac.authorization.k8s.io/v1alpha1", "rbac.authorization.k8s.io/v1beta1"]
+  input.apiVersion == apis[_]
+  msg := sprintf("%s/%s: API %s is deprecated from Kubernetes 1.20, use rbac.authorization.k8s.io/v1 instead.", [input.kind, input.metadata.name, input.apiVersion])
+}
+
+# All resources under apps/v1beta1 and apps/v1beta2 - use apps/v1 instead
+_warn = msg {
+  apis := ["apps/v1beta1", "apps/v1beta2"]
+  input.apiVersion == apis[_]
+  msg := sprintf("%s/%s: API %s has been deprecated, use apps/v1 instead.", [input.kind, input.metadata.name, input.apiVersion])
+}
+
+# daemonsets, deployments, replicasets resources under extensions/v1beta1 - use apps/v1 instead
+_warn = msg {
+  resources := ["DaemonSet", "Deployment", "ReplicaSet"]
+  input.apiVersion == "extensions/v1beta1"
+  input.kind == resources[_]
+  msg := sprintf("%s/%s: API extensions/v1beta1 for %s has been deprecated, use apps/v1 instead.", [input.kind, input.metadata.name, input.kind])
+}
+
+# Ingress resources extensions/v1beta1 will no longer be served from in v1.20. Migrate use to the networking.k8s.io/v1beta1 API, available since v1.14.
+_warn = msg {
+  input.apiVersion == "extensions/v1beta1"
+  input.kind == "Ingress"
+  msg := sprintf("%s/%s: API extensions/v1beta1 for Ingress is deprecated from Kubernetes 1.14, use networking.k8s.io/v1beta1 instead.", [input.kind, input.metadata.name])
+}

--- a/policies/kubernetes.rego
+++ b/policies/kubernetes.rego
@@ -1,0 +1,14 @@
+
+package kubernetes
+
+is_service {
+    input.kind = "Service"
+}
+
+is_deployment {
+    input.kind = "Deployment"
+}
+
+is_ingress {
+    input.kind = "Ingress"
+}


### PR DESCRIPTION
Add policices written in [rego](https://www.openpolicyagent.org/docs/latest/policy-language/) that validate kubernetes resouces. ~Only the ingresses are covered.~
This is heavily inspired from https://github.com/deliveryhero/helm-charts/tree/master/ci/helm-conftest-policies.
[conftest](https://github.com/open-policy-agent/conftest) will be used against those policies.

Ref: https://github.com/kubernetes/k8s.io/issues/1734

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>