### PR TITLE
infra/gcp/static-ips: add sippy-ingress-prod

### DIFF
--- a/infra/gcp/ensure-static-ips.sh
+++ b/infra/gcp/ensure-static-ips.sh
@@ -45,6 +45,7 @@ ADDRESSES=(
     "perf-dash-k8s-io-ingress-prod"
     "prow-k8s-io-ingress-staging"
     "slack-infra-ingress-prod"
+    "sippy-ingress-prod"
     "node-perf-dash-k8s-io-ingress-prod"
     "triage-party-release-ingress-prod"
 )


### PR DESCRIPTION
It looks like sippy's ingress calls out this ip but I don't think it's been created

Part of https://github.com/kubernetes/k8s.io/issues/1900