### PR TITLE
hack: add verify-shellcheck.sh, address shellcheck failures

### DIFF
--- a/artifactserver/tools/get_workspace_status.sh
+++ b/artifactserver/tools/get_workspace_status.sh
@@ -27,7 +27,7 @@ if [[ -z "${DOCKER_REGISTRY}" ]]; then
   DOCKER_REGISTRY="gcr.io"
 fi
 if [[ -z "${DOCKER_IMAGE_PREFIX}" ]]; then
-  DOCKER_IMAGE_PREFIX=`gcloud config get-value project`/
+  DOCKER_IMAGE_PREFIX=$(gcloud config get-value project)/
 fi
 if [[ -z "${DOCKER_TAG}" ]]; then
   DOCKER_TAG="latest"
@@ -36,6 +36,6 @@ echo "STABLE_DOCKER_REGISTRY ${DOCKER_REGISTRY}"
 echo "STABLE_DOCKER_IMAGE_PREFIX ${DOCKER_IMAGE_PREFIX}"
 echo "STABLE_DOCKER_TAG ${DOCKER_TAG}"
 if [[ -z "${K8S_CLUSTER}" ]]; then
-  K8S_CLUSTER=`kubectl config current-context`
+  K8S_CLUSTER=$(kubectl config current-context)
 fi
 echo "STABLE_K8S_CLUSTER ${K8S_CLUSTER}"

--- a/audit/check-audit-pr.sh
+++ b/audit/check-audit-pr.sh
@@ -114,7 +114,7 @@ EOF
         actual=$(cat "${f}")
 
         # policy: non-US buckets should have location in name
-        location=$(<${f} grep "Location constraint:" | awk '{ print $3 }')
+        location=$(<"${f}" grep "Location constraint:" | awk '{ print $3 }')
         if [ "${location}" == "ASIA" ] && ! { [[ "${bucket}" =~ -asia ]] || [[ "${bucket}" =~ asia\. ]]; }; then
             echo "FAIL: ${project} bucket ${bucket} change location is ${location} but bucket name lacks 'asia'"; continue
         elif [ "${location}" == "EU" ] && ! { [[ "${bucket}" =~ -eu ]] || [[ "${bucket}" =~ eu\. ]]; }; then
@@ -126,7 +126,7 @@ EOF
         #
         # however, there are many buckets that don't follow this, so triage to
         # expected buckets vs unexpected
