### PR TITLE
Add sig-cluster-lifecycle-cluster-api-alerts google group via SIG Cluster Lifecycle delegated groups management.

### DIFF
--- a/groups/sig-cluster-lifecycle/OWNERS
+++ b/groups/sig-cluster-lifecycle/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-cluster-lifecycle-leads
+approvers:
+  - sig-cluster-lifecycle-leads
+labels:
+  - sig/cluster-lifecycle

--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -1,0 +1,15 @@
+groups:
+  - email-id: sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io
+    name: sig-cluster-lifecycle-cluster-api-alerts
+    description: |-
+
+    settings:
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      ReconcileMembers: "true"
+    owners:
+      - detiber@gmail.com
+      - jdetiberus@equinix.com
+      - jeewan@vmware.com
+      - sbueringer@gmail.com
+    members:
+      - naadir@randomvariable.co.uk


### PR DESCRIPTION
Fixes #1863 

Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

/assign @ameukam