### PR TITLE
tests: Adds e2e-test-auth-img project

### DIFF
--- a/groups/sig-testing/groups.yaml
+++ b/groups/sig-testing/groups.yaml
@@ -47,6 +47,20 @@ groups:
     - jgrafton@google.com
     - skuznets@redhat.com
 
+  - email-id: k8s-infra-staging-e2e-test-auth-img@kubernetes.io
+    name: k8s-infra-staging-e2e-test-auth-img
+    description: |-
+      Group that owns pushing rights to the gcr.io/k8s-staging-e2e-test-auth-img staging registry
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - bentheelder@google.com
+      - davanum@gmail.com
+      - linusa@google.com
+      - mkumatag@in.ibm.com
+      - spiffxp@google.com
+      - spiffxp@gmail.com
+
   - email-id: k8s-infra-staging-e2e-test-images@kubernetes.io
     name: k8s-infra-staging-e2e-test-images
     description: |-

--- a/infra/gcp/infra.yaml
+++ b/infra/gcp/infra.yaml
@@ -280,6 +280,7 @@ infra:
       k8s-staging-csi-secrets-store:
       k8s-staging-descheduler:
       k8s-staging-dns:
+      k8s-staging-e2e-test-auth-img:
       k8s-staging-e2e-test-images:
       k8s-staging-etcd:
       k8s-staging-etcdadm:

--- a/k8s.gcr.io/images/k8s-staging-e2e-test-auth-img/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-e2e-test-auth-img/OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- BenTheElder
+- dims
+- listx
+- mkumatag
+- spiffxp
+reviewers:
+- BenTheElder
+- dims
+- listx
+- mkumatag
+- spiffxp
+labels:
+- sig/testing

--- a/k8s.gcr.io/images/k8s-staging-e2e-test-auth-img/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-e2e-test-auth-img/images.yaml
@@ -1,0 +1,1 @@
+# No images yet

--- a/k8s.gcr.io/manifests/k8s-staging-e2e-test-auth-img/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-e2e-test-auth-img/promoter-manifest.yaml
@@ -1,0 +1,10 @@
+# google group for gcr.io/k8s-staging-e2e-test-auth-img is k8s-infra-staging-e2e-test-auth-img@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-e2e-test-auth-img
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/e2e-test-auth-img
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/e2e-test-auth-img
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/e2e-test-auth-img
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
The ``gcr.io/k8s-staging-e2e-test-auth-img`` and ``k8s.gcr.io/kubernetes-e2e-test-auth-img`` registries are meant to be private, to be used in a few E2E test scenarios, and it is meant to replace the ``gcr.io/authenticated-image-pulling``.

An auth token with read-only access will have to be generated afterwards, and then baked into the E2E tests.

Related: https://github.com/kubernetes/k8s.io/issues/1459
Related: https://github.com/kubernetes/k8s.io/issues/1528