### PR TITLE
Add iscsi csi driver

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-sig-storage/generate.sh
+++ b/k8s.gcr.io/images/k8s-staging-sig-storage/generate.sh
@@ -24,6 +24,7 @@ csi-snapshotter
 csi-external-health-monitor-agent
 csi-external-health-monitor-controller
 hostpathplugin
+iscsiplugin
 livenessprobe
 local-volume-provisioner
 mock-driver


### PR DESCRIPTION
This PR attempts to follow the instructions at https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io for including the iSCSI CSI Driver staging repo. Once merged, we can begin configuring this driver for automated image builds.