### PR TITLE
images: add k8s-infra image

### DIFF
--- a/images/k8s-infra/Dockerfile
+++ b/images/k8s-infra/Dockerfile
@@ -1,0 +1,157 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Intended to hold all dependencies needed to build, test and run all tools
+# used by wg-k8s-infra. With sufficient credentials mounted in, should be
+# capable of running those tools to test and deploy all kubernetes project
+# infrastructure managed by wg-k8s-infra.
+
+# base image
+FROM debian:buster
+
+# build args
+
+# unless otherwise stated, versions were arbitrarily chosen to whatever was
+# latest at the time, and package-based installs from debian-maintained repos
+# are not pinned to a specific version
+
+ARG CONFTEST_VERSION=0.25.0
+ARG GCLOUD_VERSION=343.0.0
+ARG GH_VERSION=1.11.0
+ARG GO_VERSION=1.16.5
+ARG JQ_VERSION=1.6
+# K8S_VERSION should be within +/- 1 minor version of our clusters
+# ref: https://kubernetes.io/releases/version-skew-policy/#kubectl
+ARG K8S_VERSION=1.19.11
+ARG OPA_VERSION=0.28.0
+ARG SHELLCHECK_VERSION=0.7.2
+ARG TFSWITCH_VERSION=0.12.1092
+
+# build everything in /build
+WORKDIR /build
+
+# multiple ENV assignments in one layer
+# - put $(go env GOROOT)/bin on PATH
+# - disable interactive prompts for gcloud commands (use defaults, or error if unable)
+ENV PATH=/usr/local/go/bin:${PATH} \
+    CLOUDSDK_CORE_DISABLE_PROMPTS=1
+
+# used to pip install: yamllint, yq
+COPY requirements.txt .
+
+# use bash for pipefail and pushd/popd
+SHELL ["/bin/bash", "-c"]
+RUN set -o errexit nounset pipefail \
+    && echo "Installing Packages ..." \
+        && apt-get update \
+        && apt-get install -y --no-install-recommends \
+            curl \
+            git \
+            gnupg2 \
+            python3 \
+            python3-pip \
+            xz-utils \
+    && echo "Installing python tools ..." \
+        && pip3 install --requirement requirements.txt \
+    && echo "Installing go ..." \
+        && export GO_TARBALL="go${GO_VERSION}.linux-amd64.tar.gz" \
+        && curl -fsSL "https://storage.googleapis.com/golang/${GO_TARBALL}" --output tarball.tar.gz \
+        && tar xf tarball.tar.gz -C /usr/local \
+        && rm tarball.tar.gz \
+    && echo "Installing Google Cloud SDK ..." \
+        && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main" \
+            | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+        && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+            | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add - \
+        && apt-get update -o Dir::Etc::sourcelist="sources.list.d/google-cloud-sdk.list" \
+            -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" \
+        && apt-get install -y --no-install-recommends \
+            "google-cloud-sdk=${GCLOUD_VERSION}-0" \
+            python3-crcmod \
+    && echo "Installing gh ..." \
+        && echo "deb [signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+            | tee -a /etc/apt/sources.list.d/github-cli.list \
+        && curl https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+            | apt-key --keyring /usr/share/keyrings/githubcli-archive-keyring.gpg add - \
+        && apt-get update -o Dir::Etc::sourcelist="sources.list.d/github-cli.list" \
+            -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" \
+        && apt-get install -y --no-install-recommends \
+            "gh=${GH_VERSION}" \
+    && echo "Installing conftest ..." \
+        && export BASE_URL="https://github.com/open-policy-agent/conftest/releases/download" \
+        && export URL="${BASE_URL}/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz" \
+        && curl -fsSL "${URL}" --output tarball.tar.gz \
+        && tar xf tarball.tar.gz -C /usr/local/bin \
+        && rm tarball.tar.gz \
+    && echo "Installing jq ..." \
+        && curl -fsSL "https://github.com/stedolan/jq/releases/download/jq-${JQ_VERSION}/jq-linux64" --output /usr/local/bin/jq \
+        && chmod +x /usr/local/bin/jq \
+    && echo "Installing kubectl ..." \
+        && curl -fsSL "https://dl.k8s.io/release/v${K8S_VERSION}/bin/linux/amd64/kubectl" --output /usr/local/bin/kubectl \
+        && chmod +x /usr/local/bin/kubectl \
+    && echo "Installing opa ..." \
+        && curl -fsSL "https://openpolicyagent.org/downloads/v${OPA_VERSION}/opa_linux_amd64" --output /usr/local/bin/opa \
+        && chmod +x /usr/local/bin/opa \
+    && echo "Installing shellcheck ..." \
+        && export BASE_URL="https://github.com/koalaman/shellcheck/releases/download" \
+        && export URL="${BASE_URL}/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+        && curl -fsSL "${URL}" --output tarball.tar.xz \
+        && tar xf tarball.tar.xz -C /usr/local/bin --strip-components 1 "shellcheck-v${SHELLCHECK_VERSION}/shellcheck" \
+        && rm tarball.tar.xz \
+    && echo "Installing tfswitch ..." \
+        && export BASE_URL=https://github.com/warrensbox/terraform-switcher/releases/download \
+        && export URL="${BASE_URL}/${TFSWITCH_VERSION}/terraform-switcher_${TFSWITCH_VERSION}_linux_amd64.tar.gz" \
+        && curl -fsSL "${URL}" --output tarball.tar.gz \
+        && tar xf tarball.tar.gz -C /usr/local/bin tfswitch \
+        && rm tarball.tar.gz \
+    && echo "Installing terraform ..." \
+        && tfswitch --latest-stable=0.14 \
+        && tfswitch --latest-stable=0.15 \
+    && echo "Installing pr-creator" \
+        && git clone --depth 1 https://github.com/kubernetes/test-infra \
+        && pushd ./test-infra \
+        && go build -o /usr/local/bin/pr-creator ./robots/pr-creator \
+        && popd \
+    && echo "Outputting version info to confirm installation of expected tools ..." \
+        && apt list --installed         | tee apt-list.txt \
+        && bq version                   | tee bq-version.txt \
+        && conftest --version           | tee conftest-version.txt \
+        && curl --version               | tee curl-version.txt \
+        && gcloud info                  | tee gcloud-info.txt \
+        $$ git --version                | tee git-version.txt \
+        && gh --version                 | tee gh-version.txt \
+        && go version                   | tee go-version.txt \
+        && gsutil --version             | tee gsutil-version.txt \
+        && jq --version                 | tee jq-version.txt \
+        && kubectl version --client     | tee kubectl-version.txtl \
+        && opa version                  | tee opa-version.txt \
+        && pr-creator --help            | tee pr-creator-help.txt \
+        && git -C test-infra log -n1    | tee pr-creator-version.txt \
+        && python3 --version            | tee python-version.txt \
+        && shellcheck --version         | tee shellcheck-version.txt \
+        && terraform --version          | tee terraform-version.txt \
+        && tfswitch --version           | tee tfswitch-version.txt \
+        && yamllint --version           | tee yamllint-verison.txt \
+        && yq --version                 | tee yq-version.txt \
+    && echo "Cleaning up ..." \
+        && rm -rf /var/lib/apt/lists/* \
+        && rm -rf /root/.cache \
+        && rm -rf /root/go/pkg \
+        && rm -rf ./test-infra
+
+
+# run everything in /workspace
+WORKDIR /workspace
+
+CMD /bin/bash

