### PR TITLE
hack: add verify script for boilerplate and yamllint check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Verify scripts may leave programs in this directory
+bin/

--- a/artifactserver/cmd/artifactserver/main.go
+++ b/artifactserver/cmd/artifactserver/main.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/artifactserver/tools/get_workspace_status.sh
+++ b/artifactserver/tools/get_workspace_status.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 # Copyright 2018 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 # This script will be run bazel when building process starts to
 # generate key-value information that represents the status of the
 # workspace. The output should be like

--- a/audit/audit-gcp.sh
+++ b/audit/audit-gcp.sh
@@ -1,4 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 set -o errexit
 set -o nounset

--- a/dns/check-zone.py
+++ b/dns/check-zone.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 '''
 Octo-DNS Reporter / exit non-zero on failure
 '''

--- a/dns/check-zone.sh
+++ b/dns/check-zone.sh
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 # This runs as you.  It assumes you have built an image named ${USER}/octodns.
 # It also requires working gcloud credentials
 #

--- a/dns/push.sh
+++ b/dns/push.sh
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 # This runs as you.  It assumes you have built an image named ${USER}/octodns.
 
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")

--- a/hack/boilerplate/boilerplate.Dockerfile.txt
+++ b/hack/boilerplate/boilerplate.Dockerfile.txt
@@ -1,0 +1,14 @@
+# Copyright YEAR The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/hack/boilerplate/boilerplate.Makefile.txt
+++ b/hack/boilerplate/boilerplate.Makefile.txt
@@ -1,0 +1,14 @@
+# Copyright YEAR The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/hack/boilerplate/boilerplate.go.txt
+++ b/hack/boilerplate/boilerplate.go.txt
@@ -1,0 +1,16 @@
+/*
+Copyright YEAR The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+

--- a/hack/boilerplate/boilerplate.py.txt
+++ b/hack/boilerplate/boilerplate.py.txt
@@ -1,0 +1,14 @@
+# Copyright YEAR The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/hack/boilerplate/boilerplate.sh.txt
+++ b/hack/boilerplate/boilerplate.sh.txt
@@ -1,0 +1,14 @@
+# Copyright YEAR The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+VERSION=v0.2.0
+URL_BASE=https://raw.githubusercontent.com/kubernetes/repo-infra
+URL=$URL_BASE/$VERSION/hack/verify_boilerplate.py
+BIN_DIR=bin
+SCRIPT=$BIN_DIR/verify_boilerplate.py
+
+if [[ ! -f $SCRIPT ]]; then
+    mkdir -p $BIN_DIR
+    curl -sfL $URL -o $SCRIPT
+    chmod +x $SCRIPT
+fi
+
+$SCRIPT --boilerplate-dir hack/boilerplate

--- a/hack/verify-yamllint.sh
+++ b/hack/verify-yamllint.sh
@@ -37,8 +37,8 @@ if [ $# != 0 ]; then
 fi
 
 if ! command -v yamllint >/dev/null 2>&1; then
-  echo >/dev/stderr "ERROR: yamllint not found - please install with: ${pip} install -r ${pip_requirements}"
-  exit 1
+  echo "yamllint not found - installing with: ${pip} install -r ${pip_requirements}"
+  ${pip} install -r ${pip_requirements}
 fi
 
 version=$(yamllint --version | awk '{ print $2 }')

--- a/hack/verify.sh
+++ b/hack/verify.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+# Some useful colors.
+if [[ -z "${color_start-}" ]]; then
+  declare -r color_start="\033["
+  declare -r color_red="${color_start}0;31m"
+  declare -r color_yellow="${color_start}0;33m"
+  declare -r color_green="${color_start}0;32m"
+  declare -r color_norm="${color_start}0m"
+fi
+
+# Excluded check patterns are always skipped.
+EXCLUDED_PATTERNS=(
+  "verify-*-dockerized.sh"       # Don't run any scripts that intended to be run dockerized
+  )
+
+EXCLUDED_CHECKS=$(ls ${EXCLUDED_PATTERNS[@]/#/${KUBE_ROOT}\/hack\/} 2>/dev/null || true)
+
+function is-excluded {
+  for e in ${EXCLUDED_CHECKS[@]}; do
+    if [[ $1 -ef "$e" ]]; then
+      return
+    fi
+  done
+  return 1
+}
+
+function run-cmd {
+  if ${SILENT}; then
+    "$@" &> /dev/null
+  else
+    "$@"
+  fi
+}
+
+# Collect Failed tests in this Array , initialize it to nil
+FAILED_TESTS=()
+
+function print-failed-tests {
+  echo -e "========================"
+  echo -e "${color_red}FAILED TESTS${color_norm}"
+  echo -e "========================"
+  for t in ${FAILED_TESTS[@]}; do
+      echo -e "${color_red}${t}${color_norm}"
+  done
+}
+
+function run-checks {
+  local -r pattern=$1
+  local -r runner=$2
+
+  local t
+  for t in $(ls ${pattern})
+  do
+    local check_name="$(basename "${t}")"
+    if is-excluded "${t}" ; then
+      echo "Skipping ${check_name}"
+      continue
+    fi
+    echo -e "Verifying ${check_name}"
+    local start=$(date +%s)
+    run-cmd "${runner}" "${t}" && tr=$? || tr=$?
+    local elapsed=$(($(date +%s) - ${start}))
+    if [[ ${tr} -eq 0 ]]; then
+      echo -e "${color_green}SUCCESS${color_norm}  ${check_name}\t${elapsed}s"
+    else
+      echo -e "${color_red}FAILED${color_norm}   ${check_name}\t${elapsed}s"
+      ret=1
+      FAILED_TESTS+=(${t})
+    fi
+  done
+}
+
+SILENT=false
+
+while getopts ":s" opt; do
+  case ${opt} in
+    s)
+      SILENT=true
+      ;;
+    \?)
+      echo "Invalid flag: -${OPTARG}" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ${SILENT} ; then
+  echo "Running in silent mode, run without -s if you want to see script logs."
+fi
+
+ret=0
+run-checks "${KUBE_ROOT}/hack/verify-*.sh" bash
+
+if [[ ${ret} -eq 1 ]]; then
+    print-failed-tests
+fi
+exit ${ret}
+
+# ex: ts=2 sw=2 et filetype=sh

--- a/infra/gcp/backup_tools/backup_lib.sh
+++ b/infra/gcp/backup_tools/backup_lib.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/backup_tools/backup_prod.sh
+++ b/infra/gcp/backup_tools/backup_prod.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/backup_tools/backup_test.sh
+++ b/infra/gcp/backup_tools/backup_test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/cip-auditor/deploy.sh
+++ b/infra/gcp/cip-auditor/deploy.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/ensure-conformance-storage.sh
+++ b/infra/gcp/ensure-conformance-storage.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/ensure-env-cip-auditor.sh
+++ b/infra/gcp/ensure-env-cip-auditor.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/ensure-gsuite.sh
+++ b/infra/gcp/ensure-gsuite.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/ensure-main-project.sh
+++ b/infra/gcp/ensure-main-project.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/ensure-organization.sh
+++ b/infra/gcp/ensure-organization.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/ensure-prod-storage-gclb.sh
+++ b/infra/gcp/ensure-prod-storage-gclb.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/ensure-release-projects.sh
+++ b/infra/gcp/ensure-release-projects.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/ensure-releng.sh
+++ b/infra/gcp/ensure-releng.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/ensure-static-ips.sh
+++ b/infra/gcp/ensure-static-ips.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/lib_gcr.sh
+++ b/infra/gcp/lib_gcr.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/lib_gcs.sh
+++ b/infra/gcp/lib_gcs.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/lib_iam.sh
+++ b/infra/gcp/lib_iam.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2021 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/lib_util.sh
+++ b/infra/gcp/lib_util.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/namespaces/ensure-namespaces.sh
+++ b/infra/gcp/namespaces/ensure-namespaces.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/prow/ensure-e2e-projects.sh
+++ b/infra/gcp/prow/ensure-e2e-projects.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2019 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/infra/gcp/roles/generate-role-yaml.sh
+++ b/infra/gcp/roles/generate-role-yaml.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-#
+
 # Copyright 2021 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/k8s.gcr.io/images/k8s-staging-csi-secrets-store/generate.sh
+++ b/k8s.gcr.io/images/k8s-staging-csi-secrets-store/generate.sh
@@ -1,4 +1,18 @@
-#! /bin/sh
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 repos="
 driver

--- a/k8s.gcr.io/images/k8s-staging-sig-storage/generate.sh
+++ b/k8s.gcr.io/images/k8s-staging-sig-storage/generate.sh
@@ -1,4 +1,18 @@
-#! /bin/sh
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # List of repos under https://console.cloud.google.com/gcr/images/k8s-staging-sig-storage/GLOBAL
 repos="

--- a/k8s.io/Makefile
+++ b/k8s.io/Makefile
@@ -1,3 +1,17 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 all: test
 
 .PHONY: test

--- a/k8s.io/canary.sh
+++ b/k8s.io/canary.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python3
 
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 try:
     import HTMLParser
     import httplib


### PR DESCRIPTION
Ref: "ideas of follow up" in https://github.com/kubernetes/test-infra/pull/20956

This PR:

- Updates existing `verify-yamllint.sh` script to install yamllint if
it does not exist.

- Adds `verify-boilerplate.sh` script for verifying boilerplate.
This is derived from the [script](https://github.com/kubernetes/enhancements/blob/master/hack/verify-boilerplate.sh) in the enhancements repo.

- Adds `verify.sh` script to test all verify scripts at once. This would
be useful for adding future verify scripts.

- Fixes boilerplate headers to make the script pass

/assign @spiffxp 