### PR TITLE
groups: unblock group reconciliation by fixing security groups

### DIFF
--- a/groups/committee-product-security/groups.yaml
+++ b/groups/committee-product-security/groups.yaml
@@ -43,7 +43,6 @@ groups:
       - security@giantswarm.io
       - security@gravitational.com
       - security@kinvolk.io
-      - security@kubernetes.io
       - security@loodse.com
       - security@platform9.com
       - security@rancher.com


### PR DESCRIPTION
The ci-k8sio-groups and post-k8sio-groups testgrid tabs were showing continuous failure for the past N days

I noticed this when trying to deploy changes that added k8s-infra-ii-coop to IAM bindings, and got back a "group does not exist error"

These commits tell part of the story.  I had to do some manual reconciliation runs to make this work