### PR TITLE
infra/gcp/main: enable cloudasset service

### DIFF
--- a/infra/gcp/ensure-main-project.sh
+++ b/infra/gcp/ensure-main-project.sh
@@ -87,6 +87,8 @@ readonly TERRAFORM_STATE_BUCKET_ENTRIES=(
 readonly MAIN_PROJECT_SERVICES=(
     # billing data gets exported to bigquery
     bigquery.googleapis.com
+    # we use cloud asset inventory from this project to audit all projects
+    cloudasset.googleapis.com
     # GKE clusters are hosted in this project
     container.googleapis.com
     # DNS zones are managed in this project


### PR DESCRIPTION
The audit service account is in this project, and the long term intent
is to use cloud asset inventory (or a  tool that consumes it) to more
efficiently export / audit our GCP resources

This should unblock the audit job