### PR TITLE
gcp/lib: set builder permission instead of editor

### DIFF
--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -215,7 +215,7 @@ function empower_group_for_gcb() {
     gcloud \
         projects add-iam-policy-binding "${project}" \
         --member "group:${group}" \
-        --role roles/cloudbuild.builds.editor
+        --role roles/cloudbuild.builds.builder
 
     # TODO(justaugustus/thockin): This only exists to grant the
     #      serviceusage.services.use permission allow writers access to execute


### PR DESCRIPTION
The role `roles/cloudbuild.builds.editor` looks like does not have all the necessary permissions to push images from gcb (https://cloud.google.com/build/docs/iam-roles-permissions)

the builder role (`roles/cloudbuild.builds.builder`) have the permission (`storage.buckets.get`) to make it able to push the images.

I'm not sure if this is the correct way to deal or we add another role just to add the `storage.buckets.get` permission.

/assign @spiffxp 

Fixes: https://github.com/kubernetes/k8s.io/issues/1772