### PR TITLE
Refresh infra scripts to address audit followups, reduce output noise

### DIFF
--- a/infra/gcp/ensure-releng.sh
+++ b/infra/gcp/ensure-releng.sh
@@ -59,7 +59,7 @@ for PROJECT; do
 
     # Enable KMS APIs
     color 6 "Enabling the KMS API"
-    enable_api "${PROJECT}" cloudkms.googleapis.com
+    ensure_only_services "${PROJECT}" cloudkms.googleapis.com
 
     # Let project admins use KMS.
     color 6 "Empowering ${RELEASE_ADMINS} as KMS admins"

--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+readonly TMPDIR=$(mktemp -d "/tmp/k8sio-infra-gcp-lib.XXXXX")
+trap 'rm -rf "${TMPDIR}"' EXIT
+
 # This is a library of functions used to create GCP stuff.
 
 . "$(dirname "${BASH_SOURCE[0]}")/lib_util.sh"
@@ -603,15 +606,9 @@ function ensure_only_services() {
 
     local gcp_project="$1"; shift
 
-    local tmp_dir
-    tmp_dir=$(mktemp -d "/tmp/k8sio-infra-gcp-lib.XXXXX")
-    # tmp_dir is local but trap is global, so expand now to avoid unbound variable on exit
-    # shellcheck disable=SC2064
-    trap "rm -rf ${tmp_dir}" EXIT
-
-    local before="${tmp_dir}/ensure-only-services.before.yaml"
-    local after_enable="${tmp_dir}/ensure-only-services.after_enable.yaml"
-    local after_disable="${tmp_dir}/ensure-only-services.after_disable.yaml"
+    local before="${TMPDIR}/ensure-only-services.before.yaml"
+    local after_enable="${TMPDIR}/ensure-only-services.after_enable.yaml"
+    local after_disable="${TMPDIR}/ensure-only-services.after_disable.yaml"
 
     # get services before modifying to diff against when finished
     _plan_enabled_services "${gcp_project}" "$@" > "${before}"

--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -171,10 +171,7 @@ function empower_group_as_viewer() {
     local project="$1"
     local group="$2"
 
-    gcloud \
-        projects add-iam-policy-binding "${project}" \
-        --member "group:${group}" \
-        --role roles/viewer
+    ensure_project_role_binding "${project}" "group:${group}" "roles/viewer"
 }
 
 # Grant roles for running cip-auditor E2E test
@@ -201,28 +198,8 @@ function empower_service_account_for_cip_auditor_e2e_tester() {
     )
 
     for role in "${roles[@]}"; do
-        gcloud \
-            projects add-iam-policy-binding "${project}" \
-            --member "serviceAccount:${acct}" \
-            --role "${role}"
+        ensure_project_role_binding "${project}" "serviceAccount:${acct}" "${role}"
     done
-}
-
-# Grant roles for running pull-cip-vuln
-# $1: The service account
-# $2: The GCP Project
-function empower_service_account_for_cip_vuln_scanning() {
-    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
-        echo "empower_service_account_for_cip_vuln_scanning(acct, project) requires 2 arguments" >&2
-        return 1
-    fi
-    local acct="$1"
-    local project="$2"
-
-    gcloud \
-        projects add-iam-policy-binding "${project}" \
-        --member "serviceAccount:${acct}" \
-        --role roles/containeranalysis.occurrences.viewer
 }
 
 # Grant GCB admin privileges to a principal
@@ -236,20 +213,18 @@ function empower_group_for_gcb() {
     local project="$1"
     local group="$2"
 
-    gcloud \
-        projects add-iam-policy-binding "${project}" \
-        --member "group:${group}" \
-        --role roles/cloudbuild.builds.editor
-
-    # TODO(justaugustus/thockin): This only exists to grant the
-    #      serviceusage.services.use permission allow writers access to execute
-    #      Cloud Builds. We should refactor this once we develop custom roles.
-    #
-    #      Ref: https://cloud.google.com/storage/docs/access-control/iam-console
-    gcloud \
-        projects add-iam-policy-binding "${project}" \
-        --member "group:${group}" \
-        --role roles/serviceusage.serviceUsageConsumer
+    local roles=(
+        roles/cloudbuild.builds.editor
+        # TODO(justaugustus/thockin): This only exists to grant the
+        #      serviceusage.services.use permission allow writers access to execute
+        #      Cloud Builds. We should refactor this once we develop custom roles.
+        #
+        #      Ref: https://cloud.google.com/storage/docs/access-control/iam-console
+        roles/serviceusage.serviceUsageConsumer
+    )
+    for role in "${roles[@]}"; do
+        ensure_project_role_binding "${project}" "group:${group}" "${role}"
+    done
 }
 
 # Grant KMS admin privileges to a principal
