### PR TITLE
Refine terraform version constraint

### DIFF
--- a/hack/verify-terraform.sh
+++ b/hack/verify-terraform.sh
@@ -17,10 +17,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+REPO_ROOT="$(cd ${SCRIPT_ROOT}/.. && pwd)"
 
 function usage() {
-  echo >&2 "Usage: $0 <CLUSTER_NAME>"
+  echo >&2 "Usage: $0 <PATH>"
   exit 1
 }
 
@@ -54,12 +55,12 @@ if [ -z "$(which curl)" ]; then
   exit 1
 fi
 
-
 if [ -z "$(which tfswitch)" ]; then
   echo "Installing tfswitch locally"
-  curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh | sudo bash
+  curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh | bash
 else
 tfswitch --version
 fi
 
-check_terraform "${DIR}/../$1"
+cd "$REPO_ROOT"
+check_terraform $1

--- a/infra/gcp/clusters/modules/gke-cluster/versions.tf
+++ b/infra/gcp/clusters/modules/gke-cluster/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 0.13.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/infra/gcp/clusters/modules/gke-nodepool/versions.tf
+++ b/infra/gcp/clusters/modules/gke-nodepool/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 0.13.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/infra/gcp/clusters/modules/gke-project/versions.tf
+++ b/infra/gcp/clusters/modules/gke-project/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 0.13.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/00-provider.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/00-provider.tf
@@ -1,12 +1,10 @@
 /*
 This file defines:
-- Required Terraform version
 - Required provider versions
 - Storage backend details
 */
 
 terraform {
-  required_version = "~> 0.13.6"
 
   backend "gcs" {
     bucket = "k8s-infra-clusters-terraform"

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/versions.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/versions.tf
@@ -1,3 +1,8 @@
+/*
+This file defines:
+- Required Terraform version
+*/
+
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 0.13.0"
 }

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/00-provider.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/00-provider.tf
@@ -1,12 +1,10 @@
 /*
 This file defines:
-- Required Terraform version
 - Required provider versions
 - Storage backend details
 */
 
 terraform {
-  required_version = "~> 0.13.6"
 
   backend "gcs" {
     bucket = "k8s-infra-clusters-terraform"

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/versions.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/versions.tf
@@ -1,3 +1,8 @@
+/*
+This file defines:
+- Required Terraform version
+*/
+
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 0.13.0"
 }


### PR DESCRIPTION
Remove duplicate of terraform version constraint and ensure 0.14.x versions can't
be used.
Small improvements in verify-terraform.sh

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>