### PR TITLE
Updating the image sha for nginx 1.20.1 update

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -36,7 +36,8 @@
     "sha256:edd1d06bc6892b0dfb42de7d782ceb3c50eec843b09024abf3f95ba23f4feed5": ["v20210104-g2254a9186"]
     "sha256:224da667cf3047998ea691e9766fedd1eab94257a39df81374bfa14536da3688": ["v20210115-gba0502603"]
     "sha256:fcfa3e9d1f8ec3141efedbf77cf659640f452a9c22165c78006ea462b84d06f6": ["v20210324-g8baef769d"]
-
+    "sha256:a7356029dd0c26cc3466bf7a27daec0f4df73aa14ca6c8b871a767022a812c0b": ["v20210530-g6aab4c291"]
+    
 # image to run tests
 # https://github.com/kubernetes/ingress-nginx/tree/master/images/test-runner
 - name: e2e-test-runner


### PR DESCRIPTION
Adding the SHA from the latest build for custom Nginx base image for ingress, [here](https://console.cloud.google.com/gcr/images/k8s-staging-ingress-nginx/GLOBAL/nginx@sha256:a7356029dd0c26cc3466bf7a27daec0f4df73aa14ca6c8b871a767022a812c0b/details?tab=info&project=k8s-staging-ingress-nginx&folder&organizationId=758905017065). This updates the image to 1.20.1 for this issue [here](https://github.com/kubernetes/ingress-nginx/issues/7164)