### PR TITLE
Simplify go.k8s.io/owners/$ghuser

### DIFF
--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -239,7 +239,7 @@ data:
           rewrite ^/oncall$          https://storage.googleapis.com/test-infra-oncall/oncall.html redirect;
           rewrite ^/oncall-hotlist$  https://github.com/kubernetes/test-infra/search?q=label%3Akind%2Foncall-hotlist+is%3Aopen&type=Issues redirect;
           rewrite ^/owners$          https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md redirect;
-          rewrite ^/owners/([^/]*)/?$ https://cs.k8s.io/?q=$1&i=fosho&files=.*(%5E%5B%5Ev%5D.*OWNERS%24)%7C(%5Ev%5B%5Ee%5D.*OWNERS%24)%20%7C(%5Eve%5B%5En%5D.*OWNERS%24)%7C(%5Even%5B%5Ed%5D.*OWNERS%24)%7C(%5Evend%5B%5Eo%5D.*OWNERS%24)%7C(%5Evendo%5B%5Er%5D.*OWNERS%24)%7C(%5E%5B%5Ev%5D%5B%5Ee%5D%5B%5En%5D%5B%5Ed%5D%5B%5Eo%5D%5B%5Er%5D%2F.*OWNERS%24)%7C%5EOWNERS%24%7C%5EOWNERS_ALIASES%24&repos= redirect;
+          rewrite ^/owners/([^/]*)/?$ https://cs.k8s.io/?q=$1&i=fosho&files=OWNERS&excludeFiles=vendor%2F&repos= redirect;
           rewrite ^/partner-request$ https://docs.google.com/forms/d/e/1FAIpQLSdN1KtSKX2VAOPGABFlShkSd6CajQynoL4QCVtY0dj76MNDKg/viewform redirect;
           rewrite ^/pr-dashboard$    https://gubernator.k8s.io/pr redirect;
           rewrite ^/redirects$       https://github.com/kubernetes/k8s.io/tree/master/k8s.io#redirections redirect;

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -182,7 +182,7 @@ class RedirTest(HTTPTestCase):
             self.assert_temp_redirect(base + 'owners',
                 'https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md')
             self.assert_temp_redirect(base + 'owners/$ghuser',
-                'https://cs.k8s.io/?q=$ghuser&i=fosho&files=.*(%5E%5B%5Ev%5D.*OWNERS%24)%7C(%5Ev%5B%5Ee%5D.*OWNERS%24)%20%7C(%5Eve%5B%5En%5D.*OWNERS%24)%7C(%5Even%5B%5Ed%5D.*OWNERS%24)%7C(%5Evend%5B%5Eo%5D.*OWNERS%24)%7C(%5Evendo%5B%5Er%5D.*OWNERS%24)%7C(%5E%5B%5Ev%5D%5B%5Ee%5D%5B%5En%5D%5B%5Ed%5D%5B%5Eo%5D%5B%5Er%5D%2F.*OWNERS%24)%7C%5EOWNERS%24%7C%5EOWNERS_ALIASES%24&repos=',
+                'https://cs.k8s.io/?q=$ghuser&i=fosho&files=OWNERS&excludeFiles=vendor%2F&repos=',
                  ghuser=rand_num())
             self.assert_temp_redirect(
                 base + 'partner-request',


### PR DESCRIPTION
With the switch to a new version of hound, we can now specify
filepaths (like `vendor/`) that must be excluded. This means that we no
longer need to use the nastry regexp.

Ref: https://kubernetes.slack.com/archives/CCK68P2Q2/p1615493343163600

Example: https://cs.k8s.io/?q=spiffxp&i=fosho&files=OWNERS&excludeFiles=vendor%2F&repos=

/assign @spiffxp @mrbobbytables 

/hold
should be approved by someone who can deploy this