### PR TITLE
promoting echo and e2e-test-runner images

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -50,6 +50,7 @@
     "sha256:912ada34a8d51b42c0494c7b64e764f6ecaeb7702fee484aefea5a6b64e3ddc9": ["v20201228-g934009573"]
     "sha256:c463b437115fc632f8e6248aa3ed546f8fd8d99a828bb083f60e025cae85e8c8": ["v20210103-g47c0cb718"]
     "sha256:bfd55f589ea998f961825a9d09158d766cf621d1b8fc5d8c905aba07d9794e08": ["v20210104-g81a8d5cd8"]
+    "sha256:b1b684ac3cc6a1ba68611707467fe2c9fe1c9c4a60f85e19ee10ea14b5343432": ["v20210326-gb52c538bb"]
 
 # custom cfssl image for e2e tests
 # https://github.com/kubernetes/ingress-nginx/tree/master/images/cfssl
@@ -67,6 +68,7 @@
     "sha256:752831b431325ece1000796a0eb518ea860389d05fc2c9f43c8ffd71198a4afc": ["v20201029-g92de5212d"]
     "sha256:fda9a88ff1d4d22fda6b0220118252da79ff0c7cd06d4f736a89bc28b64890eb": ["v20201216-g7de30e45d"]
     "sha256:d34944a61a65382e9a81f5e28e981187b419b9d579322277c5a98c2857fd7c5e": ["v20210103-g47c0cb718"]
+    "sha256:b13e44f7bb6852b90633957e743e4a2b34f32f1694da556a9131b43950b8b2b1": ["v20210326-gb52c538bb"]
 
 # fastcgi HTTP server image for e2e tests
 # https://github.com/kubernetes/ingress-nginx/tree/master/images/fastcgi-helloserver


### PR DESCRIPTION
New images come from https://github.com/kubernetes/ingress-nginx/pull/6995, they now use the latest nginx base image