### PR TITLE
User add to k8s-infra-gcp-auditors

### DIFF
--- a/groups/wg-k8s-infra/groups.yaml
+++ b/groups/wg-k8s-infra/groups.yaml
@@ -111,6 +111,7 @@ groups:
       - spiffxp@gmail.com
       - spiffxp@google.com
       - thockin@google.com
+      - jdagostino2@gmail.com
 
   - email-id: k8s-infra-gcp-auditors@kubernetes.io
     name: k8s-infra-gcp-auditors

--- a/groups/wg-k8s-infra/groups.yaml
+++ b/groups/wg-k8s-infra/groups.yaml
@@ -130,6 +130,7 @@ groups:
       - spiffxp@google.com
       - spiffxp@gmail.com
       - thockin@google.com
+      - jdagostino2@gmail.com
 
   - email-id: k8s-infra-gcp-org-admins@kubernetes.io
     name: k8s-infra-gcp-org-admins

--- a/groups/wg-k8s-infra/groups.yaml
+++ b/groups/wg-k8s-infra/groups.yaml
@@ -106,12 +106,12 @@ groups:
       - ameukam@gmail.com
       - davanum@gmail.com
       - ihor@cncf.io
-      - k8s-infra-ii-coop@kubernetes.io
+      - jdagostino2@gmail.com
       - justinsb@google.com
+      - k8s-infra-ii-coop@kubernetes.io      
       - spiffxp@gmail.com
       - spiffxp@google.com
       - thockin@google.com
-      - jdagostino2@gmail.com
 
   - email-id: k8s-infra-gcp-auditors@kubernetes.io
     name: k8s-infra-gcp-auditors
@@ -127,11 +127,11 @@ groups:
       - cblecker@gmail.com
       - davanum@gmail.com
       - ihor@cncf.io
+      - jdagostino2@gmail.com
       - k8s-infra-ii-coop@kubernetes.io
       - spiffxp@google.com
       - spiffxp@gmail.com
       - thockin@google.com
-      - jdagostino2@gmail.com
 
   - email-id: k8s-infra-gcp-org-admins@kubernetes.io
     name: k8s-infra-gcp-org-admins


### PR DESCRIPTION
## Changes
- Add `jdagostino2@gmail.com` to **k8s-infra-gcp-auditors**
- Add `jdagostino2@gmail.com` to **k8s-infra-gcp-accounting**

## Notes
Paired with @hh today to review how I can help out in the **wg-k8s-infra** group. 
Getting added to **k8s-infra-gcp-auditors** and **k8s-infra-gcp-accounting** group was suggested as a good starting point.
As a start I could help review costs, and possibly suggest areas for improvement. 

Update: Per @hh's comment, adding **k8s-infra-gcp-accounting**