@@ -263,15 +238,14 @@ function empower_group_for_kms() {
     local project="$1"
     local group="$2"
 
-    gcloud \
-        projects add-iam-policy-binding "${project}" \
-        --member "group:${group}" \
-        --role roles/cloudkms.admin
+    local roles=(
+        roles/cloudkms.admin
+        roles/cloudkms.cryptoKeyEncrypterDecrypter
+    )
 
-    gcloud \
-        projects add-iam-policy-binding "${project}" \
-        --member "group:${group}" \
-        --role roles/cloudkms.cryptoKeyEncrypterDecrypter
+    for role in "${roles[@]}"; do
+        ensure_project_role_binding "${project}" "group:${group}" "${role}"
+    done
 }
 
 # Grant privileges to prow in a staging project
@@ -285,32 +259,20 @@ function empower_prow() {
     local project="$1"
     local bucket="$2"
 
+    local prow_principal="serviceAccount:${PROW_SVCACCT}"
+    local gcb_builder_principal="serviceAccount:${GCB_BUILDER_SVCACCT}"
     # commands are copy-pasted so that one set can turn into deletes
     # when we're ready to decommission PROW_SVCACCT
 
     # Allow prow to trigger builds.
-    gcloud \
-        projects add-iam-policy-binding "${project}" \
-        --member "serviceAccount:${PROW_SVCACCT}" \
-        --role roles/cloudbuild.builds.builder
-    gcloud \
-        projects add-iam-policy-binding "${project}" \
-        --member "serviceAccount:${GCB_BUILDER_SVCACCT}" \
-        --role roles/cloudbuild.builds.builder
+    ensure_project_role_binding "${project}" "${prow_principal}" "roles/cloudbuild.builds.builder"
+    ensure_project_role_binding "${project}" "${gcb_builder_principal}" "roles/cloudbuild.builds.builder"
 
     # Allow prow to push source and access build logs.
-    gsutil iam ch \
-        "serviceAccount:${PROW_SVCACCT}:objectCreator" \
-        "${bucket}"
-    gsutil iam ch \
-        "serviceAccount:${PROW_SVCACCT}:objectViewer" \
-        "${bucket}"
-    gsutil iam ch \
-        "serviceAccount:${GCB_BUILDER_SVCACCT}:objectCreator" \
-        "${bucket}"
-    gsutil iam ch \
-        "serviceAccount:${GCB_BUILDER_SVCACCT}:objectViewer" \
-        "${bucket}"
+    ensure_gcs_role_binding "${bucket}" "${prow_principal}" "objectCreator"
+    ensure_gcs_role_binding "${bucket}" "${prow_principal}" "objectViewer"
+    ensure_gcs_role_binding "${bucket}" "${gcb_builder_principal}" "objectCreator"
+    ensure_gcs_role_binding "${bucket}" "${gcb_builder_principal}" "objectViewer"
 }
 
 # Grant full privileges to GCR admins
@@ -325,7 +287,7 @@ function empower_gcr_admins() {
     local region="${2:-}"
     local bucket=$(gcs_bucket_for_gcr "${project}" "${region}")
 
-    empower_group_as_viewer "${project}" "${GCR_ADMINS}"
+    ensure_project_role_binding "${project}" "group:${GCR_ADMINS}" "roles/viewer"
     empower_group_to_admin_gcs_bucket "${GCR_ADMINS}" "${bucket}"
 }
 
@@ -340,7 +302,7 @@ function empower_gcs_admins() {
     local project="${1}"
     local bucket="${2}"
 
-    empower_group_as_viewer "${project}" "${GCS_ADMINS}"
+    ensure_project_role_binding "${project}" "group:${GCS_ADMINS}" "roles/viewer"
     empower_group_to_admin_gcs_bucket "${GCS_ADMINS}" "${bucket}"
 }
 
