### PR TITLE
Add initial groups reconciliation for sig-cluster-lifecycle

### DIFF
--- a/groups/sig-cluster-lifecycle/OWNERS
+++ b/groups/sig-cluster-lifecycle/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-cluster-lifecycle-leads
+approvers:
+  - sig-cluster-lifecycle-leads
+labels:
+  - sig/cluster-lifecycle

--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -1,0 +1,15 @@
+groups:
+  - email-id: kubernetes-sig-cluster-lifecycle-cluster-api-test-alerts@googlegroups.com
+    name: kubernetes-sig-cluster-lifecycle-cluster-api-test-alerts
+    description: |-
+
+    settings:
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      ReconcileMembers: "true"
+    owners:
+      - detiber@gmail.com
+      - jdetiberus@equinix.com
+      - jeewan@vmware.com
+      - sbueringer@gmail.com
+    members:
+      - naadir@randomvariable.co.uk


### PR DESCRIPTION
Creates new replacement group for lost Google Group for testgrid/prow
for Kubernetes Cluster API.

Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

/hold

As I'm expecting to add a few more folk.