### PR TITLE
releng: Promote debian-iptables:buster-v1.6.3 / setcap:buster-v2.0.2

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
@@ -169,6 +169,7 @@
 - name: debian-iptables
   dmap:
     "sha256:1ae6d76dea462973759ff1c4e02263867da1f85db9aa10462a030ca421cbf0e9": ["v12.1.0"]
+    "sha256:24725ea119dd0af0d60b17cbd640178f90c39c32a527fb4c6ac848b7ee2bdc85": ["buster-v1.6.3"]
     "sha256:27aaf19acbe10bed00c190b549f29cb774d444486c91b341122ef3d661f913c9": ["buster-v1.6.2"]
     "sha256:4c9410a4ee555dcb0e8b7bd6fc77c65ac400f7c5bd4555df8187630efaea6ea4": ["buster-v1.3.0"]
     "sha256:87f97cf2b62eb107871ee810f204ccde41affb70b29883aa898e93df85dea0f0": ["buster-v1.4.0"]
@@ -182,6 +183,7 @@
     "sha256:fff1fd5ab38fefde8c9eee5470ed6ea737f30e5ab86e1c0c0d429fa6add28a84": ["buster-v1.1.2", "v12.1.2"]
 - name: debian-iptables-amd64
   dmap:
+    "sha256:1cbd7bcc117df12d6a9047887eb670c04af153bc9cd13e8e114c7127ebf05b02": ["buster-v1.6.3"]
     "sha256:2c07068d6185e5ab4013f38083c8ca55dfae45777700a417ce9167a2b59bd1df": ["buster-v1.6.0"]
     "sha256:2fb9fa09123a41e6369cac04eb29e26237fe9e43da8e18f676d18d8fffb906fc": ["v12.1.0"]
     "sha256:448c0e019689da3f4e238922824551d02578473f7b5d11604fffd528056caafa": ["buster-v1.1.2", "v12.1.2"]
@@ -207,6 +209,7 @@
     "sha256:bb6677337a4dbc3e578a3e87642d99be740dea391dc5e8987f04211c5e23abcd": ["buster-v1.4.0"]
     "sha256:bf59578f532bfd3378c4a713eeb14cf0dbed224d5ad03f549165f8d853997ca4": ["buster-v1.3.0"]
     "sha256:c10f01b414a7cd4b2f3e26e152c90c64a1e781d99f83a6809764cf74ecbc46c3": ["v12.0.1"]
+    "sha256:d781699ce8a4b78515021398cee965a0943ceb9f0ad39d6505aae63387191778": ["buster-v1.6.3"]
     "sha256:e976a5c88105db9a3ed462c2899aabbc5758f4f76e24098981010a226d344439": ["v12.1.1"]
 - name: debian-iptables-arm64
   dmap:
@@ -216,6 +219,7 @@
     "sha256:3e354ba300a7c25dc88473589378f8e980cb7e05acdeecf029f5b06c2ea4509d": ["v11.1.0"]
     "sha256:3eefa4772a673e7d0eda706691e7829b64f62e95d464e9cd69e483a57c83a2fc": ["buster-v1.6.1"]
     "sha256:5725e6fde13a6405cf800e22846ebd2bde24b0860f1dc3f6f5f256f03cfa85bd": ["v12.0.1"]
+    "sha256:64e1a959621ef1ed03a9346812005e9e2da2a384bae7ce10e756f64041f78dd1": ["buster-v1.6.3"]
     "sha256:6ad4717d69db2cc47bc2efc91cebb96ba736be1de49e62e0deffdbaf0fa2318c": ["buster-v1.4.0"]
     "sha256:6da5b6aacb8c17615e1001aac0121517f541421036b20808a375f0dd79bf8564": ["v12.1.1"]
     "sha256:a83cf1d501ad33f5aa93e2719baa59b054939b8a819c3997f915a6acfaa8e31a": ["buster-v1.1.2", "v12.1.2"]
@@ -226,6 +230,7 @@
   dmap:
     "sha256:0ea0be4dec281b506f6ceef4cb3594cabea8d80e2dc0d93c7eb09d46259dd837": ["buster-v1.5.0"]
     "sha256:10bcfe5b4316aeb651c80d6b07e22a90de2f8ab5f702d741c47f582d13711c67": ["v11.1.0"]
+    "sha256:143f2e48b795ab09fa055bb8634cdd73d303510e11b00091efaf2a069edf0576": ["buster-v1.6.3"]
     "sha256:168ccfeb861239536826a26da24ab5f68bb5349d7439424b7008b01e8f6534fc": ["buster-v1.4.0"]
     "sha256:4193d431b1722c5334db3349ef9a0189714a8ef86e8c9b53b58b6d4cd298ea7a": ["buster-v1.6.0"]
     "sha256:63cf48fd9de1407302019ab524f7ed9ff7a05d9ecacc1a6ac77ee57fed21a078": ["v12.1.1"]
