### PR TITLE
Promote addon-manager v9.1.5 images

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-addon-manager/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-addon-manager/images.yaml
@@ -1,24 +1,30 @@
 - name: kube-addon-manager
   dmap:
+    "sha256:1f3ad8eb14dfaa2fc6dd60811e7d3dd1631c01f47cf1febc24c34d538a5409b1": ["v9.1.5"]
     "sha256:db70d0b7658fd990b4e4d053d9640f0ed88793afae2927447947b0f472bc8932": ["v9.1.4"]
     "sha256:a4f55e897391d6d46bee8bc2b7388c6fa146b9d956985db8ca3d72ca027c70f8": ["v9.1.2"]
 - name: kube-addon-manager-amd64
   dmap:
+    "sha256:1f3ad8eb14dfaa2fc6dd60811e7d3dd1631c01f47cf1febc24c34d538a5409b1": ["v9.1.5"]
     "sha256:db70d0b7658fd990b4e4d053d9640f0ed88793afae2927447947b0f472bc8932": ["v9.1.4"]
     "sha256:a4f55e897391d6d46bee8bc2b7388c6fa146b9d956985db8ca3d72ca027c70f8": ["v9.1.2"]
 - name: kube-addon-manager-arm
   dmap:
+    "sha256:f247302df80212eed9a072ea040c55e1940b75329ce39c2bec3828e30e1c31fb": ["v9.1.5"]
     "sha256:3ed3041f328534130abcd3760a9777fb0821fee1cf959fc679cd3ea77c841b1c": ["v9.1.4"]
     "sha256:7a341655fe377b2b409c38b5944e27afef557d4803b7413320c7cb387df34655": ["v9.1.2"]
 - name: kube-addon-manager-arm64
   dmap:
+    "sha256:625884d28d61c5926870171db4a3139aa5dc0d3ec68455975a0cac1f8cb2df76": ["v9.1.5"]
     "sha256:21de62e66161ec918146ab4700d1a3deda4feedf82a6da8a9c3764463054c25a": ["v9.1.4"]
     "sha256:dd17f08a81b60c8025e5e991cdd31341c7bc7b049e3fb603ed8827636aaa6dcf": ["v9.1.2"]
 - name: kube-addon-manager-ppc64le
   dmap:
+    "sha256:9879f014d862a38b23369ba38fbef19688f1ee438aee5daec0608714876f718a": ["v9.1.5"]
     "sha256:5066fdabddf39a6bb1b1e01a3af20f680674869843114b65868f33fd5d2aaefd": ["v9.1.4"]
     "sha256:a7aba057e5b31f1709121878ce21ab33de2cd7929a417bd1efa37573a7ddd92b": ["v9.1.2"]
 - name: kube-addon-manager-s390x
   dmap:
+    "sha256:69863d6ddae911333c1cc4144c5cb6d9380e8ea93d17c1a846515fe8f59bf839": ["v9.1.5"]
     "sha256:cbf5750426f09b9ef065c1c7c3e0d7cab139970c9fe18dd510b521b149b11c54": ["v9.1.4"]
     "sha256:086f879de315fc2af950c7c916e01a7a1a573032aa34a0ec8dd1fc8a003bd468": ["v9.1.2"]


### PR DESCRIPTION
We are cutting a new release for kube-addon-manager and need to promote these images.

Ref https://github.com/kubernetes/kubernetes/pull/101732.

/assign @dekkagaijin
cc @spencer-p