### PR TITLE
Going emeritus, removing myself from WGs and SIGs

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -40,12 +40,12 @@ aliases:
     - mrbobbytables
     - nikhita
   sig-docs-leads:
+    - irvifa
     - jimangel
     - kbarnard10
     - kbhawkey
     - onlydole
     - sftim
-    - zacharysarah
   sig-instrumentation-leads:
     - brancz
     - dashpole
@@ -130,7 +130,6 @@ aliases:
     - celestehorgan
     - jdumars
     - justaugustus
-    - zacharysarah
   wg-policy-leads:
     - ericavonb
     - hannibalhuang


### PR DESCRIPTION
This PR removes myself as a lead for WGs and SIGs.

I've also added @irvifa, who has been a SIG Docs chair for over a year now.

/wg naming
/sig docs

Related PRs:
- https://github.com/kubernetes/enhancements/pull/2642
- https://github.com/kubernetes/community/pull/5733
- https://github.com/kubernetes/org/pull/2649
- https://github.com/kubernetes/website/pull/27637