### PR TITLE
Ensure gcs bucket for k8s-infra prow instance

### DIFF
--- a/infra/gcp/lib_gsm.sh
+++ b/infra/gcp/lib_gsm.sh
@@ -102,8 +102,13 @@ function ensure_secret_with_admins() {
 #   $2: The secret name (e.g. "my-secret")
 #   $3: The service-account (e.g. "foo@k8s-infra.iam.gserviceaccount.com")
 function ensure_serviceaccount_key_secret() {
+<<<<<<< HEAD
     if [ ! $# -eq 3 ] || [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
         echo "${FUNCNAME[0]}(project, secret, serviceaccountt) requires 3 arguments" >&2
+=======
+    if [ ! $# -eq 3 -o -z "$1" -o -z "$2" -o -z "$3" ]; then
+        echo "ensure_serviceaccount_key_secret(project, secret, serviceaccount) requires 3 arguments" >&2
+>>>>>>> 0b821977 (Add gcs public bucket for k8s-infra-prow logs.)
         return 1
     fi
 


### PR DESCRIPTION
Following prow [documentation](https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md#configure-a-gcs-buckethttps://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md#configure-a-gcs-bucket) guidance :
Create a GCS bucket for tide history and build logs.
Create a service account and grant admin access to the bucket.
Create a service account key and add the generated key to Secret
Manager.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>