### PR TITLE
slack-moderator-words: update image for slack-moderator-words

### DIFF
--- a/slack-infra/resources/slack-moderator-words/deployment.yaml
+++ b/slack-infra/resources/slack-moderator-words/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-moderator-words
-        image: gcr.io/k8s-staging-slack-infra/slack-moderator-words:v20210223-8525eb3
+        image: gcr.io/k8s-staging-slack-infra/slack-moderator-words:v20210331-8e74e50
         args:
           - --config-path=/etc/slack-moderator-words/config.json
           - --filter-config-path=/etc/filters/filters.yaml


### PR DESCRIPTION
PR https://github.com/kubernetes-sigs/slack-infra/pull/47 is merged and that produces a new image.
this PR update the deployment to use the latest image which contains the features we added 


/assign @nikhita @ameukam 