### PR TITLE
prow: use container.deployer role for deployer SA

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
@@ -35,6 +35,10 @@ locals {
   prow_deployer_sa_name        = "prow-deployer"                // Allowed to deploy to prow build clusters
 }
 
+data "google_organization" "org" {
+  domain = "kubernetes.io"
+}
+
 module "project" {
   source = "../../../modules/gke-project"
   project_id            = local.project_id
@@ -116,12 +120,12 @@ resource "google_service_account_iam_policy" "prow_deployer_sa_iam" {
 
 resource "google_project_iam_member" "prow_deployer_for_prow_build_trusted" {
   project = local.project_id
-  role    = "roles/container.developer"
+  role    = "${data.google_organization.org.name}/roles/container.deployer"
   member  = "serviceAccount:${local.prow_deployer_sa_name}@${local.project_id}.iam.gserviceaccount.com"
 }
 resource "google_project_iam_member" "prow_deployer_for_prow_build" {
   project = "k8s-infra-prow-build"
-  role    = "roles/container.developer"
+  role    = "${data.google_organization.org.name}/roles/container.deployer"
   member  = "serviceAccount:${local.prow_deployer_sa_name}@${local.project_id}.iam.gserviceaccount.com"
 }
 


### PR DESCRIPTION
prow-deployer was using roles/container.developer which is insufficient to automatically deploy resources related to RBAC and webhooks, so we've created a custom role to allow full control of all in-cluster resources without granting access to control the cluster itself

This is followup to https://github.com/kubernetes/k8s.io/pull/2156 which created the role

And https://github.com/kubernetes/k8s.io/pull/2148#issuecomment-856385138 which is where we discovered the insufficiency of `roles/container.developer` for auto-deploying kubernetes-external-secrets