### PR TITLE
prow: update kubernetes-external-secrets to v8.1.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Verify scripts may leave programs in this directory
 bin/
+tmp/

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/kubernetes-external-secrets.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/kubernetes-external-secrets.yaml
@@ -37,8 +37,8 @@ spec:
       serviceAccountName: kubernetes-external-secrets
       containers:
         - name: kubernetes-external-secrets
-          image: "ghcr.io/external-secrets/kubernetes-external-secrets:7.0.1"
-          imagePullPolicy: Always
+          image: "ghcr.io/external-secrets/kubernetes-external-secrets:8.1.2"
+          imagePullPolicy: IfNotPresent
           ports:
           - name: prometheus
             containerPort: 3001

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/kubernetes-external-secrets_crd.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/kubernetes-external-secrets_crd.yaml
@@ -1,80 +1,86 @@
+# From https://github.com/external-secrets/kubernetes-external-secrets/blob/8.1.2/charts/kubernetes-external-secrets/crds/kubernetes-client.io_externalsecrets_crd.yaml
 ---
-# From https://github.com/external-secrets/kubernetes-external-secrets/tree/f866e34e0319d9c54ea17d07f5d5818a28d9d0f6
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: externalsecrets.kubernetes-client.io
   annotations:
-    # for helm v2 backwards compatibility
-    helm.sh/hook: crd-install
     # used in e2e testing
     app.kubernetes.io/managed-by: helm
 spec:
   group: kubernetes-client.io
-  version: v1
   scope: Namespaced
 
-  names:
-    shortNames:
-      - es
-    kind: ExternalSecret
-    plural: externalsecrets
-    singular: externalsecret
+  preserveUnknownFields: false
 
-  additionalPrinterColumns:
-    - JSONPath: .status.lastSync
-      name: Last Sync
-      type: date
-    - JSONPath: .status.status
-      name: status
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          required:
+            - spec
           type: object
           properties:
-            template:
-              description: Template which will be deep merged without mutating
-                any existing fields. into generated secret, can be used to
-                set for example annotations or type on the generated secret
+            spec:
               type: object
-            backendType:
-              type: string
-              enum:
-                - secretsManager
-                - systemManager
-                - vault
-                - azureKeyVault
-                - gcpSecretsManager
-                - alicloudSecretsManager
-            vaultRole:
-              type: string
-            vaultMountPoint:
-              type: string
-            kvVersion:
-              description: Vault K/V version either 1 or 2, default = 2
-              type: integer
-              minimum: 1
-              maximum: 2
-            keyVaultName:
-              type: string
-            key:
-              type: string
-            dataFrom:
-              type: array
-              items:
-                type: string
-            data:
-              type: array
-              items:
-                type: object
-                anyOf:
-                  - properties:
+              properties:
+                controllerId:
+                  description: The ID of controller instance that manages this ExternalSecret.
+                    This is needed in case there is more than a KES controller instances within the cluster.
+                  type: string
+                type:
+                  type: string
+                  description: >-
+                    DEPRECATED: Use spec.template.type
+                template:
+                  description: Template which will be deep merged without mutating
+                    any existing fields. into generated secret, can be used to
+                    set for example annotations or type on the generated secret
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                backendType:
+                  description: >-
+                    Determines which backend to use for fetching secrets
+                  type: string
+                  enum:
+                    - secretsManager
+                    - systemManager
+                    - vault
+                    - azureKeyVault
+                    - gcpSecretsManager
+                    - alicloudSecretsManager
+                    - ibmcloudSecretsManager
+                    - akeyless
+                vaultRole:
+                  description: >-
+                    Used by: vault
+                  type: string
+                vaultMountPoint:
+                  description: >-
+                    Used by: vault
+                  type: string
+                kvVersion:
+                  description: Vault K/V version either 1 or 2, default = 2
+                  type: integer
+                  minimum: 1
+                  maximum: 2
+                keyVaultName:
+                  description: >-
+                    Used by: azureKeyVault
+                  type: string
+                dataFrom:
+                  type: array
+                  items:
+                    type: string
+                data:
+                  type: array
+                  items:
+                    type: object
+                    properties:
                       key:
                         description: Secret key in backend
                         type: string
