### PR TITLE
Deploy kubernetes-external-secrets to aaa cluster

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -202,6 +202,7 @@ groups:
       - k8s-infra-rbac-kettle@kubernetes.io
       - k8s-infra-rbac-k8s-io-canary@kubernetes.io
       - k8s-infra-rbac-k8s-io-prod@kubernetes.io
+      - k8s-infra-rbac-kubernetes-external-secrets@kubernetes.io
       - k8s-infra-rbac-perfdash@kubernetes.io
       - k8s-infra-rbac-prow@kubernetes.io
       - k8s-infra-rbac-publishing-bot@kubernetes.io

--- a/groups/wg-k8s-infra/groups.yaml
+++ b/groups/wg-k8s-infra/groups.yaml
@@ -160,3 +160,13 @@ groups:
       - davanum@gmail.com
       - spiffxp@google.com
       - thockin@google.com
+
+  - email-id: k8s-infra-rbac-kubernetes-external-secrets@kubernetes.io
+    name: k8s-infra-rbac-kubernetes-external-secrets
+    description: |-
+      Grants access to the `namespace-user` role in the `kubernetes-external-secrets` namespace on the `aaa` cluster
+    settings:
+      ReconcileMembers: "true"
+      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # required
+    members:
+      - k8s-infra-cluster-admins@kubernetes.io

--- a/infra/gcp/ensure-main-project.sh
+++ b/infra/gcp/ensure-main-project.sh
@@ -180,6 +180,24 @@ ensure_project_role_binding \
     "serviceAccount:${MONITORING_SVCACCT_NAME}" \
     "roles/monitoring.viewer"
 
+# Kubernetes External Secrets
+color 6 -n "Ensure the kubernetes-external-secrets serviceaccount exists"
+ensure_service_account \
+    "${PROJECT}" \
+    "kubernetes-external-secrets" \
+    "Kubernetes External Secrets Service Account"
+
+color 6 -n "Empowering kubernetes-external-secrets serviceaccount to be used on aaa cluster"
+empower_ksa_to_svcacct \
+    "kubernetes-public.svc.id.goog[kubernetes-external-secrets/kubernetes-external-secrets]" \
+    "${PROJECT}" \
+    "$(svc_acct_email "${PROJECT}" "kubernetes-external-secrets")"
+
+color 6 "Empowering service account kubernetes-external-services to access payloads of the secrets"
+ensure_project_role_binding "${PROJECT}" \
+    "serviceAccount:$(svc_acct_email "${PROJECT}" "kubernetes-external-secrets")" \
+    roles/secretmanager.secretAccessor
+
 # Bootstrap DNS zones
 ensure_dns_zone "${PROJECT}" "k8s-io" "k8s.io"
 ensure_dns_zone "${PROJECT}" "kubernetes-io" "kubernetes.io"

