### PR TITLE
Remove deprecated interpolation syntax.

### DIFF
--- a/infra/gcp/clusters/projects/kubernetes-public/aaa/10-cluster-configuration.tf
+++ b/infra/gcp/clusters/projects/kubernetes-public/aaa/10-cluster-configuration.tf
@@ -50,7 +50,7 @@ resource "google_bigquery_dataset" "usage_metering" {
   }
   access {
     role          = "WRITER"
-    user_by_email = "${google_service_account.cluster_node_sa.email}"
+    user_by_email = google_service_account.cluster_node_sa.email
   }
 
   // This restricts deletion of this dataset if there is data in it


### PR DESCRIPTION
Since Terraform 0.12, interpolation syntax is deprecated.

```
Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.
```

The change will not impact GKE Cluster aaa.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>