### PR TITLE
Promote etcdadm 3.0.20210430 images

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-etcdadm/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-etcdadm/images.yaml
@@ -1,1 +1,10 @@
-# No images yet
+# 3.0.20210430
+- name: etcd-backup
+  dmap:
+    "sha256:d3042152737d5b7a54f368b8a54a58a87601366f1682a1792bf375e0c5da7317": ["3.0.20210430"]
+- name: etcd-dump
+  dmap:
+    "sha256:7113a3198a7892195384f657166423d67cbe54bb42aecf19ce40b64374d02339": ["3.0.20210430"]
+- name: etcd-manager
+  dmap:
+    "sha256:ebb73d3d4a99da609f9e01c556cd9f9aa7a0aecba8f5bc5588d7c45eb38e3a7e": ["3.0.20210430"]


### PR DESCRIPTION
Created with:

## Propose promotion of artifacts

Create container promotion PR:


```
gcrane ls gcr.io/k8s-staging-etcdadm/etcd-manager
STAGING_VERSION=v20210430-v0.1.3-739-g7da12acc
RELEASE_VERSION=3.0.20210430
```

```
cd ${GOPATH}/src/k8s.io/k8s.io

git checkout main
git pull
git checkout -b etcdadm_images_${RELEASE_VERSION}

cd k8s.gcr.io/images/k8s-staging-etcdadm
echo "" >> images.yaml
echo "# ${RELEASE_VERSION}" >> images.yaml
k8s-container-image-promoter --snapshot gcr.io/k8s-staging-etcdadm --snapshot-tag ${STAGING_VERSION} | sed s@${STAGING_VERSION}@${RELEASE_VERSION}@g >> images.yaml
```

You can dry-run the promotion with 

```
cd ${GOPATH}/src/k8s.io/k8s.io
k8s-container-image-promoter --thin-manifest-dir k8s.gcr.io
```

Currently we send the image and non-image artifact promotion PRs separately.

```
git add -p k8s.gcr.io/images/k8s-staging-etcdadm/images.yaml
git commit -m "Promote etcdadm $RELEASE_VERSION images"
git push ${USER}
hub pull-request -b main
```
