### PR TITLE
images/k8s-infra: include _PULL_BASE_REF

### DIFF
--- a/images/k8s-infra/cloudbuild.yaml
+++ b/images/k8s-infra/cloudbuild.yaml
@@ -10,10 +10,14 @@ steps:
     - build
     - TAG=$_TAG
     - TAG_DATE_SHA=$_GIT_TAG
+    - _=$_PULL_BASE_REF # unused
 substitutions:
   # variables set by kubernetes/test-infra/images/builder
   # set by image-builder to vYYYYMMDD-hash
   _GIT_TAG: "12345"
+  # set by image-builder to branch name; we don't use this, but we
+  # want strict validation of substitution vars to catch typos early
+  _PULL_BASE_REF: ""
   _TAG: "latest"
 images:
 - "gcr.io/$PROJECT_ID/k8s-infra:$_GIT_TAG"


### PR DESCRIPTION
one more try at unblocking https://github.com/kubernetes/test-infra/pull/22463

image-builder is always going to pass this substitution along, but we
are using the default substitutionOptions setting of MUST_MATCH to
catch typos or unused variables as early as possible, which causes
cloudbuild to error unless we use _PULL_BASE_REF somewhere in the build
template