### PR TITLE
Remove org-level role/binding cleanup, improve lib_iam output

### DIFF
--- a/infra/gcp/ensure-organization.sh
+++ b/infra/gcp/ensure-organization.sh
@@ -43,19 +43,7 @@ org_roles=(
     iam.serviceAccountLister
 )
 
-old_org_roles=(
-    StorageBucketLister
-)
-
-# TODO(https://github.com/kubernetes/k8s.io/issues/1659): obviated by organization.admin, remove when bindings gone
-old_org_admin_roles=(
-    roles/billing.user
-    roles/iam.organizationRoleAdmin
-    roles/resourcemanager.organizationAdmin
-    roles/resourcemanager.projectCreator
-    roles/resourcemanager.projectDeleter
-    roles/servicemanagement.quotaAdmin
-)
+old_org_roles=()
 
 color 6 "Ensuring organization custom roles exist"
 (
@@ -90,11 +78,7 @@ color 6 "Ensuring organization IAM bindings exist"
 
 color 6 "Ensuring removed organization IAM bindings do not exist"
 (
-    # TODO(spiffxp): remove this once the old bindings are confirmed gone
-    for role in "${old_org_admin_roles[@]}"; do
-        ensure_removed_org_role_binding "user:thockin@google.com" "${role}"
-        ensure_removed_org_role_binding "user:davanum@gmail.com" "${role}"
-    done
+    color 6 "No bindings to remove"
 ) 2>&1 | indent
 
 color 6 "Ensuring removed organization custom roles do not exist"

--- a/infra/gcp/lib_util.sh
+++ b/infra/gcp/lib_util.sh
@@ -107,3 +107,8 @@ function join_by() {
   # and $@ returns array which doesn't respect IFS
   echo "$*"
 }
+
+# use git-diff for color output, strip patch header
+function diff_colorized() {
+  git --no-pager diff --color --no-prefix --no-index "$@" | tail -n+5
+}

--- a/infra/gcp/roles/audit.viewer.yaml
+++ b/infra/gcp/roles/audit.viewer.yaml
@@ -545,15 +545,27 @@ includedPermissions:
   - deploymentmanager.typeProviders.list
   - deploymentmanager.types.list
   - dialogflow.agents.list
+  - dialogflow.answerrecords.list
+  - dialogflow.callMatchers.list
   - dialogflow.contexts.list
+  - dialogflow.conversationDatasets.list
+  - dialogflow.conversationModels.list
+  - dialogflow.conversationProfiles.list
+  - dialogflow.conversations.list
   - dialogflow.documents.list
   - dialogflow.entityTypes.list
   - dialogflow.environments.list
   - dialogflow.flows.list
   - dialogflow.intents.list
   - dialogflow.knowledgeBases.list
+  - dialogflow.messages.list
+  - dialogflow.modelEvaluations.list
   - dialogflow.pages.list
+  - dialogflow.participants.list
+  - dialogflow.phoneNumberOrders.list
+  - dialogflow.phoneNumbers.list
   - dialogflow.sessionEntityTypes.list
+  - dialogflow.smartMessagingEntries.list
   - dialogflow.transitionRouteGroups.list
   - dialogflow.versions.list
   - dialogflow.webhooks.list


### PR DESCRIPTION
Part of umbrella issue to manage organization-level IAM assets (ref: https://github.com/kubernetes/k8s.io/issues/1659)

Followup to previous PRs:
- https://github.com/kubernetes/k8s.io/pull/1726
- https://github.com/kubernetes/k8s.io/pull/1737

See individual commit messages for details.

The first two commits are hopefully going to dramatically reduce output from IAM changes, such that unexpected additions or removals are more likely to stand out.  A bunch of infra/gcp scripts could be updated to use `lib_iam.sh` instead of calling gcloud directly.