### PR TITLE
docs/sig-release: Add SIG docs shadows to sig-release

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -364,7 +364,8 @@ groups:
       - sig-release-leads@kubernetes.io
       - alessandro.vozza@microsoft.com # 1.21 Bug Triage Shadow
       - arunmk@gmail.com # 1.21 RT Enhancements Shadow
-      - ashnehete@gmail.com # 1.21 Release Notes Shadow
+      - ashnehete@gmail.com # 1.22 Release Docs Shadow
+      - carlisia@grokkingtech.io # 1.22 Release Docs Shadow
       - chandani.madnani@gmail.com # 1.21 Docs Shadow
       - desponda@vmware.com # 1.21 Bug Triage Shadow
       - evelyn.cupil.garcia@duke.edu # 1.21 Comms Shadow
@@ -381,13 +382,15 @@ groups:
       - peeyushgupta91@gmail.com # 1.21 Comms Shadow
       - pmmalinov01@gmail.com # 1.21 Release Notes Shadow
       - priyankahariharan421@gmail.com # 1.21 CI Signal Shadow
+      - rpanjwani@vmware.com # 1.22 Release Docs Shadow
       - rlejano@gmail.com # 1.21 Docs Lead
       - saumya00@outlook.com # 1.21 CI Signal Shadow
       - snichols@vmware.com # 1.21 CI Signal Shadow
       - soniasingla.1812@gmail.com # 1.21 Release Notes Shadow
+      - striker57@gmail.com # 1.22 Release Docs Shadow
       - tengqim@cn.ibm.com # 1.21 Docs Shadow
       - thejoycekung@gmail.com # 1.21 CI Signal Lead
-      - victor@cloudflavor.io # 1.21 Docs Shadow
+      - victor@cloudflavor.io # 1.22 Docs Lead
       - wilsonehusin@gmail.com # 1.21 Release Notes Lead
       - xander@grzy.dev # 1.21 Comms Shadow
 
@@ -411,8 +414,8 @@ groups:
     members:
       - alessandro.vozza@microsoft.com # 1.21 Bug Triage Shadow
       - arunmk@gmail.com # 1.21 RT Enhancements Shadow
-      - ashnehete@gmail.com # 1.21 Release Notes Shadow
-      - chandani.madnani@gmail.com # 1.21 Docs Shadow
+      - ashnehete@gmail.com # 1.22 Release Docs Shadow
+      - carlisia@grokkingtech.io # 1.22 Release Docs Shadow
       - desponda@vmware.com # 1.21 Bug Triage Shadow
       - evelyn.cupil.garcia@duke.edu # 1.21 Comms Shadow
       - james@jameslaverack.com # 1.21 RT Enhancements Shadow
@@ -423,13 +426,12 @@ groups:
       - max@koerbaecher.io # 1.21 CI Signal Shadow
       - meloncattiel@gmail.com # 1.21 Release Notes Shadow
       - monmonmsc@gmail.com # 1.21 Bug Triage Shadow
-      - mvortizr@gmail.com # 1.21 Docs Shadow
       - peeyushgupta91@gmail.com # 1.21 Comms Shadow
       - pmmalinov01@gmail.com # 1.21 Release Notes Shadow
       - priyankahariharan421@gmail.com # 1.21 CI Signal Shadow
+      - rpanjwani@vmware.com # 1.22 Release Docs Shadow
       - saumya00@outlook.com # 1.21 CI Signal Shadow
       - snichols@vmware.com # 1.21 CI Signal Shadow
       - soniasingla.1812@gmail.com # 1.21 Release Notes Shadow
-      - tengqim@cn.ibm.com # 1.21 Docs Shadow
-      - victor@cloudflavor.io # 1.21 Docs Shadow
+      - striker57@gmail.com # 1.22 Release Docs Shadow
       - xander@grzy.dev # 1.21 Comms Shadow


### PR DESCRIPTION
and sig-release-shadows google groups.

This change removes the previous shadows batch for the
docs release from sig-release-shadows google group and
adds the current v1.22 team.

Signed-off-by: Victor Palade <victor@cloudflavor.io>