### PR TITLE
Remove gianarb from release-managers groups

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -74,7 +74,6 @@ groups:
       - k8s-infra-release-editors@kubernetes.io
       - k8s-infra-google-build-admins@kubernetes.io
       - ameukam@gmail.com
-      - gianarb92@gmail.com
       - gveronicalg@gmail.com
       - jameswangel@gmail.com
       - jeremy.r.rickard@gmail.com
@@ -293,7 +292,6 @@ groups:
       - bentheelder@google.com
       - ctadeu@gmail.com
       - feiskyer@gmail.com
-      - gianarb92@gmail.com
       - gmccloskey@google.com
       - gveronicalg@gmail.com
       - idealhack@gmail.com


### PR DESCRIPTION
Removes gianarb from release-managers and k8s-infra-release-viewers as
part of release manager associate offboarding.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Last part of https://github.com/kubernetes/sig-release/issues/1442

/assign @saschagrunert @justaugustus @jeremyrickard 