@@ -356,28 +318,26 @@ function empower_group_to_admin_artifact_auditor() {
     local group="$2"
     local acct=$(svc_acct_email "${project}" "${AUDITOR_SVCACCT}")
 
-    # Grant privileges to deploy the auditor Cloud Run service. See
-    # https://cloud.google.com/run/docs/reference/iam/roles#additional-configuration.
-    gcloud \
-        projects add-iam-policy-binding "${project}" \
-        --member "group:${group}" \
-        --role roles/run.admin
-    # To read auditor's logs, we need serviceusage.services.use
-    gcloud \
-        projects add-iam-policy-binding "${project}" \
-        --member "group:${group}" \
-        --role roles/serviceusage.serviceUsageConsumer
+    local roles=(
+        # Grant privileges to deploy the auditor Cloud Run service. See
+        # https://cloud.google.com/run/docs/reference/iam/roles#additional-configuration.
+        roles/run.admin
+        # To read auditor's logs, we need serviceusage.services.use
+        roles/serviceusage.serviceUsageConsumer
+        # Also grant privileges to resolve Stackdriver Error Reporting errors.
+        roles/errorreporting.user
+    )
+
+    for role in "${roles[@]}"; do
+        ensure_project_role_binding "${project}" "group:${group}" "${role}"
+    done
+
     gcloud \
         --project="${project}" \
         iam service-accounts add-iam-policy-binding \
         "${acct}" \
         --member="group:${group}" \
         --role="roles/iam.serviceAccountUser"
-    # Also grant privileges to resolve Stackdriver Error Reporting errors.
-    gcloud \
-        projects add-iam-policy-binding "${project}" \
-        --member "group:${group}" \
-        --role roles/errorreporting.user
 }
 
 # Grant full privileges to the GCR promoter bot
