### PR TITLE
capg: enable compute api for CAPG to build the node images

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/build-serviceaccounts.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/build-serviceaccounts.yaml
@@ -63,3 +63,11 @@ metadata:
     iam.gke.io/gcp-service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod-bak.iam.gserviceaccount.com
   name: k8s-infra-gcr-promoter-bak
   namespace: test-pods
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com
+  name: gcb-builder-cluster-api-gcp
+  namespace: test-pods

--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -311,3 +311,13 @@ color 6 "Configuring special case for k8s-staging-releng-test"
 (
     ensure_staging_gcb_builder_service_account "releng-test" "k8s-infra-prow-build"
 )
+
+# Special case: In order to build the node images using image-builder it needs
+#               the compute api to be enabled because it will create a VM
+#               to build the node image.
+color 6 "Configuring special case for k8s-staging-cluster-api-gcp"
+(
+    readonly STAGING_PROJECT="k8s-staging-cluster-api-gcp"
+    enable_api "${STAGING_PROJECT}" compute.googleapis.com
+    ensure_staging_gcb_builder_service_account "cluster-api-gcp" "k8s-infra-prow-build-trusted"
+)


### PR DESCRIPTION
This PR enables the compute API to be used in the `k8s-staging-cluster-api-gcp` project to build the nightly images for CAPG

Related PRs:
- prow job: https://github.com/kubernetes/test-infra/pull/22041
- image-builder scripts: https://github.com/kubernetes-sigs/image-builder/pull/445

Fixes: https://github.com/kubernetes/k8s.io/issues/1993

## Open questions
 - It is not clear to me is how to use the credentials for this project in the prow job.


/assign @dims @ameukam @spiffxp 