### PR TITLE
dl.k8s.io: Redirect CI URIs to Kubernetes Community infra

### DIFF
--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -158,7 +158,7 @@ data:
           # Don't require /release/ if you want to get at the Kubernetes release artifacts, the common case.
           rewrite ^/(v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?/.*)$   https://storage.googleapis.com/kubernetes-release/release/$1 redirect;
           # Provide a convenient redirect for CI (continuous integration) artifacts as well, which live in a different bucket.
-          rewrite ^/ci(-cross)?/?(.*)$              https://storage.googleapis.com/kubernetes-release-dev/ci$1/$2 redirect;
+          rewrite ^/ci(-cross)?/?(.*)$     https://storage.googleapis.com/k8s-release-dev/ci$1/$2 redirect;
           rewrite ^/(.*)$                  https://storage.googleapis.com/kubernetes-release/$1 redirect;
         }
       }

--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -158,7 +158,7 @@ data:
           # Don't require /release/ if you want to get at the Kubernetes release artifacts, the common case.
           rewrite ^/(v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?/.*)$   https://storage.googleapis.com/kubernetes-release/release/$1 redirect;
           # Provide a convenient redirect for CI (continuous integration) artifacts as well, which live in a different bucket.
-          rewrite ^/ci(-cross)?/?(.*)$     https://storage.googleapis.com/k8s-release-dev/ci$1/$2 redirect;
+          rewrite ^/ci/?(.*)$              https://storage.googleapis.com/k8s-release-dev/ci$1/$2 redirect;
           rewrite ^/(.*)$                  https://storage.googleapis.com/kubernetes-release/$1 redirect;
         }
       }

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -296,10 +296,6 @@ class RedirTest(HTTPTestCase):
                 base + '/ci/latest-$ver.txt',
                 'https://storage.googleapis.com/k8s-release-dev/ci/latest-$ver.txt',
                 ver=rand_num())
-            self.assert_temp_redirect(
-                base + '/ci-cross/v$ver/$path',
-                'https://storage.googleapis.com/k8s-release-dev/ci-cross/v$ver/$path',
-                ver=rand_num(), path=rand_num())
             # Base case
             self.assert_temp_redirect(
                 base + '/$path',

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -290,15 +290,15 @@ class RedirTest(HTTPTestCase):
             # A few /ci/ tests
             self.assert_temp_redirect(
                 base + '/ci/v$ver/$path',
-                'https://storage.googleapis.com/kubernetes-release-dev/ci/v$ver/$path',
+                'https://storage.googleapis.com/k8s-release-dev/ci/v$ver/$path',
                 ver=rand_num(), path=rand_num())
             self.assert_temp_redirect(
                 base + '/ci/latest-$ver.txt',
-                'https://storage.googleapis.com/kubernetes-release-dev/ci/latest-$ver.txt',
+                'https://storage.googleapis.com/k8s-release-dev/ci/latest-$ver.txt',
                 ver=rand_num())
             self.assert_temp_redirect(
                 base + '/ci-cross/v$ver/$path',
-                'https://storage.googleapis.com/kubernetes-release-dev/ci-cross/v$ver/$path',
+                'https://storage.googleapis.com/k8s-release-dev/ci-cross/v$ver/$path',
                 ver=rand_num(), path=rand_num())
             # Base case
             self.assert_temp_redirect(


### PR DESCRIPTION
- dl.k8s.io: Redirect CI URIs to Kubernetes Community infra

  krel ci-build has been successfully building and pushing CI Kubernetes
  builds for a time now.
  
  Updating this redirect (dl.k8s.io/ci) to Kubernetes Community infra
  moves us closer to no longer relying on the kubernetes-release-dev
  (Google-owned) bucket.

  ref: https://github.com/kubernetes/test-infra/pull/20663, https://github.com/kubernetes/test-infra/pull/20964

- dl.k8s.io: Remove ci-cross redirects
  
  All Kubernetes builds that land in the 'ci' directory of k8s-release-dev
  are cross builds, so this reference is no longer required.

  ref: https://github.com/kubernetes/test-infra/pull/18517

Signed-off-by: Stephen Augustus <foo@auggie.dev>

Part of https://github.com/kubernetes/release/issues/1711 and https://github.com/kubernetes/k8s.io/issues/1569