### PR TITLE
Fix settings for k8s-infra-ci-robot

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -181,6 +181,7 @@ groups:
       Github admins for github account k8s-infra-ci-robot
     settings:
       ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
       WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # required
     managers:
       - ameukam@gmail.com


### PR DESCRIPTION
Allow k8s-infra-ci-robot@kubernetes.io to receive messages from
the outside.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>