### PR TITLE
Add github admins for k8s-staging-ci-robot

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -175,6 +175,18 @@ groups:
       - nikitaraghunath@gmail.com
       - killen.bob@gmail.com
 
+  - email-id: k8s-infra-ci-robot@kubernetes.io
+    name: k8s-infra-ci-robot
+    description: |-
+      Github admins for github account k8s-infra-ci-robot
+    settings:
+      ReconcileMembers: "true"
+      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # required
+    managers:
+      - ameukam@gmail.com
+      - spiffxp@gmail.com
+      - spiffxp@google.com
+
   # Every RBAC group should be added here.
   - email-id: gke-security-groups@kubernetes.io
     name: gke-security-groups


### PR DESCRIPTION
For https://github.com/kubernetes/k8s.io/issues/1394, we will need
a new github account acting as a new bot
[k8s-staging-ci-robot](https://github.com/k8s-staging-ci-robot). Adding
a new mailing list that list be use for administration of this robot.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>