### PR TITLE
groups/sig-cluster-lifecycle: make kubeadm alerts group discoverable

### DIFF
--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -17,6 +17,8 @@ groups:
     description: |-
 
     settings:
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
       WhoCanPostMessage: "ANYONE_CAN_POST"
       WhoCanJoin: "ANYONE_CAN_JOIN"
       MessageModerationLevel: "MODERATE_ALL_MESSAGES"


### PR DESCRIPTION
Make the group viewable / discoverable by non-members.

These settings were discussed on slack:
https://kubernetes.slack.com/archives/CCK68P2Q2/p1621524263005700