### PR TITLE
Add 1.22 CI Signal shadows to email groups

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -539,6 +539,7 @@ groups:
       - k8s-infra-release-viewers@kubernetes.io
       - alarcj137@gmail.com
       - ameukam@gmail.com
+      - ania0102@gmail.com # 1.22 CI Signal Shadow
       - antonio.ojea.garcia@gmail.com
       - bartek@smykla.com
       - eddiezane@gmail.com
@@ -546,15 +547,14 @@ groups:
       - gmccloskey@google.com
       - helenfengzhi@gmail.com
       - liggitt@google.com
-      - max@koerbaecher.io # 1.21 CI Signal Shadow
+      - max@koerbaecher.io # 1.22 CI Signal Lead
       - mrfaizal@google.com
-      - priyankahariharan421@gmail.com # 1.21 CI Signal Shadow
+      - ramses.green.2@gmail.com # 1.22 CI Signal Shadow
       - ricardo.katz@gmail.com
       - rob.kielty@gmail.com
-      - saumya00@outlook.com # 1.21 CI Signal Shadow
-      - snichols@vmware.com # 1.21 CI Signal Shadow
+      - salahi.hossein@gmail.com # 1.22 CI Signal Shadow
+      - soniasingla.1812@gmail.com # 1.22 CI Signal Shadow
       - spiffxp@gmail.com
-      - thejoycekung@gmail.com
       - neolit123@gmail.com
       - philjohnson96@gmail.com
       - k8s-infra-sig-scalability-oncall@kubernetes.io

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -363,6 +363,7 @@ groups:
     members:
       - sig-release-leads@kubernetes.io
       - alessandro.vozza@microsoft.com # 1.21 Bug Triage Shadow
+      - ania0102@gmail.com # 1.22 CI Signal Shadow
       - arunmk@gmail.com # 1.21 RT Enhancements Shadow
       - ashnehete@gmail.com # 1.21 Release Notes Shadow
       - chandani.madnani@gmail.com # 1.21 Docs Shadow
@@ -373,20 +374,18 @@ groups:
       - justinleegarrison@gmail.com # 1.21 Comms Shadow
       - kcmartin2@mac.com # 1.21 Bug Triage Shadow
       - kefroden@gmail.com # 1.21 RT Enhancements Shadow
-      - max@koerbaecher.io # 1.21 CI Signal Shadow
+      - max@koerbaecher.io # 1.22 CI Signal Lead
       - meloncattiel@gmail.com # 1.21 Release Notes Shadow
       - monmonmsc@gmail.com # 1.21 Bug Triage Shadow
       - mvortizr@gmail.com # 1.21 Docs Shadow
       - onlydole@gmail.com # 1.21 Emeritus Advisor
       - peeyushgupta91@gmail.com # 1.21 Comms Shadow
       - pmmalinov01@gmail.com # 1.21 Release Notes Shadow
-      - priyankahariharan421@gmail.com # 1.21 CI Signal Shadow
+      - ramses.green.2@gmail.com # 1.22 CI Signal Shadow
       - rlejano@gmail.com # 1.21 Docs Lead
-      - saumya00@outlook.com # 1.21 CI Signal Shadow
-      - snichols@vmware.com # 1.21 CI Signal Shadow
-      - soniasingla.1812@gmail.com # 1.21 Release Notes Shadow
+      - salahi.hossein@gmail.com # 1.22 CI Signal Shadow
+      - soniasingla.1812@gmail.com # 1.22 CI Signal Shadow
       - tengqim@cn.ibm.com # 1.21 Docs Shadow
-      - thejoycekung@gmail.com # 1.21 CI Signal Lead
       - victor@cloudflavor.io # 1.21 Docs Shadow
       - wilsonehusin@gmail.com # 1.21 Release Notes Lead
       - xander@grzy.dev # 1.21 Comms Shadow
@@ -410,6 +409,7 @@ groups:
       - tpepper@vmware.com # Release Team subproject owner
     members:
       - alessandro.vozza@microsoft.com # 1.21 Bug Triage Shadow
+      - ania0102@gmail.com # 1.22 CI Signal Shadow
       - arunmk@gmail.com # 1.21 RT Enhancements Shadow
       - ashnehete@gmail.com # 1.21 Release Notes Shadow
       - chandani.madnani@gmail.com # 1.21 Docs Shadow
@@ -420,16 +420,14 @@ groups:
       - justinleegarrison@gmail.com # 1.21 Comms Shadow
       - kcmartin2@mac.com # 1.21 Bug Triage Shadow
       - kefroden@gmail.com # 1.21 RT Enhancements Shadow
-      - max@koerbaecher.io # 1.21 CI Signal Shadow
       - meloncattiel@gmail.com # 1.21 Release Notes Shadow
       - monmonmsc@gmail.com # 1.21 Bug Triage Shadow
       - mvortizr@gmail.com # 1.21 Docs Shadow
       - peeyushgupta91@gmail.com # 1.21 Comms Shadow
       - pmmalinov01@gmail.com # 1.21 Release Notes Shadow
-      - priyankahariharan421@gmail.com # 1.21 CI Signal Shadow
-      - saumya00@outlook.com # 1.21 CI Signal Shadow
-      - snichols@vmware.com # 1.21 CI Signal Shadow
-      - soniasingla.1812@gmail.com # 1.21 Release Notes Shadow
+      - ramses.green.2@gmail.com # 1.22 CI Signal Shadow
+      - salahi.hossein@gmail.com # 1.22 CI Signal Shadow
+      - soniasingla.1812@gmail.com # 1.22 CI Signal Shadow
       - tengqim@cn.ibm.com # 1.21 Docs Shadow
       - victor@cloudflavor.io # 1.21 Docs Shadow
       - xander@grzy.dev # 1.21 Comms Shadow


### PR DESCRIPTION
Adds 1.22 CI Signal shadows to:
-  release-team@
-  release-team-shadows@
-  k8s-infra-prow-viewers@

Removes 1.21 CI Signal shadows from:
-  release-team@
-  release-team-shadows@
-  k8s-infra-prow-viewers@
