### PR TITLE
triage-party: fix deployment replicas

### DIFF
--- a/triage-party/release-team/deployment.yaml
+++ b/triage-party/release-team/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: triage-party
 spec:
+  replicas: 1
   selector:
     matchLabels:
       app: triage-party


### PR DESCRIPTION
Looking the pods for the triage-party deployment, notice we have two pod but the second stay in creating forever because of the PVC.

AFAIK we can attach just one PVC per pod, so for now we can use just one replica

```console
ctadeu@cloudshell:~/k/k8s.io/triage-party (kubernetes-public)$ k get po -n triageparty-release
NAME                            READY   STATUS              RESTARTS   AGE
triage-party-58cbbd65d-k9c78    0/1     ContainerCreating   0          4m36s
triage-party-7df695bd97-6dgnb   1/1     Running             0          4m36s

ctadeu@cloudshell:~/k/k8s.io/triage-party (kubernetes-public)$ k describe po triage-party-58cbbd65d-k9c78 -n triageparty-release
...
  Warning  FailedAttachVolume  4m38s                attachdetach-controller  Multi-Attach error for volume "pvc-01502ea6-c680-11ea-a890-42010a80001f" Volume is already used by pod(s) triage-party-7df695bd97-6dgnb
  Warning  FailedMount         21s (x2 over 2m35s)  kubelet                  Unable to mount volumes for pod "triage-party-58cbbd65d-k9c78_triageparty-release(4f7befb3-8a3e-4e5a-8ad1-e5f3ceaa1471)": timeout expired waiting for volumes to attach or mount for p
od "triageparty-release"/"triage-party-58cbbd65d-k9c78". list of unmounted volumes=[pcache]. list of unattached volumes=[config pcache default-token-n78v
```

/assign @ameukam 