### PR TITLE
lib_util: diff_colorized always exits 0

### DIFF
--- a/infra/gcp/lib_util.sh
+++ b/infra/gcp/lib_util.sh
@@ -110,5 +110,5 @@ function join_by() {
 
 # use git-diff for color output, strip patch header
 function diff_colorized() {
-  git --no-pager diff --color --no-prefix --no-index "$@" | tail -n+5
+  (git --no-pager diff --color --no-prefix --no-index "$@" | tail -n+5) || true
 }


### PR DESCRIPTION
Since diff_colorized is intended for human consumption (log output),
always return true so that diff output doesn't cause things to halt.

Somehow I thought `git diff` was always exiting with 0, regardless of
whether the two files differed or not.  Turns out it _will_ exit
non-zero if files differ.

I bumped into this when deploying https://github.com/kubernetes/k8s.io/pull/1794