### PR TITLE
Fix sippy manifests to work on 1.16 cluster

### DIFF
--- a/sippy/sippy/certificate.yaml
+++ b/sippy/sippy/certificate.yaml
@@ -1,4 +1,4 @@
-apiVersion: cert-manager.io/v1
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: sippy-k8s-io

--- a/sippy/sippy/ingress.yaml
+++ b/sippy/sippy/ingress.yaml
@@ -8,10 +8,8 @@ metadata:
   labels:
     app: sippy
 spec:
-  defaultBackend:
-    service:
-      name: sippy
-      port:
-        number: 8080
+  backend:
+    serviceName: sippy
+    servicePort: 8080
   tls:
   - secretName : sippy-k8s-io-tls


### PR DESCRIPTION
/assign @deads2k 