### PR TITLE
infra/gcp/prow: Add e2e project for sig-scalability

### DIFF
--- a/infra/gcp/infra.yaml
+++ b/infra/gcp/infra.yaml
@@ -204,6 +204,8 @@ infra:
       k8s-infra-e2e-ingress-project:
       k8s-infra-e2e-node-e2e-project:
       k8s-infra-e2e-scale-project:
+      # e2e projects for scalability jobs with 5000 nodes
+      k8s-infra-e2e-scale-5k-project:
 
   prod:
     managed_by: infra/gcp/ensure-prod-storage.sh


### PR DESCRIPTION
Add e2e projects for sig-scalability prowjobs that need 5K nodes.
Initial suggestion : https://github.com/kubernetes/test-infra/pull/22430#pullrequestreview-677953930

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>