### PR TITLE
Switch gcsweb to GKE managed certs

### DIFF
--- a/gcsweb.k8s.io/certificate.yaml
+++ b/gcsweb.k8s.io/certificate.yaml
@@ -1,16 +1,8 @@
-apiVersion: cert-manager.io/v1alpha2
-kind: Certificate
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
 metadata:
-  name: gcsweb-k8s-io
-  namespace: gcsweb
-  annotations:
-    cert-manager.io/issue-temporary-certificate: "true"
+  name: gcsweb
 spec:
-  secretName: gcsweb-k8s-io-tls
-  issuerRef:
-    kind: ClusterIssuer
-    name: letsencrypt-prod
-  commonName: gcsweb.k8s.io
-  dnsNames:
+  domains:
   - gcsweb.k8s.io
   - gcsweb.kubernetes.io

--- a/gcsweb.k8s.io/ingress.yaml
+++ b/gcsweb.k8s.io/ingress.yaml
@@ -3,13 +3,11 @@ kind: Ingress
 metadata:
   name: gcsweb
   namespace: gcsweb
-  labels:
-    app: gcsweb
   annotations:
     kubernetes.io/ingress.global-static-ip-name: gcsweb-k8s-io
+    kubernetes.io/ingress.class: gce
+    networking.gke.io/managed-certificates: gcsweb
 spec:
-  tls:
-  - secretName: gcsweb-k8s-io-tls
   backend:
     serviceName: gcsweb
     servicePort: http


### PR DESCRIPTION
This is a proof of concept, following up from the tests I ran last
month.  Here are the steps I took to roll this out.

1) Add new cert resource
2) Deploy
3) Add annotations to ingress
4) Deploy
5) Wait for cert to be "active"
6) Verify in cloud console (2 certs)
7) Remove TLS config from ingress
8) Deploy
9) Verify in cloud console (1 cert)
10) Verify in an SSL checker
11) Delete old certificate in cluster
12) Verify in an SSL checker

Assuming this passes muster, we can look to repeat for all of our properties.
xref #1943