### PR TITLE
triage-party: update cache configuration

### DIFF
--- a/triage-party/release-team/deployment.yaml
+++ b/triage-party/release-team/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             - name: PERSIST_BACKEND
               value: "disk"
             - name: PERSIST_PATH
-              value: "/app/triage-party/cache"
+              value: "/app/triage-party/"
           ports:
             - containerPort: 8080
           readinessProbe:


### PR DESCRIPTION
cache management is revamped since 1.4.0
See: https://github.com/google/triage-party/pull/255/commits/37880fd53b5b386abb3a0020985e45bb71c1c7ef

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>