--- a/images/k8s-infra/Makefile
+++ b/images/k8s-infra/Makefile
@@ -1,0 +1,78 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## user-facing variables
+# build run
+IMAGE ?= k8s-infra
+REPO ?= gcr.io/k8s-staging-infra-tools
+TAG_DATE_SHA ?= v$(shell date -u '+%Y%m%d')-$(shell git describe --tags --always --dirty)
+TAG ?= $(TAG_DATE_SHA)
+
+# run
+WHAT ?= /bin/bash
+# cloudbuild
+PROJECT_ID ?= k8s-staging-infra-tools
+GCB_BUCKET ?= gs://$(PROJECT_ID)
+
+## user-facing targets
+.PHONY: build run cloudbuild
+
+## variables
+
+# allow bash-isms to be used in $(shell foo)
+SHELL := /usr/bin/env bash
+makefile_root := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+repo_root := $(abspath $(makefile_root)/../..)
+image_spec := $(REPO)/$(IMAGE):$(TAG)
+
+## targets
+
+build:
+	docker build \
+		--file Dockerfile \
+		--tag $(image_spec) \
+		--tag $(REPO)/$(IMAGE):$(TAG_DATE_SHA) \
+		.
+
+# includes env vars known to be consumed by k8s-infra scripts:
+# - audit/audit-gcp.sh
+# - infra/gcp/lib.sh
+# - infra/gcp/lib_services.sh (via infra/gcp/ensure-*.sh)
+# - infra/gcp/prow/ensure-e2e-projects.sh
+run:
+	docker run \
+		--rm --interactive \
+		--tty \
+		--volume $(HOME)/.config/gcloud:/root/.config/gcloud \
+		--volume $(HOME)/.gitconfig:/root/.gitconfig \
+		--volume $(HOME)/.secrets/github.token:/etc/github-token/token \
+		--volume $(repo_root):/workspace/kubernetes/k8s.io \
+		--workdir /workspace/kubernetes/k8s.io \
+		--env K8S_INFRA_AUDIT_SERVICES \
+		--env K8S_INFRA_DEBUG \
+		--env K8S_INFRA_ENSURE_E2E_PROJECTS_RESETS_SSH_KEYS \
+		--env K8S_INFRA_ENSURE_ONLY_SERVICES_WILL_FORCE_DISABLE \
+		$(image_spec) \
+		$(WHAT)
+
+# an approximation of what kubernetes/test-infra/images/builder calls,
+# with TAG overriden to prevent accidental manual pushes to :latest
+cloudbuild:
+	gcloud builds submit \
+		--verbosity info \
+		--config cloudbuild.yaml \
+		--substitutions _TAG=$(TAG_DATE_SHA),_GIT_TAG=$(TAG_DATE_SHA) \
+		--project $(PROJECT_ID) \
+		--gcs-source-staging-dir $(GCB_BUCKET)/source \
+		.

