### PR TITLE
triage-party: add sig-release repo and update sig-release-team filters

### DIFF
--- a/triage-party/release-team/configmap.yaml
+++ b/triage-party/release-team/configmap.yaml
@@ -12,6 +12,7 @@ data:
       repos:
         - https://github.com/kubernetes/kubernetes
         - https://github.com/kubernetes/release
+        - https://github.com/kubernetes/sig-release
 
       # Who should automatically be considered a project member?
       # See: https://developer.github.com/v4/enum/commentauthorassociation/
@@ -403,7 +404,6 @@ data:
         name: "sig-release-issues"
         type: issue
         filters:
-          - label: area/release-eng
           - label: area/release-team
           - milestone: "v1.22"
 
@@ -411,7 +411,6 @@ data:
         name: "sig-release-prs"
         type: pull_request
         filters:
-          - label: area/release-eng
           - label: area/release-team
           - milestone: "v1.22"
 

--- a/triage-party/release-team/deployment.yaml
+++ b/triage-party/release-team/deployment.yaml
@@ -21,7 +21,6 @@ spec:
           command:
             - "/app/main"
           args:
-            - --github-api-url=http://ghproxy.prow.svc.cluster.local/
             - --min-refresh=30s
             - --max-refresh=5m
             - --site=/app/site


### PR DESCRIPTION
- add sig-release github repo
- update filters for the sig release tab

Also update the deployment to remove the gh proxy, we are not using that right now

/assign @ameukam 