### PR TITLE
infra/gcp/aaa: fix k8s-infra-prow.tf

### DIFF
--- a/infra/gcp/clusters/projects/kubernetes-public/aaa/k8s-infra-prow.tf
+++ b/infra/gcp/clusters/projects/kubernetes-public/aaa/k8s-infra-prow.tf
@@ -85,7 +85,8 @@ resource "google_storage_bucket_iam_member" "k8s_infra_prow_oncall" {
 
 // Create a secret for GCP Service Account key of k8s-infra-prow
 resource "google_secret_manager_secret" "k8s_infra_prow_key" {
-  secret_id = google_service_account.k8s_infra_prow.name
+  project   = data.google_project.project.project_id
+  secret_id = "${local.prow_service_account}-sa-key"
 
   replication {
     automatic = true


### PR DESCRIPTION
* The attribute `name` is for `google_service_account_key.k8s_infra_prow`
is the same as the attribute `id`. This is incompatible to `secret_id`
of a `google_secret_manager_secret`.
* Add required project

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>