### PR TITLE
Upgrade terraform provider for aaa Cluster

### DIFF
--- a/infra/gcp/clusters/projects/kubernetes-public/aaa/00-inputs.tf
+++ b/infra/gcp/clusters/projects/kubernetes-public/aaa/00-inputs.tf
@@ -7,7 +7,7 @@ This file defines:
 */
 
 terraform {
-  required_version = ">= 0.12.8"
+  required_version = ">= 0.13.6"
 
   backend "gcs" {
     bucket = "k8s-infra-tf-public-clusters"
@@ -15,11 +15,11 @@ terraform {
   }
 
   required_providers {
-    google      = {
-      version = "~> 2.14"
+    google = {
+      version = "~> 3.1.0"
     }
     google-beta = {
-      version = "~> 2.14"
+      version = "~> 3.1.0"
     }
   }
 }

--- a/infra/gcp/clusters/projects/kubernetes-public/aaa/10-cluster-configuration.tf
+++ b/infra/gcp/clusters/projects/kubernetes-public/aaa/10-cluster-configuration.tf
@@ -15,24 +15,24 @@ locals {
 
 // Create SA for nodes
 resource "google_service_account" "cluster_node_sa" {
-  project      = data.google_project.project.id
+  project      = "kubernetes-public"
   account_id   = "gke-nodes-${local.cluster_name}"
   display_name = "Nodes in GKE cluster '${local.cluster_name}'"
 }
 
 // Add roles for SA
 resource "google_project_iam_member" "cluster_node_sa_logging" {
-  project = data.google_project.project.id
+  project = "kubernetes-public"
   role    = "roles/logging.logWriter"
   member  = "serviceAccount:${google_service_account.cluster_node_sa.email}"
 }
 resource "google_project_iam_member" "cluster_node_sa_monitoring_viewer" {
-  project = data.google_project.project.id
+  project = "kubernetes-public"
   role    = "roles/monitoring.viewer"
   member  = "serviceAccount:${google_service_account.cluster_node_sa.email}"
 }
 resource "google_project_iam_member" "cluster_node_sa_monitoring_metricwriter" {
-  project = data.google_project.project.id
+  project = "kubernetes-public"
   role    = "roles/monitoring.metricWriter"
   member  = "serviceAccount:${google_service_account.cluster_node_sa.email}"
 }
@@ -40,7 +40,7 @@ resource "google_project_iam_member" "cluster_node_sa_monitoring_metricwriter" {
 // BigQuery dataset for usage data
 resource "google_bigquery_dataset" "usage_metering" {
   dataset_id  = replace("usage_metering_${local.cluster_name}", "-", "_")
-  project     = data.google_project.project.id
+  project     = "kubernetes-public"
   description = "GKE Usage Metering for cluster '${local.cluster_name}'"
   location    = local.bigquery_location
 
@@ -64,7 +64,7 @@ resource "google_container_cluster" "cluster" {
   location = local.cluster_location
 
   provider = google-beta
-  project  = data.google_project.project.id
+  project  = "kubernetes-public"
 
   // GKE clusters are critical objects and should not be destroyed
   // IMPORTANT: should be false on test clusters
@@ -75,8 +75,8 @@ resource "google_container_cluster" "cluster" {
   // Network config
   network = "default"
   ip_allocation_policy {
-    use_ip_aliases    = true
-    create_subnetwork = true
+    cluster_ipv4_cidr_block  = "10.40.0.0/14"
+    services_ipv4_cidr_block = "10.107.16.0/20"
   }
 
   // Start with a single node, because we're going to delete the default pool
@@ -96,6 +96,11 @@ resource "google_container_cluster" "cluster" {
     }
   }
 
+  // Release Channel subscriptions. See https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels
+  release_channel {
+    channel = "STABLE"
+  }
+
   // Enable google-groups for RBAC
   authenticator_groups_config {
     security_group = "gke-security-groups@kubernetes.io"
@@ -103,7 +108,7 @@ resource "google_container_cluster" "cluster" {
 
   // Enable workload identity for GCP IAM
   workload_identity_config {
-    identity_namespace = "${data.google_project.project.id}.svc.id.goog"
+    identity_namespace = "kubernetes-public.svc.id.goog"
   }
 
   // Enable Stackdriver Kubernetes Monitoring
@@ -153,12 +158,12 @@ resource "google_container_cluster" "cluster" {
     enabled = true
     resource_limits {
       resource_type = "cpu"
-      minimum = 2
-      maximum = 64
+      minimum       = 2
+      maximum       = 64
     }
     resource_limits {
       resource_type = "memory"
-      maximum = 256
+      maximum       = 256
     }
   }
 

--- a/infra/gcp/clusters/projects/kubernetes-public/aaa/11-pool1-configuration.tf
+++ b/infra/gcp/clusters/projects/kubernetes-public/aaa/11-pool1-configuration.tf
@@ -12,7 +12,7 @@ resource "google_container_node_pool" "pool1" {
   cluster     = google_container_cluster.cluster.name
 
   provider = google-beta
-  project  = data.google_project.project.id
+  project  = "kubernetes-public"
 
   // Start with a single node
   initial_node_count = 1
@@ -47,6 +47,11 @@ resource "google_container_node_pool" "pool1" {
     metadata = {
       disable-legacy-endpoints = "true"
     }
+  }
+
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 0
   }
 
   // If we need to destroy the node pool, create the new one before destroying

--- a/infra/gcp/clusters/projects/kubernetes-public/aaa/11-pool2-configuration.tf
+++ b/infra/gcp/clusters/projects/kubernetes-public/aaa/11-pool2-configuration.tf
@@ -12,7 +12,7 @@ resource "google_container_node_pool" "pool2" {
   cluster     = google_container_cluster.cluster.name
 
   provider = google-beta
-  project  = data.google_project.project.id
+  project  = "kubernetes-public"
 
   // Start with a single node
   initial_node_count = 1
@@ -47,6 +47,11 @@ resource "google_container_node_pool" "pool2" {
     metadata = {
       disable-legacy-endpoints = "true"
     }
+  }
+
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 0
   }
 
   // If we need to destroy the node pool, create the new one before destroying


### PR DESCRIPTION
Ref: https://github.com/kubernetes/k8s.io/issues/1403

First commit is needed because the terraform state got converted to 0.13 because of the deployment of #1974. 
The second commit help migrate to the 3.x version of the terraform provider.


Signed-off-by: Arnaud Meukam <ameukam@gmail.com>