@@ -83,6 +89,7 @@ spec:
                         type: string
                       property:
                         description: Property to extract if secret in backend is a JSON object
+                        type: string
                       isBinary:
                         description: >-
                           Whether the backend secret shall be treated as binary data
@@ -90,49 +97,110 @@ spec:
                           for any base64-encoded binary data in the backend - to ensure it
                           is not encoded in base64 again. Default is false.
                         type: boolean
-                    required:
-                      - key
-                      - name
-                  - properties:
                       path:
                         description: >-
                           Path from SSM to scrape secrets
                           This will fetch all secrets and use the key from the secret as variable name
+                        type: string
                       recursive:
-                        description: Allow to recurse thru all child keys on a given path
+                        description: Allow to recurse thru all child keys on a given path, default false
                         type: boolean
-                    required:
-                      - path
-            roleArn:
-              type: string
-          oneOf:
-            - properties:
-                backendType:
-                  enum:
-                    - secretsManager
-                    - systemManager
-            - properties:
-                backendType:
-                  enum:
-                    - vault
-            - properties:
-                backendType:
-                  enum:
-                    - azureKeyVault
-              required:
-                - keyVaultName
-            - properties:
-                backendType:
-                  enum:
-                    - gcpSecretsManager
-            - properties:
-                backendType:
-                  enum:
-                    - alicloudSecretsManager
-          anyOf:
-            - required:
-                - data
-            - required:
-                - dataFrom
-  subresources:
-    status: {}
+                      secretType:
+                        description: >-
+                          Used by: ibmcloudSecretsManager
+                          Type of secret - one of username_password, iam_credentials or arbitrary
+                        type: string
+                      version:
+                        description: >-
+                          Used by: gcpSecretsManager
+                        type: string
+                        x-kubernetes-int-or-string: true
+                      versionStage:
+                        description: >-
+                          Used by: alicloudSecretsManager, secretsManager
+                        type: string
+                      versionId:
+                        description: >-
+                          Used by: secretsManager
+                        type: string
+                    oneOf:
+                      - required:
+                          - key
+                          - name
+                      - required:
+                          - path
+                roleArn:
+                  type: string
+                  description: >-
+                    Used by: alicloudSecretsManager, secretsManager, systemManager
+                region:
+                  type: string
+                  description: >-
+                    Used by: secretsManager, systemManager
+                projectId:
+                  type: string
+                  description: >-
+                    Used by: gcpSecretsManager
+              oneOf:
+                - properties:
+                    backendType:
+                      enum:
+                        - secretsManager
+                        - systemManager
+                - properties:
+                    backendType:
+                      enum:
+                        - vault
+                - properties:
+                    backendType:
+                      enum:
+                        - azureKeyVault
+                  required:
+                    - keyVaultName
+                - properties:
+                    backendType:
+                      enum:
+                        - gcpSecretsManager
+                - properties:
+                    backendType:
+                      enum:
+                        - alicloudSecretsManager
+                - properties:
+                    backendType:
+                      enum:
+                        - ibmcloudSecretsManager
+                - properties:
+                    backendType:
+                      enum:
+                        - akeyless
+              anyOf:
+                - required:
+                    - data
+                - required:
+                    - dataFrom
+            status:
+              type: object
+              properties:
+                lastSync:
+                  type: string
+                status:
+                  type: string
+                observedGeneration:
+                  type: number
+      additionalPrinterColumns:
+        - jsonPath: .status.lastSync
+          name: Last Sync
+          type: date
+        - jsonPath: .status.status
+          name: status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+
+  names:
+    shortNames:
+      - es
+    kind: ExternalSecret
+    plural: externalsecrets
+    singular: externalsecret

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/kubernetes-external-secrets_rbac.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/kubernetes-external-secrets_rbac.yaml
@@ -22,9 +22,6 @@ rules:
   - apiGroups: ["kubernetes-client.io"]
     resources: ["externalsecrets/status"]
     verbs: ["get", "update"]
-  - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
-    verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Trialing on prow before aaa to verify it comes up OK, and that prow is capable of auto-deploying this

Also using this as an opportunity to exercise the changes in https://github.com/kubernetes/test-infra/pull/22525 and https://github.com/kubernetes/k8s.io/pull/2190