### PR TITLE
releng: Drop temporary RM access for mkorbi

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -60,7 +60,6 @@ groups:
       - georgedanielmangum@gmail.com
       - idealhack@gmail.com
       - k8s@auggie.dev
-      - max@koerbaecher.io
       - mudrinic.mare@gmail.com
       - saschagrunert@gmail.com
 


### PR DESCRIPTION
Dropping temporary access granted in #1766 to Max Körbächer to cut the `v1.20.1-beta.1` release

SIG Release issue: https://github.com/kubernetes/sig-release/issues/1486

/assign @dims @cblecker
cc: @kubernetes/release-engineering

/priority important-soon
/sig release

Signed-off-by: Adolfo García Veytia (Puerco) adolfo.garcia@uservers.net
