### PR TITLE
audit: fix create-or-update-audit-pr.sh

### DIFF
--- a/audit/create-or-update-audit-pr.sh
+++ b/audit/create-or-update-audit-pr.sh
@@ -36,6 +36,7 @@ GH_NAME="CNCF CI Bot"
 GH_EMAIL="cncf-ci@ii.coop"
 FORK_GH_REPO=k8s.io
 FORK_GH_BRANCH=autoaudit-${PROW_INSTANCE_NAME:-prow}
+FORK_URI="https://github.com/${GH_USER}/${FORK_GH_REPO}"
 
 echo "Ensure git configured" >&2
 git config user.name "${GH_NAME}"
@@ -43,6 +44,9 @@ git config user.email "${GH_EMAIL}"
 
 echo "Ensure gcloud creds are working" >&2
 gcloud config list
+
+echo "Ensure git creds are working" >&2
+git config --list
 
 echo "Running Audit Script to dump GCP configuration to yaml" >&2
 pushd ./audit
@@ -52,7 +56,11 @@ popd
 echo "Determining whether there are changes to push" >&2
 git add --all audit
 git commit -m "audit: update as of $(date +%Y-%m-%d)"
-git remote add fork "https://github.com/${GH_USER}/${FORK_GH_BRANCH}"
+if git remote get-url fork >/dev/null; then
+  git remote set-url fork "${FORK_URI}"
+else
+  git remote add fork "${FORK_URI}"
+fi
 if git fetch fork "${FORK_GH_BRANCH}"; then
     if git diff --quiet HEAD "fork/${FORK_GH_BRANCH}" -- audit; then
     echo "No new changes to push, exiting early..." >&2
@@ -60,17 +68,21 @@ if git fetch fork "${FORK_GH_BRANCH}"; then
     fi
 fi
 
-echo "Generating pr-creator binary from k/test-infra/robots" >&2
-pushd ../../kubernetes/test-infra
-go build -o /workspace/pr-creator robots/pr-creator/main.go
-popd
+prcreator=pr-creator
+if ! command -v "${prcreator}" &>/dev/null; then
+    echo "Generating pr-creator binary from k/test-infra/robots" >&2
+    pushd ../../kubernetes/test-infra
+    go build -o /workspace/pr-creator robots/pr-creator/main.go
+    prcreator=/workspace/pr-creator
+    popd
+fi
 
 echo "Pushing commit to github.com/${GH_USER}/${FORK_GH_REPO}..." >&2
 GH_TOKEN=$(cat /etc/github-token/token)
 git push -f "https://${GH_USER}:${GH_TOKEN}@github.com/${GH_USER}/${FORK_GH_REPO}" "HEAD:${FORK_GH_BRANCH}" 2>/dev/null
 
 echo "Creating or updating PR to merge ${GH_USER}:${FORK_GH_BRANCH} into kubernetes:main..." >&2
-/workspace/pr-creator \
+"${prcreator}" \
     --github-token-path=/etc/github-token/token \
     --org=kubernetes --repo=k8s.io --branch=main \
     --source="${GH_USER}:${FORK_GH_BRANCH}" \


### PR DESCRIPTION
A fix and some changes to support k8s-infra image:

- fix typo in 'fork' remote uri
- create or update 'fork' remote
- don't rebuild pr-creator if it's already in PATH