### PR TITLE
Bump Google terraform providers

### DIFF
--- a/infra/gcp/clusters/modules/gke-cluster/versions.tf
+++ b/infra/gcp/clusters/modules/gke-cluster/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.46.0"
+      version = "~> 3.66.1"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.46.0"
+      version = "~> 3.66.1"
     }
   }
 }

--- a/infra/gcp/clusters/modules/gke-nodepool/versions.tf
+++ b/infra/gcp/clusters/modules/gke-nodepool/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.46.0"
+      version = "~> 3.66.1"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.46.0"
+      version = "~> 3.66.1"
     }
   }
 }

--- a/infra/gcp/clusters/modules/gke-project/versions.tf
+++ b/infra/gcp/clusters/modules/gke-project/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.46.0"
+      version = "~> 3.66.1"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.46.0"
+      version = "~> 3.66.1"
     }
   }
 }

--- a/infra/gcp/clusters/projects/k8s-infra-ii-sandbox/provider.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-ii-sandbox/provider.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.46.0"
+      version = "~> 3.66.1"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.46.0"
+      version = "~> 3.66.1"
     }
   }
 }

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/00-provider.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/00-provider.tf
@@ -14,11 +14,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.46.0"
+      version = "~> 3.66.1"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.46.0"
+      version = "~> 3.66.1"
     }
   }
 }

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/versions.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/versions.tf
@@ -4,5 +4,5 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 0.13.0"
+  required_version = "~> 0.13.7"
 }

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/00-provider.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/00-provider.tf
@@ -14,11 +14,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.46.0"
+      version = "~> 3.66.1"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.46.0"
+      version = "~> 3.66.1"
     }
   }
 }

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/versions.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/versions.tf
@@ -4,5 +4,5 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 0.13.0"
+  required_version = "~> 0.13.7"
 }

--- a/infra/gcp/clusters/projects/kubernetes-public/aaa/00-inputs.tf
+++ b/infra/gcp/clusters/projects/kubernetes-public/aaa/00-inputs.tf
@@ -7,7 +7,7 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 0.13.6"
+  required_version = "~> 0.13.7"
 
   backend "gcs" {
     bucket = "k8s-infra-tf-public-clusters"
@@ -16,10 +16,10 @@ terraform {
 
   required_providers {
     google = {
-      version = "~> 3.46.0"
+      version = "~> 3.66.1"
     }
     google-beta = {
-      version = "~> 3.46.0"
+      version = "~> 3.66.1"
     }
   }
 }


### PR DESCRIPTION
Bump terraform provider to 3.66.1 :
https://github.com/hashicorp/terraform-provider-google/blob/master/CHANGELOG.md#3661-april-29-2021.

This change is required to enable local ssd disks for build clusters: https://github.com/kubernetes/k8s.io/issues/1187

No change expected.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>