### PR TITLE
Revert "add extra role to be able to create gcp vms"

### DIFF
--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -422,7 +422,8 @@ function staging_special_case__k8s_staging_cluster_api_gcp() {
 
     ensure_services "${STAGING_PROJECT}" compute.googleapis.com
     ensure_project_role_binding "${STAGING_PROJECT}" "serviceAccount:${serviceaccount}" "roles/compute.instanceAdmin.v1"
-    ensure_project_role_binding "${STAGING_PROJECT}" "serviceAccount:${serviceaccount}" "roles/iam.serviceAccountUser"
+    ensure_removed_project_role_binding "${STAGING_PROJECT}" "serviceAccount:${serviceaccount}" "roles/iam.serviceAccountUser"
+    ensure_serviceaccount_role_binding "${serviceaccount}" "serviceAccount:${serviceaccount}" "roles/iam.serviceAccountUser"
     ensure_staging_gcb_builder_service_account "cluster-api-gcp" "k8s-infra-prow-build-trusted"
 }
 


### PR DESCRIPTION
Revert of https://github.com/kubernetes/k8s.io/pull/2124 which
introduces an exposure to privilege escalation.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>