### PR TITLE
audit: redo organizations, storage-api and add container/clusters, logging, monitoring

### DIFF
--- a/audit/audit-gcp.sh
+++ b/audit/audit-gcp.sh
@@ -291,10 +291,22 @@ function audit_gcp_project_service() {
                 > "${service_dir}/zones.json"
             ;;
         logging)
-            echo "TODO: ${service} needs serviceusage.services.use"
-            ##### gcloud logging logs list --format=json > "projects/${project}/services/logging.logs.json"
-            ##### gcloud logging metrics list --format=json > "projects/${project}/services/logging.metrics.json"
-            ##### gcloud logging sinks list --format=json > "projects/${project}/services/logging.sinks.json"
+            # TODO: does this actually need serviceusage.services.use?
+            echo "logs"
+            gcloud logging logs list \
+              --project="${project}" \
+              --format=json | format_gcloud_json \
+              > "${service_dir}/logs.json"
+            echo "metrics"
+            gcloud logging metrics list \
+              --project="${project}" \
+              --format=json | format_gcloud_json \
+              > "${service_dir}/metrics.json"
+            echo "sinks"
+            gcloud logging sinks list \
+              --project="${project}" \
+              --format=json | format_gcloud_json \
+              > "${service_dir}/sinks.json"
             ;;
         monitoring)
             echo "TODO: ${service} needs serviceusage.services.use"

--- a/audit/audit-gcp.sh
+++ b/audit/audit-gcp.sh
@@ -309,7 +309,19 @@ function audit_gcp_project_service() {
               > "${service_dir}/sinks.json"
             ;;
         monitoring)
-            echo "TODO: ${service} needs serviceusage.services.use"
+            # TODO: does this actually need serviceusage.services.use?
+            local dashboards_dir="${service_dir}/dashboards"
+            ensure_clean_dir "${dashboards_dir}"
+            gcloud monitoring dashboards list \
+              --project="${project}" \
+              --format=json | format_gcloud_json \
+            | jq -r 'map("\(.displayName) \(.)")[]' \
+            | while read -r name json; do \
+                echo "dashboard: ${name}"
+                echo "${json}" \
+                > "${dashboards_dir}/${name}.json"
+            done
+            # TODO: ensure gcloud beta and gcloud alpha are available
             #### gcloud alpha monitoring policies list > "projects/${project}/services/monitoring.policies.json"
             #### gcloud alpha monitoring channels list > "projects/${project}/services/monitoring.channels.json"
             #### gcloud alpha monitoring channel-descriptors list > "projects/${project}/services/monitoring.channel-descriptors.json"

