### PR TITLE
Drop Verolop's temporary RM access 

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -57,7 +57,6 @@ groups:
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
       - georgedanielmangum@gmail.com
-      - gveronicalg@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
       - saschagrunert@gmail.com


### PR DESCRIPTION

Verónica is a Release Manager Associate with SIG Release who was granted temporary access to cut the `v1.22.0-alpha.2` release.

The release is out now and therefore we are dropping the temporary access privileges. 

SIG Release issue:  https://github.com/kubernetes/sig-release/issues/1573

/assign @dims @cblecker
cc: @kubernetes/release-engineering

/priority important-soon
/sig release

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>