### PR TITLE
Add jhvhs to the list of SIG/WG/UG Leads

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -93,6 +93,7 @@ groups:
       - kikis.github@gmail.com
       - kim.andrewsy@gmail.com
       - klaus1982.cn@gmail.com
+      - ksemenov@vmware.com
       - lachlan.evenson@gmail.com
       - lauri.d.apple@gmail.com
       - liggitt@google.com


### PR DESCRIPTION
jhvhs is the co-chair of of the Service Catalog SIG - https://github.com/kubernetes/community/blob/master/sig-service-catalog/README.md#chairs