### PR TITLE
Use ghproxy as cache for Triage-Party.

### DIFF
--- a/triage-party/release-team/deployment.yaml
+++ b/triage-party/release-team/deployment.yaml
@@ -18,6 +18,14 @@ spec:
       containers:
         - name: triage-party
           image: triageparty/triage-party:1.4.0-beta.1
+          command:
+            - "/app/main"
+          args:
+            - --github-api-url http://ghproxy.prow.svc.cluster.local/
+            - --min-refresh=30s
+            - --max-refresh=5m
+            - --site=/app/site
+            - --3p=/app/third_party
           env:
             - name: GITHUB_TOKEN
               valueFrom:


### PR DESCRIPTION
Followup of https://github.com/kubernetes/k8s.io/pull/1832

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>