### PR TITLE
Switch to ManagedCertificate for Triage-Party.

### DIFF
--- a/triage-party/release-team/certificate.yaml
+++ b/triage-party/release-team/certificate.yaml
@@ -1,15 +1,8 @@
-apiVersion: cert-manager.io/v1alpha2
-kind: Certificate
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
 metadata:
   name: release-triage-k8s-io
   namespace: triageparty-release
-  annotations:
-    acme.cert-manager.io/http01-override-ingress-name: "triage-party-release"
-    cert-manager.io/issue-temporary-certificate: "true"
 spec:
-  secretName: release-triage-k8s-io-tls
-  issuerRef:
-    kind: ClusterIssuer
-    name: letsencrypt-prod
-  dnsNames:
+  domains:
     - release.triage.k8s.io

--- a/triage-party/release-team/ingress.yaml
+++ b/triage-party/release-team/ingress.yaml
@@ -4,12 +4,13 @@ metadata:
   name: triage-party-release
   namespace: triageparty-release
   annotations:
+    kubernetes.io/ingress.allow-http: "false"
+    kubernetes.io/ingress.class: "gce"
     kubernetes.io/ingress.global-static-ip-name: "triage-party-release-ingress-prod"
+    networking.gke.io/managed-certificates: "release-triage-k8s-io"
   labels:
     app: triage-party
 spec:
   backend:
     serviceName: triage-party-release
     servicePort: 8080
-  tls:
-  - secretName : release-triage-k8s-io-tls


### PR DESCRIPTION
Use a Google-managed SSL certificate through `ManagedCertificate`
for Triage-Party.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>