### PR TITLE
Add initial terraform manifests for monitoring

### DIFF
--- a/infra/gcp/monitoring/k8s.io/00-provider.tf
+++ b/infra/gcp/monitoring/k8s.io/00-provider.tf
@@ -1,0 +1,23 @@
+
+/*
+This file defines:
+- Required provider versions
+- Storage backend details
+*/
+
+terraform {
+
+  backend "gcs" {
+    bucket = "k8s-infra-clusters-terraform"
+    prefix = "monitoring/state" // $project_name/$cluster_name
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.63.0"
+    }
+  }
+}
+
+

--- a/infra/gcp/monitoring/k8s.io/10-thockin-k8s-io.tf
+++ b/infra/gcp/monitoring/k8s.io/10-thockin-k8s-io.tf
@@ -1,0 +1,75 @@
+locals {
+  project_id       = "kubernetes-public"
+  monitored_domain = "thockin-test1.k8s.io"
+}
+
+// Needed to import the notification channel
+provider "google" {
+  project = local.project_id
+}
+
+// Manual step: Create a StackDriver alert channel pointing to a channel in Slack
+// It will select the channel here by its display name
+data "google_monitoring_notification_channel" "alertchannel" {
+  display_name = "Kubernetes.io Cert Alert"
+}
+
+
+// We can turn this into a module and then add then standardize the resource display names
+resource "google_monitoring_uptime_check_config" "uptime_check" {
+  display_name = "${local.monitored_domain} https"
+  timeout      = "5s"
+  period       = "300s"
+
+  http_check {
+    path         = "/"
+    port         = "443"
+    use_ssl      = true
+    validate_ssl = true
+  }
+
+  monitored_resource {
+    type = "uptime_url"
+    labels = {
+      project_id = local.project_id
+      // Host to be verified (1)
+      host = local.monitored_domain
+    }
+  }
+}
+
+
+resource "google_monitoring_alert_policy" "cert_expiration_alert" {
+  combiner              = "OR"
+  display_name          = "${local.monitored_domain} certificate monitor"
+  enabled               = true
+  notification_channels = [data.google_monitoring_notification_channel.alertchannel.name]
+  project               = local.project_id
+
+  conditions {
+    display_name = "${local.monitored_domain} expiration days is below the defined threshold"
+
+    condition_threshold {
+      comparison = "COMPARISON_LT"
+
+      // = 5 minutes failing! may be increased or reduced
+      duration = "300s"
+
+      // resource.label.host should be changed accordingly with the uptime check created before (1)
+      filter = "metric.type=\"monitoring.googleapis.com/uptime_check/time_until_ssl_cert_expires\" resource.type=\"uptime_url\" resource.label.\"host\"=\"${local.monitored_domain}\" metric.label.\"checker_location\"=\"usa-iowa\""
+
+      // Number in days until the cert expires that should trigger an alert
+      threshold_value = 15
+
+      aggregations {
+        alignment_period   = "300s"
+        per_series_aligner = "ALIGN_MEAN"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+}
+

--- a/infra/gcp/monitoring/k8s.io/10-thockin-k8s-io.tf
+++ b/infra/gcp/monitoring/k8s.io/10-thockin-k8s-io.tf
@@ -11,9 +11,11 @@ provider "google" {
 // Manual step: Create a StackDriver alert channel pointing to a channel in Slack
 // It will select the channel here by its display name
 data "google_monitoring_notification_channel" "alertchannel" {
-  display_name = "Kubernetes.io Cert Alert"
+  type = "slack"
+  labels = {
+    "channel_name" = "#k8s-infra-alerts"
+  }
 }
-
 
 // We can turn this into a module and then add then standardize the resource display names
 resource "google_monitoring_uptime_check_config" "uptime_check" {

--- a/infra/gcp/monitoring/k8s.io/versions.tf
+++ b/infra/gcp/monitoring/k8s.io/versions.tf
@@ -1,0 +1,8 @@
+/*
+This file defines:
+- Required Terraform version
+*/
+
+terraform {
+  required_version = "~> 0.14.0"
+}

--- a/infra/gcp/monitoring/k8s.io/versions.tf
+++ b/infra/gcp/monitoring/k8s.io/versions.tf
@@ -4,5 +4,5 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 0.14.0"
+  required_version = ">= 0.13.0"
 }


### PR DESCRIPTION
Add initial manifest for gitops monitoring.

Some points of attention for this PR:

* This is not repeatable. Although I think adding too much modules for terraform can turn things more complicated, maybe we can define how and what we monitor in URLs. Assuming we always use SSL/TLS we could create a module and have this simpler in a future, like:
```
module "thockin_test1_monitoring" {
  source = "../../../modules/monitoring"
  project_name       = "kubernetes-public"
  url       = "thockin-test1.k8s.io"
  cert_expiration_threshold = 15
  // Channel needs to be manually created in GCP interface with the following display name
  channel_notification = "Kubernetes.io Cert Alert"
}
```
* We should probably want to define the structure for this. I'm proposing inside infra/monitoring just because got no better idea :D
* We can add more parameters, and more notification channel/options (like, we can add a list of emails that can turn into Email Notification Channel on GCP) 
* I'm using all the GCP locations, but getting only metrics from usa-iowa as valid to cert_expiration. This can be changed later as well, depending on what we want to do (like, properly monitoring and alerting in case of some downtime/increased latency)

