### PR TITLE
infra/gcp: extract projects to infra.yaml

### DIFF
--- a/infra/gcp/ensure-conformance-storage.sh
+++ b/infra/gcp/ensure-conformance-storage.sh
@@ -41,9 +41,10 @@ function usage() {
     echo > /dev/stderr
 }
 
-PROJECT="k8s-conform"
+PROJECT=$(k8s_infra_project "public" "k8s-conform")
+readonly PROJECT
 
-CONFORMANCE_SERVICES=(
+readonly CONFORMANCE_SERVICES=(
     # secretmanager to host service-account keys
     secretmanager.googleapis.com
     # storage-api to store results in GCS via JSON API
@@ -56,7 +57,7 @@ readonly CONFORMANCE_RETENTION="10y"
 
 # "Offering" comes from https://github.com/cncf/k8s-conformance/blob/master/terms-conditions/Certified_Kubernetes_Terms.md
 # NB: Please keep this sorted.
-CONFORMANCE_OFFERINGS=(
+readonly CONFORMANCE_OFFERINGS=(
     cri-o
     huaweicloud
     inspur

--- a/infra/gcp/ensure-env-cip-auditor.sh
+++ b/infra/gcp/ensure-env-cip-auditor.sh
@@ -168,4 +168,4 @@ function ensure_cip_auditor_env() {
 }
 
 # We want to run in the artifacts project to get pubsub most easily.
-ensure_cip_auditor_env "k8s-artifacts-prod"
+ensure_cip_auditor_env "$(k8s_infra_project "prod" "k8s-artifacts-prod")"

--- a/infra/gcp/ensure-gsuite.sh
+++ b/infra/gcp/ensure-gsuite.sh
@@ -35,7 +35,7 @@ if [ $# != 0 ]; then
 fi
 
 # The GCP project name.
-PROJECT="k8s-gsuite"
+PROJECT=$(k8s_infra_project "public" "k8s-gsuite")
 
 # The service account name in $PROJECT.
 GSUITE_SVCACCT="gsuite-groups-manager"

--- a/infra/gcp/ensure-main-project.sh
+++ b/infra/gcp/ensure-main-project.sh
@@ -34,7 +34,8 @@ if [ $# != 0 ]; then
 fi
 
 # The GCP project name.
-readonly PROJECT="kubernetes-public"
+PROJECT=$(k8s_infra_project "public" "kubernetes-public")
+readonly PROJECT
 
 # The BigQuery dataset for billing data.
 readonly BQ_BILLING_DATASET="kubernetes_public_billing"

--- a/infra/gcp/ensure-organization.sh
+++ b/infra/gcp/ensure-organization.sh
@@ -69,7 +69,7 @@ org_role_bindings=(
 
   # empower k8s-infra-gcp-auditors@ and equivalent service-account
   "group:k8s-infra-gcp-auditors@kubernetes.io:$(custom_org_role_name "audit.viewer")"
-  "serviceAccount:$(svc_acct_email "kubernetes-public" "k8s-infra-gcp-auditor"):$(custom_org_role_name "audit.viewer")"
+  "serviceAccount:$(svc_acct_email "$(k8s_infra_project "public" "kubernetes-public")" "k8s-infra-gcp-auditor"):$(custom_org_role_name "audit.viewer")"
 )
 
 removed_org_role_bindings=()

--- a/infra/gcp/ensure-prod-storage-gclb.sh
+++ b/infra/gcp/ensure-prod-storage-gclb.sh
@@ -34,14 +34,15 @@ if [ $# != 0 ]; then
 fi
 
 # The GCP project name.
-PROD_PROJECT="k8s-artifacts-prod"
+PROD_PROJECT=$(k8s_infra_project "prod" "k8s-artifacts-prod")
+readonly PROD_PROJECT
 
 # Name for cloud objects (url-map, gclb, etc)
-NAME=k8s-artifacts-prod
+readonly NAME=${PROD_PROJECT}
 
 # Name for the prod bucket
 # This must match the prod GCS bucket name
-BUCKET_NAME=k8s-artifacts-prod
+readonly BUCKET_NAME=${NAME}
 
 # Domain name on which we serve artifacts
 DOMAIN=artifacts.k8s.io

--- a/infra/gcp/ensure-prod-storage.sh
+++ b/infra/gcp/ensure-prod-storage.sh
@@ -39,36 +39,28 @@ fi
 #
 
 # This is the "real" prod project for artifacts serving and backups.
-PROD_PROJECT="k8s-artifacts-prod"
-PRODBAK_PROJECT="${PROD_PROJECT}-bak"
+PROD_PROJECT=$(k8s_infra_project "prod" "k8s-artifacts-prod")
+PRODBAK_PROJECT=$(k8s_infra_project "prod" "${PROD_PROJECT}-bak")
 
 # These are for testing the image promoter's promotion process.
-PROMOTER_TEST_PROD_PROJECT="k8s-cip-test-prod"
-PROMOTER_TEST_STAGING_PROJECT="k8s-staging-cip-test"
+PROMOTER_TEST_PROD_PROJECT=$(k8s_infra_project "prod" "k8s-cip-test-prod")
+PROMOTER_TEST_STAGING_PROJECT=$(k8s_infra_project "staging" "k8s-staging-cip-test")
 
 # These are for testing the GCR backup/restore process.
-GCR_BACKUP_TEST_PROD_PROJECT="k8s-gcr-backup-test-prod"
-GCR_BACKUP_TEST_PRODBAK_PROJECT="${GCR_BACKUP_TEST_PROD_PROJECT}-bak"
+GCR_BACKUP_TEST_PROD_PROJECT=$(k8s_infra_project "prod" "k8s-gcr-backup-test-prod")
+GCR_BACKUP_TEST_PRODBAK_PROJECT=$(k8s_infra_project "prod" "${GCR_BACKUP_TEST_PROD_PROJECT}-bak")
 
 # This is for testing the GCR auditing mechanism.
-GCR_AUDIT_TEST_PROD_PROJECT="k8s-gcr-audit-test-prod"
+GCR_AUDIT_TEST_PROD_PROJECT=$(k8s_infra_project "prod" "k8s-gcr-audit-test-prod")
 
 # This is for testing the release tools.
-RELEASE_TESTPROD_PROJECT="k8s-release-test-prod"
+RELEASE_TESTPROD_PROJECT=$(k8s_infra_project "prod" "k8s-release-test-prod")
 RELEASE_STAGING_CLOUDBUILD_ACCOUNT="615281671549@cloudbuild.gserviceaccount.com"
 
 # This is a list of all prod projects.  Each project will be configured
 # similarly, with a GCR repository and a GCS bucket of the same name.
-#
-ALL_PROD_PROJECTS=(
-    "${PROD_PROJECT}"
-    "${PRODBAK_PROJECT}"
-    "${PROMOTER_TEST_PROD_PROJECT}"
-    "${GCR_BACKUP_TEST_PROD_PROJECT}"
-    "${GCR_BACKUP_TEST_PRODBAK_PROJECT}"
-    "${GCR_AUDIT_TEST_PROD_PROJECT}"
-    "${RELEASE_TESTPROD_PROJECT}"
-)
+mapfile -t ALL_PROD_PROJECTS < <(k8s_infra_projects "prod")
+readonly ALL_PROD_PROJECTS
 
 # This is a list of all prod GCS buckets, but only their trailing "name".  Each
 # name will get a GCS bucket called "k8s-artifacts-${name}", and write access
@@ -106,7 +98,7 @@ PROD_RETENTION="10y"
 #
 # $1: The GCP project name (GCR names == project names)
 function ensure_prod_gcr() {
-    if [ $# -ne 1 -o -z "$1" ]; then
+    if [ $# != 1 ] || [ -z "$1" ]; then
         echo "ensure_prod_gcr(project) requires 1 argument" >&2
         return 1
     fi

--- a/infra/gcp/ensure-release-projects.sh
+++ b/infra/gcp/ensure-release-projects.sh
@@ -32,11 +32,8 @@ function usage() {
     echo > /dev/stderr
 }
 
-# NB: Please keep this sorted.
-PROJECTS=(
-    k8s-release
-    k8s-release-test-prod
-)
+mapfile -t PROJECTS < <(k8s_infra_projects "release")
+readonly PROJECTS
 
 if [ $# = 0 ]; then
     # default to all release projects
@@ -53,8 +50,8 @@ readonly RELEASE_PROJECT_SERVICES=(
 
 for PROJECT; do
 
-    if ! (printf '%s\n' "${PROJECTS[@]}" | grep -q "^${PROJECT}$"); then
-        color 2 "Skipping unrecognized release project name: ${PROJECT}"
+    if ! k8s_infra_project "release" "${PROJECT}" >/dev/null; then
+        color 1 "Skipping unrecognized release project name: ${PROJECT}"
         continue
     fi
 

--- a/infra/gcp/ensure-static-ips.sh
+++ b/infra/gcp/ensure-static-ips.sh
@@ -24,7 +24,7 @@ set -o pipefail
 SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
 . "${SCRIPT_DIR}/lib.sh"
 
-PROJECT_NAME="kubernetes-public"
+PROJECT_NAME=$(k8s_infra_project "public" "kubernetes-public")
 
 function usage() {
     echo "usage: $0" > /dev/stderr

--- a/infra/gcp/infra.yaml
+++ b/infra/gcp/infra.yaml
@@ -1,0 +1,321 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# List of all projects currently managed by wg-k8s-infra broken up into
+# the following schema:
+#
+# infra:
+#   {project_type}: # ideally this ~= folder
+#     [managed_by:] # default script/file used to manage projects
+#     projects:
+#       {project_id}:
+#         [managed_by:] overrides default; script used to manage _this_ project
+#
+# TODO:
+# - these project don't actually live in folders yet; consider this a proposal
+# - validate the schema
+# - validate audit results against this
+# - consider breaking up into multiple files vs. one large file
+infra:
+  e2e:
+    managed_by: infra/gcp/prow/ensure-e2e-projects.sh
+    projects:
+      # general purpose e2e projects, no quota changes
+      k8s-infra-e2e-boskos-001:
+      k8s-infra-e2e-boskos-002:
+      k8s-infra-e2e-boskos-003:
+      k8s-infra-e2e-boskos-004:
+      k8s-infra-e2e-boskos-005:
+      k8s-infra-e2e-boskos-006:
+      k8s-infra-e2e-boskos-007:
+      k8s-infra-e2e-boskos-008:
+      k8s-infra-e2e-boskos-009:
+      k8s-infra-e2e-boskos-010:
+      k8s-infra-e2e-boskos-011:
+      k8s-infra-e2e-boskos-012:
+      k8s-infra-e2e-boskos-013:
+      k8s-infra-e2e-boskos-014:
+      k8s-infra-e2e-boskos-015:
+      k8s-infra-e2e-boskos-016:
+      k8s-infra-e2e-boskos-017:
+      k8s-infra-e2e-boskos-018:
+      k8s-infra-e2e-boskos-019:
+      k8s-infra-e2e-boskos-020:
+      k8s-infra-e2e-boskos-021:
+      k8s-infra-e2e-boskos-022:
+      k8s-infra-e2e-boskos-023:
+      k8s-infra-e2e-boskos-024:
+      k8s-infra-e2e-boskos-025:
+      k8s-infra-e2e-boskos-026:
+      k8s-infra-e2e-boskos-027:
+      k8s-infra-e2e-boskos-028:
+      k8s-infra-e2e-boskos-029:
+      k8s-infra-e2e-boskos-030:
+      k8s-infra-e2e-boskos-031:
+      k8s-infra-e2e-boskos-032:
+      k8s-infra-e2e-boskos-033:
+      k8s-infra-e2e-boskos-034:
+      k8s-infra-e2e-boskos-035:
+      k8s-infra-e2e-boskos-036:
+      k8s-infra-e2e-boskos-037:
+      k8s-infra-e2e-boskos-038:
+      k8s-infra-e2e-boskos-039:
+      k8s-infra-e2e-boskos-040:
+      k8s-infra-e2e-boskos-041:
+      k8s-infra-e2e-boskos-042:
+      k8s-infra-e2e-boskos-043:
+      k8s-infra-e2e-boskos-044:
+      k8s-infra-e2e-boskos-045:
+      k8s-infra-e2e-boskos-046:
+      k8s-infra-e2e-boskos-047:
+      k8s-infra-e2e-boskos-048:
+      k8s-infra-e2e-boskos-049:
+      k8s-infra-e2e-boskos-050:
+      k8s-infra-e2e-boskos-051:
+      k8s-infra-e2e-boskos-052:
+      k8s-infra-e2e-boskos-053:
+      k8s-infra-e2e-boskos-054:
+      k8s-infra-e2e-boskos-055:
+      k8s-infra-e2e-boskos-056:
+      k8s-infra-e2e-boskos-057:
+      k8s-infra-e2e-boskos-058:
+      k8s-infra-e2e-boskos-059:
+      k8s-infra-e2e-boskos-060:
+      k8s-infra-e2e-boskos-061:
+      k8s-infra-e2e-boskos-062:
+      k8s-infra-e2e-boskos-063:
+      k8s-infra-e2e-boskos-064:
+      k8s-infra-e2e-boskos-065:
+      k8s-infra-e2e-boskos-066:
+      k8s-infra-e2e-boskos-067:
+      k8s-infra-e2e-boskos-068:
+      k8s-infra-e2e-boskos-069:
+      k8s-infra-e2e-boskos-070:
+      k8s-infra-e2e-boskos-071:
+      k8s-infra-e2e-boskos-072:
+      k8s-infra-e2e-boskos-073:
+      k8s-infra-e2e-boskos-074:
+      k8s-infra-e2e-boskos-075:
+      k8s-infra-e2e-boskos-076:
+      k8s-infra-e2e-boskos-077:
+      k8s-infra-e2e-boskos-078:
+      k8s-infra-e2e-boskos-079:
+      k8s-infra-e2e-boskos-080:
+      k8s-infra-e2e-boskos-081:
+      k8s-infra-e2e-boskos-082:
+      k8s-infra-e2e-boskos-083:
+      k8s-infra-e2e-boskos-084:
+      k8s-infra-e2e-boskos-085:
+      k8s-infra-e2e-boskos-086:
+      k8s-infra-e2e-boskos-087:
+      k8s-infra-e2e-boskos-088:
+      k8s-infra-e2e-boskos-089:
+      k8s-infra-e2e-boskos-090:
+      k8s-infra-e2e-boskos-091:
+      k8s-infra-e2e-boskos-092:
+      k8s-infra-e2e-boskos-093:
+      k8s-infra-e2e-boskos-094:
+      k8s-infra-e2e-boskos-095:
+      k8s-infra-e2e-boskos-096:
+      k8s-infra-e2e-boskos-097:
+      k8s-infra-e2e-boskos-098:
+      k8s-infra-e2e-boskos-099:
+      k8s-infra-e2e-boskos-100:
+      k8s-infra-e2e-boskos-101:
+      k8s-infra-e2e-boskos-102:
+      k8s-infra-e2e-boskos-103:
+      k8s-infra-e2e-boskos-104:
+      k8s-infra-e2e-boskos-105:
+      k8s-infra-e2e-boskos-106:
+      k8s-infra-e2e-boskos-107:
+      k8s-infra-e2e-boskos-108:
+      k8s-infra-e2e-boskos-109:
+      k8s-infra-e2e-boskos-110:
+      k8s-infra-e2e-boskos-111:
+      k8s-infra-e2e-boskos-112:
+      k8s-infra-e2e-boskos-113:
+      k8s-infra-e2e-boskos-114:
+      k8s-infra-e2e-boskos-115:
+      k8s-infra-e2e-boskos-116:
+      k8s-infra-e2e-boskos-117:
+      k8s-infra-e2e-boskos-118:
+      k8s-infra-e2e-boskos-119:
+      k8s-infra-e2e-boskos-120:
+      # e2e projects for gpu jobs (--gcp-project-type=gpu-project)
+      # - us-west1 Committed NVIDIA K80 GPUs raised to 2
+      k8s-infra-e2e-boskos-gpu-01:
+      k8s-infra-e2e-boskos-gpu-02:
+      k8s-infra-e2e-boskos-gpu-03:
+      k8s-infra-e2e-boskos-gpu-04:
+      k8s-infra-e2e-boskos-gpu-05:
+      k8s-infra-e2e-boskos-gpu-06:
+      k8s-infra-e2e-boskos-gpu-07:
+      k8s-infra-e2e-boskos-gpu-08:
+      k8s-infra-e2e-boskos-gpu-09:
+      k8s-infra-e2e-boskos-gpu-10:
+      # e2e projects for scalability jobs (--gcp-project-type=scalability-project)
+      # - us-east1 cpu quota raised to 125
+      # - us-east1 in-use addresses quota raised to 125
+      k8s-infra-e2e-boskos-scale-01:
+      k8s-infra-e2e-boskos-scale-02:
+      k8s-infra-e2e-boskos-scale-03:
+      k8s-infra-e2e-boskos-scale-04:
+      k8s-infra-e2e-boskos-scale-05:
+      k8s-infra-e2e-boskos-scale-06:
+      k8s-infra-e2e-boskos-scale-07:
+      k8s-infra-e2e-boskos-scale-08:
+      k8s-infra-e2e-boskos-scale-09:
+      k8s-infra-e2e-boskos-scale-10:
+      k8s-infra-e2e-boskos-scale-11:
+      k8s-infra-e2e-boskos-scale-12:
+      k8s-infra-e2e-boskos-scale-13:
+      k8s-infra-e2e-boskos-scale-14:
+      k8s-infra-e2e-boskos-scale-15:
+      k8s-infra-e2e-boskos-scale-16:
+      k8s-infra-e2e-boskos-scale-17:
+      k8s-infra-e2e-boskos-scale-18:
+      k8s-infra-e2e-boskos-scale-19:
+      k8s-infra-e2e-boskos-scale-20:
+      k8s-infra-e2e-boskos-scale-21:
+      k8s-infra-e2e-boskos-scale-22:
+      k8s-infra-e2e-boskos-scale-23:
+      k8s-infra-e2e-boskos-scale-24:
+      k8s-infra-e2e-boskos-scale-25:
+      k8s-infra-e2e-boskos-scale-26:
+      k8s-infra-e2e-boskos-scale-27:
+      k8s-infra-e2e-boskos-scale-28:
+      k8s-infra-e2e-boskos-scale-29:
+      k8s-infra-e2e-boskos-scale-30:
+      # e2e projects for manual use (e.g. job migration, debugging a job)
+      # - one for each --gcp-project-type value used in prow.k8s.io job configs
+      k8s-infra-e2e-gce-project:
+      k8s-infra-e2e-gpu-project:
+      k8s-infra-e2e-ingress-project:
+      k8s-infra-e2e-node-e2e-project:
+      k8s-infra-e2e-scale-project:
+
+  prod:
+    managed_by: infra/gcp/ensure-prod-storage.sh
+    projects:
+      k8s-artifacts-prod: # TODO: _also_ managed by ensure-env-cip-auditor.sh
+      k8s-artifacts-prod-bak:
+      k8s-cip-test-prod:
+      k8s-gcr-backup-test-prod:
+      k8s-gcr-backup-test-prod-bak:
+      k8s-gcr-audit-test-prod:
+      k8s-release-test-prod: # TODO: should this be prod or release?:
+
+  prow:
+    projects:
+      k8s-infra-prow-build:
+        managed_by: infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
+      k8s-infra-prow-build-trusted:
+        managed_by: infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
+
+  public:
+    projects:
+      k8s-conform:
+        managed_by: infra/gcp/ensure-conformance-storage.sh
+      k8s-gsuite:
+        managed_by: infra/gcp/ensure-gsuite.sh
+      k8s-infra-public-pii:
+        managed_by: TODO
+      kubernetes-public:
+        managed_by: infra/gcp/ensure-main-project.sh
+
+  release:
+    managed_by: infra/gcp/ensure-release-projects.sh
+    projects:
+      k8s-release:
+      k8s-release-test-prod: # TODO: should this be prod or release?:
+      k8s-releng-prod:
+        managed_by: infra/gcp/ensure-releng-project.sh
+
+  sandbox:
+    projects:
+      k8s-infra-ii-sandbox:
+        managed_by: infra/gcp/clusters/projects/k8s-infra-ii-sandbox/main.tf
+
+  staging:
+    managed_by: infra/gcp/ensure-staging-storage.sh
+    projects:
+      k8s-staging-addon-manager:
+      k8s-staging-apisnoop:
+      k8s-staging-artifact-promoter:
+      k8s-staging-autoscaling:
+      k8s-staging-bootkube:
+      k8s-staging-boskos:
+      k8s-staging-build-image:
+      k8s-staging-capi-docker:
+      k8s-staging-capi-kubeadm:
+      k8s-staging-capi-openstack:
+      k8s-staging-capi-vsphere:
+      k8s-staging-ci-images:
+      k8s-staging-cip-test:
+      k8s-staging-cloud-provider-gcp:
+      k8s-staging-cluster-addons:
+      k8s-staging-cluster-api:
+      k8s-staging-cluster-api-aws:
+      k8s-staging-cluster-api-azure:
+      k8s-staging-cluster-api-do:
+      k8s-staging-cluster-api-gcp:
+      k8s-staging-cluster-api-nested:
+      k8s-staging-coredns:
+      k8s-staging-cpa:
+      k8s-staging-cri-tools:
+      k8s-staging-csi:
+      k8s-staging-csi-secrets-store:
+      k8s-staging-descheduler:
+      k8s-staging-dns:
+      k8s-staging-e2e-test-images:
+      k8s-staging-etcd:
+      k8s-staging-etcdadm:
+      k8s-staging-examples:
+      k8s-staging-experimental:
+      k8s-staging-external-dns:
+      k8s-staging-gateway-api:
+      k8s-staging-git-sync:
+      k8s-staging-infra-tools:
+      k8s-staging-ingress-nginx:
+      k8s-staging-ingressconformance:
+      k8s-staging-k8s-gsm-tools:
+      k8s-staging-kas-network-proxy:
+      k8s-staging-kind:
+      k8s-staging-kops:
+      k8s-staging-kube-state-metrics:
+      k8s-staging-kubeadm:
+      k8s-staging-kubernetes:
+      k8s-staging-kubetest2:
+      k8s-staging-kustomize:
+      k8s-staging-metrics-server:
+      k8s-staging-mirror:
+      k8s-staging-multitenancy:
+      k8s-staging-networking:
+      k8s-staging-nfd:
+      k8s-staging-npd:
+      k8s-staging-provider-aws:
+      k8s-staging-provider-azure:
+      k8s-staging-provider-openstack:
+      k8s-staging-publishing-bot:
+      k8s-staging-releng:
+      k8s-staging-releng-test:
+      k8s-staging-scheduler-plugins:
+      k8s-staging-scl-image-builder:
+      k8s-staging-sig-docs:
+      k8s-staging-sig-storage:
+      k8s-staging-slack-infra:
+      k8s-staging-sp-operator:
+      k8s-staging-storage-migrator:
+      k8s-staging-test-infra:
+      k8s-staging-txtdirect:

--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -36,6 +36,8 @@ trap 'cleanup_tmpdir' EXIT
 # order matters here
 # - utils are used by everthing
 . "$(dirname "${BASH_SOURCE[0]}")/lib_util.sh"
+# - declarations in infra.yaml should be available as early as possible
+. "$(dirname "${BASH_SOURCE[0]}")/lib_infra.sh"
 # - iam is used by almost everything
 . "$(dirname "${BASH_SOURCE[0]}")/lib_iam.sh"
 # - gcs is used by gcr
@@ -104,7 +106,7 @@ readonly PROW_UNTRUSTED_BUILD_CLUSTER_PROJECTS=(
     # TODO(spiffxp): remove support for this where possible
     "k8s-prow-builds"
     # The kubernetes.io build cluster
-    "k8s-infra-prow-build"
+    "$(k8s_infra_project "prow" "k8s-infra-prow-build")"
 )
 
 # Projects hosting prow build clusters that run trusted code, such as periodics
@@ -114,7 +116,7 @@ readonly PROW_TRUSTED_BUILD_CLUSTER_PROJECTS=(
     # TODO(spiffxp): remove support for this where possible
     "k8s-prow"
     # The kubernetes.io build cluster
-    "k8s-infra-prow-build-trusted"
+    "$(k8s_infra_project "prow" "k8s-infra-prow-build-trusted")"
 )
 
 # The namespace prowjobs run in; at present things are configured to use the

--- a/infra/gcp/lib_infra.sh
+++ b/infra/gcp/lib_infra.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Utility functions for reading / validating data from infra/gcp/infra.yaml
+
+# This MUST NOT be used directly. Source it via lib.sh instead.
+
+INFRA_YAML="$(dirname "${BASH_SOURCE[0]}")/infra.yaml"
+readonly INFRA_YAML
+
+# Echo the name of the given project if it has been
+# declared in infra.yaml, otherwise return an error
+#
+# $1: The "type" of the project, e.g. "staging"
+# $2: The id of the project, e.g. "k8s-infra-foo"
+function k8s_infra_project() {
+    if [ $# != 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
+        echo "${FUNCNAME[0]}(project_type, project) requires 2 arguments" >&2
+        return 1
+    fi
+    local project_type="${1}"
+    local project="${2}"
+    if <"${INFRA_YAML}" yq --exit-status ".infra.${project_type}.projects | has(\"${project}\")" >/dev/null; then
+        echo "${project}"
+    else
+        color 1 "ERROR: undeclared ${project_type} project: ${project}" >&2
+        return 1
+    fi
+}
+
+# Echo the names of all projects of the given project_type as
+# declared in infra.yaml
+#
+# $1: The "type" of the project, e.g. "staging"
+function k8s_infra_projects() {
+    if [ $# != 1 ] || [ -z "$1" ]; then
+        echo "${FUNCNAME[0]}(project_type) requires 1 arguments" >&2
+        return 1
+    fi
+    local project_type="${1}"
+    <"${INFRA_YAML}" yq --raw-output ".infra.${project_type}.projects | keys[]"
+}

--- a/infra/gcp/namespaces/ensure-namespaces.sh
+++ b/infra/gcp/namespaces/ensure-namespaces.sh
@@ -142,7 +142,7 @@ parse_args "$@";
 # Project names
 #
 
-ALL_PROJECTS=(
+ALL_APPS=(
     gcsweb
     kettle
     k8s-io-prod
@@ -157,7 +157,7 @@ ALL_PROJECTS=(
     triageparty-release
 )
 
-for prj in "${ALL_PROJECTS[@]}"; do
+for prj in "${ALL_APPS[@]}"; do
     color 6 "Create namespace: ${prj}"
     apply_namespace "${prj}"
 

--- a/k8s.gcr.io/README.md
+++ b/k8s.gcr.io/README.md
@@ -45,18 +45,18 @@ Be sure to add the project owners to the
 `images/k8s-staging-<project-name>/OWNERS` file to increase the number of
 people who can approve new images for promotion for your project.
 
-3. Add the project name to `STAGING_PROJECTS` in
-   [ensure-staging-storage.sh].
+3. Add the project name to the `infra.staging.projects` list defined in
+   [`infra/gcp/infra.yaml`][infra.yaml]
 
-4. Once the PR merges:
-    - ping @dims or @cblecker to create the necessary google group.
-    - ping @thockin or @justinsb to run [ensure-staging-storage.sh] to create
-    the staging repo.
+4. One your PR merges:
+    - a postsubmit job will create the necessary google group
+    - whoever approved your PR will run [the necessary bash script(s)][staging-bash]
+      to create the staging repo
 
 ### Enabling automatic builds
 
 Once your staging repo is up and running, you can enable automatic build and
-push.  Instructions are here: [1].
+push.  For more info, see [the instructions here][image-pushing-readme]
 
 NOTE: All sub-projects are *strongly* encouraged to use this mechanism, though
 it is not mandatory yet.  Over time this will become the primary way to build
@@ -73,17 +73,21 @@ To promote an image, follow these steps:
    gcr.io/k8s-staging-coredns/foo:1.3, then add a "foo" image entry into the
    manifest in `images/k8s-staging-coredns/images.yaml`.
 1. Create a PR to this git repo for your changes.
-1. The PR should trigger a `pull-k8sio-cip` job; check that the `k8s-ci-robot`
-   responds 'Job succeeded' for it.
-1. Merge the PR. This will trigger the actual promotion (the `pull-k8sio-cip`
-   is just a dry run). The actual promotion job is called `post-k8sio-cip` [2].
+1. The PR should trigger a `pull-k8sio-cip` job which will validate and dry-run
+   your changes; check that the `k8s-ci-robot` responds 'Job succeeded' for it.
+1. Merge the PR. Your image will be promoted by one of two jobs:
+   - [`post-k8sio-image-promo`][post-promo-job] is a postsubmit that runs immediately after merge
+   - [`ci-k8sio-cip`][ci-promo-job] is a postsubmit that runs immediately after merge
+1. A periodic 
 1. Published images will appear on k8s.gcr.io and can be viewed [here](https://console.cloud.google.com/gcr/images/k8s-artifacts-prod).
 
 Essentially, in order to get images published to a production repo, you have to
 use the image promotion (PR creation) process defined above.
 
-[1]: https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md
-[2]: https://k8s-testgrid.appspot.com/sig-release-releng-blocking#post-k8sio-cip
-[ensure-staging-storage.sh]: /infra/gcp/ensure-staging-storage.sh
+[image-pushing-readme]: https://git.k8s.io/test-infra/config/jobs/image-pushing/README.md
 [groups.yaml]: /groups/groups.yaml
-[vdf]:https://github.com/kubernetes/k8s.io/blob/master/k8s.gcr.io/Vanity-Domain-Flip.md
+[infra.yaml]: /infra/gcp/infra.yaml
+[staging-bash]: /infra/gcp/ensure-staging-storage.sh
+[vdf]: /k8s.gcr.io/Vanity-Domain-Flip.md
+[post-promo-job]: https://testgrid.k8s.io/sig-release-releng-blocking#post-k8sio-image-promo
+[ci-promo-job]: https://testgrid.k8s.io/sig-release-releng-blocking#ci-k8sio-image-promo


### PR DESCRIPTION
Pull out project lists from hardcoded bash arrays into a file called "infra.yaml"

The schema is completely subject to change. I'd like to have a longer discussion about it once I've had some time to prove whether this is workable.  Pull from comments at the top of `infra/gcp/infra.yaml`:

```yaml
infra:
  {project_type}: # ideally this ~= folder
    [managed_by:] # default script/file used to manage projects
    projects:
      {project_id}:
        [managed_by:] # overrides default; script used to manage _this_ project
```

The changes to scripts boil down to two things:
- instead of using hardcoded arrays, use lists pull from infra.yaml, e.g.
```bash
STAGING_PROJECTS=( $(k8s_infra_projects "staging") )
```
- when using hardcoded project names, do using a function that will error if they haven't been declared in infra.yaml
```
PROJECT=$(k8s_infra_project "prod" "k8s-artifacts-prod")
```

I wanted to trial run just with projects before I extracted anything more like services or constants, let alone try something wild like consume the `managed_by` field in a postsubmit.