### PR TITLE
Fix sippy ingress by changing underlying service to NodePort

### DIFF
--- a/sippy/sippy/service.yaml
+++ b/sippy/sippy/service.yaml
@@ -13,5 +13,5 @@ spec:
   selector:
     app: sippy
   sessionAffinity: None
-  type: ClusterIP
+  type: NodePort
 


### PR DESCRIPTION
Ref #1900

Currently ingress reconciliation is failing with
```
2m13s       Normal    Sync        ingress/sippy   Scheduled for sync
61s         Warning   Translate   ingress/sippy   Translation failed: invalid ingress spec: service "sippy/sippy" is type "ClusterIP", expected "NodePort" or "LoadBalancer"
```

/assign @deads2k 