### PR TITLE
Promote cluster-api-provider-gcp:v0.3.1

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cluster-api-gcp/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api-gcp/images.yaml
@@ -1,4 +1,5 @@
 - name: cluster-api-gcp-controller
   dmap:
+    "sha256:11c35d42f84d263184f89471f51f4a8b17bfde78c84b924d65b94d80121aa467": ["v0.3.1"]
+    "sha256:24c8d7e98b7aa6a032d10e3ffe7375d06cdeaa6600b952bbae47a29193e1a6dc": ["v0.3.0"]
     "sha256:6dd212144fcfabc95b238e7614e54ad46087979fed8fdeea945e3ef188ec4944": ["v0.2.0-alpha.2"]
-    "sha256:24c8d7e98b7aa6a032d10e3ffe7375d06cdeaa6600b952bbae47a29193e1a6dc": [v0.3.0]


### PR DESCRIPTION
- Image available: https://console.cloud.google.com/gcr/images/k8s-staging-cluster-api-gcp/GLOBAL/cluster-api-gcp-controller@sha256:11c35d42f84d263184f89471f51f4a8b17bfde78c84b924d65b94d80121aa467/details?tab=info&project=k8s-staging-cluster-api-gcp&folder&organizationId=758905017065

- Prow post job: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-cluster-api-provider-gcp-push-images/1402548524784029696


/assign @detiber @vincepri 