### PR TITLE
adding CAA record

### DIFF
--- a/dns/zone-configs/kubernetes.io._0_base.yaml
+++ b/dns/zone-configs/kubernetes.io._0_base.yaml
@@ -18,6 +18,14 @@
       preference: 10
     - exchange: alt4.aspmx.l.google.com.
       preference: 10
+  - type: CAA # The CAA record set for a domain also applies to all sub-domains. If a sub-domain has its own CAA record set, it takes precedence.
+    values:
+    - flags: 0
+      tag: issue
+      value: pki.goog
+    - flags: 0
+      tag: issue
+      value: letsencrypt.org
   - type: TXT
     values:
     - google-site-verification=oPORCoq9XU6CmaR7G_bV00CLmEz-wLGOL7SXpeEuTt8


### PR DESCRIPTION
Adding a [CAA record](https://letsencrypt.org/docs/caa/) for kubernetes.io to prevent non-explicit CAs from issuing certificates for k/website.

A couple things to look out for:
- Are there any other CAs issuing certs for kubernetes.io?
- If this works, it will probably need to be added to k8s.io zone as well
- ~~I'm not sure if the quotes need to be escaped~~
- ~~I'm not sure if the CAA `type:` will take a map of values or how it interfaces with Google DNS~~

Any other concerns?

/cc @celestehorgan 