### PR TITLE
infra/gcp/main: give tf bucket owners buckets.list

### DIFF
--- a/infra/gcp/ensure-main-project.sh
+++ b/infra/gcp/ensure-main-project.sh
@@ -160,6 +160,9 @@ function ensure_terraform_state_buckets() {
             ensure_private_gcs_bucket "${project}" "${bucket}"
             empower_group_to_admin_gcs_bucket "${owners}" "${bucket}"
             ensure_gcs_role_binding "${bucket}" "group:k8s-infra-gcp-org-admins@kubernetes.io" "admin"
+            # ensure owners have storage.buckets.list permission for their bucket
+            # TODO(spiffxp): figure out a way to do this per-bucket
+            ensure_project_role_binding "${project}" "group:${owners}" "roles/viewer"
         ) 2>&1 | indent
     done
 }


### PR DESCRIPTION
This addresses https://github.com/kubernetes/k8s.io/pull/1974#discussion_r626871617

So apparently the only off-the-shelf roles that grant `storage.buckets.list` are:

- `roles/storage.admin`
- `roles/owner`
- `roles/editor`
- `roles/viewer`

We're trying to follow the principle of least-privilege for the `k8s-infra-tf-*` buckets. Unfortunately none of the basic roles like `roles/viewer` can be applied directly to a bucket.

This leaves us with either:
- `roles/viewer` on the project hosting the buckets
- `roles/storage.admin` directly on the buckets

The latter would grant the following addition permissions compared to the existing set of `roles/storage.legacyBucketOwner` + `roles/storage.objectAdmin`:

- `storage.buckets.create` - doesn't matter for a single bucket
- `storage.buckets.delete` - this might be concerning for some buckets
- `storage.buckets.list` - this is what we want

The reason delete might be concerning is if someone accidentally deleted a very public, very hardcoded bucket (e.g. the k8s.gcr.io GCS buckets) just long enough for another project to create a bucket with the now-available name, thus stealing ownership of a very critical asset. (ref: https://cloud.google.com/storage/docs/naming-buckets#considerations)

So as much as I would like to default to `roles/storage.admin` on specific buckets instead of a combination of legacy roles on buckets and projects, I'm not yet prepared to make that call for all of our GCS buckets.

Thus, we're left with assigning `roles/viewer` on the project hosting the bucket.