### PR TITLE
infra/gcp: fix audit.viewer role and remove stray bindings

### DIFF
--- a/infra/gcp/ensure-organization.sh
+++ b/infra/gcp/ensure-organization.sh
@@ -71,7 +71,9 @@ org_role_bindings=(
   "serviceAccount:$(svc_acct_email "kubernetes-public" "k8s-infra-gcp-auditor"):$(custom_org_role_name "audit.viewer")"
 )
 
-removed_org_role_bindings=()
+removed_org_role_bindings=(
+  "group:k8s-infra-gcp-auditors@kubernetes.io:roles/secretmanager.viewer"
+)
 
 function ensure_org_roles() {
     for role in "${org_roles[@]}"; do

--- a/infra/gcp/ensure-organization.sh
+++ b/infra/gcp/ensure-organization.sh
@@ -72,7 +72,19 @@ org_role_bindings=(
 )
 
 removed_org_role_bindings=(
+  # TODO(spiffxp): remove all of these in followup PR once deployed
   "group:k8s-infra-gcp-auditors@kubernetes.io:roles/secretmanager.viewer"
+  "user:davanum@gmail.com:roles/compute.viewer"
+  "user:davanum@gmail.com:roles/dns.reader"
+  "user:davanum@gmail.com:roles/iam.securityReviewer"
+  "user:davanum@gmail.com:roles/resourcemanager.organizationViewer"
+  "user:davanum@gmail.com:roles/serviceusage.serviceUsageConsumer"
+  "user:thockin@google.com:roles/compute.viewer"
+  "user:thockin@google.com:roles/dns.reader"
+  "user:thockin@google.com:roles/iam.securityReviewer"
+  "user:thockin@google.com:roles/resourcemanager.organizationViewer"
+  "user:thockin@google.com:roles/serviceusage.serviceUsageConsumer"
+  "user:spiffxp@google.com:roles/resourcemanager.organizationAdmin"
 )
 
 function ensure_org_roles() {

--- a/infra/gcp/roles/audit.viewer.yaml
+++ b/infra/gcp/roles/audit.viewer.yaml
@@ -15,6 +15,8 @@
 #   - roles/dns.reader
 #   # read access to cloud assets metadata
 #   - roles/cloudasset.viewer
+#   # read access to secrets metadata (not their contents)
+#   - roles/secretmanager.viewer
 # 
 #   # meta roles (regardless of roles/viewer)
 #   # read access for the project hierarchy (org, folders, projects)
@@ -1004,9 +1006,12 @@ includedPermissions:
   - runtimeconfig.variables.list
   - runtimeconfig.waiters.getIamPolicy
   - runtimeconfig.waiters.list
+  - secretmanager.locations.get
   - secretmanager.locations.list
+  - secretmanager.secrets.get
   - secretmanager.secrets.getIamPolicy
   - secretmanager.secrets.list
+  - secretmanager.versions.get
   - secretmanager.versions.list
   - securitycenter.assets.list
   - securitycenter.findings.list

--- a/infra/gcp/roles/audit.viewer.yaml
+++ b/infra/gcp/roles/audit.viewer.yaml
@@ -70,6 +70,7 @@ includedPermissions:
   - aiplatform.modelEvaluationSlices.list
   - aiplatform.modelEvaluations.list
   - aiplatform.models.list
+  - aiplatform.nasJobs.list
   - aiplatform.operations.list
   - aiplatform.specialistPools.list
   - aiplatform.studies.list
@@ -192,6 +193,7 @@ includedPermissions:
   - clientauthconfig.brands.list
   - clientauthconfig.clients.list
   - cloudasset.assets.analyzeIamPolicy
+  - cloudasset.assets.analyzeMove
   - cloudasset.assets.exportAccessLevel
   - cloudasset.assets.exportAccessPolicy
   - cloudasset.assets.exportAllAccessPolicy
@@ -283,6 +285,7 @@ includedPermissions:
   - cloudasset.assets.exportSpannerInstances
   - cloudasset.assets.exportSqladminInstances
   - cloudasset.assets.exportStorageBuckets
+  - cloudasset.assets.listCloudkmsCryptoKeys
   - cloudasset.assets.searchAllIamPolicies
   - cloudasset.assets.searchAllResources
   - cloudasset.feeds.list
@@ -682,18 +685,23 @@ includedPermissions:
   - dialogflow.participants.list
   - dialogflow.phoneNumberOrders.list
   - dialogflow.phoneNumbers.list
+  - dialogflow.securitySettings.list
   - dialogflow.sessionEntityTypes.list
   - dialogflow.smartMessagingEntries.list
   - dialogflow.transitionRouteGroups.list
   - dialogflow.versions.list
   - dialogflow.webhooks.list
   - dlp.analyzeRiskTemplates.list
+  - dlp.columnDataProfiles.list
   - dlp.deidentifyTemplates.list
+  - dlp.estimates.list
   - dlp.inspectFindings.list
   - dlp.inspectTemplates.list
   - dlp.jobTriggers.list
   - dlp.jobs.list
+  - dlp.projectDataProfiles.list
   - dlp.storedInfoTypes.list
+  - dlp.tableDataProfiles.list
   - dns.changes.get
   - dns.changes.list
   - dns.dnsKeys.get
@@ -706,6 +714,7 @@ includedPermissions:
   - dns.policies.getIamPolicy
   - dns.policies.list
   - dns.projects.get
+  - dns.resourceRecordSets.get
   - dns.resourceRecordSets.list
   - documentai.evaluations.list
   - documentai.labelerPools.list
@@ -978,6 +987,7 @@ includedPermissions:
   - resourcemanager.tagKeys.list
   - resourcemanager.tagValues.getIamPolicy
   - resourcemanager.tagValues.list
+  - resourcesettings.settings.list
   - retail.catalogs.list
   - retail.operations.list
   - retail.products.list

--- a/infra/gcp/roles/specs/audit.viewer.yaml
+++ b/infra/gcp/roles/specs/audit.viewer.yaml
@@ -13,6 +13,8 @@ include:
   - roles/dns.reader
   # read access to cloud assets metadata
   - roles/cloudasset.viewer
+  # read access to secrets metadata (not their contents)
+  - roles/secretmanager.viewer
 
   # meta roles (regardless of roles/viewer)
   # read access for the project hierarchy (org, folders, projects)


### PR DESCRIPTION
See commits for details.

I have already deployed up to 16506e0f, but opted to hold on the last one for review.

This will fix the main part of https://github.com/kubernetes/k8s.io/issues/2055