### PR TITLE
groups/sig-cluster-lifecycle: fix email in owners

### DIFF
--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -24,5 +24,5 @@ groups:
       MessageModerationLevel: "MODERATE_ALL_MESSAGES"
       ReconcileMembers: "false"
     owners:
-      - fabriziopandini@gmail.com
+      - fabrizio.pandini@gmail.com
       - neolit123@gmail.com


### PR DESCRIPTION
Fix Fabrizio's email in the kubeadm alerts group.