### PR TITLE
capg/image-builder: add extra role to be able to create gcp vms

### DIFF
--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -421,6 +421,7 @@ function staging_special_case__k8s_staging_cluster_api_gcp() {
 
     ensure_services "${STAGING_PROJECT}" compute.googleapis.com
     ensure_project_role_binding "${STAGING_PROJECT}" "serviceAccount:${serviceaccount}" "roles/compute.instanceAdmin.v1"
+    ensure_project_role_binding "${STAGING_PROJECT}" "serviceAccount:${serviceaccount}" "roles/iam.serviceAccountUser"
     ensure_staging_gcb_builder_service_account "cluster-api-gcp" "k8s-infra-prow-build-trusted"
 }
 


### PR DESCRIPTION
Add extra role `"roles/iam.serviceAccountUser"` for the service account

more context: https://github.com/kubernetes-sigs/image-builder/pull/625#issuecomment-853808094

/assign @ameukam @spiffxp @dims 