### PR TITLE
setup separate gcs buckets for different sets of terraform resources

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-ii-sandbox/provider.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-ii-sandbox/provider.tf
@@ -7,7 +7,9 @@ This file defines:
 terraform {
 
   backend "gcs" {
-    bucket = "k8s-infra-clusters-terraform"
+    bucket = "k8s-infra-tf-sandbox-ii"
+    // TODO(spiffxp): the names not matching weirds me out a bit, it would be
+    //                nice to rename the project at some point
     prefix = "k8s-infra-ii-sandbox"
   }
 

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/00-provider.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/00-provider.tf
@@ -7,7 +7,7 @@ This file defines:
 terraform {
 
   backend "gcs" {
-    bucket = "k8s-infra-clusters-terraform"
+    bucket = "k8s-infra-tf-prow-clusters"
     prefix = "k8s-infra-prow-build-trusted/prow-build-trusted" // $project_name/$cluster_name
   }
 

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/00-provider.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/00-provider.tf
@@ -7,7 +7,7 @@ This file defines:
 terraform {
 
   backend "gcs" {
-    bucket = "k8s-infra-clusters-terraform"
+    bucket = "k8s-infra-tf-prow-clusters"
     prefix = "k8s-infra-prow-build/prow-build" // $project_name/$cluster_name
   }
 

--- a/infra/gcp/clusters/projects/kubernetes-public/aaa/00-inputs.tf
+++ b/infra/gcp/clusters/projects/kubernetes-public/aaa/00-inputs.tf
@@ -10,13 +10,17 @@ terraform {
   required_version = ">= 0.12.8"
 
   backend "gcs" {
-    bucket = "k8s-infra-clusters-terraform"
+    bucket = "k8s-infra-tf-public-clusters"
     prefix = "kubernetes-public/aaa" // $project_name/$cluster_name
   }
 
   required_providers {
-    google      = "~> 2.14"
-    google-beta = "~> 2.14"
+    google      = {
+      version = "~> 2.14"
+    }
+    google-beta = {
+      version = "~> 2.14"
+    }
   }
 }
 


### PR DESCRIPTION
Allow groups less privileged than k8s-infra-gcp-org-admins to use terraform to manage resources over which they have ownership.

Terraform state can include potentially include sensitive values. Since we have terraform setup to store state in GCS, we need to ensure visibility and access to state matches ownership of (privileges to modify) the resources it describes.

We're using uniform bucket-level access on our GCS buckets to avoid the complexity introduced by per-object ACLs. This means if we want different groups with different privilege levels using terraform to manage different sets of resources, we need to provision a GCS bucket for each group.

The new bucket schema is `k8s-infra-tf-{folder}[-{suffix}]` where:
- `{folder}` is the intended GCP folder for GCP projects managed by this group, access level should be ~owners of folder
- `{suffix}` is subset of resources contained somewhere underneath folder, access level should  ~editors of those resources
- `k8s-infra-tf-`: is 14 chars, leaving 49 before max length for bucket name

So for example I was tempted to create `gs://k8s-infra-tf-public` and move `aaa` cluster state there. But we may want to use terraform to manage a whole bunch of other resources beside clusters in `kubernetes-public`, and we might not want to grant `cluster-admins` the privileges to acccidentally delete everything in `kubernetes-public` (e.g. DNS)

The GCP folders don't actually exist yet, but the plan is:
- `public`: kubernetes-public (potentially release related projects too)
- `prow`: prow-build clusters and e2e projects
- `aws`: if there are gcp projects being used to manage aws resources
- `sandbox`: temporary projects

The buckets being added are:
- `k8s-infra-tf-aws`: to manage aws resources
- `k8s-infra-tf-prow-clusters`: to manage prow-build, prow-build-trusted
- `k8s-infra-tf-public-clusters`: to manage aaa
- `k8s-infra-tf-sandbox-ii`: for the ii team to manage things in sandbox

Organization admins are given `storage.admin` privileges to all `k8s-infra-tf-` buckets for break-glass purposes.

Terraform modules were migrated by running `terraform init` and `terraform refresh` for each module

/cc @ameukam @thockin