### PR TITLE
Update SIG Release mailing lists and OWNERS aliases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -175,27 +175,17 @@ aliases:
     - BenTheElder
     - MushuEE
     - spiffxp
-  build-image-approvers:
-    - BenTheElder
-    - cblecker
-    - dims
-    - justaugustus
-    - listx
-  build-image-reviewers:
-    - BenTheElder
-    - cblecker
-    - dims
-    - justaugustus
-    - listx
   cip-approvers:
+    - hasheddan
     - justaugustus
-    - justinsb
     - listx
+    - saschagrunert
     - thockin
   cip-reviewers:
+    - hasheddan
     - justaugustus
-    - justinsb
     - listx
+    - saschagrunert
     - thockin
   provider-aws:
     - d-nishi
@@ -218,28 +208,20 @@ aliases:
     - cantbewong
     - frapposelli
   release-engineering-approvers:
-    - alejandrox1 # SIG Technical Lead
     - cpanato # Release Manager
-    - feiskyer # Release Manager
     - hasheddan # subproject owner / Release Manager / SIG Technical Lead
-    - idealhack # Release Manager
     - jeremyrickard # SIG Technical Lead
     - justaugustus # subproject owner / Release Manager / SIG Chair
     - puerco # Release Manager
     - saschagrunert # subproject owner / Release Manager / SIG Chair
-    - tpepper # subproject owner
     - xmudrii # Release Manager
   release-engineering-reviewers:
-    - alejandrox1 # SIG Technical Lead
     - cpanato # Release Manager
-    - feiskyer # Release Manager
     - hasheddan # subproject owner / Release Manager / SIG Technical Lead
-    - idealhack # Release Manager
     - jeremyrickard # SIG Technical Lead
     - justaugustus # subproject owner / Release Manager / SIG Chair
     - puerco # Release Manager
     - saschagrunert # subproject owner / Release Manager / SIG Chair
-    - tpepper # subproject owner
     - xmudrii # Release Manager
   # business hours oncall for prow etc (https://go.k8s.io/oncall)
   test-infra-oncall:

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -84,8 +84,11 @@ groups:
       - marky.r.jackson@gmail.com
       - max@koerbaecher.io
       - onlydole@gmail.com
+      - pal.nabarun95@gmail.com
       - saveetha13@gmail.com
       - sethpmccombs@gmail.com
+      - thejoycekung@gmail.com
+      - wilsonehusin@gmail.com
 
   - email-id: k8s-infra-staging-artifact-promoter@kubernetes.io
     name: k8s-infra-staging-artifact-promoter
@@ -305,10 +308,13 @@ groups:
       - marky.r.jackson@gmail.com
       - max@koerbaecher.io
       - mudrinic.mare@gmail.com
+      - pal.nabarun95@gmail.com
       - onlydole@gmail.com
       - saveetha13@gmail.com
       - sethpmccombs@gmail.com
       - spiffxp@google.com
+      - thejoycekung@gmail.com
+      - wilsonehusin@gmail.com
 
   - email-id: security-release-team@kubernetes.io
     name: security-release-team

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -79,7 +79,6 @@ groups:
       - jameswangel@gmail.com
       - jeremy.r.rickard@gmail.com
       - kikis.github@gmail.com
-      - marky.r.jackson@gmail.com
       - max@koerbaecher.io
       - onlydole@gmail.com
       - pal.nabarun95@gmail.com
@@ -289,7 +288,6 @@ groups:
       - jameswangel@gmail.com
       - kikis.github@gmail.com
       - lauri.d.apple@gmail.com
-      - marky.r.jackson@gmail.com
       - max@koerbaecher.io
       - mudrinic.mare@gmail.com
       - pal.nabarun95@gmail.com

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -56,9 +56,7 @@ groups:
       - k8s-infra-release-admins@kubernetes.io
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
-      - feiskyer@gmail.com
       - georgedanielmangum@gmail.com
-      - idealhack@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
       - saschagrunert@gmail.com
@@ -111,11 +109,6 @@ groups:
       ReconcileMembers: "true"
     members:
       - k8s-infra-release-editors@kubernetes.io
-      - bentheelder@google.com
-      - cblecker@gmail.com
-      - davanum@gmail.com
-      - k8s@auggie.dev
-      - linusa@google.com
 
   - email-id: k8s-infra-staging-ci-images@kubernetes.io
     name: k8s-infra-staging-ci-images
