### PR TITLE
infra/gcp: disable containerscanning and test-infra-trusted prow access for staging and release projects

### DIFF
--- a/infra/gcp/ensure-env-cip-auditor.sh
+++ b/infra/gcp/ensure-env-cip-auditor.sh
@@ -74,21 +74,6 @@ function get_push_endpoint() {
         --region=us-central1
 }
 
-# This enables the necessary services to use Cloud Run.
-#
-#   $1: GCP project ID
-function enable_services() {
-    if [ $# != 1 ] || [ -z "$1" ]; then
-        echo "${FUNCNAME[0]}(project) requires 1 argument" >&2
-        return 1
-    fi
-    local project="$1"
-
-    for service in "${CIP_AUDITOR_SERVICES[@]}"; do
-        gcloud --project="${project}" services enable "${service}"
-    done
-}
-
 # This sets up the GCP project so that it can be ready to deploy the cip-auditor
 # service onto Cloud Run.
 #
@@ -171,7 +156,7 @@ function ensure_cip_auditor_env() {
     project_number=$(gcloud projects describe "${project}" --format "value(projectNumber)")
 
     echo "Enabling services"
-    enable_services "${project}"
+    ensure_services "${project}" "${CIP_AUDITOR_SERVICES[@]}" 2>&1 | indent
 
     if ! get_push_endpoint "${project}"; then
         echo >&2 "Could not determine push endpoint for the auditor's Cloud Run service."

--- a/infra/gcp/ensure-prod-storage-gclb.sh
+++ b/infra/gcp/ensure-prod-storage-gclb.sh
@@ -50,7 +50,7 @@ color 6 "Ensuring project exists: ${PROD_PROJECT}"
 ensure_project "${PROD_PROJECT}"
 
 color 6 "Enabling the compute API: ${PROD_PROJECT}"
-enable_api "${PROD_PROJECT}" compute.googleapis.com
+ensure_services "${PROD_PROJECT}" compute.googleapis.com
 
 color 6 "Reconciling Global Address"
 ensure_global_address "${PROD_PROJECT}" "${NAME}" "IP Address for GCLB for binary artifacts"

--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -82,6 +82,15 @@ ALL_PROD_BUCKETS=(
     "kind"
 )
 
+readonly PROD_PROJECT_SERVICES=(
+    # prod projects may perform container analysis
+    containeranalysis.googleapis.com
+    # prod projects host containers in GCR
+    containerregistry.googleapis.com
+    # prod projects host binaries in GCS
+    storage-component.googleapis.com
+)
+
 # Regions for prod GCR.
 PROD_REGIONS=(us eu asia)
 
@@ -182,17 +191,11 @@ function ensure_all_prod_projects() {
         color 6 "Ensuring project exists: ${prj}"
         ensure_project "${prj}"
 
-        color 6 "Enabling the container registry API: ${prj}"
-        enable_api "${prj}" containerregistry.googleapis.com
-
-        color 6 "Enabling the container analysis API: ${prj}"
-        enable_api "${prj}" containeranalysis.googleapis.com
+        color 6 "Ensuring Services to host and analyze aritfacts: ${prj}"
+        ensure_services "${prj}" "${PROD_PROJECT_SERVICES[@]}" 2>&1 | indent
 
         color 6 "Ensuring the GCR repository: ${prj}"
         ensure_prod_gcr "${prj}" 2>&1 | indent
-
-        color 6 "Enabling the GCS API: ${prj}"
-        enable_api "${prj}" storage-component.googleapis.com
 
         color 6 "Ensuring the GCS bucket: gs://${prj}"
         ensure_prod_gcs_bucket "${prj}" "gs://${prj}" 2>&1 | indent

--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -91,6 +91,11 @@ readonly PROD_PROJECT_SERVICES=(
     storage-component.googleapis.com
 )
 
+readonly PROD_PROJECT_DISABLED_SERVICES=(
+    # Disabling per https://github.com/kubernetes/k8s.io/issues/1963
+    containerscanning.googleapis.com
+)
+
 # Regions for prod GCR.
 PROD_REGIONS=(us eu asia)
 
@@ -194,6 +199,9 @@ function ensure_all_prod_projects() {
         color 6 "Ensuring Services to host and analyze aritfacts: ${prj}"
         ensure_services "${prj}" "${PROD_PROJECT_SERVICES[@]}" 2>&1 | indent
 
+        color 6 "Ensuring disabled services for prod project: ${prj}"
+        ensure_disabled_services "${prj}" "${PROD_PROJECT_DISABLED_SERVICES[@]}" 2>&1 | indent
+
         color 6 "Ensuring the GCR repository: ${prj}"
         ensure_prod_gcr "${prj}" 2>&1 | indent
 
@@ -226,10 +234,6 @@ function ensure_all_prod_special_cases() {
     upload_gcs_static_content \
         "gs://${PROD_PROJECT}" \
         "${SCRIPT_DIR}/static/prod-storage"
-
-    # Special case: enable vulnerability scanning on the prod GCR.
-    color 6 "Enabling GCR vulnerability scanning in the prod GCR"
-    enable_api "${PROD_PROJECT}" containerscanning.googleapis.com
 
     # Special case: enable people to read vulnerability reports.
     color 6 "Empowering artifact-security group to real vulnerability reports"

--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -57,16 +57,6 @@ GCR_AUDIT_TEST_PROD_PROJECT="k8s-gcr-audit-test-prod"
 RELEASE_TESTPROD_PROJECT="k8s-release-test-prod"
 RELEASE_STAGING_CLOUDBUILD_ACCOUNT="615281671549@cloudbuild.gserviceaccount.com"
 
-PROW_UNTRUSTED_BUILD_CLUSTER_PROJECTS=(
-    "k8s-prow-builds"
-    "k8s-infra-prow-build"
-)
-
-PROW_TRUSTED_BUILD_CLUSTER_PROJECTS=(
-    "k8s-prow"
-    "k8s-infra-prow-build-trusted"
-)
-
 # This is a list of all prod projects.  Each project will be configured
 # similarly, with a GCR repository and a GCS bucket of the same name.
 #

--- a/infra/gcp/ensure-release-projects.sh
+++ b/infra/gcp/ensure-release-projects.sh
@@ -43,10 +43,6 @@ if [ $# = 0 ]; then
     set -- "${PROJECTS[@]}"
 fi
 
-ADMINS="k8s-infra-release-admins@kubernetes.io"
-WRITERS="k8s-infra-release-editors@kubernetes.io"
-VIEWERS="k8s-infra-release-viewers@kubernetes.io"
-
 readonly RELEASE_PROJECT_SERVICES=(
     cloudbuild.googleapis.com
     cloudkms.googleapis.com
@@ -67,7 +63,7 @@ for PROJECT; do
     color 6 "Ensuring project exists: ${PROJECT}"
     ensure_project "${PROJECT}"
 
-    for group in ${ADMINS} ${WRITERS} ${VIEWERS}; do
+    for group in ${RELEASE_ADMINS} ${RELEASE_MANAGERS} ${RELEASE_VIEWERS}; do
         # Enable admins to use the UI
         color 6 "Empowering ${group} as project viewers"
         empower_group_as_viewer "${PROJECT}" "${group}"
@@ -88,7 +84,7 @@ for PROJECT; do
     empower_gcr_admins "${PROJECT}"
 
     # Enable GCR writers
-    for group in ${ADMINS} ${WRITERS}; do
+    for group in ${RELEASE_ADMINS} ${RELEASE_MANAGERS}; do
         color 6 "Empowering ${group} to GCR"
         empower_group_to_write_gcr "${group}" "${PROJECT}"
     done
@@ -107,7 +103,7 @@ for PROJECT; do
         empower_gcs_admins "${PROJECT}" "${BUCKET}"
 
         # Enable writers on the bucket
-        for group in ${ADMINS} ${WRITERS}; do
+        for group in ${RELEASE_ADMINS} ${RELEASE_MANAGERS}; do
             color 6 "Empowering ${group} to GCS"
             empower_group_to_write_gcs_bucket "${group}" "${BUCKET}"
         done
@@ -116,7 +112,7 @@ for PROJECT; do
     # Enable GCB and Prow to build and push images.
 
     # Let project writers use GCB.
-    for group in ${ADMINS} ${WRITERS}; do
+    for group in ${RELEASE_ADMINS} ${RELEASE_MANAGERS}; do
         color 6 "Empowering ${group} as GCB editors"
         empower_group_for_gcb "${PROJECT}" "${group}"
     done
@@ -126,8 +122,8 @@ for PROJECT; do
     empower_prow "${PROJECT}" "${GCB_BUCKET}"
 
     # Let project admins use KMS.
-    color 6 "Empowering ${ADMINS} as KMS admins"
-    empower_group_for_kms "${PROJECT}" "${ADMINS}"
+    color 6 "Empowering ${RELEASE_ADMINS} as KMS admins"
+    empower_group_for_kms "${PROJECT}" "${RELEASE_ADMINS}"
 
     color 6 "Done"
 done
@@ -141,7 +137,6 @@ RELEASE_BUCKETS=(
   "gs://k8s-release-dev-eu"
   "gs://k8s-release-pull"
 )
-PROW_BUILD_SVCACCT=$(svc_acct_email "k8s-infra-prow-build" "prow-build")
 
 for BUCKET in "${RELEASE_BUCKETS[@]}"; do
     color 3 "Configuring bucket: ${BUCKET}"
@@ -155,10 +150,10 @@ for BUCKET in "${RELEASE_BUCKETS[@]}"; do
     empower_gcs_admins "k8s-release" "${BUCKET}"
 
     # Enable prow to write to the bucket
-    empower_svcacct_to_write_gcs_bucket "${PROW_BUILD_SVCACCT}" "${BUCKET}"
+    empower_svcacct_to_write_gcs_bucket "${PROW_BUILD_SERVICE_ACCOUNT}" "${BUCKET}"
 
     # Enable writers on the bucket
-    for group in ${ADMINS} ${WRITERS}; do
+    for group in ${RELEASE_ADMINS} ${RELEASE_MANAGERS}; do
         color 6 "Empowering ${group} to GCS"
         empower_group_to_write_gcs_bucket "${group}" "${BUCKET}"
     done

--- a/infra/gcp/ensure-release-projects.sh
+++ b/infra/gcp/ensure-release-projects.sh
@@ -124,8 +124,16 @@ for PROJECT; do
     done
 
     # Let prow trigger builds and access the scratch bucket
-    color 6 "Empowering Prow"
-    empower_prow "${PROJECT}" "${GCB_BUCKET}"
+    serviceaccount="${GCB_BUILDER_SVCACCT}"
+    principal="serviceAccount:${serviceaccount}"
+
+    color 6 "Ensuring ${serviceaccount} can use GCB in project: ${PROJECT}"
+    ensure_project_role_binding "${PROJECT}" "${principal}" "roles/cloudbuild.builds.builder"
+    ensure_gcs_role_binding "${GCB_BUCKET}" "${principal}" "objectCreator"
+    ensure_gcs_role_binding "${GCB_BUCKET}" "${principal}" "objectViewer"
+
+    color 6 "Ensuring k8s-prow / test-infra-trusted can no longer use GCB in project: ${PROJECT}"
+    ensure_removed_google_prow_bindings "${PROJECT}" "${GCB_BUCKET}"
 
     # Let project admins use KMS.
     color 6 "Empowering ${RELEASE_ADMINS} as KMS admins"

--- a/infra/gcp/ensure-release-projects.sh
+++ b/infra/gcp/ensure-release-projects.sh
@@ -52,6 +52,12 @@ readonly RELEASE_PROJECT_SERVICES=(
 )
 
 for PROJECT; do
+
+    if ! (printf '%s\n' "${PROJECTS[@]}" | grep -q "^${PROJECT}$"); then
+        color 2 "Skipping unrecognized release project name: ${PROJECT}"
+        continue
+    fi
+
     color 3 "Configuring: ${PROJECT}"
 
     # The names of the buckets

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -312,6 +312,9 @@ function ensure_staging_gcb() {
     ensure_project_role_binding "${project}" "${principal}" "roles/cloudbuild.builds.builder"
     ensure_gcs_role_binding "${bucket}" "${principal}" "objectCreator"
     ensure_gcs_role_binding "${bucket}" "${principal}" "objectViewer"
+
+    color 6 "Ensuring k8s-prow / test-infra-trusted can no longer use GCB in project: ${project}"
+    ensure_removed_google_prow_bindings "${project}" "${bucket}"
 }
 
 # TODO(spiffxp): rename this to just prow@project and deprecate/rm the gcb-builder-foo

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -37,7 +37,9 @@ function usage() {
     echo > /dev/stderr
 }
 
-PROD_PROJECT="k8s-artifacts-prod"
+#
+# Staging project configuration
+#
 
 # NB: Please keep this sorted.
 readonly STAGING_PROJECTS=(
@@ -119,162 +121,212 @@ readonly RELEASE_STAGING_PROJECTS=(
 )
 
 readonly STAGING_PROJECT_SERVICES=(
+    # These projects use GCB to build/push images to GCR
     cloudbuild.googleapis.com
+    # Some GCB jobs may use KMS
     cloudkms.googleapis.com
+    # These projects host images in GCR
     containerregistry.googleapis.com
+    # TODO(spiffxp): disable this per https://github.com/kubernetes/k8s.io/issues/1963
     containerscanning.googleapis.com
+    # Some GCB jobs may use Secret Manager (preferred over KMS)
     secretmanager.googleapis.com
+    # These projects may host binaries in GCS
     storage-component.googleapis.com
 )
 
-if [ $# = 0 ]; then
-    # default to all staging projects
-    set -- "${STAGING_PROJECTS[@]}"
-fi
+# A short expiration - it can always be raised, but it is hard to lower
+# We expect promotion within 60d, or for testing to "move on", but
+# it is also short enough that people should notice occasionally,
+# and not accidentally think of the staging buckets as permanent.
+#
+# TODO: currently this only applies to GCS, as GCR has no native way
+#       of auto-deleting images based on age
+readonly AUTO_DELETION_DAYS=60
 
-for REPO; do
+#
+# Global k8s-infra configuration (something else provisioned these)
+#
 
-    if ! (printf '%s\n' "${STAGING_PROJECTS[@]}" | grep -q "^${REPO}$"); then
-      color 2 "Skipping unrecognized staging project name: ${REPO}"
-      continue
+readonly PROD_PROJECT="k8s-artifacts-prod"
+
+PROD_PROMOTER_SCANNING_SERVICE_ACCOUNT="$(svc_acct_email "${PROD_PROJECT}" "${PROMOTER_VULN_SCANNING_SVCACCT}")"
+readonly PROD_PROMOTER_SCANNING_SERVICE_ACCOUNT
+
+#
+# Staging functions
+#
+
+# Provision and configure a "staging" GCP project, intended to hold 
+# temporary release artifacts in a pre-provisioned GCS bucket or 
+# GCR. The intent is to then promote some of these artifacts to
+# production, which is long-lived and immutable.
+#
+# Artifacts are ideally written here via automation, either via GCB
+# builds run within the project, or by prowjobs running in a trusted
+# cluster (currently: k8s-infra-prow-build-trusted)
+#
+# As a fallback, a per-project group of humans is given access to
+# manually write artifacts andtrigger GCB builds in the project
+#
+# $1: GCP project name (e.g. "k8s-staging-foo")
+# $2: Group for manual access (e.g. "k8s-infra-staging-foo@kubernetes.io")
+function ensure_staging_project() {
+    if [ $# != 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
+        echo "${FUNCNAME[0]}(gcp_project, writers_group) requires 2 arguments" >&2
+        return 1
     fi
+    local project="${1}"
+    local writers="${2}"
 
-    color 3 "Configuring staging: ${REPO}"
+    # The names of the buckets
+    local staging_bucket="gs://${project}" # used by humans
+    local gcb_bucket="gs://${project}-gcb" # used by GCB
 
-    (
-        # The GCP project name.
-        PROJECT="k8s-staging-${REPO}"
+    local cip_principal="serviceAccount:${PROD_PROMOTER_SCANNING_SERVICE_ACCOUNT}"
 
-        # The group that can write to this staging repo.
-        WRITERS="k8s-infra-staging-${REPO}@kubernetes.io"
+    color 6 "Ensuring project exists: ${project}"
+    ensure_project "${project}"
 
-        # The names of the buckets
-        STAGING_BUCKET="gs://${PROJECT}" # used by humans
-        GCB_BUCKET="gs://${PROJECT}-gcb" # used by GCB
-        ALL_BUCKETS=("${STAGING_BUCKET}" "${GCB_BUCKET}")
+    color 6 "Ensuring ${writers} are project viewers"
+    ensure_project_role_binding "${project}" "group:${writers}" "roles/viewer"
 
-        # A short expiration - it can always be raised, but it is hard to lower
-        # We expect promotion within 60d, or for testing to "move on", but
-        # it is also short enough that people should notice occasionally,
-        # and not accidentally think of the staging buckets as permanent.
-        AUTO_DELETION_DAYS=60
+    # Enable services for staging projects and their direct dependencies; prune anything else
+    color 6 "Ensuring necessary enabled services staging project: ${project}"
+    # TODO: this may eventually disable other services; for now it
+    #       only does so if an obnoxiously long environment var is set,
+    #       K8S_INFRA_ENSURE_ONLY_SERVICES_WILL_FORCE_DISABLE=true
+    ensure_only_services "${project}" "${STAGING_PROJECT_SERVICES[@]}"
 
-        # Make the project, if needed
-        color 6 "Ensuring project exists: ${PROJECT}"
-        ensure_project "${PROJECT}"
+    # Enable image promoter access to vulnerability scanning results
+    color 6 "Ensuring ${cip_principal} can view vulnernability scanning results for project: ${project}"
+    ensure_project_role_binding "${project}" "${cip_principal}" "roles/containeranalysis.occurrences.viewer"
 
-        # Enable writers to use the UI
-        color 6 "Empowering ${WRITERS} as project viewers"
-        ensure_project_role_binding "${PROJECT}" "group:${WRITERS}" "roles/viewer"
+    # Ensure staging project GCR
 
-        # Enable services for staging projects and their direct dependencies; prune anything else
-        color 6 "Ensuring only necessary services are enabled for staging project: ${PROJECT}"
-        ensure_only_services "${PROJECT}" "${STAGING_PROJECT_SERVICES[@]}"
+    color 3 "Ensuring staging GCR repo: gcr.io/${project}"
+    ensure_staging_gcr_repo "${project}" "${writers}" 2>&1 | indent
 
-        # Enable image promoter access to vulnerability scanning results
-        serviceaccount="$(svc_acct_email "${PROD_PROJECT}" "${PROMOTER_VULN_SCANNING_SVCACCT}")"
-        color 6 "Empowering ${serviceaccount} to view vulnernability scanning results for project: ${PROJECT}"
-        ensure_project_role_binding "${PROJECT}" "serviceAccount:${serviceaccount}" "roles/containeranalysis.occurrences.viewer"
+    # Ensure staging project GCS
 
-        # Every project gets a GCR repo
+    color 3 "Ensuring staging GCS bucket: ${staging_bucket}"
+    ensure_staging_gcs_bucket "${project}" "${staging_bucket}" "${writers}" 2>&1 | indent
 
-        # Push an image to trigger the bucket to be created
-        color 6 "Ensuring the registry exists and is readable"
-        ensure_gcr_repo "${PROJECT}"
+    # Ensure staging project GCB
 
-        # Enable GCR admins
-        color 6 "Empowering GCR admins"
-        empower_gcr_admins "${PROJECT}"
+    color 3 "Ensuring staging GCB"
+    ensure_staging_gcb "${project}" "${gcb_bucket}" "${writers}" 2>&1 | indent
 
-        # Enable GCR writers
-        color 6 "Empowering ${WRITERS} to GCR"
-        empower_group_to_write_gcr "${WRITERS}" "${PROJECT}"
+    # Ensure any additional special case configuration
 
-        # Every project gets some GCS buckets
-        for BUCKET in "${ALL_BUCKETS[@]}"; do
-          color 3 "Configuring bucket: ${BUCKET}"
+    local special_case_func="staging_special_case__${project//-/_}"
+    if [ "$(type -t "${special_case_func}")" == "function" ]; then
+        color 6 "Ensuring special case configuration for ${project}"
+        "${special_case_func}"
+    fi
+}
 
-          (
-              # Create the bucket
-              color 6 "Ensuring the bucket exists and is world readable"
-              ensure_public_gcs_bucket "${PROJECT}" "${BUCKET}"
+# Ensure the given GCS bucket exists in the given staging project
+# with auto-deletion enabled and appropriate permissions for the
+# given group and GCS admins
+#
+# $1: The GCP project (e.g. k8s-staging-foo)
+# $2: The GCS bucket (e.g. gs://k8s-staging-foo)
+# $3: The group to grant write access (e.g. k8s-infra-staging-foo@kubernetes.io)
+function ensure_staging_gcs_bucket() {
+    if [ $# != 3 ] || [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
+        echo "${FUNCNAME[0]}(project, gcs_bucket, writers) requires 3 arguments" >&2
+        return 1
+    fi
+    local project="${1}"
+    local bucket="${2}"
+    local writers="${3}"
 
-              # Set bucket auto-deletion
-              color 6 "Ensuring the bucket has auto-deletion of ${AUTO_DELETION_DAYS} days"
-              ensure_gcs_bucket_auto_deletion "${BUCKET}" "${AUTO_DELETION_DAYS}"
+    color 6 "Ensuring ${bucket} exists and is world readable in project: ${project}"
+    ensure_public_gcs_bucket "${project}" "${bucket}"
 
-              # Enable admins on the bucket
-              color 6 "Empowering GCS admins"
-              empower_gcs_admins "${PROJECT}" "${BUCKET}"
+    color 6 "Ensuring ${bucket} has auto-deletion of ${AUTO_DELETION_DAYS} days"
+    ensure_gcs_bucket_auto_deletion "${bucket}" "${AUTO_DELETION_DAYS}"
 
-              # Enable writers on the bucket
-              color 6 "Empowering ${WRITERS} to GCS"
-              empower_group_to_write_gcs_bucket "${WRITERS}" "${BUCKET}"
-          ) 2>&1 | indent
-        done
+    color 6 "Ensuring GCS admins can admin ${bucket} in project: ${project}"
+    empower_gcs_admins "${project}" "${bucket}"
 
+    color 6 "Ensuring ${writers} can write to ${bucket} in project: ${project}"
+    empower_group_to_write_gcs_bucket "${writers}" "${bucket}"
+}
 
-        # Enable GCB and Prow to build and push images.
+# Ensure a GCR repo is provisioned in the given staging project, with
+# appropriate permissions for the given group and GCR admins
+# with auto-deletion enabled and appropriate permissions for the
+# given group and GCS admins
+#
+# $1: The GCP project (e.g. k8s-staging-foo)
+# $2: The group to grant write access (e.g. k8s-infra-staging-foo@kubernetes.io)
+function ensure_staging_gcr_repo() {
+    if [ $# != 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
+        echo "${FUNCNAME[0]}(project, writers) requires 2 arguments" >&2
+        return 1
+    fi
+    local project="${1}"
+    local writers="${2}"
 
-        # Let sub-project writers use GCB.
-        color 6 "Empowering ${WRITERS} as GCB editors"
-        empower_group_for_gcb "${PROJECT}" "${WRITERS}"
+    color 6 "Ensuring a GCR repo exists for project: ${project}"
+    ensure_gcr_repo "${project}"
 
-        # Let prow trigger builds and access the scratch bucket
-        color 6 "Empowering Prow"
-        empower_prow "${PROJECT}" "${GCB_BUCKET}"
-    ) 2>&1 | indent
+    color 6 "Ensuring ${writers} can write to GCR for project: ${project}"
+    empower_group_to_write_gcr "${writers}" "${project}"
 
-    color 6 "Done"
-done
+    color 6 "Ensuring GCR admins can admin GCR for project: ${project}"
+    empower_gcr_admins "${project}"
+}
 
-# Special case: Release Managers
-color 6 "Configuring special cases for Release Managers"
-for repo in "${RELEASE_STAGING_PROJECTS[@]}"; do
-    (
-        # The GCP project name.
-        PROJECT="k8s-staging-${repo}"
+# Ensure GCB is setup for the given staging project, by ensuring the
+# given staging GCS bucket exists, and allowing the given group and a
+# prow service account to write to the GCS bucket and trigger GCB
+#
+# $1: The GCP project (e.g. k8s-staging-foo)
+# $2: The GCS bucket (e.g. gs://k8s-staging-foo)
+# $3: The group to grant write access (e.g. k8s-infra-staging-foo@kubernetes.io)
+function ensure_staging_gcb() {
+  if [ $# != 3 ] || [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
+        echo "${FUNCNAME[0]}(project, gcs_bucket, writers) requires 3 arguments" >&2
+        return 1
+    fi
+    local project="${1}"
+    local bucket="${2}"
+    local writers="${3}"
 
-        # Enable Release Manager Associates view access to
-        # Release Engineering projects
-        color 6 "Empowering ${RELEASE_VIEWERS} as project viewers in ${PROJECT}"
-        ensure_project_role_binding "${PROJECT}" "group:${RELEASE_VIEWERS}" "roles/viewer"
+    # TODO: this should use ensure_staging_gcb_builder_service_account and
+    #       grant access to that instead; once image-builder jobs have been
+    #       moved over, remove support for this service account
+    local serviceaccount="${GCB_BUILDER_SVCACCT}"
+    local principal="serviceAccount:${serviceaccount}"
 
-        # Grant the kubernete-release-test (old staging) GCB service account
-        # admin GCR access to the new staging project for Kubernetes releases.
-        # This is required for VDF as we need to continue running
-        # stages/releases from the old project while publishing container
-        # images to new project.
-        #
-        # ref: https://github.com/kubernetes/release/pull/1230
-        if [[ "${PROJECT}" == "k8s-staging-kubernetes" ]]; then
-            color 6 "Empowering kubernetes-release-test GCB service account to admin GCR"
-            empower_svcacct_to_admin_gcr "648026197307@cloudbuild.gserviceaccount.com" "${PROJECT}"
-        fi
-    ) 2>&1 | indent
-done
+    color 6 "Ensuring staging bucket: ${bucket}"
+    ensure_staging_gcs_bucket "${project}" "${bucket}" "${writers}" 2>&1 | indent
 
-# Special case: In order for ci-kubernetes-build to run on k8s-infra-prow-build,
-#               it needs write access to gcr.io/k8s-staging-ci-images. For now,
-#               we will grant the prow-build service account write access. Longer
-#               term we would prefer service accounts per project, and restrictions
-#               on which jobs can use which service accounts.
-color 6 "Configuring special case for k8s-staging-ci-images"
-(
-    PROJECT="k8s-staging-ci-images"
-    SERVICE_ACCOUNT=$(svc_acct_email "k8s-infra-prow-build" "prow-build")
-    empower_svcacct_to_write_gcr "${SERVICE_ACCOUNT}" "${PROJECT}"
-)
+    color 6 "Ensuring ${writers} can use GCB in project: ${project}"
+    empower_group_for_gcb "${project}" "${writers}"
 
+    color 6 "Ensuring ${serviceaccount} can use GCB in project: ${project}"
+    ensure_project_role_binding "${project}" "${principal}" "roles/cloudbuild.builds.builder"
+    ensure_gcs_role_binding "${bucket}" "${principal}" "objectCreator"
+    ensure_gcs_role_binding "${bucket}" "${principal}" "objectViewer"
+}
+
+# TODO(spiffxp): rename this to just prow@project and deprecate/rm the gcb-builder-foo
+#                serviceaccounts; this will allow prowjobs to write to GCS or GCR in
+#                the project directly, as well as triggering GCB to do the same
 # Create a gcb-builder-{staging} GCP service account in project k8s-staging-{staging}
 # that can trigger GCB within that project. Allow GKE clusters in {prow_project}
 # to use this when running as a kubernetes service account of the same name in
 # the "test-pods" namespace
+#
 # $1: The staging name (e.g. kubetest2)
 # $2: The prow project name (e.g. k8s-infra-prow-build)
 function ensure_staging_gcb_builder_service_account() {
-    if [ $# != 2 -o -z "$1" -o -z "$2" ]; then
-        echo "ensure_staging_gcb_builder_service_account(staging, prow_project) requires 2 arguments" >&2
+    if [ $# != 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
+        echo "${FUNCNAME[0]}(staging, prow_project) requires 2 arguments" >&2
         return 1
     fi
 
@@ -284,40 +336,116 @@ function ensure_staging_gcb_builder_service_account() {
     local project="k8s-staging-${staging}"
     local sa_name="gcb-builder-${staging}"
     local sa_email="${sa_name}@${project}.iam.gserviceaccount.com"
+    # TODO(spiffxp): pass these in?
+    local staging_bucket="gs://${project}"
+    local gcb_bucket="gs://${project}-gcb"
 
+    color 6 "Ensuring ${sa_email} exists and can use GCB, GCS, GCR in project: ${project}"
     ensure_service_account \
       "${project}" \
       "${sa_name}" \
-      "used by k8s-infra-prow-build to trigger GCB, write to GCR for ${project}"
+      "used by prow to use GCB, write to GCR and GCS for ${project}"
 
     empower_svcacct_to_write_gcr "${sa_email}" "${project}"
 
-    ensure_project_role_binding \
-      "${project}" \
-      "serviceAccount:${sa_email}" \
-      "roles/cloudbuild.builds.builder"
+    local principal="serviceAccount:${sa_email}"
+    ensure_project_role_binding "${project}" "${principal}" "roles/cloudbuild.builds.builder"
+    ensure_gcs_role_binding "${staging_bucket}" "${principal}" "objectCreator"
+    ensure_gcs_role_binding "${staging_bucket}" "${principal}" "objectViewer"
+    ensure_gcs_role_binding "${gcb_bucket}" "${principal}" "objectCreator"
+    ensure_gcs_role_binding "${gcb_bucket}" "${principal}" "objectViewer"
 
+    color 6 "Ensuring ${sa_email} usable by GKE clusters in ${prow_project} running as ${sa_name} in ${prow_job_namespace} namespace"
     empower_ksa_to_svcacct \
         "${prow_project}.svc.id.goog[${prow_job_namespace}/${sa_name}]" \
         "${project}" \
         "${sa_email}"
 }
 
-# Special case: In order for pull-release-image-* to run on k8s-infra-prow-build,
-#               it needs write access to gcr.io/k8s-staging-releng-test. We are
-#               wary of what untrusted code is allowed to do, so we don't allow
-#               presubmits to run on k8s-infra-prow-build-trusted.
-color 6 "Configuring special case for k8s-staging-releng-test"
-(
-    ensure_staging_gcb_builder_service_account "releng-test" "k8s-infra-prow-build"
-)
+#
+# Special cases
+#
 
-# Special case: In order to build the node images using image-builder it needs
-#               the compute api to be enabled because it will create a VM
-#               to build the node image.
-color 6 "Configuring special case for k8s-staging-cluster-api-gcp"
-(
-    readonly STAGING_PROJECT="k8s-staging-cluster-api-gcp"
-    enable_api "${STAGING_PROJECT}" compute.googleapis.com
+# Release Manager Associates need view access to Release Engineering projects
+#
+# For k8s-staging-kubernetes, grant the kubernetes-release-test (old staging)
+# GCB service account admin GCR access to the new stging project for
+# Kubernetes releases. This is required for VDF as we need to continue
+# running stages/releases from the old project while publishing container
+# images to new project. ref: https://github.com/kubernetes/release/pull/1230
+function ensure_release_manager_special_cases() {
+    for repo in "${RELEASE_STAGING_PROJECTS[@]}"; do
+        (
+            # The GCP project name.
+            local project="k8s-staging-${repo}"
+
+            color 6 "Empowering ${RELEASE_VIEWERS} as project viewers in ${project}"
+            ensure_project_role_binding "${project}" "group:${RELEASE_VIEWERS}" "roles/viewer"
+
+            if [[ "${project}" == "k8s-staging-kubernetes" ]]; then
+                color 6 "Empowering kubernetes-release-test GCB service account to admin GCR"
+                empower_svcacct_to_admin_gcr "648026197307@cloudbuild.gserviceaccount.com" "${project}"
+            fi
+        ) 2>&1 | indent
+    done
+}
+
+# In order for ci-kubernetes-build to run on k8s-infra-prow-build,
+# it needs write access to gcr.io/k8s-staging-ci-images. For now,
+# we will grant the prow-build service account write access. Longer
+# term we would prefer service accounts per project, and restrictions
+# on which jobs can use which service accounts.
+function staging_special_case__k8s_staging_ci_images() {
+    empower_svcacct_to_write_gcr "${PROW_BUILD_SERVICE_ACCOUNT}" "k8s-staging-ci-images"
+}
+
+# In order for pull-release-image-* to run on k8s-infra-prow-build,
+# it needs write access to gcr.io/k8s-staging-releng-test. We are
+# wary of what untrusted code is allowed to do, so we don't allow
+# presubmits to run on k8s-infra-prow-build-trusted.
+function staging_special_case__k8s_staging_releng_test() {
+    ensure_staging_gcb_builder_service_account "releng-test" "k8s-infra-prow-build"
+}
+
+# In order to build the node images using image-builder it needs
+# the compute api to be enabled because it will create a VM
+# to build the node image.
+function staging_special_case__k8s_staging_cluster_api_gcp() {
+    ensure_services "k8s-staging-cluster-api-gcp" compute.googleapis.com
     ensure_staging_gcb_builder_service_account "cluster-api-gcp" "k8s-infra-prow-build-trusted"
-)
+}
+
+
+#
+# main
+#
+
+function ensure_staging_projects() {
+    color 6 "Ensuring staging projects..."
+
+    # default to all staging projects
+    if [ $# = 0 ]; then
+        set -- "${STAGING_PROJECTS[@]}"
+    fi
+
+    for repo in "${@}"; do
+        if ! (printf '%s\n' "${STAGING_PROJECTS[@]}" | grep -q "^${repo}$"); then
+          color 2 "Skipping unrecognized staging project name: ${repo}"
+          continue
+        fi
+
+        color 3 "Configuring staging: ${repo}"
+        ensure_staging_project \
+          "k8s-staging-${repo}" \
+          "k8s-infra-staging-${repo}@kubernetes.io" \
+          2>&1 | indent
+
+    done
+
+    color 6 "Configuring special cases for Release Managers"
+    ensure_release_manager_special_cases
+
+    color 6 "Done"
+}
+
+ensure_staging_projects "${@}"

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -127,12 +127,15 @@ readonly STAGING_PROJECT_SERVICES=(
     cloudkms.googleapis.com
     # These projects host images in GCR
     containerregistry.googleapis.com
-    # TODO(spiffxp): disable this per https://github.com/kubernetes/k8s.io/issues/1963
-    containerscanning.googleapis.com
     # Some GCB jobs may use Secret Manager (preferred over KMS)
     secretmanager.googleapis.com
     # These projects may host binaries in GCS
     storage-component.googleapis.com
+)
+
+readonly STAGING_PROJECT_DISABLED_SERVICES=(
+    # Disabling per https://github.com/kubernetes/k8s.io/issues/1963
+    containerscanning.googleapis.com
 )
 
 # A short expiration - it can always be raised, but it is hard to lower
@@ -197,6 +200,9 @@ function ensure_staging_project() {
     #       only does so if an obnoxiously long environment var is set,
     #       K8S_INFRA_ENSURE_ONLY_SERVICES_WILL_FORCE_DISABLE=true
     ensure_only_services "${project}" "${STAGING_PROJECT_SERVICES[@]}"
+
+    color 6 "Ensuring disabled services for staging project: ${project}"
+    ensure_disabled_services "${project}" "${STAGING_PROJECT_DISABLED_SERVICES[@]}"
 
     # Enable image promoter access to vulnerability scanning results
     color 6 "Ensuring ${cip_principal} can view vulnernability scanning results for project: ${project}"

--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -298,31 +298,24 @@ function empower_group_for_kms() {
     done
 }
 
-# Grant privileges to prow in a staging project
+# TODO(spiffxp): remove this in a follow-up PR
+# Remove privileges previously granted to the google-owned test-infra-trusted
+# cluster's "deployer" service account
 # $1: The GCP project
 # $2: The GCS scratch bucket
-function empower_prow() {
-    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
-        echo "empower_prow(project, bucket) requires 2 arguments" >&2
+function ensure_removed_google_prow_bindings() {
+    if [ $# -lt 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
+        echo "${FUNCNAME[0]}(project, bucket) requires 2 arguments" >&2
         return 1
     fi
     local project="$1"
     local bucket="$2"
 
-    local prow_principal="serviceAccount:${PROW_GOOGLE_TRUSTED_SERVICE_ACCOUNT}"
-    local gcb_builder_principal="serviceAccount:${GCB_BUILDER_SVCACCT}"
-    # commands are copy-pasted so that one set can turn into deletes
-    # when we're ready to decommission PROW_GOOGLE_TRUSTED_SERVICE_ACCOUNT
+    local google_prow_principal="serviceAccount:${PROW_GOOGLE_TRUSTED_SERVICE_ACCOUNT}"
 
-    # Allow prow to trigger builds.
-    ensure_project_role_binding "${project}" "${prow_principal}" "roles/cloudbuild.builds.builder"
-    ensure_project_role_binding "${project}" "${gcb_builder_principal}" "roles/cloudbuild.builds.builder"
-
-    # Allow prow to push source and access build logs.
-    ensure_gcs_role_binding "${bucket}" "${prow_principal}" "objectCreator"
-    ensure_gcs_role_binding "${bucket}" "${prow_principal}" "objectViewer"
-    ensure_gcs_role_binding "${bucket}" "${gcb_builder_principal}" "objectCreator"
-    ensure_gcs_role_binding "${bucket}" "${gcb_builder_principal}" "objectViewer"
+    ensure_removed_project_role_binding "${project}" "${google_prow_principal}" "roles/cloudbuild.builds.builder"
+    ensure_removed_gcs_role_binding "${bucket}" "${google_prow_principal}" "objectCreator"
+    ensure_removed_gcs_role_binding "${bucket}" "${google_prow_principal}" "objectViewer"
 }
 
 # Grant full privileges to GCR admins

--- a/infra/gcp/lib_services.sh
+++ b/infra/gcp/lib_services.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GCP Services utility functions
+#
+# This is intended to be very general-purpose and "low-level".  Higher-level
+# policy does not belong here.
+#
+# This MUST NOT be used directly. Source it via lib.sh instead.
+
+# Enable an API
+# $1: The GCP project
+# $2: The API (e.g. containerregistry.googleapis.com)
+function enable_api() {
+    if [ $# != 2 -o -z "$1" -o -z "$2" ]; then
+        echo "enable_api(project, api) requires 2 arguments" >&2
+        return 1
+    fi
+    local project="$1"
+    local api="$2"
+
+    gcloud --project "${project}" services enable "${api}"
+}
+
+# Output a plan of services to enable/disable for a given gcp project; format
+# is YAML, each key is a list of services e.g. [pubsub.googleapis.com, ...]
+#   intent:     # services we wish to enable
+#   enabled:    # services that are presently enabled
+#   expected:   # intent + any services directly depended on by intent
+#   to_enable:  # services in intent that are not enabled
+#   to_disable: # services that are enabled but not in expected
+# $1  The GCP project
+# $2+ Service names that are expected to be enabled (e.g. pubsub.googleapis.com)
+function _plan_enabled_services() {
+    if [ $# -lt 2 -o -z "$1" ]; then
+        echo "list_services(gcp_project, service...) requires at least 2 arguments" >&2
+        return 1
+    fi
+
+    local gcp_project="$1"; shift
+
+    gcloud services list --enabled --project="${gcp_project}" \
+      --format='yaml(config.name,dependencyConfig.directlyDependsOn)' \
+      | yq --slurp -y --args '($ARGS.positional | sort) as $intent | {
+        intent: $intent,
+        enabled: map(.config.name) | sort,
+        expected: (
+          map(
+            select([.config.name] | inside($intent))
+            | (.dependencyConfig?.directlyDependsOn // [])
+          ) + $intent
+        )
+        | flatten
+        | map({key:., value:true}) | from_entries | keys | sort
+      } | . += {
+        to_enable: (.expected - .enabled),
+        to_disable: (.enabled - .expected)
+      }' "$@"
+}
+
+# Ensure that only the given services and their direct dependencies are enabled; disable any other services
+# $1  The GCP project for which to enable/disable services
+# $2+ The service names (e.g. pubsub.googleapis.com)
+function ensure_only_services() {
+    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+        echo "ensure_only_services(gcp_project, service...) requires at least 2 arguments" >&2
+        return 1
+    fi
+
+    local gcp_project="$1"; shift
+
+    local before="${TMPDIR}/ensure-only-services.before.yaml"
+    local after_enable="${TMPDIR}/ensure-only-services.after_enable.yaml"
+    local after_disable="${TMPDIR}/ensure-only-services.after_disable.yaml"
+
+    # get services before modifying to diff against when finished
+    _plan_enabled_services "${gcp_project}" "$@" > "${before}"
+
+    # if there's nothing to do, return early
+    if ! <"${before}" yq --exit-status '[.to_enable, .to_disable] | map (length > 0) | any' >/dev/null; then
+      return
+    fi
+
+    echo "plan to enable/disable the following services"
+    <"${before}" yq -y '{to_enable, to_disable}'
+
+    # enable services that need to be enabled
+    for service in $(<"${before}" yq -r '.to_enable[]'); do
+        gcloud services enable --project="${gcp_project}" "${service}"
+    done
+
+    # disable services not explicitly enabled or directly required
+    _plan_enabled_services "${gcp_project}" "$@" > "${after_enable}"
+
+
+    # TODO(spiffxp): get comfortable with --force or redo to disable in dep-order;
+    #                until then, set an obnoxiously long env var to actually disable
+    local disable_cmd='echo "INFO: dry-run mode, would run:" gcloud'
+    if [ "${K8S_INFRA_ENSURE_ONLY_SERVICES_WILL_FORCE_DISABLE:-""}" == "true" ]; then
+        disable_cmd=gcloud
+    fi
+    for service in $( (<"${after_enable}" yq -r '.to_disable[]') | sort | uniq -u); do
+        ${disable_cmd} services disable --force "${service}" --project="${gcp_project}"
+    done
+
+    _plan_enabled_services "${gcp_project}" "$@" > "${after_disable}"
+
+    # in the event that an enable/disable cycle doesn't do enough, let's warn
+    if <"${after_disable}" yq --exit-status '[.to_enable, .to_disable] | map (length > 0) | any' >/dev/null; then
+      echo "WARN: ensure_only_services: after enable/disable cycle, still projects to enable/disable: ${gcp_project}"
+      cat "${after_disable}"
+    fi
+
+    diff_colorized "${before}" "${after_disable}"
+}


### PR DESCRIPTION
This is an attempt at making some progress on the audit followup issue to ensure we don't have random services enabled https://github.com/kubernetes/k8s.io/issues/1887

It's also more directly motivated by ensuring that containerscanning is disabled for https://github.com/kubernetes/k8s.io/issues/1963

EDIT: I'm going to cap this off before it gets too sprawling.  See individual commits for details.

Brief summary:
- Nice to have stuff
  - split out services-related functions into `lib_services.sh`, rename `ensure_api` to `ensure_services`
  - add comments to and organize the top of `lib.sh`
  - reorganize `ensure-staging-storage.sh` into functions, as has been done for `ensure-organization.sh` and `ensure-main-project.sh`
- Disable container scanning
  - remove from required staging project services
  - explicitly disable via new `ensure_disabled_services`
- Starting to sprawl
  - remove `deployer@k8s-prow` bindings from staging/release projects, `test-infra-trusted` no longer runs jobs here
  - start moving `ensure_staging_gcb_builder_service_account` toward something that will be used by default for all staging projects, to implement the "gcb account per staging project" approach described in https://github.com/kubernetes/test-infra/issues/20652#issuecomment-774233051 (which should also address https://github.com/kubernetes/k8s.io/issues/1544)

