### PR TITLE
groups/sig-cluster-lifecycle: update kubeadm-alerts group

### DIFF
--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -18,7 +18,9 @@ groups:
 
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
-      ReconcileMembers: "true"
-    members:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      MessageModerationLevel: "MODERATE_ALL_MESSAGES"
+      ReconcileMembers: "false"
+    owners:
       - fabriziopandini@gmail.com
       - neolit123@gmail.com


### PR DESCRIPTION
- Allow anyone to join and post
- Have owners that can moderate

The idea is for only prow to post on this ML.
Once it sends its first message we will allow it for future
messages too.

these suggestions came from this slack thread:
https://kubernetes.slack.com/archives/CCK68P2Q2/p1621524263005700