@@ -230,13 +223,10 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
-      - alarcj137@gmail.com
       - georgedanielmangum@gmail.com
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
       - saschagrunert@gmail.com
-    managers:
-      - tpepper@vmware.com # Release Team subproject owner
     members:
       - divya.mohan0209@gmail.com # 1.21 Comms Lead
       - evelyn.cupil.garcia@duke.edu # 1.21 Comms Shadow
@@ -260,7 +250,6 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
-      - alarcj137@gmail.com
       - georgedanielmangum@gmail.com
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
@@ -269,8 +258,6 @@ groups:
       - adolfo.garcia@uservers.net
       - augustus@cisco.com
       - ctadeu@gmail.com
-      - feiskyer@gmail.com
-      - idealhack@gmail.com
       - mudrinic.mare@gmail.com
 
   - email-id: release-managers@kubernetes.io
@@ -283,7 +270,6 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
-      - alarcj137@gmail.com
       - georgedanielmangum@gmail.com
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
@@ -298,10 +284,8 @@ groups:
       - ctadeu@gmail.com
       - dcampau1@gmail.com
       - divya.mohan0209@gmail.com
-      - feiskyer@gmail.com
       - gmccloskey@google.com
       - gveronicalg@gmail.com
-      - idealhack@gmail.com
       - jameswangel@gmail.com
       - kikis.github@gmail.com
       - lauri.d.apple@gmail.com
@@ -338,7 +322,6 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
-      - alarcj137@gmail.com
       - georgedanielmangum@gmail.com
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
@@ -354,7 +337,6 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
-      - alarcj137@gmail.com
       - georgedanielmangum@gmail.com
       - k8s@auggie.dev
       - lauri.d.apple@gmail.com
@@ -365,7 +347,6 @@ groups:
       - divya.mohan0209@gmail.com # 1.22 RT Lead Shadow
       - kikis.github@gmail.com # 1.22 RT Lead Shadow
       - saveetha13@gmail.com # 1.22 RT Lead
-      - tpepper@vmware.com # Release Team subproject owner
     members:
       - sig-release-leads@kubernetes.io
       - alessandro.vozza@microsoft.com # 1.21 Bug Triage Shadow
@@ -409,14 +390,12 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
-      - alarcj137@gmail.com
       - georgedanielmangum@gmail.com
       - k8s@auggie.dev
       - lauri.d.apple@gmail.com
       - saschagrunert@gmail.com
     managers:
       - guineveresaenger@gmail.com # 1.22 Emeritus Advisor
-      - tpepper@vmware.com # Release Team subproject owner
     members:
       - alessandro.vozza@microsoft.com # 1.21 Bug Triage Shadow
       - arunmk@gmail.com # 1.21 RT Enhancements Shadow

--- a/k8s.gcr.io/images/k8s-staging-build-image/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-build-image/OWNERS
@@ -1,9 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - build-image-approvers
+  - release-engineering-approvers
 reviewers:
-  - build-image-reviewers
+  - release-engineering-reviewers
 
 labels:
   - sig/release


### PR DESCRIPTION
- groups/releng: Add @wilsonehusin, @thejoycekung, and @palnabarun as RMAs (https://github.com/kubernetes/sig-release/issues/1567, https://github.com/kubernetes/sig-release/issues/1483)
- groups/sig-release: Prune inactive members
- OWNERS: Update Release Engineering aliases
  - `release-engineer-approvers`/`-reviewers`:
    - Emeritus @alejandrox1, @tpepper, @feiskyer, and @idealhack
  - `cip-approvers`/`-reviewers`:
    - Remove @justinsb 
    - Add @hasheddan and @saschagrunert
  - Remove `build-image-approvers`/`-reviewers`:
    This group was initially created to provider additional approval
    coverage for build/base image promotions as we transitioned the image
    builds to the Release Engineering subproject.
    
    Now that we have @kubernetes/release-managers actively involved in image building,
    we simplify approvals by placing it in the hands of the RelMgr group.
- groups/releng: Offboard @markyjackson-taulia from the RMA group

/assign @dims @cblecker @hasheddan @saschagrunert 
cc: @kubernetes/sig-release-leads @kubernetes/release-engineering 