### PR TITLE
Adding tjferrara to k8s-infra-staging-cip-test

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -149,6 +149,7 @@ groups:
       - linusa@google.com
       - thockin@google.com
       - rajib.jolite@gmail.com
+      - tjferrara@google.com
 
   - email-id: k8s-infra-staging-experimental@kubernetes.io
     name: k8s-infra-staging-experimental


### PR DESCRIPTION
Require access to `gcr.io/k8s-staging-cip-test` for Bazel Deprecation in [CIP](https://github.com/kubernetes-sigs/k8s-container-image-promoter).

**Purpose:**
Existing e2e tests will no longer build test images, in favor of storing image archives locally. Since our e2e tests rely on the exact same images (static image digest), we look to archive the existing images located in `gcr.io/k8s-staging-cip-test`.

Related to issues: [#304](https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/304) [#300](https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/300)
Blocking PR: [#305](https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/305)

cc @kubernetes/release-engineering @listx @justaugustus @amwat