### PR TITLE
Promote 0.4.0 filestore image

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cloud-provider-gcp/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-cloud-provider-gcp/images.yaml
@@ -1,3 +1,4 @@
 - name: gcp-filestore-csi-driver
   dmap:
     "sha256:351548ca4bb0556e717c27309e1e559f65c9ae5826e60d48e0215f267835b80f": ["v0.3.1"]
+    "sha256:3c1571074aab73f430aae43a35cb7ad81148248aa1807cb75df640f09368ed71": ["v0.4.0"]


### PR DESCRIPTION
promote [staging](https://pantheon.corp.google.com/gcr/images/k8s-staging-cloud-provider-gcp/GLOBAL/gcp-filestore-csi-driver@sha256:3c1571074aab73f430aae43a35cb7ad81148248aa1807cb75df640f09368ed71/details?tab=info&project=k8s-staging-cloud-provider-gcp&folder&supportedpurview=project) filestore driver image to prod