@@ -412,6 +372,16 @@ function empower_artifact_auditor() {
     fi
     local project="$1"
 
+    local roles=(
+        # Allow auditor to write logs.
+        roles/logging.logWriter
+        # Allow auditor to write Stackdriver Error Reporting alerts.
+        roles/errorreporting.writer
+        # No other permissions are necessary because the cip-auditor process in the
+        # Cloud Run instance running as this service account will read the
+        # production GCR which is already world-readable.
+    )
+
     local acct=$(svc_acct_email "${project}" "${AUDITOR_SVCACCT}")
 
     if ! gcloud --project "${project}" iam service-accounts describe "${acct}" >/dev/null 2>&1; then
@@ -421,21 +391,9 @@ function empower_artifact_auditor() {
             --display-name="k8s-infra container image auditor"
     fi
 
-    # Allow auditor to write logs.
-    gcloud \
-        projects add-iam-policy-binding "${project}" \
-        --member "serviceAccount:${acct}" \
-        --role roles/logging.logWriter
-
-    # Allow auditor to write Stackdriver Error Reporting alerts.
-    gcloud \
-        projects add-iam-policy-binding "${project}" \
-        --member "serviceAccount:${acct}" \
-        --role roles/errorreporting.writer
-
-    # No other permissions are necessary because the cip-auditor process in the
-    # Cloud Run instance running as this service account will read the
-    # production GCR which is already world-readable.
+    for role in "${roles[@]}"; do
+        ensure_project_role_binding "${project}" "serviceAccount:${acct}" "${role}"
+    done
 }
 
 # Ensure the artifact auditor invoker service account exists and has the ability
@@ -540,11 +498,7 @@ function empower_ksa_to_svcacct() {
     local gcp_project="$2"
     local gcp_svcacct="$3"
 
-    gcloud iam service-accounts add-iam-policy-binding \
-        --role roles/iam.workloadIdentityUser \
-        --member "serviceAccount:${ksa_scope}" \
-        "${gcp_svcacct}" \
-        --project="${gcp_project}"
+    ensure_serviceaccount_role_binding "${gcp_svcacct}" "serviceAccount:${ksa_scope}" "roles/iam.workloadIdentityUser"
 }
 
 # Ensure that a global ip address exists, creating one if needed

--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -601,3 +601,101 @@ function ensure_regional_address() {
         --region="${region}"
     fi
 }
+
+# Output a plan of services to enable/disable for a given gcp project; format
+# is YAML, each key is a list of services e.g. [pubsub.googleapis.com, ...]
+#   intent:     # services we wish to enable
+#   enabled:    # services that are presently enabled
+#   expected:   # intent + any services directly depended on by intent
+#   to_enable:  # services in intent that are not enabled
+#   to_disable: # services that are enabled but not in expected
+# $1  The GCP project
+# $2+ Service names that are expected to be enabled (e.g. pubsub.googleapis.com)
+function _plan_enabled_services() {
+    if [ $# -lt 2 -o -z "$1" ]; then
+        echo "list_services(gcp_project, service...) requires at least 2 arguments" >&2
+        return 1
+    fi
+
+    local gcp_project="$1"; shift
+
+    gcloud services list --enabled --project="${gcp_project}" \
+      --format='yaml(config.name,dependencyConfig.directlyDependsOn)' \
+      | yq --slurp -y --args '($ARGS.positional | sort) as $intent | {
+        intent: $intent,
+        enabled: map(.config.name) | sort,
+        expected: (
+          map(
+            select([.config.name] | inside($intent))
+            | (.dependencyConfig?.directlyDependsOn // [])
+          ) + $intent
+        )
+        | flatten
+        | map({key:., value:true}) | from_entries | keys | sort
+      } | . += {
+        to_enable: (.expected - .enabled),
+        to_disable: (.enabled - .expected)
+      }' "$@"
+}
+
+# Ensure that only the given services and their direct dependencies are enabled; disable any other services
+# $1  The GCP project for which to enable/disable services
+# $2+ The service names (e.g. pubsub.googleapis.com)
+function ensure_only_services() {
+    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+        echo "ensure_only_services(gcp_project, service...) requires at least 2 arguments" >&2
+        return 1
+    fi
+
+    local gcp_project="$1"; shift
+
+    local tmp_dir
+    tmp_dir=$(mktemp -d "/tmp/k8sio-infra-gcp-lib.XXXXX")
+    # tmp_dir is local but trap is global, so expand now to avoid unbound variable on exit
+    # shellcheck disable=SC2064
+    trap "rm -rf ${tmp_dir}" EXIT
+
+    local before="${tmp_dir}/ensure-only-services.before.yaml"
+    local after_enable="${tmp_dir}/ensure-only-services.after_enable.yaml"
+    local after_disable="${tmp_dir}/ensure-only-services.after_disable.yaml"
+
+    # get services before modifying to diff against when finished
+    _plan_enabled_services "${gcp_project}" "$@" > "${before}"
+
+    # if there's nothing to do, return early
+    if ! <"${before}" yq --exit-status '[.to_enable, .to_disable] | map (length > 0) | any' >/dev/null; then
+      return
+    fi
+
+    echo "plan to enable/disable the following services"
+    <"${before}" yq -y '{to_enable, to_disable}'
+
+    # enable services that need to be enabled
+    for service in $(<"${before}" yq -r '.to_enable[]'); do
+        gcloud services enable --project="${gcp_project}" "${service}"
+    done
+
+    # disable services not explicitly enabled or directly required
+    _plan_enabled_services "${gcp_project}" "$@" > "${after_enable}"
+
+
+    # TODO(spiffxp): get comfortable with --force or redo to disable in dep-order;
+    #                until then, set an obnoxiously long env var to actually disable
+    local disable_cmd='echo "INFO: dry-run mode, would run:" gcloud'
+    if [ "${K8S_INFRA_ENSURE_ONLY_SERVICES_WILL_FORCE_DISABLE:-""}" == "true" ]; then
+        disable_cmd=gcloud
+    fi
+    for service in $( (<"${after_enable}" yq -r '.to_disable[]') | sort | uniq -u); do
+        ${disable_cmd} services disable --force "${service}" --project="${gcp_project}"
+    done
+
+    _plan_enabled_services "${gcp_project}" "$@" > "${after_disable}"
+
+    # in the event that an enable/disable cycle doesn't do enough, let's warn
+    if <"${after_disable}" yq --exit-status '[.to_enable, .to_disable] | map (length > 0) | any' >/dev/null; then
+      echo "WARN: ensure_only_services: after enable/disable cycle, still projects to enable/disable: ${gcp_project}"
+      cat "${after_disable}"
+    fi
+
+    diff_colorized "${before}" "${after_disable}"
+}

--- a/infra/gcp/lib_gcr.sh
+++ b/infra/gcp/lib_gcr.sh
@@ -78,8 +78,7 @@ function ensure_gcr_repo() {
             container images delete --quiet "${dest}:latest"
     fi
 
-    gsutil iam ch allUsers:objectViewer "${bucket}"
-    gsutil bucketpolicyonly set on "${bucket}"
+    ensure_public_gcs_bucket "${project}" "${bucket}"
 }
 
 # Grant write privileges on a GCR to a group

--- a/infra/gcp/lib_gcs.sh
+++ b/infra/gcp/lib_gcs.sh
@@ -123,15 +123,9 @@ function ensure_gcs_bucket_auto_deletion() {
     local bucket="$1"
     local auto_deletion_days="$2"
 
-    local tmp_dir
-    tmp_dir=$(mktemp -d "/tmp/k8sio-infra-gcp-lib.XXXXX")
-    # tmp_dir is local but trap is global, so expand now to avoid unbound variable on exit
-    # shellcheck disable=SC2064
-    trap "rm -rf ${tmp_dir}" EXIT
-
-    local intent="${tmp_dir}/gcs-lifecycle.intent.yaml"
-    local before="${tmp_dir}/gcs-lifecycle.before.yaml"
-    local after="${tmp_dir}/gcs-lifecycle.after.yaml"
+    local intent="${TMPDIR}/gcs-lifecycle.intent.yaml"
+    local before="${TMPDIR}/gcs-lifecycle.before.yaml"
+    local after="${TMPDIR}/gcs-lifecycle.after.yaml"
 
     echo "{\"rule\": [{\"action\": {\"type\": \"Delete\"}, \"condition\": {\"age\": ${auto_deletion_days}}}]}" > "${intent}"
     gsutil lifecycle get "${bucket}"> "${before}"
@@ -187,14 +181,8 @@ ensure_gcs_role_binding() {
     local principal="${2}"
     local role="${3}"
 
-    local tmp_dir
-    tmp_dir=$(mktemp -d "/tmp/k8sio-infra-gcp-lib.XXXXX")
-    # tmp_dir is local but trap is global, so expand now to avoid unbound variable on exit
-    # shellcheck disable=SC2064
-    trap "rm -rf ${tmp_dir}" EXIT
-
-    local before="${tmp_dir}/gcs-bind.before.yaml"
-    local after="${tmp_dir}/gcs-bind.after.yaml"
+    local before="${TMPDIR}/gcs-bind.before.yaml"
+    local after="${TMPDIR}/gcs-bind.after.yaml"
 
     gsutil iam get "${bucket}" | yq -y | _format_iam_policy > "${before}"
 
@@ -225,14 +213,8 @@ ensure_removed_gcs_role_binding() {
     local principal="${2}"
     local role="${3}"
 
-    local tmp_dir
-    tmp_dir=$(mktemp -d "/tmp/k8sio-infra-gcp-lib.XXXXX")
-    # tmp_dir is local but trap is global, so expand now to avoid unbound variable on exit
-    # shellcheck disable=SC2064
-    trap "rm -rf ${tmp_dir}" EXIT
-
-    local before="${tmp_dir}/gcs-bind.before.yaml"
-    local after="${tmp_dir}/gcs-bind.after.yaml"
+    local before="${TMPDIR}/gcs-bind.before.yaml"
+    local after="${TMPDIR}/gcs-bind.after.yaml"
 
     gsutil iam get "${bucket}" | yq -y | _format_iam_policy > "${before}"
 

--- a/infra/gcp/lib_iam.sh
+++ b/infra/gcp/lib_iam.sh
@@ -289,15 +289,9 @@ function _ensure_custom_iam_role_from_file() {
 
     local scope_flag="--${scope} ${id}"
 
-    local tmp_dir
-    tmp_dir=$(mktemp -d "/tmp/k8sio-infra-gcp-lib.XXXXX")
-    # tmp_dir is local but trap is global, so expand now to avoid unbound variable on exit
-    # shellcheck disable=SC2064
-    trap "rm -rf ${tmp_dir}" EXIT
-
-    local before="${tmp_dir}/custom-role.before.yaml"
-    local ready="${tmp_dir}/custom-role.ready.yaml"
-    local after="${tmp_dir}/custom-role.after.yaml"
+    local before="${TMPDIR}/custom-role.before.yaml"
+    local ready="${TMPDIR}/custom-role.ready.yaml"
+    local after="${TMPDIR}/custom-role.after.yaml"
 
     # detect if we should create or update and dump role; silently ignore error
     verb="update"
@@ -343,13 +337,8 @@ function _ensure_removed_custom_iam_role() {
 
     local scope_flag="--${scope} ${id}"
 
-    local tmp_dir
-    tmp_dir=$(mktemp -d "/tmp/k8sio-infra-gcp-lib.XXXXX")
-    # tmp_dir is local but trap is global, so expand now to avoid unbound variable on exit
-    # shellcheck disable=SC2064
-    trap "rm -rf ${tmp_dir}" EXIT
-
-    local before="${tmp_dir}/iam-bind.before.txt"
+    local before="${TMPDIR}/iam-bind.before.txt"
+    local before="${TMPDIR}/iam-bind.after.txt"
 
     # gcloud iam roles delete errors if role doesn't exist, so confirm it does
     if ! gcloud iam roles describe ${scope_flag} ${name} --format="value(deleted)" > "${before}" 2>/dev/null; then
@@ -397,14 +386,8 @@ function _ensure_resource_role_binding() {
     local principal="${3}"
     local role="${4}"
 
-    local tmp_dir
-    tmp_dir=$(mktemp -d "/tmp/k8sio-infra-gcp-lib.XXXXX")
-    # tmp_dir is local but trap is global, so expand now to avoid unbound variable on exit
-    # shellcheck disable=SC2064
-    trap "rm -rf ${tmp_dir}" EXIT
-
-    local before="${tmp_dir}/iam-bind.before.yaml"
-    local after="${tmp_dir}/iam-bind.after.yaml"
+    local before="${TMPDIR}/iam-bind.before.yaml"
+    local after="${TMPDIR}/iam-bind.after.yaml"
 
     # intentionally word-split resource, e.g. iam service-accounts
     # shellcheck disable=SC2086
@@ -445,14 +428,8 @@ function _ensure_removed_resource_role_binding() {
     local principal="${3}"
     local role="${4}"
 
-    local tmp_dir
-    tmp_dir=$(mktemp -d "/tmp/k8sio-infra-gcp-lib.XXXXX")
-    # tmp_dir is local but trap is global, so expand now to avoid unbound variable on exit
-    # shellcheck disable=SC2064
-    trap "rm -rf ${tmp_dir}" EXIT
-
-    local before="${tmp_dir}/iam-bind.before.txt"
-    local after="${tmp_dir}/iam-bind.after.txt"
+    local before="${TMPDIR}/iam-bind.before.txt"
+    local after="${TMPDIR}/iam-bind.after.txt"
 
     # intentionally word-split resource, e.g. iam service-accounts
     # shellcheck disable=SC2086

--- a/infra/gcp/lib_util.sh
+++ b/infra/gcp/lib_util.sh
@@ -25,7 +25,7 @@ script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd "${script_dir}/../.." && pwd)
 
 function _color() {
-    tput setf "$1" || true
+    tput setaf "$1" || true
 }
 
 function _nocolor() {

--- a/infra/gcp/roles/CustomRole.yaml
+++ b/infra/gcp/roles/CustomRole.yaml
@@ -33,6 +33,7 @@
 #
 description: View access to billing info
 includedPermissions:
+  - billing.accounts.getPricing
   - billing.accounts.getSpendingInformation
   - billing.budgets.get
   - billing.budgets.list
@@ -41,6 +42,7 @@ includedPermissions:
   - billing.resourceCosts.get
   - billing.subscriptions.get
   - billing.subscriptions.list
+  - commerceoffercatalog.offers.get
   - resourcemanager.projects.get
   - resourcemanager.projects.list
 name: CustomRole

--- a/infra/gcp/roles/audit.viewer.yaml
+++ b/infra/gcp/roles/audit.viewer.yaml
@@ -76,6 +76,7 @@ includedPermissions:
   - apigee.developerapps.list
   - apigee.developerattributes.list
   - apigee.developers.list
+  - apigee.developersubscriptions.list
   - apigee.envgroupattachments.list
   - apigee.envgroups.list
   - apigee.environments.getIamPolicy
@@ -94,6 +95,7 @@ includedPermissions:
   - apigee.proxies.list
   - apigee.proxyrevisions.list
   - apigee.queries.list
+  - apigee.rateplans.list
   - apigee.references.list
   - apigee.reports.list
   - apigee.resourcefiles.list
@@ -190,6 +192,7 @@ includedPermissions:
   - cloudkms.importJobs.list
   - cloudkms.keyRings.getIamPolicy
   - cloudkms.keyRings.list
+  - cloudkms.locations.list
   - cloudnotifications.activities.list
   - cloudprivatecatalogproducer.associations.list
   - cloudprivatecatalogproducer.catalogAssociations.list
@@ -234,6 +237,7 @@ includedPermissions:
   - cloudvolumesgcp-api.netapp.com/serviceLevels.list
   - cloudvolumesgcp-api.netapp.com/snapshots.list
   - cloudvolumesgcp-api.netapp.com/volumes.list
+  - commerceprice.privateoffers.list
   - composer.environments.list
   - composer.imageversions.list
   - composer.operations.list
@@ -508,6 +512,8 @@ includedPermissions:
   - datafusion.instances.getIamPolicy
   - datafusion.instances.list
   - datafusion.locations.list
+  - datafusion.namespaces.getIamPolicy
+  - datafusion.namespaces.list
   - datafusion.operations.list
   - datalabeling.annotateddatasets.list
   - datalabeling.annotationspecsets.list
@@ -646,6 +652,12 @@ includedPermissions:
   - genomics.datasets.getIamPolicy
   - genomics.datasets.list
   - genomics.operations.list
+  - gkemulticloud.awsClusters.list
+  - gkemulticloud.awsNodePools.list
+  - gkemulticloud.azureClients.list
+  - gkemulticloud.azureClusters.list
+  - gkemulticloud.azureNodePools.list
+  - gkemulticloud.operations.list
   - gsuiteaddons.deployments.list
   - healthcare.annotationStores.getIamPolicy
   - healthcare.annotationStores.list
@@ -705,6 +717,7 @@ includedPermissions:
   - memcache.instances.list
   - memcache.locations.list
   - memcache.operations.list
+  - metastore.backups.list
   - metastore.imports.list
   - metastore.locations.list
   - metastore.operations.list
@@ -763,6 +776,7 @@ includedPermissions:
   - notebooks.schedules.getIamPolicy
   - notebooks.schedules.list
   - ondemandscanning.operations.list
+  - opsconfigmonitoring.resourceMetadata.list
   - osconfig.guestPolicies.list
   - osconfig.patchDeployments.list
   - osconfig.patchJobs.list

--- a/infra/gcp/roles/prow.viewer.yaml
+++ b/infra/gcp/roles/prow.viewer.yaml
@@ -403,6 +403,7 @@ includedPermissions:
   - monitoring.timeSeries.list
   - monitoring.uptimeCheckConfigs.get
   - monitoring.uptimeCheckConfigs.list
+  - opsconfigmonitoring.resourceMetadata.list
   - resourcemanager.projects.get
   - resourcemanager.projects.list
   - serviceusage.quotas.get


### PR DESCRIPTION
I've run these a few times locally and the results are showing up in audit PRs, so I should probably share what I'm working on.

Will update this description to link to issues these fixes resolve once I've taken care of the WIP commits

Should allow us to address https://github.com/kubernetes/k8s.io/issues/1675
- Running `K8S_INFRA_ENSURE_ONLY_SERVICES_WILL_FORCE_DISABLE=true ./infra/gcp/ensure-staging-storage.sh` should disable all of the unexpected services.  I plan on doing a first pass without that set to get a log of which projects would have which services disabled first.

Fixes https://github.com/kubernetes/k8s.io/issues/299
- Any new projects going forward will have the `user:foo roles/owner` binding removed immediately after the project is created.  I plan on running ./infra/gcp/*.sh to ensure the `roles/owner` binding is removed for all existing projects.

See individual commits for details