-        acl=$(<${f} grep "\tACL:" | awk '{ print $2 }')
+        acl=$(<"${f}" grep "\tACL:" | awk '{ print $2 }')
         if [ "${acl}" != "[]" ]; then
             if [[ "${bucket}" =~ ^kubernetes-staging-[0-9a-f]+ ]] \
                 && {    [[ "${project}" =~ ^k8s-infra-e2e-boskos- ]] \
@@ -160,7 +160,7 @@ EOF
         # policy: most buckets should not have lifecycles; if they do, it
         #         should be one of three well known lifecycles depending on
         #         the project name and bucket name
-        lifecycle=$(<${f} grep "\tLifecycle configuration:" | awk '{ print $3 }')
+        lifecycle=$(<"${f}" grep "\tLifecycle configuration:" | awk '{ print $3 }')
         if [ "${lifecycle}" == "Present" ]; then
             lifecycle_file="projects/${project}/buckets/${bucket}/lifecycle.json"
             lifecycle=$(cat "${lifecycle_file}")
@@ -180,7 +180,7 @@ EOF
 
         # policy: most buckets should not have logging; if they do, it
         #         should be a well known configuration
-        logging=$(<${f} grep "\tLogging configuration:" | awk '{ print $3 }')
+        logging=$(<"${f}" grep "\tLogging configuration:" | awk '{ print $3 }')
         if [ "${logging}" == "Present" ]; then
             logging_file="projects/${project}/buckets/${bucket}/logging.json"
             logging=$(cat "${logging_file}")
@@ -197,7 +197,7 @@ EOF
         #         adhering to naming conventions and durations appropriate to each
         # for whatever reason a bucket with no retention policy doesn't have
         # "None" for the field, but lacks the field entirely
-        if <${f} grep -q "\tRetention Policy:.*Present"; then
+        if <"${f}" grep -q "\tRetention Policy:.*Present"; then
             retention_file="projects/${project}/buckets/${bucket}/retention.txt"
             retention=$(<"${retention_file}" grep Duration | cut -d: -f2)
             if { { [[ "${project}" == "k8s-conform" ]] && [[ "${bucket}" =~ ^k8s-conform- ]]; } \
@@ -219,7 +219,7 @@ EOF
         #         match a standard template, excluding the case-by-case
         #         exceptions made for specific fields above
         if [ "${project}" != "k8s-infra-ii-sandbox" ]; then
-            if ! diff <(</tmp/expected_metadata grep -E "${metadata_fields_regex}") <(<${f} grep -E "${metadata_fields_regex}") >/tmp/diff.txt; then
+            if ! diff <(</tmp/expected_metadata grep -E "${metadata_fields_regex}") <(<"${f}" grep -E "${metadata_fields_regex}") >/tmp/diff.txt; then
                 if [ "${project}" == "kubernetes-public" ] && </tmp/diff.txt grep -q "Storage class:"; then
                     # TODO: this should probably be corrected
                     echo "SKIP: ${project} bucket ${bucket} change has a non-default storage class, which is a known policy violation"
@@ -267,7 +267,7 @@ function check_container() {
     for f in "${files[@]}"; do
         project=$(echo "${f}" | cut -d/ -f2)
         if [[ "${f}" =~ services/container/clusters/[a-z-]*.json ]]; then
-            cluster=$(basename ${f} .json)
+            cluster=$(basename "${f}" .json)
             cluster_tf_dir="${REPO_ROOT}/infra/gcp/clusters/projects/${project}/${cluster}"
             if [ -d "${cluster_tf_dir}" ]; then
                 echo "PASS: ${project} has container cluster resource ${cluster} is expected, auto-accepting for now"
@@ -311,9 +311,9 @@ function check_logging() {
     )
     for f in "${files[@]}"; do
         project=$(echo "${f}" | cut -d/ -f2)
-        case "$(basename ${f})" in
+        case "$(basename "${f}")" in
         metrics.json)
-            actual=$(cat ${f})
+            actual=$(cat "${f}")
             if [ "${actual}" == "[]" ]; then
                 # TODO: this should be corrected
                 echo "SKIP: ${project} has empty logging metrics change, which is a known policy violation"

--- a/dns/lib.sh
+++ b/dns/lib.sh
@@ -31,7 +31,7 @@ precook_zone_configs() {
     for z in "${zones[@]}"; do
         # Every zone should have 1 file $z.yaml or N files $z._*.yaml.
         # $z already ends in a period.
-        cat zone-configs/${z}yaml zone-configs/${z}_*.yaml \
+        cat "zone-configs/${z}"yaml "zone-configs/${z}"_*.yaml \
             > "${path}/${z}yaml" 2>/dev/null
         if [ ! -s "${path}/${z}yaml" ]; then
             echo "${path}/${z}yaml appears to be empty after pre-processing!"

--- a/dns/push.sh
+++ b/dns/push.sh
@@ -104,8 +104,7 @@ precook_zone_configs "${TMPCFG}" "${ALL_ZONES[@]}"
 
 # Push to canaries.
 echo "Dry-run to canary zones"
-push "${CANARY_ZONES[@]}" > "${LOGS_PATH}/log.canary" 2>&1
-if [ $? != 0 ]; then
+if ! push "${CANARY_ZONES[@]}" > "${LOGS_PATH}/log.canary" 2>&1; then
     echo "Canary dry-run FAILED, halting; log follows:"
     echo "========================================="
     cat "${LOGS_PATH}/log.canary"
@@ -114,8 +113,7 @@ fi
 
 if [ "${DRY_RUN}" = false ]; then
   echo "Pushing to canary zones"
-  push --doit "${CANARY_ZONES[@]}" >> "${LOGS_PATH}/log.canary" 2>&1
-  if [ $? != 0 ]; then
+  if ! push --doit "${CANARY_ZONES[@]}" >> "${LOGS_PATH}/log.canary" 2>&1; then
       echo "Canary push FAILED, halting; log follows:"
       echo "========================================="
       cat "${LOGS_PATH}/log.canary"
@@ -127,12 +125,11 @@ if [ "${DRY_RUN}" = false ]; then
       TRIES=12
       echo "Testing canary zone: $zone"
       for i in $(seq 1 "$TRIES"); do
-          ./check-zone.sh -c "${TMPCFG}" -o "${TMP_OCTODNS_CFG}" \
-            "$zone" >> "${LOGS_PATH}/log.canary" 2>&1
-          if [ $? == 0 ]; then
+          if ./check-zone.sh -c "${TMPCFG}" -o "${TMP_OCTODNS_CFG}" \
+            "$zone" >> "${LOGS_PATH}/log.canary" 2>&1; then
               break
           fi
-          if [ $i != "$TRIES" ]; then
+          if [ "$i" != "$TRIES" ]; then
               echo "  test failed, might be propagation delay, will retry..."
               sleep 10
           else
@@ -148,8 +145,7 @@ fi
 
 # Push to prod.
 echo "Dry-run to prod zones"
-push "${PROD_ZONES[@]}" > "${LOGS_PATH}/log.prod" 2>&1
-if [ $? != 0 ]; then
+if ! push "${PROD_ZONES[@]}" > "${LOGS_PATH}/log.prod" 2>&1; then
     echo "Prod dry-run FAILED, halting; log follows:"
     echo "========================================="
     cat "${LOGS_PATH}/log.prod"
@@ -158,8 +154,7 @@ fi
 
 if [ "${DRY_RUN}" = false ]; then
   echo "Pushing to prod zones"
-  push --doit "${PROD_ZONES[@]}" >> "${LOGS_PATH}/log.prod" 2>&1
-  if [ $? != 0 ]; then
+  if ! push --doit "${PROD_ZONES[@]}" >> "${LOGS_PATH}/log.prod" 2>&1; then
       echo "Prod push FAILED, halting; log follows:"
       echo "========================================="
       cat "${LOGS_PATH}/log.prod"
@@ -171,12 +166,11 @@ if [ "${DRY_RUN}" = false ]; then
       TRIES=12
       echo "Testing prod zone: $zone"
       for i in $(seq 1 "$TRIES"); do
-          ./check-zone.sh -c "${TMPCFG}" -o "${TMP_OCTODNS_CFG}" \
-            "$zone" >> "${LOGS_PATH}/log.prod" 2>&1
-          if [ $? == 0 ]; then
+          if ./check-zone.sh -c "${TMPCFG}" -o "${TMP_OCTODNS_CFG}" \
+            "$zone" >> "${LOGS_PATH}/log.prod" 2>&1; then
               break
           fi
-          if [ $i != "$TRIES" ]; then
+          if [ "$i" != "$TRIES" ]; then
               echo "  test failed, might be propagation delay, will retry..."
               sleep 10
           else

--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# runs shellcheck for all *.sh files in this repo, assuming a bash dialect
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+readonly REPO_ROOT
+
+readonly TMPDIR="${TMPDIR:-${REPO_ROOT}/tmp}"
+readonly SHELLCHECK_OUTPUT="${TMPDIR}/shellcheck.txt"
+mkdir -p "$(dirname "${SHELLCHECK_OUTPUT}")"
+echo -n '' > "${SHELLCHECK_OUTPUT}"
+
+mapfile -t files < <(
+    find "${REPO_ROOT}" -type f -name '*.sh' | sort
+)
+readonly files
+
+readonly shellcheck_cmd=(
+    shellcheck
+    --shell=bash
+    --external-sources
+    --source-path=SCRIPTDIR
+)
+
+failed_files=()
+passed_files=()
+# calling shellcheck for each file takes longer, but:
+# - allows --source-path to work for adjacent files
+# - allows listing which specific files failed at end
+for file in "${files[@]}"; do
+    echo "# checking ${file#${REPO_ROOT}\/}"
+    if ! "${shellcheck_cmd[@]}" "${file}" >>"${SHELLCHECK_OUTPUT}" 2>&1; then
+        failed_files+=("${file}")
+    else
+        passed_files+=("${file}")
+    fi
+done 
+
+result="passed"
+code=0
+if [ ${#failed_files[@]} != 0 ]; then
+    result="failed"
+    code=1
+fi
+
+echo "result: ${result}"
+echo "shellcheck_cmd: ${shellcheck_cmd[*]} {file}"
+echo "shellcheck_output: >"
+<"${SHELLCHECK_OUTPUT}" sed -e 's/^/  /'
+echo "passing_files:"
+printf "%s\n" "${passed_files[@]/#${REPO_ROOT}\//- }"
+echo "failing_files:"
+printf "%s\n" "${failed_files[@]/#${REPO_ROOT}\//- }"
+exit "${code}"

--- a/hack/verify-terraform.sh
+++ b/hack/verify-terraform.sh
@@ -17,8 +17,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
-REPO_ROOT="$(cd ${SCRIPT_ROOT}/.. && pwd)"
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
 
 function usage() {
   echo >&2 "Usage: $0 <PATH>"
@@ -63,4 +62,4 @@ tfswitch --version
 fi
 
 cd "$REPO_ROOT"
-check_terraform $1
+check_terraform "$1"

--- a/hack/verify-yamllint.sh
+++ b/hack/verify-yamllint.sh
@@ -39,7 +39,7 @@ fi
 # we assume that pip3 is already installed
 if ! command -v yamllint >/dev/null 2>&1; then
   echo "yamllint not found - installing with: ${pip} install -r ${pip_requirements}"
-  ${pip} install -r ${pip_requirements}
+  "${pip}" install -r "${pip_requirements}"
 fi
 
 version=$(yamllint --version | awk '{ print $2 }')

--- a/hack/verify.sh
+++ b/hack/verify.sh
@@ -24,7 +24,6 @@ REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 if [[ -z "${color_start-}" ]]; then
   declare -r color_start="\033["
   declare -r color_red="${color_start}0;31m"
-  declare -r color_yellow="${color_start}0;33m"
   declare -r color_green="${color_start}0;32m"
   declare -r color_norm="${color_start}0m"
 fi
@@ -35,11 +34,11 @@ EXCLUDED_PATTERNS=(
   "verify-terraform.sh"          # Expect a cluster as an argument
   )
 
-EXCLUDED_CHECKS=$(ls ${EXCLUDED_PATTERNS[@]/#/${REPO_ROOT}\/hack\/} 2>/dev/null || true)
+EXCLUDED_CHECKS=$(ls "${EXCLUDED_PATTERNS[@]/#/${REPO_ROOT}\/hack\/}" 2>/dev/null || true)
 
 function is-excluded {
-  for e in ${EXCLUDED_CHECKS[@]}; do
-    if [[ $1 -ef "$e" ]]; then
+  for e in "${EXCLUDED_CHECKS[@]}"; do
+    if [[ "${1}" -ef "$e" ]]; then
       return
     fi
   done
@@ -61,7 +60,7 @@ function print-failed-tests {
   echo -e "========================"
   echo -e "${color_red}FAILED TESTS${color_norm}"
   echo -e "========================"
-  for t in ${FAILED_TESTS[@]}; do
+  for t in "${FAILED_TESTS[@]}"; do
       echo -e "${color_red}${t}${color_norm}"
   done
 }
@@ -69,25 +68,26 @@ function print-failed-tests {
 function run-checks {
   local -r pattern=$1
   local -r runner=$2
+  local check_name start elapsed
 
   local t
-  for t in $(ls ${pattern})
+  for t in ${pattern};
   do
-    local check_name="$(basename "${t}")"
+    check_name="$(basename "${t}")"
     if is-excluded "${t}" ; then
       echo "Skipping ${check_name}"
       continue
     fi
     echo -e "Verifying ${check_name}"
-    local start=$(date +%s)
+    start=$(date +%s)
     run-cmd "${runner}" "${t}" && tr=$? || tr=$?
-    local elapsed=$(($(date +%s) - ${start}))
+    elapsed=$(($(date +%s) - start))
     if [[ ${tr} -eq 0 ]]; then
       echo -e "${color_green}SUCCESS${color_norm}  ${check_name}\t${elapsed}s"
     else
       echo -e "${color_red}FAILED${color_norm}   ${check_name}\t${elapsed}s"
       ret=1
-      FAILED_TESTS+=(${t})
+      FAILED_TESTS+=("${t}")
     fi
   done
 }

--- a/infra/gcp/ensure-conformance-storage.sh
+++ b/infra/gcp/ensure-conformance-storage.sh
@@ -111,9 +111,9 @@ function ensure_conformance_serviceaccount() {
     local bucket="${2}"
     local secret_accessors="${3}"
 
-    local email="$(svc_acct_email "${PROJECT}" "${name}")"
+    local email
+    email="$(svc_acct_email "${PROJECT}" "${name}")"
     local secret="${name}-key"
-    local private_key_file="${TMPDIR}/key.json"
 
     color 6 "Ensuring service account exists: ${email}"
     ensure_service_account "${PROJECT}"  "${name}" "Grants write access to ${bucket}"

--- a/infra/gcp/ensure-gsuite.sh
+++ b/infra/gcp/ensure-gsuite.sh
@@ -113,6 +113,6 @@ color 4 "  1: enable domain-wide delegation on that service account"
 color 4 "  2: download the JSON key and give it to GSuite"
 echo
 color 4 "Press enter to acknowledge"
-read -s
+read -r -s
 
 color 6 "Done"

--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -18,7 +18,7 @@
 
 # Setup TMPDIR before including any other functions
 TMPDIR=$(mktemp -d "/tmp/k8sio-infra-gcp-lib.XXXXX")
-readonly TMPDIR
+export TMPDIR
 function cleanup_tmpdir() {
   if [ "${K8S_INFRA_DEBUG:-"false"}" == "true" ]; then
     echo "K8S_INFRA_DEBUG mode, not removing tmpdir: ${TMPDIR}"
@@ -80,27 +80,32 @@ readonly AUDITOR_SERVICE_NAME="cip-auditor"
 readonly PROMOTER_SVCACCT="k8s-infra-gcr-promoter"
 
 # The service account name for the image promoter's vulnerability check.
-readonly PROMOTER_VULN_SCANNING_SVCACCT="k8s-infra-gcr-vuln-scanning"
+# used in: ensure-prod-storage.sh ensure-staging-storage.sh
+export PROMOTER_VULN_SCANNING_SVCACCT="k8s-infra-gcr-vuln-scanning"
 
 # Release Engineering umbrella groups
 # - admins - edit and KMS access (Release Engineering subproject owners)
 # - managers - access to run stage/release jobs (Patch Release Team / Branch Managers)
 # - viewers - view access to Release Engineering projects (Release Manager Associates)
-readonly RELEASE_ADMINS="k8s-infra-release-admins@kubernetes.io"
-readonly RELEASE_MANAGERS="k8s-infra-release-editors@kubernetes.io"
-readonly RELEASE_VIEWERS="k8s-infra-release-viewers@kubernetes.io"
+# used in: ensure-release-projects.sh ensure-releng.sh ensure-staging-storage.sh
+export RELEASE_ADMINS="k8s-infra-release-admins@kubernetes.io"
+export RELEASE_MANAGERS="k8s-infra-release-editors@kubernetes.io"
+export RELEASE_VIEWERS="k8s-infra-release-viewers@kubernetes.io"
 
 #
 # Prow constants
 #
 
 # The service account email used by prow-build-trusted to trigger GCB and push to GCS
-readonly GCB_BUILDER_SVCACCT="gcb-builder@k8s-infra-prow-build-trusted.iam.gserviceaccount.com"
+# used in: ensure-release-proejcts.sh ensure-staging-storage.sh
+export GCB_BUILDER_SVCACCT="gcb-builder@k8s-infra-prow-build-trusted.iam.gserviceaccount.com"
 
-readonly PROW_BUILD_SERVICE_ACCOUNT="prow-build@k8s-infra-prow-build.iam.gserviceaccount.com"
+# used in: ensure-release-proejcts.sh ensure-staging-storage.sh
+export PROW_BUILD_SERVICE_ACCOUNT="prow-build@k8s-infra-prow-build.iam.gserviceaccount.com"
 
 # Projects hosting prow build clusters that run untrusted code, such as
 # presubmits that build and test unmerged code from PRs
+# shellcheck disable=SC2034 # TODO(spiffxp): can't export arrays; address when infra.yaml PR merged
 readonly PROW_UNTRUSTED_BUILD_CLUSTER_PROJECTS=(
     # The google.com build cluster for prow.k8s.io
     # TODO(spiffxp): remove support for this where possible
@@ -111,6 +116,7 @@ readonly PROW_UNTRUSTED_BUILD_CLUSTER_PROJECTS=(
 
 # Projects hosting prow build clusters that run trusted code, such as periodics
 # that run merged/approved code that need access to sensitive secrets
+# shellcheck disable=SC2034 # TODO(spiffxp): can't export arrays; address when infra.yaml PR merged
 readonly PROW_TRUSTED_BUILD_CLUSTER_PROJECTS=(
     # The google.com trusted build cluster for prow.k8s.io
     # TODO(spiffxp): remove support for this where possible
@@ -127,7 +133,8 @@ readonly PROW_TRUSTED_BUILD_CLUSTER_PROJECTS=(
 # - infra/gcp/clusters/projects/k8s-infra-prow-*/*/main.tf # pod_namespace = test-pods
 # # TODO: not all resources belong in test-pods, would be good to shard into folders
 # - infra/gcp/clusters/projects/k8s-infra-prow-*/*/resources/* # namespace: test-pods
-readonly PROWJOB_POD_NAMESPACE="test-pods"
+# used in: ensure-gsuite.sh ensure-main-project.sh ensure-prod-storage.sh ensure-staging-storage.sh
+export PROWJOB_POD_NAMESPACE="test-pods"
 
 #
 # Functions
@@ -137,7 +144,7 @@ readonly PROWJOB_POD_NAMESPACE="test-pods"
 # $1: The GCP project
 # $2: The name
 function svc_acct_email() {
-    if [ $# != 2 -o -z "$1" -o -z "$2" ]; then
+    if [ $# != 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "svc_acct_email(project, name) requires 2 arguments" >&2
         return 1
     fi
@@ -151,7 +158,7 @@ function svc_acct_email() {
 #   ref: https://cloud.google.com/cloud-build/docs/securing-builds/configure-access-control#service_account
 # $1 The GCP project
 function gcb_service_account_email() {
-    if [ $# != 1 -o -z "$1" ]; then
+    if [ $# != 1 ] || [ -z "$1" ]; then
         echo "gcb_service_account_email(project) requires 1 argument" >&2
         return 1
     fi
@@ -167,7 +174,7 @@ function gcb_service_account_email() {
 # we want them (e.g. billing).
 # $1: The GCP project
 function ensure_project() {
-    if [ $# != 1 -o -z "$1" ]; then
+    if [ $# != 1 ] || [ -z "$1" ]; then
         echo "ensure_project(project) requires 1 argument" >&2
         return 1
     fi
@@ -222,7 +229,7 @@ function ensure_project() {
 # $1: The GCP project
 # $2: The group email
 function empower_group_as_viewer() {
-    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+    if [ $# -lt 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "empower_group_as_viewer(project, group) requires 2 arguments" >&2
         return 1
     fi
@@ -238,7 +245,7 @@ function empower_group_as_viewer() {
 # $1: The GCP project
 # $2: The service account
 function empower_service_account_for_cip_auditor_e2e_tester() {
-    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+    if [ $# -lt 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "empower_service_account_for_cip_auditor_e2e_tester(acct, project) requires 2 arguments" >&2
         return 1
     fi
@@ -264,7 +271,7 @@ function empower_service_account_for_cip_auditor_e2e_tester() {
 # $1: The GCP project
 # $2: The group email
 function empower_group_for_gcb() {
-    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+    if [ $# -lt 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "empower_group_for_gcb(project, group) requires 2 arguments" >&2
         return 1
     fi
@@ -289,7 +296,7 @@ function empower_group_for_gcb() {
 # $1: The GCP project
 # $2: The group email
 function empower_group_for_kms() {
-    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+    if [ $# -lt 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "empower_group_for_kms(project, group) requires 2 arguments" >&2
         return 1
     fi
@@ -310,13 +317,14 @@ function empower_group_for_kms() {
 # $1: The GCP project
 # $2: The GCR region (optional)
 function empower_gcr_admins() {
-    if [ $# -lt 1 -o $# -gt 2 -o -z "$1" ]; then
+    if [ $# -lt 1 ] || [ $# -gt 2 ] || [ -z "$1" ]; then
         echo "empower_gcr_admins(project, [region]) requires 1 or 2 arguments" >&2
         return 1
     fi
     local project="$1"
     local region="${2:-}"
-    local bucket=$(gcs_bucket_for_gcr "${project}" "${region}")
+    local bucket
+    bucket=$(gcs_bucket_for_gcr "${project}" "${region}")
 
     ensure_project_role_binding "${project}" "group:${GCR_ADMINS}" "roles/viewer"
     empower_group_to_admin_gcs_bucket "${GCR_ADMINS}" "${bucket}"
@@ -326,7 +334,7 @@ function empower_gcr_admins() {
 # $1: The GCP project
 # $2: The bucket
 function empower_gcs_admins() {
-    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+    if [ $# -lt 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "empower_gcs_admins(project, bucket) requires 2 arguments" >&2
         return 1
     fi
@@ -347,7 +355,8 @@ function empower_group_to_admin_artifact_auditor() {
     fi
     local project="$1"
     local group="$2"
-    local acct=$(svc_acct_email "${project}" "${AUDITOR_SVCACCT}")
+    local acct
+    acct=$(svc_acct_email "${project}" "${AUDITOR_SVCACCT}")
 
     local roles=(
         # Grant privileges to deploy the auditor Cloud Run service. See
@@ -375,14 +384,14 @@ function empower_group_to_admin_artifact_auditor() {
 # $1: The GCP project
 # $2: The GCR region (optional)
 function empower_artifact_promoter() {
-    if [ $# -lt 1 -o $# -gt 2 -o -z "$1" ]; then
+    if [ $# -lt 1 ] || [ $# -gt 2 ] || [ -z "$1" ]; then
         echo "empower_artifact_promoter(project, [region]) requires 1 or 2 arguments" >&2
         return 1
     fi
     local project="$1"
     local region="${2:-}"
-
-    local acct=$(svc_acct_email "${project}" "${PROMOTER_SVCACCT}")
+    local acct=
+    acct=$(svc_acct_email "${project}" "${PROMOTER_SVCACCT}")
 
     if ! gcloud --project "${project}" iam service-accounts describe "${acct}" >/dev/null 2>&1; then
         gcloud --project "${project}" \
@@ -397,7 +406,7 @@ function empower_artifact_promoter() {
 # Ensure the auditor service account exists and has the ability to write logs and fire alerts to Stackdriver Error Reporting.
 # $1: The GCP project
 function empower_artifact_auditor() {
-    if [ $# -lt 1 -o -z "$1" ]; then
+    if [ $# -lt 1 ] || [ -z "$1" ]; then
         echo "empower_artifact_auditor(project) requires 1 argument" >&2
         return 1
     fi
@@ -413,7 +422,8 @@ function empower_artifact_auditor() {
         # production GCR which is already world-readable.
     )
 
-    local acct=$(svc_acct_email "${project}" "${AUDITOR_SVCACCT}")
+    local acct
+    acct=$(svc_acct_email "${project}" "${AUDITOR_SVCACCT}")
 
     if ! gcloud --project "${project}" iam service-accounts describe "${acct}" >/dev/null 2>&1; then
         gcloud --project "${project}" \
@@ -434,13 +444,14 @@ function empower_artifact_auditor() {
 # GCR are posted).
 # $1: The GCP project
 function empower_artifact_auditor_invoker() {
-    if [ $# -lt 1 -o -z "$1" ]; then
+    if [ $# -lt 1 ] || [ -z "$1" ]; then
         echo "empower_artifact_auditor_invoker(project) requires 1 argument" >&2
         return 1
     fi
     local project="$1"
 
-    local acct=$(svc_acct_email "${project}" "${AUDITOR_INVOKER_SVCACCT}")
+    local acct
+    acct=$(svc_acct_email "${project}" "${AUDITOR_INVOKER_SVCACCT}")
 
     if ! gcloud --project "${project}" iam service-accounts describe "${acct}" >/dev/null 2>&1; then
         gcloud --project "${project}" \
@@ -467,7 +478,7 @@ function empower_artifact_auditor_invoker() {
 # $2 The managed zone name (e.g. kubernetes-io)
 # $3 The DNS zone name (e.g. kubernetes.io)
 function ensure_dns_zone() {
-    if [ $# != 3 -o -z "$1" -o -z "$2" -o -z "$3" ]; then
+    if [ $# != 3 ] || [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
         echo "ensure_dns_zone(project, zone_name, dns_name) requires 3 arguments" >&2
         return 1
     fi
@@ -549,7 +560,7 @@ function unempower_gke_for_serviceaccount() {
 # $2 The address name (e.g. foo-ingress), IPv6 addresses must have a "-v6" suffix
 # $3 The address description (e.g. "IP address for the foo GCLB")
 function ensure_global_address() {
-    if [ ! $# -eq 3 -o -z "$1" -o -z "$2" -o -z "$3" ]; then
+    if [ ! $# -eq 3 ] || [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
         echo "ensure_global_address(gcp_project, name, description) requires 3 arguments" >&2
         return 1
     fi
@@ -580,7 +591,7 @@ function ensure_global_address() {
 # $3 The address name (e.g. foo-ingress)
 # $4 The address description (e.g. "IP address for the foo GCLB")
 function ensure_regional_address() {
-    if [ ! $# -eq 4 -o -z "$1" -o -z "$2" -o -z "$3" -o -z "$4" ]; then
+    if [ ! $# -eq 4 ] || [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ] || [ -z "$4" ]; then
         echo "ensure_regional_address(gcp_project, region, name, description) requires 4 arguments" >&2
         return 1
     fi

--- a/infra/gcp/lib_gcr.sh
+++ b/infra/gcp/lib_gcr.sh
@@ -25,7 +25,7 @@
 # $1: The GCR repo (same as the GCP project name)
 # $2: The GCR region (optional)
 function gcs_bucket_for_gcr() {
-    if [ $# -lt 1 -o $# -gt 2 -o -z "$1" ]; then
+    if [ $# -lt 1 ] || [ $# -gt 2 ] || [ -z "$1" ]; then
         echo "gcs_bucket_for_gcr(repo, [region]) requires 1 or 2 arguments" >&2
         return 1
     fi
@@ -59,16 +59,18 @@ function gcr_host_for_region() {
 # $1: The GCP project
 # $2: The GCR region (optional)
 function ensure_gcr_repo() {
-    if [ $# -lt 1 -o $# -gt 2 -o -z "$1" ]; then
+    if [ $# -lt 1 ] || [ $# -gt 2 ] || [ -z "$1" ]; then
         echo "ensure_gcr_repo(project, [region]) requires 1 or 2 arguments" >&2
         return 1
     fi
     local project="$1"
     local region="${2:-}"
 
-    local bucket=$(gcs_bucket_for_gcr "${project}" "${region}")
+    local bucket
+    bucket=$(gcs_bucket_for_gcr "${project}" "${region}")
     if ! gsutil ls "${bucket}" >/dev/null 2>&1; then
-        local host=$(gcr_host_for_region "${region}")
+        local host
+        host=$(gcr_host_for_region "${region}")
         local image="ceci-nest-pas-une-image"
         local dest="${host}/${project}/${image}"
         docker pull k8s.gcr.io/pause
@@ -86,14 +88,15 @@ function ensure_gcr_repo() {
 # $2: The GCP project
 # $3: The GCR region (optional)
 function empower_group_to_write_gcr() {
-    if [ $# -lt 2 -o $# -gt 3 -o -z "$1" -o -z "$2" ]; then
+    if [ $# -lt 2 ] || [ $# -gt 3 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "empower_group_to_write_gcr(group_name, project, [region]) requires 2 or 3 arguments" >&2
         return 1
     fi
     local group="$1"
     local project="$2"
     local region="${3:-}"
-    local bucket=$(gcs_bucket_for_gcr "${project}" "${region}")
+    local bucket
+    bucket=$(gcs_bucket_for_gcr "${project}" "${region}")
 
     empower_group_to_write_gcs_bucket "${group}" "${bucket}"
 }
@@ -103,14 +106,15 @@ function empower_group_to_write_gcr() {
 # $2: The GCP project
 # $3: The GCR region (optional)
 function empower_group_to_admin_gcr() {
-    if [ $# -lt 2 -o $# -gt 3 -o -z "$1" -o -z "$2" ]; then
+    if [ $# -lt 2 ] || [ $# -gt 3 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "empower_group_to_admin_gcr(group_name, project, [region]) requires 2 or 3 arguments" >&2
         return 1
     fi
     local group="$1"
     local project="$2"
     local region="${3:-}"
-    local bucket=$(gcs_bucket_for_gcr "${project}" "${region}")
+    local bucket
+    bucket=$(gcs_bucket_for_gcr "${project}" "${region}")
 
     empower_group_to_admin_gcs_bucket "${group}" "${bucket}"
 }
@@ -120,14 +124,15 @@ function empower_group_to_admin_gcr() {
 # $2: The GCP project
 # $3: The GCR region (optional)
 function empower_svcacct_to_write_gcr () {
-    if [ $# -lt 2 -o $# -gt 3 -o -z "$1" -o -z "$2" ]; then
+    if [ $# -lt 2 ] || [ $# -gt 3 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "empower_svcacct_to_write_gcr(acct, project, [region]) requires 2 or 3 arguments" >&2
         return 1
     fi
     local acct="$1"
     local project="$2"
     local region="${3:-}"
-    local bucket=$(gcs_bucket_for_gcr "${project}" "${region}")
+    local bucket
+    bucket=$(gcs_bucket_for_gcr "${project}" "${region}")
 
     empower_svcacct_to_write_gcs_bucket "${acct}" "${bucket}"
 }
@@ -137,14 +142,15 @@ function empower_svcacct_to_write_gcr () {
 # $2: The GCP project
 # $3: The GCR region (optional)
 function empower_svcacct_to_admin_gcr () {
-    if [ $# -lt 2 -o $# -gt 3 -o -z "$1" -o -z "$2" ]; then
+    if [ $# -lt 2 ] || [ $# -gt 3 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "empower_svcacct_to_admin_gcr(acct, project, [region]) requires 2 or 3 arguments" >&2
         return 1
     fi
     local acct="$1"
     local project="$2"
     local region="${3:-}"
-    local bucket=$(gcs_bucket_for_gcr "${project}" "${region}")
+    local bucket
+    bucket=$(gcs_bucket_for_gcr "${project}" "${region}")
 
     empower_svcacct_to_admin_gcs_bucket "${acct}" "${bucket}"
 }

--- a/infra/gcp/lib_gcs.sh
+++ b/infra/gcp/lib_gcs.sh
@@ -25,7 +25,7 @@
 # $1: The GCP project
 # $2: The bucket (e.g. gs://bucket-name)
 function _ensure_gcs_bucket() {
-    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+    if [ $# -lt 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "_ensure_gcs_bucket(project, bucket) requires 2 arguments" >&2
         return 1
     fi
@@ -45,7 +45,7 @@ function _ensure_gcs_bucket() {
 # $1: The GCP project
 # $2: The bucket (e.g. gs://bucket-name)
 function ensure_public_gcs_bucket() {
-    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+    if [ $# -lt 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "ensure_public_gcs_bucket(project, bucket) requires 2 arguments" >&2
         return 1
     fi
@@ -60,7 +60,7 @@ function ensure_public_gcs_bucket() {
 # $1: The GCP project
 # $2: The bucket (e.g. gs://bucket-name)
 function ensure_private_gcs_bucket() {
-    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+    if [ $# -lt 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "ensure_private_gcs_bucket(project, bucket) requires 2 arguments" >&2
         return 1
     fi
@@ -94,7 +94,7 @@ function ensure_private_gcs_bucket() {
 # Sets the web policy on the bucket, including a default index.html page
 # $1: The bucket (e.g. gs://bucket-name)
 function ensure_gcs_web_policy() {
-    if [ $# -lt 1 -o -z "$1" ]; then
+    if [ $# -lt 1 ] || [ -z "$1" ]; then
         echo "ensure_gcs_web_policy(bucket) requires 1 argument" >&2
         return 1
     fi
@@ -107,7 +107,7 @@ function ensure_gcs_web_policy() {
 # $1: The bucket (e.g. gs://bucket-name)
 # $2: The source directory
 function upload_gcs_static_content() {
-    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+    if [ $# -lt 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "upload_gcs_static_content(bucket, dir) requires 2 arguments" >&2
         return 1
     fi
@@ -122,7 +122,7 @@ function upload_gcs_static_content() {
 # $1: The GCS bucket (e.g. gs://bucket-name)
 # $2: The retention
 function ensure_gcs_bucket_retention() {
-    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+    if [ $# -lt 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "ensure_gcs_bucket_retention(bucket, retention) requires 2 arguments" >&2
         return 1
     fi
@@ -136,7 +136,7 @@ function ensure_gcs_bucket_retention() {
 # $1: The GCS bucket (e.g. gs://bucket-name)
 # $2: The auto-deletion policy
 function ensure_gcs_bucket_auto_deletion() {
-    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+    if [ $# -lt 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "ensure_gcs_bucket_auto_deletion(bucket, auto_delettion_days) requires 2 arguments" >&2
         return 1
     fi
@@ -160,7 +160,7 @@ function ensure_gcs_bucket_auto_deletion() {
 # $1: The principal (group:<g> or serviceAccount:<s> or ...)
 # $2: The bucket (e.g. gs://bucket-name)
 function _empower_principal_to_write_gcs_bucket() {
-    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+    if [ $# -lt 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "_empower_principal_to_write_gcs_bucket(principal, bucket) requires 2 arguments" >&2
         return 1
     fi
@@ -175,7 +175,7 @@ function _empower_principal_to_write_gcs_bucket() {
 # $1: The principal (group:<g> or serviceAccount:<s> or ...)
 # $2: The bucket (e.g. gs://bucket-name)
 function _empower_principal_to_admin_gcs_bucket() {
-    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+    if [ $# -lt 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "_empower_principal_to_admin_gcs_bucket(principal, bucket) requires 2 arguments" >&2
         return 1
     fi
@@ -192,7 +192,7 @@ function _empower_principal_to_admin_gcs_bucket() {
 #   $2:  The principal (e.g. "group:k8s-infra-foo@kubernetes.io", "allUsers", etc.)
 #   $3:  The role name (e.g. "objectAdmin", "legacyBucketOwner", etc.)
 ensure_gcs_role_binding() {
-    if [ ! $# -eq 3 -o -z "$1" -o -z "$2" -o -z "$3" ]; then
+    if [ ! $# -eq 3 ] || [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
         echo "ensure_gcs_role_binding(bucket, principal, role) requires 3 arguments" >&2
         return 1
     fi
@@ -216,6 +216,7 @@ ensure_gcs_role_binding() {
         >/dev/null; then
 
         # add the binding, then merge with existing bindings
+        # shellcheck disable=SC2016 # jq uses $foo for variables
         <"${before_json}" yq --arg role "${role}" --arg principal "${principal}" \
           '.bindings |= (
               . + [{
@@ -242,7 +243,7 @@ ensure_gcs_role_binding() {
 #   $2:  The principal (e.g. "group:k8s-infra-foo@kubernetes.io", "allUsers", etc.)
 #   $3:  The role name (e.g. "objectAdmin", "legacyBucketOwner", etc.)
 ensure_removed_gcs_role_binding() {
-    if [ ! $# -eq 3 -o -z "$1" -o -z "$2" -o -z "$3" ]; then
+    if [ ! $# -eq 3 ] || [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
         echo "ensure_removed_gcs_role_binding(bucket, principal, role) requires 3 arguments" >&2
         return 1
     fi
@@ -267,6 +268,7 @@ ensure_removed_gcs_role_binding() {
 
         # remove member from role if it exists; gcs deletes bindings with no
         # members, so we don't need to bother pruning them here
+        # shellcheck disable=SC2016 # jq uses $foo for variables
         <"${before_json}" yq --arg role "${role}" --arg principal "${principal}" \
           '.bindings |= map(
               if .role == ("roles/storage." + $role) then
@@ -287,7 +289,7 @@ ensure_removed_gcs_role_binding() {
 # $1: The googlegroups group email
 # $2: The bucket (e.g. gs://bucket-name)
 function empower_group_to_write_gcs_bucket() {
-    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+    if [ $# -lt 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "empower_group_to_write_gcs_bucket(group_email, bucket) requires 2 arguments" >&2
         return 1
     fi
@@ -301,7 +303,7 @@ function empower_group_to_write_gcs_bucket() {
 # $1: The googlegroups group email
 # $2: The bucket (e.g. gs://bucket-name)
 function empower_group_to_admin_gcs_bucket() {
-    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+    if [ $# -lt 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "empower_group_to_admin_gcs_bucket(group_email, bucket) requires 2 arguments" >&2
         return 1
     fi
@@ -315,7 +317,7 @@ function empower_group_to_admin_gcs_bucket() {
 # $1: The service account email
 # $2: The bucket (e.g. gs://bucket-name)
 function empower_svcacct_to_write_gcs_bucket() {
-    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+    if [ $# -lt 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "empower_svcacct_to_write_gcs_bucket(svcacct_email, bucket) requires 2 arguments" >&2
         return 1
     fi
@@ -329,7 +331,7 @@ function empower_svcacct_to_write_gcs_bucket() {
 # $1: The service account email
 # $2: The bucket (e.g. gs://bucket-name)
 function empower_svcacct_to_admin_gcs_bucket() {
-    if [ $# -lt 2 -o -z "$1" -o -z "$2" ]; then
+    if [ $# -lt 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "empower_svcacct_to_admin_gcs_bucket(svcacct_email, bucket) requires 2 arguments" >&2
         return 1
     fi

--- a/infra/gcp/lib_iam.sh
+++ b/infra/gcp/lib_iam.sh
@@ -27,7 +27,7 @@
 # $2: The account name (e.g. "foo-manager")
 # $3: The account display-name (e.g. "Manages all foo")
 function ensure_service_account() {
-    if [ $# != 3 -o -z "$1" -o -z "$2" -o -z "$3" ]; then
+    if [ $# != 3 ] || [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
         echo "ensure_service_account(project, name, display_name) requires 3 arguments" >&2
         return 1
     fi
@@ -35,7 +35,8 @@ function ensure_service_account() {
     local name="$2"
     local display_name="$3"
 
-    local email=$(svc_acct_email "${project}" "${name}")
+    local email
+    email=$(svc_acct_email "${project}" "${name}")
 
     local before="${TMPDIR}/service-account.before.yaml"
     local after="${TMPDIR}/service-account.after.yaml"
@@ -66,7 +67,7 @@ function ensure_service_account() {
 #   $1:  The role name (e.g. "foo.barrer")
 #   $2:  The file (e.g. "/path/to/file.yaml")
 function ensure_custom_org_iam_role_from_file() {
-    if [ ! $# -eq 2 -o -z "$1" -o -z "$2" ]; then
+    if [ ! $# -eq 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "ensure_custom_org_iam_role_from_file(name, file) requires 2 arguments" >&2
         return 1
     fi
@@ -84,7 +85,7 @@ function ensure_custom_org_iam_role_from_file() {
 #   $2:  The role name (e.g. "foo.barrer")
 #   $3:  The file (e.g. "/path/to/file.yaml")
 function ensure_custom_project_iam_role_from_file() {
-    if [ ! $# -eq 3 -o -z "$1" -o -z "$2" -o -z "$3" ]; then
+    if [ ! $# -eq 3 ] || [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
         echo "ensure_custom_project_iam_role_from_file(project, name, file) requires 3 arguments" >&2
         return 1
     fi
@@ -100,7 +101,7 @@ function ensure_custom_project_iam_role_from_file() {
 # Arguments:
 #   $1:  The role name (e.g. "foo.barrer")
 function ensure_removed_custom_org_iam_role() {
-    if [ ! $# -eq 1 -o -z "$1" ]; then
+    if [ ! $# -eq 1 ] || [ -z "$1" ]; then
         echo "ensure_removed_custom_org_iam_role(name) requires 1 arguments" >&2
         return 1
     fi
@@ -116,7 +117,7 @@ function ensure_removed_custom_org_iam_role() {
 #   $1:  The id of the project (e.g. "k8s-infra-foo")
 #   $2:  The role name (e.g. "foo.barrer")
 function ensure_removed_custom_project_iam_role() {
-    if [ ! $# -eq 2 -o -z "$1" -o -z "$2" ]; then
+    if [ ! $# -eq 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "ensure_removed_custom_project_iam_role(project, name) requires 2 arguments" >&2
         return 1
     fi
@@ -131,7 +132,7 @@ function ensure_removed_custom_project_iam_role() {
 # Arguments:
 #   $1:  The role name (e.g. "foo.barrer")
 function custom_org_role_name() {
-    if [ ! $# -eq 1 -o -z "$1" ]; then
+    if [ ! $# -eq 1 ] || [ -z "$1" ]; then
         echo "custom_org_role_name(name) requires 1 arguments" >&2
         return 1
     fi
@@ -148,7 +149,7 @@ function custom_org_role_name() {
 #   $1:  The is of the project (e.g. "k8s-infra-foo")
 #   $2:  The role name (e.g. "foo.barrer")
 function custom_project_role_name() {
-    if [ ! $# -eq 2 -o -z "$1" -o -z "$2" ]; then
+    if [ ! $# -eq 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "custom_project_role_name(project, name) requires 2 arguments" >&2
         return 1
     fi
@@ -166,7 +167,7 @@ function custom_project_role_name() {
 #   $1:  The role name (e.g. "foo.barrer")
 #   $2:  The file (e.g. "/path/to/file.yaml")
 function ensure_org_role_binding() {
-    if [ ! $# -eq 2 -o -z "$1" -o -z "$2" ]; then
+    if [ ! $# -eq 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "ensure_org_role_binding(principal, role) requires 2 arguments" >&2
         return 1
     fi
@@ -184,7 +185,7 @@ function ensure_org_role_binding() {
 #   $2:  The principal (e.g. "group:k8s-infra-foo@kubernetes.io")
 #   $3:  The role name (e.g. "roles/storage.objectAdmin")
 function ensure_project_role_binding() {
-    if [ ! $# -eq 3 -o -z "$1" -o -z "$2" -o -z "$3" ]; then
+    if [ ! $# -eq 3 ] || [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
         echo "ensure_project_role_binding(project, principal, role) requires 3 arguments" >&2
         return 1
     fi
@@ -202,7 +203,7 @@ function ensure_project_role_binding() {
 #   $2:  The principal (e.g. "group:k8s-infra-foo@kubernetes.io")
 #   $3:  The role name (e.g. "roles/storage.objectAdmin")
 function ensure_secret_role_binding() {
-    if [ ! $# -eq 3 -o -z "$1" -o -z "$2" -o -z "$3" ]; then
+    if [ ! $# -eq 3 ] || [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
         echo "ensure_secret_role_binding(secret, principal, role) requires 3 arguments" >&2
         return 1
     fi
@@ -245,7 +246,7 @@ function ensure_serviceaccount_role_binding() {
 #   $1:  The principal (e.g. "group:k8s-infra-foo@kubernetes.io")
 #   $2:  The role name (e.g. "roles/foo.bar")
 function ensure_removed_org_role_binding() {
-    if [ ! $# -eq 2 -o -z "$1" -o -z "$2" ]; then
+    if [ ! $# -eq 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
         echo "ensure_removed_org_role_binding(principal, role) requires 2 arguments" >&2
         return 1
     fi
@@ -263,7 +264,7 @@ function ensure_removed_org_role_binding() {
 #   $2:  The principal (e.g. "group:k8s-infra-foo@kubernetes.io")
 #   $3:  The role name (e.g. "roles/foo.bar")
 function ensure_removed_project_role_binding() {
-    if [ ! $# -eq 3 -o -z "$1" -o -z "$2" -o -z "$3" ]; then
+    if [ ! $# -eq 3 ] || [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
         echo "ensure_removed_project_role_binding(project, principal, role) requires 3 arguments" >&2
         return 1
     fi
@@ -281,7 +282,7 @@ function ensure_removed_project_role_binding() {
 #   $2:  The principal (e.g. "group:k8s-infra-foo@kubernetes.io")
 #   $3:  The role name (e.g. "roles/storage.objectAdmin")
 function ensure_removed_secret_role_binding() {
-    if [ ! $# -eq 3 -o -z "$1" -o -z "$2" -o -z "$3" ]; then
+    if [ ! $# -eq 3 ] || [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
         echo "ensure_removed_secret_role_binding(secret, principal, role) requires 3 arguments" >&2
         return 1
     fi
@@ -326,7 +327,7 @@ function ensure_removed_serviceaccount_role_binding() {
 #   $3:  The role name (e.g. "foo.barrer")
 #   $4:  The file (e.g. "/path/to/file.yaml")
 function _ensure_custom_iam_role_from_file() {
-    if [ ! $# -eq 4 -o -z "$1" -o -z "$2" -o -z "$3" -o -z "$4" ]; then
+    if [ ! $# -eq 4 ] || [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ] || [ -z "$4" ]; then
         echo "_ensure_custom_iam_role_from_file(scope, id, name, file) requires 4 arguments" >&2
         return 1
     fi
@@ -343,7 +344,7 @@ function _ensure_custom_iam_role_from_file() {
         ;;
     esac
 
-    local scope_flag="--${scope} ${id}"
+    local scope_flag="--${scope}=${id}"
 
     local before="${TMPDIR}/custom-role.before.yaml"
     local ready="${TMPDIR}/custom-role.ready.yaml"
@@ -351,20 +352,20 @@ function _ensure_custom_iam_role_from_file() {
 
     # detect if we should create or update and dump role; silently ignore error
     verb="update"
-    if ! (gcloud iam roles describe ${scope_flag} "${name}" | yq -y 'del(.etag)' >"${before}") >/dev/null 2>&1; then
+    if ! (gcloud iam roles describe "${scope_flag}" "${name}" | yq -y 'del(.etag)' >"${before}") >/dev/null 2>&1; then
         verb="create"
     fi
 
     # deleted roles can be undeleted within 7 days; after that must wait 30 days to create a role with same id
     # ref: https://cloud.google.com/iam/docs/creating-custom-roles#deleting-custom-role
     if <"${before}" grep -q "^deleted: true"; then
-        gcloud iam roles undelete ${scope_flag} "${name}"
+        gcloud iam roles undelete "${scope_flag}" "${name}"
     fi
 
     # name is foo.bar, but gcloud wants scopes/id/role/foo.bar in the file
     local full_name="${scope}s/${id}/roles/${name}"
     <"${file}" sed -e "s|^name: ${name}|name: ${full_name}|" >"${ready}"
-    gcloud iam roles "${verb}" ${scope_flag} "${name}" --file "${ready}" | yq -y 'del(.etag)' > "${after}"
+    gcloud iam roles "${verb}" "${scope_flag}" "${name}" --file "${ready}" | yq -y 'del(.etag)' > "${after}"
 
     diff_colorized "${before}" "${after}"
 }
@@ -375,7 +376,7 @@ function _ensure_custom_iam_role_from_file() {
 #   $2:  The id of the scope (e.g. "12345819", "k8s-infra-foo")
 #   $3:  The role name (e.g. "foo.barrer")
 function _ensure_removed_custom_iam_role() {
-    if [ ! $# -eq 3 -o -z "$1" -o -z "$2" -o -z "$3" ]; then
+    if [ ! $# -eq 3 ] || [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]; then
         echo "_ensure_removed_custom_iam_role(scope, id, name) requires 3 arguments" >&2
         return 1
     fi
@@ -391,13 +392,13 @@ function _ensure_removed_custom_iam_role() {
         ;;
     esac
 
-    local scope_flag="--${scope} ${id}"
+    local scope_flag="--${scope}=${id}"
 
     local before="${TMPDIR}/iam-bind.before.txt"
     local before="${TMPDIR}/iam-bind.after.txt"
 
     # gcloud iam roles delete errors if role doesn't exist, so confirm it does
-    if ! gcloud iam roles describe ${scope_flag} ${name} --format="value(deleted)" > "${before}" 2>/dev/null; then
+    if ! gcloud iam roles describe "${scope_flag}" "${name}" --format="value(deleted)" > "${before}" 2>/dev/null; then
         # not found, or can't see... no point in continuing
         return
     fi
@@ -407,7 +408,7 @@ function _ensure_removed_custom_iam_role() {
         return
     fi
 
-    gcloud iam roles delete ${scope_flag} "${name}" > "${after}"
+    gcloud iam roles delete "${scope_flag}" "${name}" > "${after}"
 
     diff_colorized "${before}" "${after}"
 }

--- a/infra/gcp/roles/generate-role-yaml.sh
+++ b/infra/gcp/roles/generate-role-yaml.sh
@@ -125,7 +125,7 @@ if [ $# = 0 ]; then
 fi
 
 for path; do
-  for f in $(find ${path} -type f -name '*.yaml' | sort); do
+  for f in $(find "${path}" -type f -name '*.yaml' | sort); do
     output_role_yaml "${f}"
   done
 done

--- a/k8s.gcr.io/images/k8s-staging-csi-secrets-store/generate.sh
+++ b/k8s.gcr.io/images/k8s-staging-csi-secrets-store/generate.sh
@@ -14,12 +14,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-repos="
-driver
-"
+set -o errexit
+set -o nounset
+set -o pipefail
 
-for repo in $repos; do
-    echo "- name: $repo"
+readonly repo="gcr.io/k8s-staging-csi-secrets-store"
+readonly tag_filter="tags~^v[0-9]+.[0-9]+.[0-9]+$ AND NOT tags=v0.0.11"
+readonly images=(
+    driver
+)
+
+for image in "${images[@]}"; do
+    echo "- name: ${image}"
     echo "  dmap:"
-    gcloud container images list-tags gcr.io/k8s-staging-csi-secrets-store/$repo --format='get(digest, tags)' --sort-by='tags' --filter='tags~^v[0-9]+.[0-9]+.[0-9]+$ AND NOT tags=v0.0.11' | sed -e 's/\([^ ]*\)\t\(.*\)/    "\1": [ "\2" ]/'
+    gcloud container images list-tags \
+        "${repo}/$image" \
+        --format="get(digest, tags)" \
+        --sort-by="tags" \
+        --filter="${tag_filter}" \
+        | sed -e 's/\([^ ]*\)\t\(.*\)/    "\1": [ "\2" ]/'
 done

--- a/k8s.gcr.io/images/k8s-staging-sig-storage/generate.sh
+++ b/k8s.gcr.io/images/k8s-staging-sig-storage/generate.sh
@@ -14,30 +14,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
+readonly repo="gcr.io/k8s-staging-sig-storage"
+readonly tag_filter="tags~^v AND NOT tags~v2020 AND NOT tags~-rc"
 # List of repos under https://console.cloud.google.com/gcr/images/k8s-staging-sig-storage/GLOBAL
-repos="
-csi-attacher
-csi-node-driver-registrar
-csi-provisioner
-csi-resizer
-csi-snapshotter
-csi-external-health-monitor-agent
-csi-external-health-monitor-controller
-hostpathplugin
-iscsiplugin
-livenessprobe
-local-volume-provisioner
-mock-driver
-nfs-provisioner
-nfs-subdir-external-provisioner
-snapshot-controller
-snapshot-validation-webhook
-"
+readonly images=(
+    csi-attacher
+    csi-external-health-monitor-agent
+    csi-external-health-monitor-controller
+    csi-node-driver-registrar
+    csi-provisioner
+    csi-resizer
+    csi-snapshotter
+    hostpathplugin
+    iscsiplugin
+    livenessprobe
+    local-volume-provisioner
+    mock-driver
+    nfs-provisioner
+    nfs-subdir-external-provisioner
+    # TODO: nfsplugin?
+    snapshot-controller
+    snapshot-validation-webhook
+    # TODO: validation-webhook?
+)
 
-for repo in $repos; do
-    echo "- name: $repo"
+for image in "${images[@]}"; do
+    echo "- name: ${image}"
     echo "  dmap:"
-    gcloud container images list-tags gcr.io/k8s-staging-sig-storage/$repo --format='get(digest, tags)' --filter='tags~^v AND NOT tags~v2020 AND NOT tags~-rc' --sort-by=tags |
-        sed -e 's/\([^ ]*\)\t\(.*\)/    "\1": [ "\2" ]/'
+    gcloud container images list-tags \
+        "${repo}/$image" \
+        --format="get(digest, tags)" \
+        --sort-by="tags" \
+        --filter="${tag_filter}" \
+        | sed -e 's/\([^ ]*\)\t\(.*\)/    "\1": [ "\2" ]/'
 done
-

--- a/k8s.io/deploy.sh
+++ b/k8s.io/deploy.sh
@@ -18,11 +18,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ $# -ne 1 -o -z "${1:-}" ]; then
+if [ $# -ne 1 ] || [ -z "${1:-}" ]; then
     echo "usage: $0 [ canary | prod ]"
     exit 1
 fi
-if [ "$1" != "canary" -a "$1" != "prod" ]; then
+if [ "$1" != "canary" ] && [ "$1" != "prod" ]; then
     echo "unsupported target '$1'"
     echo "usage: $0 [ canary | prod ]"
     exit 1
@@ -49,18 +49,18 @@ kc rollout restart deployment k8s-io
 echo "waiting for all replicas to be up"
 while true; do
   sleep 3
-  read WANT HAVE UNAVAIL < <( \
+  read -r WANT HAVE UNAVAIL < <( \
       kc get deployment k8s-io \
           -o go-template='{{.spec.replicas}} {{.status.readyReplicas}} {{.status.unavailableReplicas}}{{"\n"}}'
   )
 
-  if [ -z "${HAVE}" -o "${HAVE}" == "<no value>" ]; then
+  if [ -z "${HAVE}" ] || [ "${HAVE}" == "<no value>" ]; then
       HAVE=0
   fi
-  if [ -z "${UNAVAIL}" -o "${UNAVAIL}" == "<no value>" ]; then
+  if [ -z "${UNAVAIL}" ] || [ "${UNAVAIL}" == "<no value>" ]; then
       UNAVAIL=0
   fi
-  if [ -n "${WANT}" -a -n "${HAVE}" -a "${WANT}" == "${HAVE}" -a "${UNAVAIL}" == 0 ]; then
+  if [ -n "${WANT}" ] && [ -n "${HAVE}" ] && [ "${WANT}" == "${HAVE}" ] && [ "${UNAVAIL}" == 0 ]; then
     break
   fi
   echo "  want ${WANT}, found ${HAVE} ready and ${UNAVAIL} unavailable"


### PR DESCRIPTION
With all the bash we have, I think it's time to start enforcing shellcheck failures. I managed to address a lot of them piecemeal with my PRs to infra/gcp and audit, because my editor has shellcheck integration, and I'm a completionist. So I decided to go the rest of the way and address the remaining failures.

As of this PR, verify-shellcheck.sh will run by default as part of pull-k8sio-verify

None of the failures were so annoying that I felt compelled to add a .shellcheck config file to exclude

See individual commits for the specific failures fixed. I have run all of these scripts in gcr.io/k8s-staging-infra-tools/k8s-infra:latest to verify lack of breakage