### PR TITLE
Switch sippy to GKE managed certificate

### DIFF
--- a/sippy/sippy/certificate.yaml
+++ b/sippy/sippy/certificate.yaml
@@ -1,15 +1,8 @@
-apiVersion: cert-manager.io/v1alpha2
-kind: Certificate
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
 metadata:
   name: sippy-k8s-io
   namespace: sippy
-  annotations:
-    acme.cert-manager.io/http01-override-ingress-name: "sippy"
-    cert-manager.io/issue-temporary-certificate: "true"
 spec:
-  secretName: sippy-k8s-io-tls
-  issuerRef:
-    kind: ClusterIssuer
-    name: letsencrypt-prod
-  dnsNames:
+  domains:
     - sippy.k8s.io

--- a/sippy/sippy/ingress.yaml
+++ b/sippy/sippy/ingress.yaml
@@ -4,12 +4,12 @@ metadata:
   name: sippy
   namespace: sippy
   annotations:
+    kubernetes.io/ingress.class: gce
     kubernetes.io/ingress.global-static-ip-name: "sippy-ingress-prod"
+    networking.gke.io/managed-certificates: sippy-k8s-io
   labels:
     app: sippy
 spec:
   backend:
     serviceName: sippy
     servicePort: 8080
-  tls:
-  - secretName : sippy-k8s-io-tls


### PR DESCRIPTION
Ref: https://github.com/kubernetes/k8s.io/issues/1943

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>