### PR TITLE
Switch node-perf-dash to GKE Managed certificate

### DIFF
--- a/node-perf-dash.k8s.io/certificate.yaml
+++ b/node-perf-dash.k8s.io/certificate.yaml
@@ -1,15 +1,8 @@
-apiVersion: cert-manager.io/v1alpha2
-kind: Certificate
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
 metadata:
   name: node-perf-dash-k8s-io
   namespace: node-perf-dash
-  annotations:
-    acme.cert-manager.io/http01-override-ingress-name: "node-perf-dash"
-    cert-manager.io/issue-temporary-certificate: "true"
 spec:
-  secretName: node-perf-dash-k8s-io-tls
-  issuerRef:
-    kind: ClusterIssuer
-    name: letsencrypt-prod
-  dnsNames:
+  domains:
   - node-perf-dash.k8s.io

--- a/node-perf-dash.k8s.io/ingress.yaml
+++ b/node-perf-dash.k8s.io/ingress.yaml
@@ -6,10 +6,10 @@ metadata:
   labels:
     app: node-perf-dash
   annotations:
+    kubernetes.io/ingress.class: gce
     kubernetes.io/ingress.global-static-ip-name: node-perf-dash-k8s-io-ingress-prod
+    networking.gke.io/managed-certificates: node-perf-dash-k8s-io
 spec:
-  tls:
-  - secretName: node-perf-dash-k8s-io-tls
   backend:
     serviceName: node-perf-dash-status
     servicePort: status


### PR DESCRIPTION
Ref. : https://github.com/kubernetes/k8s.io/issues/1943.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>