### PR TITLE
k8s.io: add no_parent_owners: true for OWNERS

### DIFF
--- a/k8s.io/OWNERS
+++ b/k8s.io/OWNERS
@@ -1,5 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+options:
+  no_parent_owners: true
 approvers:
 - ixdy
 - thockin


### PR DESCRIPTION
Changes to this directory need to be deployed manually and should not be approved by someone who cannot deploy.

Previous cases where `/hold` is explicitly used to ensure this - https://github.com/kubernetes/k8s.io/pull/1791, https://github.com/kubernetes/k8s.io/pull/1789, https://github.com/kubernetes/k8s.io/pull/1764

Adding `no_parent_owners: true` removes the need to add an explict hold and enforces this restriction.

/assign @thockin 
/cc @spiffxp @ameukam 