### PR TITLE
Deploy ghproxy

### DIFF
--- a/prow/ghproxy_deployment.yaml
+++ b/prow/ghproxy_deployment.yaml
@@ -1,0 +1,91 @@
+# Copyright 2021 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  labels:
+    app: ghproxy
+  name: ghproxy
+  namespace: prow
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+  storageClassName: ssd
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: ghproxy
+  name: ghproxy
+  namespace: prow
+spec:
+  selector:
+    matchLabels:
+      app: ghproxy
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: ghproxy
+    spec:
+      containers:
+        - name: ghproxy
+          image: gcr.io/k8s-prow/ghproxy:v20210318-ffb8032f91
+          args:
+            - --cache-dir=/cache
+            - --cache-sizeGB=99
+            - --serve-metrics=true
+          ports:
+            - containerPort: 8888
+          resources:
+            requests:
+              cpu: 2
+              memory: 2Gi
+            limits:
+              cpu: 2
+              memory: 2Gi
+          securityContext:
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: cache
+              mountPath: /cache
+      volumes:
+        - name: cache
+          persistentVolumeClaim:
+            claimName: ghproxy
+      serviceAccountName: ghproxy
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: ghproxy
+  name: ghproxy
+  namespace: prow
+spec:
+  ports:
+    - name: main
+      port: 80
+      targetPort: 8888
+    - name: metrics
+      port: 9090
+  selector:
+    app: ghproxy
+  type: ClusterIP

--- a/prow/ghproxy_rbac.yaml
+++ b/prow/ghproxy_rbac.yaml
@@ -1,0 +1,20 @@
+# Copyright 2021 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: ghproxy
+  namespace: prow


### PR DESCRIPTION
Triage-Party sometimes hit the Github API Limit.
```
message: "oh snap! I reached the GitHub search API limit: GET https://api.github.com/repos/kubernetes/release/issues?per_page=100&since=2021-02-23T15%3A13%3A29Z&state=closed: 403 API rate limit of 5000 still exceeded until 2021-03-25 15:17:12 +0000 UTC, not making remote request. [rate reset in 3m42s]"
```
GH Proxy can be used to cache TP API calls.

Ultimately, ghproxy needs to be deployed as part of
https://github.com/kubernetes/k8s.io/issues/1394.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>