### PR TITLE
releng: Temporary RM access for Verolop

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -57,6 +57,7 @@ groups:
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
       - georgedanielmangum@gmail.com
+      - gveronicalg@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
       - saschagrunert@gmail.com


### PR DESCRIPTION
Verónica (@Verolop) is a Release Manager Associate being granted temporary elevated access to cut the `v1.22.0-alpha.2` release. Access will be revoked after the 1.22.0-alpha.2 release is cut.

SIG Release issue: https://github.com/kubernetes/sig-release/issues/1573

/assign @dims @cblecker
cc: @kubernetes/release-engineering

/priority important-soon

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>