--- a/infra/gcp/namespaces/ensure-namespaces.sh
+++ b/infra/gcp/namespaces/ensure-namespaces.sh
@@ -147,6 +147,7 @@ ALL_PROJECTS=(
     kettle
     k8s-io-prod
     k8s-io-canary
+    kubernetes-external-secrets
     node-perf-dash
     perfdash
     prow

--- a/kubernetes-external-secrets/00-namespace.yaml
+++ b/kubernetes-external-secrets/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: namespace
+metadata:
+  name: kubernetes-external-secrets

--- a/kubernetes-external-secrets/OWNERS
+++ b/kubernetes-external-secrets/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+    - wg-k8s-infra-leads
+reviewers:
+    - wg-k8s-infra-leads

--- a/kubernetes-external-secrets/README.md
+++ b/kubernetes-external-secrets/README.md
@@ -1,0 +1,19 @@
+# Kubernetes External Secrets
+
+[Kubernetes External Secrets](https://github.com/external-secrets/kubernetes-external-secrets) is mainly used to ensure synchronization of secrets stored in AWS and GCP Secrets Manager to community-owned GKE cluster `aaa`.
+
+## How to deploy
+
+Ensure you have [access to the cluster]
+
+Ensure you are a member of:
+
+- k8s-infra-cluster-admins@kubernetes.io
+
+To boostrap Kubernetes External Secrets:
+
+```shell
+kubectl apply -Rf kubernetes-external-secrets/
+```
+
+[access to the cluster]: https://github.com/kubernetes/k8s.io/blob/main/running-in-community-clusters.md#access-the-cluster

--- a/kubernetes-external-secrets/deployment.yaml
+++ b/kubernetes-external-secrets/deployment.yaml
@@ -1,0 +1,57 @@
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubernetes-external-secrets
+  namespace: kubernetes-external-secrets
+  labels:
+    app: kubernetes-external-secrets
+spec:
+  selector:
+    app: kubernetes-external-secrets
+  ports:
+    - protocol: TCP
+      port: 3001
+      name: prometheus
+      targetPort: prometheus
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubernetes-external-secrets
+  namespace: kubernetes-external-secrets
+  labels:
+    app: kubernetes-external-secrets
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubernetes-external-secrets
+  template:
+    metadata:
+      labels:
+        app: kubernetes-external-secrets
+    spec:
+      serviceAccountName: kubernetes-external-secrets
+      containers:
+        - name: kubernetes-external-secrets
+          image: "ghcr.io/external-secrets/kubernetes-external-secrets:7.0.1"
+          imagePullPolicy: Always
+          ports:
+          - name: prometheus
+            containerPort: 3001
+          env:
+          - name: "LOG_LEVEL"
+            value: "debug" # TODO(ameukam): switch to info
+          - name: "LOG_MESSAGE_KEY"
+            value: "msg"
+          - name: "METRICS_PORT"
+            value: "3001"
+          - name: "POLLER_INTERVAL_MILLISECONDS"
+            value: "10000"
+          - name: "WATCH_TIMEOUT"
+            value: "60000"
+          # Params for env vars populated from k8s secrets
+      securityContext:
+        runAsNonRoot: true

--- a/kubernetes-external-secrets/kubernetes-client.io_externalsecrets_crd.yaml
+++ b/kubernetes-external-secrets/kubernetes-client.io_externalsecrets_crd.yaml
@@ -1,0 +1,141 @@
+# Source: https://github.com/external-secrets/kubernetes-external-secrets/blob/master/charts/kubernetes-external-secrets/crds/kubernetes-client.io_externalsecrets_crd.yaml
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: externalsecrets.kubernetes-client.io
+  annotations:
+    # used in e2e testing
+    app.kubernetes.io/managed-by: helm
+spec:
+  group: kubernetes-client.io
+  version: v1
+  scope: Namespaced
+
+  names:
+    shortNames:
+      - es
+    kind: ExternalSecret
+    plural: externalsecrets
+    singular: externalsecret
+
+  additionalPrinterColumns:
+    - JSONPath: .status.lastSync
+      name: Last Sync
+      type: date
+    - JSONPath: .status.status
+      name: status
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            template:
+              description: Template which will be deep merged without mutating
+                any existing fields. into generated secret, can be used to
+                set for example annotations or type on the generated secret
+              type: object
+            backendType:
+              type: string
+              enum:
+                - secretsManager
+                - systemManager
+                - vault
+                - azureKeyVault
+                - gcpSecretsManager
+                - alicloudSecretsManager
+                - ibmcloudSecretsManager
+            vaultRole:
+              type: string
+            vaultMountPoint:
+              type: string
+            kvVersion:
+              description: Vault K/V version either 1 or 2, default = 2
+              type: integer
+              minimum: 1
+              maximum: 2
+            keyVaultName:
+              type: string
+            key:
+              type: string
+            dataFrom:
+              type: array
+              items:
+                type: string
+            data:
+              type: array
+              items:
+                type: object
+                anyOf:
+                  - properties:
+                      key:
+                        description: Secret key in backend
+                        type: string
+                      name:
+                        description: Name set for this key in the generated secret
+                        type: string
+                      property:
+                        description: Property to extract if secret in backend is a JSON object
+                      isBinary:
+                        description: >-
+                          Whether the backend secret shall be treated as binary data
+                          represented by a base64-encoded string. You must set this to true
+                          for any base64-encoded binary data in the backend - to ensure it
+                          is not encoded in base64 again. Default is false.
+                        type: boolean
+                    required:
+                      - key
+                      - name
+                  - properties:
+                      path:
+                        description: >-
+                          Path from SSM to scrape secrets
+                          This will fetch all secrets and use the key from the secret as variable name
+                      recursive:
+                        description: Allow to recurse thru all child keys on a given path
+                        type: boolean
+                    required:
+                      - path
+            roleArn:
+              type: string
+          oneOf:
+            - properties:
+                backendType:
+                  enum:
+                    - secretsManager
+                    - systemManager
+            - properties:
+                backendType:
+                  enum:
+                    - vault
+            - properties:
+                backendType:
+                  enum:
+                    - azureKeyVault
+              required:
+                - keyVaultName
+            - properties:
+                backendType:
+                  enum:
+                    - gcpSecretsManager
+            - properties:
+                backendType:
+                  enum:
+                    - alicloudSecretsManager
+            - properties:
+                backendType:
+                  enum:
+                    - ibmcloudSecretsManager
+          anyOf:
+            - required:
+                - data
+            - required:
+                - dataFrom
+  subresources:
+    status: {}

--- a/kubernetes-external-secrets/rbac.yaml
+++ b/kubernetes-external-secrets/rbac.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubernetes-external-secrets
+  namespace: kubernetes-external-secrets
+  annotations:
+    iam.gke.io/gcp-service-account: kubernetes-external-secrets@kubernetes-public.iam.gserviceaccount.com
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubernetes-external-secrets
+  labels:
+    app: kubernetes-external-secrets
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "update"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    resourceNames: ["externalsecrets.kubernetes-client.io"]
+    verbs: ["get", "update"]
+  - apiGroups: ["kubernetes-client.io"]
+    resources: ["externalsecrets"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["kubernetes-client.io"]
+    resources: ["externalsecrets/status"]
+    verbs: ["get", "update"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-external-secrets
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubernetes-external-secrets
+subjects:
+  - name: RELEASE-NAME-kubernetes-external-secrets
+    namespace: kubernetes-external-secrets
+    kind: ServiceAccount
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-external-secrets-auth
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- name: kubernetes-external-secrets
+  namespace: kubernetes-external-secrets
+  kind: ServiceAccount


### PR DESCRIPTION
Use Kubernetes External Secrets for auto sync secrets from GCP Secrets
Manager.
Initial discussion started here : https://docs.google.com/document/d/1Jo8dyNiJ1fnYh30M_6Gq2XDU9B3bGFmkD2QokyKYwEg/.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>