### PR TITLE
Bump Triage-Party to 1.4.0

### DIFF
--- a/triage-party/release-team/deployment.yaml
+++ b/triage-party/release-team/deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: triage-party
-          image: triageparty/triage-party:1.4.0-beta.1
+          image: triageparty/triage-party:1.4.0
           command:
             - "/app/main"
           args:


### PR DESCRIPTION
Release notes: https://github.com/google/triage-party/blob/master/CHANGELOG.md#version-140---2021-05-25

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>