### PR TITLE
OWNERS: updates for k8s.io, gcsweb, groups

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,7 +7,8 @@ approvers:
 - nikhita # sig-contribex tl
 - spiffxp # wg-k8s-infra chair
 - thockin
-emeritus:
+
+emeritus_approvers:
 - mikedanese
 - bartsmykla
 

--- a/gcsweb.k8s.io/OWNERS
+++ b/gcsweb.k8s.io/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- ixdy
+- spiffxp
 - thockin
+emeritus_approvers:
+- ixdy
+
+labels:
+- sig/testing

--- a/groups/OWNERS
+++ b/groups/OWNERS
@@ -1,7 +1,18 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+# approval is restricted to members of k8s-infra-group-admins@
+# because they have the ability to manually run, troubleshoot, and undo
+# changes
+#
+# approval will not be delegated to deeper directories until sufficient
+# checks are in place (via testing or policy enforcement) to ensure that
+# someone can't escalate privileges or create arbitrary groups
+#
+# ref: https://github.com/kubernetes/k8s.io/issues/460#issuecomment-849958721
+
 options:
   no_parent_owners: true
+
 approvers:
   - cblecker
   - dims

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -366,6 +366,7 @@ groups:
       - bentheelder@google.com
       - cblecker@gmail.com
       - davanum@gmail.com
+      - nikhitaraghunath@gmail.com
       - spiffxp@gmail.com
       - thockin@google.com
 

--- a/groups/sig-cluster-lifecycle/OWNERS
+++ b/groups/sig-cluster-lifecycle/OWNERS
@@ -2,7 +2,5 @@
 
 reviewers:
   - sig-cluster-lifecycle-leads
-approvers:
-  - sig-cluster-lifecycle-leads
 labels:
   - sig/cluster-lifecycle

--- a/groups/wg-k8s-infra/OWNERS
+++ b/groups/wg-k8s-infra/OWNERS
@@ -1,6 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-approvers:
-  - wg-k8s-infra-leads
 reviewers:
   - wg-k8s-infra-leads

--- a/k8s.io/OWNERS
+++ b/k8s.io/OWNERS
@@ -10,14 +10,11 @@ approvers:
 - bentheelder
 - cblecker
 - dims
+- nikhita
 - spiffxp
 - thockin
 emeritus_approvers:
 - ixdy
-
-# limiting factor from being an approver is inability to deploy changes once PRs merge
-reviewers:
-- nikhita
 
 labels:
 - sig/contributor-experience

--- a/k8s.io/OWNERS
+++ b/k8s.io/OWNERS
@@ -1,7 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+# deploying this is still a manual process, so restricting
+# to approvers who are comfortable doing so
 options:
   no_parent_owners: true
+
 approvers:
 - aojea
 - bentheelder
@@ -9,6 +12,8 @@ approvers:
 - dims
 - spiffxp
 - thockin
+emeritus_approvers:
+- ixdy
 
 # limiting factor from being an approver is inability to deploy changes once PRs merge
 reviewers:


### PR DESCRIPTION
Some miscellaneous housekeeping:
- I forget where I saw it now, but I'm pretty sure @ixdy wants out of approvers for gcsweb.k8s.io. Also gave @ixdy `emeritus_approver` for k8s.io, I should have done that last time.
- Thanks to @thockin adding k8s.io docs in https://github.com/kubernetes/k8s.io/pull/1796 I wondered if @nikhita is interested in being an approver for k8s.io
- I didn't catch that some groups/sig-foo/OWNERS with approvers had snuck in. I dropped them and added a comment explaining what it would take to allow delegated approval here: https://github.com/kubernetes/k8s.io/issues/460#issuecomment-849958721

/assign @nikhita @ixdy
let me know if you're OK with the changes related to you, or want me to revert

/cc @cblecker @dims
as other groups approvers

/hold
for confirmation from assignees