### PR TITLE
Add project k8s-test-infra

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -1306,6 +1306,15 @@ groups:
       - nikitaraghunath@gmail.com
       - rajula96reddy@gmail.com
 
+  - email-id: k8s-infra-staging-test-infra@kubernetes.io
+    name: k8s-infra-staging-test-infra
+    description: |
+      ACL for staging Test Infra
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - k8s-infra-prow-oncall@kubernetes.io
+
   - email-id: k8s-infra-staging-txtdirect@kubernetes.io
     name: k8s-infra-staging-txtdirect
     description: |-

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -107,6 +107,7 @@ readonly STAGING_PROJECTS=(
     slack-infra
     sp-operator
     storage-migrator
+    test-infra
     txtdirect
 )
 

--- a/k8s.gcr.io/images/k8s-staging-test-infra/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-test-infra/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+    - sig-testing-leads
+    - test-infra-on-call
+reviewers:
+    - sig-testing-leads
+    - test-infra-on-call
+
+labels:
+    sig/testing

--- a/k8s.gcr.io/images/k8s-staging-test-infra/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-test-infra/images.yaml
@@ -1,0 +1,1 @@
+# No images yet

--- a/k8s.gcr.io/manifests/k8s-staging-test-infra/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-test-infra/promoter-manifest.yaml
@@ -1,0 +1,14 @@
+# google group for gcr.io/k8s-staging-test-infra is k8s-infra-staging-test-infra@kubernetes.io
+
+registries:
+- name: gcr.io/k8s-staging-test-infra
+  src: true
+
+# Promotes to the following GCR locations:
+# - {us,eu,asia}.gcr.io/k8s-test-infra --> k8s.gcr.io
+- name: us.gcr.io/k8s-test-infra
+  service-account: k8s-infra-gcr-promoter@k8s-test-infra.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-test-infra
+  service-account: k8s-infra-gcr-promoter@k8s-test-infra.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-test-infra
+  service-account: k8s-infra-gcr-promoter@k8s-test-infra.iam.gserviceaccount.com


### PR DESCRIPTION
Add k8s-test-infra project that will images built from
https://github.com/kubernetes/test-infra/tree/master/.

We should not use the staging project k8s-staging-k8s-infra and maintain
image building and pushing done today by automation.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>