### PR TITLE
add tam7t as reviewer for secrets-store-csi-driver images

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-csi-secrets-store/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-csi-secrets-store/OWNERS
@@ -3,3 +3,6 @@
 approvers:
 - aramase
 - ritazh
+
+reviewers:
+- tam7t


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

@tam7t is already a reviewer for the Secrets Store CSI Driver sig-auth subproject. Adding Tommy as reviewer to the images config as well.

Membership request for kubernetes org is complete: https://github.com/kubernetes/org/issues/2638

/assign @ritazh 