### PR TITLE
gcp-compute-persistent-disk-csi-drive: promote image release v1.2.1

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cloud-provider-gcp/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-cloud-provider-gcp/images.yaml
@@ -1,3 +1,6 @@
+- name: gcp-compute-persistent-disk-csi-driver
+  dmap:
+    "sha256:23d2fe20c5307c3ef2580ed035084d9a57866717bd8b80bdc2dabd2097591227": ["v1.2.1"]
 - name: gcp-filestore-csi-driver
   dmap:
     "sha256:351548ca4bb0556e717c27309e1e559f65c9ae5826e60d48e0215f267835b80f": ["v0.3.1"]


### PR DESCRIPTION
release v1.2.1 is out https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/releases/tag/v1.2.1

and image `gcr.io/k8s-staging-cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.2.1` is available in the staging repo, so promoting this to the production bucket to continue the work described here: https://github.com/kubernetes/k8s.io/issues/1525

and with this PR we can close this issue https://github.com/kubernetes/k8s.io/issues/1821 because we will don't need to copy anymore.

/assign @spiffxp @msau42 @mattcary @saad-ali 

```console
skopeo inspect docker://gcr.io/k8s-staging-cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.2.1 --raw
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 956,
         "digest": "sha256:1e211048bad5275cdbb61d0554f236869e4d35be3d8de1592d327ccbf20bb139",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.18363.1440"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 956,
         "digest": "sha256:2ff447cd5c854cf1b20ccfe39c41e57713e1b2faaa3f704c5dc3ef976b9971cc",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.19041.867"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 956,
         "digest": "sha256:2faa23d8b4f3be071757abf347e628ba3ea2491d146a167296a3218ee22ea9b8",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.19042.867"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1162,
         "digest": "sha256:ae2ee5eee2681790c2a84def8cd2a1280849dfbc8922da7451e60fc69ca94f64",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 956,
         "digest": "sha256:a9648d7a19d1759766df7255842c0f899b301d2609918d682d1e3582859054a8",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.17763.1817"
         }
      }
   ]
}
```