### PR TITLE
Align OWNERS for CAPI image to CAPI mantainers list

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cluster-api/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api/OWNERS
@@ -1,9 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- davidewatson
+- CecileRobertMichon
+- fabriziopandini
 - detiber
 - justinsb
+- neolit123
 - timothysc
 - vincepri
 


### PR DESCRIPTION
This PR aligns OWNERFILE for CAPI image to CAPI mantainers list + SCL leads

/assign @vincepri 