### PR TITLE
image-builder/capg: add more permissions to the service account

### DIFF
--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -420,10 +420,13 @@ function staging_special_case__k8s_staging_releng_test() {
 # the compute api to be enabled because it will create a VM
 # to build the node image.
 function staging_special_case__k8s_staging_cluster_api_gcp() {
-    ensure_services "k8s-staging-cluster-api-gcp" compute.googleapis.com
+    readonly STAGING_PROJECT="k8s-staging-cluster-api-gcp"
+    readonly serviceaccount="$(svc_acct_email "${STAGING_PROJECT}" "gcb-builder-cluster-api-gcp")"
+
+    ensure_services "${STAGING_PROJECT}" compute.googleapis.com
+    ensure_project_role_binding "${STAGING_PROJECT}" "serviceAccount:${serviceaccount}" "roles/compute.instanceAdmin.v1"
     ensure_staging_gcb_builder_service_account "cluster-api-gcp" "k8s-infra-prow-build-trusted"
 }
-
 
 #
 # main


### PR DESCRIPTION
after we merge: https://github.com/kubernetes/k8s.io/pull/2057 and https://github.com/kubernetes/k8s.io/pull/2025

the periodic job ran https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-image-builder-gcp-all-nightly/1394944554532081664 but we got an error

```
Error creating instance: googleapi: Error 403: Required 'compute.zones.get' permission for 'projects/k8s-staging-cluster-api-gcp/zones/us-central1-a', forbidden
```

So looks like we need to give a bit more permissions to the svcacc in order to work. 
doing a search saw the `role/editor` have the necessary permissions. However, I don't know if this the correct way to enable it.

/assign @spiffxp @ameukam 