### PR TITLE
Add JAORMX, cmurphy and jhrozek to security-profiles-operator image approvers

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-sp-operator/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-sp-operator/OWNERS
@@ -1,6 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+  - JAORMX
   - hasheddan
+  - jhrozek
   - pjbgf
   - saschagrunert


### PR DESCRIPTION
This gives us a higher flexibility for promoting container images. All
maintainers of the project are now allowed to approve image promotions.

/cc @JAORMX @cmurphy @jhrozek