### PR TITLE
Sync github token from Google Secret Manager

### DIFF
--- a/triage-party/release-team/secret.yaml
+++ b/triage-party/release-team/secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-token
+  namespace: triageparty-release
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-public
+  data:
+  - key: triage-party-github-token
+    name: triage-party-github-token
+    version: latest


### PR DESCRIPTION
Use the Custom Resource `External Secret` to sync github token for
Triage-Party from Google Secret Manager.

Also validate https://github.com/kubernetes/k8s.io/pull/1872.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>