--- a/audit/create-or-update-audit-pr.sh
+++ b/audit/create-or-update-audit-pr.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run the audit script and create or update a PR containing any changes
+
+# NOTE: This is intended to run on k8s-infra-prow-build-trusted as
+#       k8s-infra-gcp-auditor@kubernetes-public.iam.gserviceaccount.com
+
+# TODO: Running locally is a work in progress, there are assumptions
+#       made about the environment in which this runs:
+#       - must have certain env vars present
+#       - must have kubernetes/test-infra in a certain location
+#       - must be able to build kubernetes/test-infra
+#       - must have gcloud already authenticated as someone who has the
+#         custom org role "audit.viewer"
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+GH_USER=cncf-ci
+GH_NAME="CNCF CI Bot"
+GH_EMAIL="cncf-ci@ii.coop"
+FORK_GH_REPO=k8s.io
+FORK_GH_BRANCH=autoaudit-${PROW_INSTANCE_NAME:-prow}
+
+echo "Ensure git configured" >&2
+git config user.name "${GH_NAME}"
+git config user.email "${GH_EMAIL}"
+
+echo "Ensure gcloud creds are working" >&2
+gcloud config list
+
+echo "Running Audit Script to dump GCP configuration to yaml" >&2
+pushd ./audit
+bash ./audit-gcp.sh
+popd
+
+echo "Determining whether there are changes to push" >&2
+git add --all audit
+git commit -m "audit: update as of $(date +%Y-%m-%d)"
+git remote add fork "https://github.com/${GH_USER}/${FORK_GH_BRANCH}"
+if git fetch fork "${FORK_GH_BRANCH}"; then
+    if git diff --quiet HEAD "fork/${FORK_GH_BRANCH}" -- audit; then
+    echo "No new changes to push, exiting early..." >&2
+    exit
+    fi
+fi
+
+echo "Generating pr-creator binary from k/test-infra/robots" >&2
+pushd ../../kubernetes/test-infra
+go build -o /workspace/pr-creator robots/pr-creator/main.go
+popd
+
+echo "Pushing commit to github.com/${GH_USER}/${FORK_GH_REPO}..." >&2
+GH_TOKEN=$(cat /etc/github-token/token)
+git push -f "https://${GH_USER}:${GH_TOKEN}@github.com/${GH_USER}/${FORK_GH_REPO}" "HEAD:${FORK_GH_BRANCH}" 2>/dev/null
+
+echo "Creating or updating PR to merge ${GH_USER}:${FORK_GH_BRANCH} into kubernetes:main..." >&2
+/workspace/pr-creator \
+    --github-token-path=/etc/github-token/token \
+    --org=kubernetes --repo=k8s.io --branch=main \
+    --source="${GH_USER}:${FORK_GH_BRANCH}" \
+    --head-branch="${FORK_GH_BRANCH}" \
+    --title="audit: update as of $(date +%Y-%m-%d)" \
+    --body="Audit Updates wg-k8s-infra" \
+    --confirm

--- a/infra/gcp/lib_util.sh
+++ b/infra/gcp/lib_util.sh
@@ -70,7 +70,7 @@ function verify_prereqs() {
         >&2 echo "jq not found. Please install: https://stedolan.github.io/jq/download/"
         exit 1
     fi
-    # generate-role-yaml relies on this
+    # generate-role-yaml, lib_iam, lib_gcs, lib_services rely on this
     # opting for https://kislyuk.github.io/yq/ over https://github.com/mikefarah/yq due to
     # parity with jq, but may be worth reconsidering
     if ! command -v yq &>/dev/null; then


### PR DESCRIPTION
This is part of a series of PRs:
- based on https://github.com/kubernetes/k8s.io/pull/2104 (unbreaks ci runs of audit)
- this PR
- followup pr is https://github.com/kubernetes/k8s.io/pull/2103 (actually runs the migration)

Makes the following layout changes / resource additions by service type
- `organizations`:
  - mv `org_kubenetes.io` to `organizations/kubernetes.io`
  - add `organizations/kubernetes.io/description.json`
- `containers`:
  - rm `projects/{project}/services/container/clusters.txt`
  - add`projects/{project}/sevices/container/clusters/{cluster}.json`
- `logging`:
  - add `projects/{project}/services/logging/logs.json` 
  - add `projects/{project}/services/logging/metrics.json`
  - add `projects/{project}/services/logging/sinks.json`
- `monitoring`: 
  - add `projects/{project}/services/monitoring/dashboards/{dashboard}.json`
- `storage-api`:
  - reduce `gsutil` calls by listing buckets, avoiding specific configurations unless present
  - add `projects/{project}/buckets/{bucket}/metadata.txt`
  - add `projects/{project}/buckets/{bucket}/logging.json` (if configured)
  - add `projects/{project}/buckets/{bucket}/lifecycle.json` (if configured)
  - add `projects/{project}/buckets/{bucket}/retention.json` (if configured)
  - rm `projects/{project}/buckets/{bucket}/bucketpolicyonly.txt` (now redundant given `metadata.txt`)
  - rm `projects/{project}/buckets/{bucket}/cors.txt` (now redundant given `metadata.txt`)
  - rm `projects/{project}/buckets/{bucket}/logging.txt` (now redundant given `logging.json`, `metadata.txt`)

The actual migration to the new format is in followup PR https://github.com/kubernetes/k8s.io/pull/2103