--- a/images/k8s-infra/README.md
+++ b/images/k8s-infra/README.md
@@ -1,0 +1,50 @@
+# k8s-infra
+
+Intended to hold all dependencies needed to build, test and run all tools used by wg-k8s-infra. With sufficient credentials mounted in, should be capable of running those tools to test and deploy all kubernetes project infrastructure managed by wg-k8s-infra.
+
+One goal is to use this image for all of of our CI jobs, and make it easy to run locally to verify CI job changes prior to deployment.
+
+## contents
+
+- base:
+  - debian as provided by `debian:buster`
+- directories:
+  - `/build` contains "info" or "version" output for each of the included tools/languages
+  - `/workspace` default working directory for `run` commands
+- languages:
+  - `go`
+  - `python3` and `pip3`
+- tools:
+  - `conftest`
+  - `curl`
+  - `gcloud` (via `apt-get` for smaller size); components include:
+    - `bq`
+    - `gcloud alpha`
+    - `gcloud beta`
+    - `gsutil`
+  - `git`
+  - `gh`
+  - `jq`
+  - `kubectl`
+  - `opa`
+  - `pr-creator` (from kubernetes/test-infra)
+  - `shellcheck`
+  - `terraform` (via `tfswitch`)
+  - `tfswitch`
+  - `yamlint`
+  - `yq`
+
+## usage
+
+Example: build a local copy tagged as `gcr.io/this/is:fine` and use it to run `hack/verify-boilerplate.sh`:
+
+```sh
+export REPO=gcr.io/this IMAGE=is TAG=fine
+make build
+make run WHAT="hack/verify-boilerplate.sh"
+```
+Example: use Google Cloud Build in `my-project` with staging bucket `gs://my-bucket` to build/push `gcr.io/my-repo/k8s-infra:v{date}-{sha}`:
+```sh
+export PROJECT_ID=`my-project` GCB_BUCKET=`my-bucket` REPO=`gcr.io/my-repo`
+make cloudbuild
+```

--- a/images/k8s-infra/cloudbuild.yaml
+++ b/images/k8s-infra/cloudbuild.yaml
@@ -1,0 +1,20 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 1200s
+options:
+  machineType: 'E2_HIGHCPU_8'
+steps:
+- name: gcr.io/cloud-builders/docker
+  dir: .
+  entrypoint: /usr/bin/make
+  args:
+    - build
+    - TAG=$_TAG
+    - TAG_DATE_SHA=$_GIT_TAG
+substitutions:
+  # variables set by kubernetes/test-infra/images/builder
+  # set by image-builder to vYYYYMMDD-hash
+  _GIT_TAG: "12345"
+  _TAG: "latest"
+images:
+- "gcr.io/$PROJECT_ID/k8s-infra:$_GIT_TAG"
+- "gcr.io/$PROJECT_ID/k8s-infra:$_TAG"

--- a/images/k8s-infra/requirements.txt
+++ b/images/k8s-infra/requirements.txt
@@ -1,0 +1,20 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# libs
+ruamel.yaml==0.17.7
+
+# tools
+yamllint==1.13.0
+yq==2.12.0


### PR DESCRIPTION
This is intended to be used for running scripts and tests in CI, but may also serve as a development environment if someone were to mount things in appropriately.

I'm trying an approach of not copy-pasting the same set of default values around, so until we need variants, the Dockerfile is the place to change them.

Setup a `make cloudbuild` target that doesn't push `:latest` for dev/test purposes

Verified by running `make -C images/k8s-infra build run TAG=spiffxp WHAT=...`

- ./audit/audit-gcp.sh
- ./audit/check-audit-pr.sh
- ./audit/create-or-update-audit-pr.sh
- ./hack/verify.sh
- ./hack/verify-terraform.sh
- ./infra/gcp/ensure-organization.sh
- ./infra/gcp/prow/ensure-e2e-projects.sh

Verified cloudbuild.yaml via `make -C images/k8s-infra cloudbuild`