### PR TITLE
infra/gcp: fix variable in ensure_staging_storage

### DIFF
--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -417,7 +417,7 @@ function staging_special_case__k8s_staging_releng_test() {
 # to build the node image.
 function staging_special_case__k8s_staging_cluster_api_gcp() {
     readonly STAGING_PROJECT="k8s-staging-cluster-api-gcp"
-    readonly serviceaccount="$(svc_acct_email "${STAGING_PROJECT}" "gcb-builder-cluster-api-gcp")"
+    local serviceaccount="$(svc_acct_email "${STAGING_PROJECT}" "gcb-builder-cluster-api-gcp")"
 
     ensure_services "${STAGING_PROJECT}" compute.googleapis.com
     ensure_project_role_binding "${STAGING_PROJECT}" "serviceAccount:${serviceaccount}" "roles/compute.instanceAdmin.v1"


### PR DESCRIPTION
Followup of https://github.com/kubernetes/k8s.io/pull/2061.
`ensure_staging_gcb_builder_service_account` invokes
`ensure_serviceaccount_role_binding` lib_iam.sh function but can't be
used with readonly variables.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>