### PR TITLE
Update groups.yaml

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -100,6 +100,7 @@ groups:
       - ihor@cncf.io
       - linusa@google.com
       - thockin@google.com
+      - tjferrara@google.com
 
   - email-id: k8s-infra-staging-build-image@kubernetes.io
     name: k8s-infra-staging-build-image


### PR DESCRIPTION
Adding my google corp email under k8s-infra-staging-artifact-promoter.
This is required to allow me to invoke tests pertaining to the [container-image-promoter](https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/266).