### PR TITLE
groups/sig-testing: Add Christian Glombek to k8s-infra-staging-test-infra

### DIFF
--- a/groups/sig-testing/groups.yaml
+++ b/groups/sig-testing/groups.yaml
@@ -104,6 +104,7 @@ groups:
       ReconcileMembers: "true"
     members:
     - k8s-infra-prow-oncall@kubernetes.io
+    - cglombek@redhat.com
 
   #
   # sig-testing k8s-infra gcs write access


### PR DESCRIPTION
This commit adds myself to the k8s-infra-staging-test-infra group.

I'm currently working on getting `arm64` images built for Prow, and this will give me access to the staging infra so I can test the changes myself.
Adding myself here per @spiffxp's invitation on Slack.
/assign @spiffxp 

(I'm not (yet) a member of the `kubernetes` org, is that a prerequisite for this?)