@@ -239,6 +244,7 @@
 - name: debian-iptables-s390x
   dmap:
     "sha256:1b91a2788750552913377bf1bc99a095544dfb523d80a55674003c974c8e0905": ["v12.1.0"]
+    "sha256:20b149323ea0b46cad0fb517734d9f7d5416cab38705b0050aa9c9cc2156d650": ["buster-v1.6.3"]
     "sha256:2cff11d50b4a368b95a78408caf93c9d2c1e9a5e98556813db24517f2bc7a86f": ["v11.1.0"]
     "sha256:39e67e9bf25d67fe35bd9dcb25367277e5967368e02f2741e0efd4ce8874db14": ["v12.0.1"]
     "sha256:50ef25fba428b6002ef0a9dea7ceae5045430dc1035d50498a478eefccba17f5": ["buster-v1.5.0"]
@@ -339,24 +345,30 @@
 - name: setcap
   dmap:
     "sha256:b0fede27e44020bd9305c29540d7f8d9c1df8edc21adc3278946bbd994418946": ["buster-v1.4.0"]
+    "sha256:b56334f0e7a2c5bac5d69923941f85b68e2f9ac419b41a161f6c2c1881d241a9": ["buster-v2.0.2"]
     "sha256:cf3b220d7ecc92e18979b2249933373ac959e46dee22579425a200f375093e2a": ["buster-v2.0.1"]
 - name: setcap-amd64
   dmap:
     "sha256:55a3f08949f9d2bc1f108c3b02dc2f0393c5efaa1e45cf7b79b150c40202884e": ["buster-v1.4.0"]
+    "sha256:6734620909c13c7eec87f4288b98faf3c7666ddf6f3abfe560ac5cac8077d13d": ["buster-v2.0.2"]
     "sha256:9ecf95d4576ff31a9a2070fee118c6e771831a828e607d69660f5797d2f6d07b": ["buster-v2.0.1"]
 - name: setcap-arm
   dmap:
     "sha256:7c736a06b540599ec3f6db867c20c611bc20a7d8ac0597163d715ea200717a16": ["buster-v2.0.1"]
+    "sha256:e26aa5f12dfb3138dbc355eca080599013c4dc68c41aa0286c178a4cd570ae69": ["buster-v2.0.2"]
     "sha256:f90282d9af7046e0ab47a9a1b1ff5c3720af2a320943bb5fb748d63898592f42": ["buster-v1.4.0"]
 - name: setcap-arm64
   dmap:
     "sha256:d37a70f8e2198b8dd86511b009d963a66df34228f0485861023e7be52faa6a3f": ["buster-v1.4.0"]
     "sha256:db3f6b90f4849a756ebc669add28c6dcfc1c0f39cc5497cd01a2b82cdb8d25ef": ["buster-v2.0.1"]
+    "sha256:e15dc057ac267f1d8e335ce9da5bea2bed3b9ac1396a19c592b1f3ed44797076": ["buster-v2.0.2"]
 - name: setcap-ppc64le
   dmap:
     "sha256:198bfd5378949af1e1c2ed8f5da945a091bb40866e70f60b3896cd0cfccdaea0": ["buster-v1.4.0"]
     "sha256:253e86a3f18cb27f0a7628ed9a99c5e5713770c7464663ffaf42fc159b94706e": ["buster-v2.0.1"]
+    "sha256:a79e3f2f011e715470b59390bc791b76ae64392dcff8d38eb47a8230f83d1b8f": ["buster-v2.0.2"]
 - name: setcap-s390x
   dmap:
     "sha256:06f6e3bc9566c38bd81dbfa2e54a080ca37ac03a47d171415d19e2742392b62a": ["buster-v2.0.1"]
     "sha256:a4775180f6a24b1d708d1e0aa884eeb7f30f4b2ac9dcb987664ccbf33823ee31": ["buster-v1.4.0"]
+    "sha256:c7d5b55c98c1299d34525f1f8d84d053966c2d99938d57ec7a65b4b5a9ef62d1": ["buster-v2.0.2"]


### PR DESCRIPTION
Promotion PR for https://github.com/kubernetes/release/pull/2118.

Image builds:
- debian-iptables: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-release-push-image-debian-iptables/1403135449999872000
- setcap: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-release-push-image-setcap/1403135450016649216

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @cpanato @puerco @saschagrunert 
cc: @kubernetes/release-engineering @rikatz 
xref: https://kubernetes.slack.com/archives/CCK68P2Q2/p1623421541144900