### PR TITLE
Increase NAP limits in aaa cluster

### DIFF
--- a/infra/gcp/clusters/projects/kubernetes-public/aaa/10-cluster-configuration.tf
+++ b/infra/gcp/clusters/projects/kubernetes-public/aaa/10-cluster-configuration.tf
@@ -158,7 +158,7 @@ resource "google_container_cluster" "cluster" {
     }
     resource_limits {
       resource_type = "memory"
-      maximum = 500
+      maximum = 256
     }
   }
 

--- a/infra/gcp/clusters/projects/kubernetes-public/aaa/10-cluster-configuration.tf
+++ b/infra/gcp/clusters/projects/kubernetes-public/aaa/10-cluster-configuration.tf
@@ -154,7 +154,7 @@ resource "google_container_cluster" "cluster" {
     resource_limits {
       resource_type = "cpu"
       minimum = 2
-      maximum = 200
+      maximum = 64
     }
     resource_limits {
       resource_type = "memory"

--- a/infra/gcp/clusters/projects/kubernetes-public/aaa/10-cluster-configuration.tf
+++ b/infra/gcp/clusters/projects/kubernetes-public/aaa/10-cluster-configuration.tf
@@ -154,11 +154,11 @@ resource "google_container_cluster" "cluster" {
     resource_limits {
       resource_type = "cpu"
       minimum = 2
-      maximum = 16
+      maximum = 200
     }
     resource_limits {
       resource_type = "memory"
-      maximum = 64
+      maximum = 500
     }
   }
 


### PR DESCRIPTION
https://github.com/kubernetes/k8s.io/pull/1604 incorrectly sets resource limits to 16 cores and 64GiB of memory, while the existing cluster has already 26 cores and 94GiB of memory (and the limits are for the entire clusters, not for a single node as I thought)

/assign @ameukam 