### PR TITLE
Add domain to invite block list due to problem report from Slack-Admins.

### DIFF
--- a/slack-infra/resources/slackin/bad-domains-configmap.yaml
+++ b/slack-infra/resources/slackin/bad-domains-configmap.yaml
@@ -9493,6 +9493,7 @@ data:
     napalm51.gq
     napalm51.ml
     napalm51.tk
+    narod.ru
     nash.ml
     nasinyang.cf
     nasinyang.ga


### PR DESCRIPTION
Per issue report on Slack Admins, block vanity domain.