### PR TITLE
infra/clusters: upgrade terraform to 0.15 for all but k8s-infra-public-pii

### DIFF
--- a/infra/gcp/clusters/modules/gke-cluster/versions.tf
+++ b/infra/gcp/clusters/modules/gke-cluster/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.14.0"
+  required_version = "~> 0.15.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/infra/gcp/clusters/modules/gke-nodepool/versions.tf
+++ b/infra/gcp/clusters/modules/gke-nodepool/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.14.0"
+  required_version = "~> 0.15.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/infra/gcp/clusters/modules/gke-project/versions.tf
+++ b/infra/gcp/clusters/modules/gke-project/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.14.0"
+  required_version = "~> 0.15.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/infra/gcp/clusters/projects/k8s-infra-ii-sandbox/versions.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-ii-sandbox/versions.tf
@@ -4,5 +4,5 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 0.14"
+  required_version = "~> 0.15"
 }

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/versions.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/versions.tf
@@ -4,5 +4,5 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 0.14.0"
+  required_version = "~> 0.15.0"
 }

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/main.tf
@@ -106,6 +106,24 @@ resource "google_service_account_iam_policy" "boskos_janitor_sa_iam" {
   policy_data        = data.google_iam_policy.boskos_janitor_sa_workload_identity.policy_data
 }
 
+// external ip formerly managed by infra/gcp/prow/ensure-e2e-projects.sh
+resource "google_compute_address" "boskos_metrics" {
+  name         = "boskos-metrics"
+  description  = "to allow monitoring.k8s.prow.io to scrape boskos metrics"
+  project      = local.project_id
+  region       = local.cluster_location
+  address_type = "EXTERNAL"
+}
+
+// external ip formerly managed by infra/gcp/prow/ensure-e2e-projects.sh
+resource "google_compute_address" "greenhouse_metrics" {
+  name         = "greenhouse-metrics"
+  description  = "to allow monitoring.k8s.prow.io to scrape greenhouse metrics"
+  project      = local.project_id
+  region       = local.cluster_location
+  address_type = "EXTERNAL"
+}
+
 module "prow_build_cluster" {
   source = "../../../modules/gke-cluster"
   project_name       = local.project_id

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/versions.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/versions.tf
@@ -4,5 +4,5 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 0.14.0"
+  required_version = "~> 0.15.0"
 }

--- a/infra/gcp/clusters/projects/kubernetes-public/aaa/00-inputs.tf
+++ b/infra/gcp/clusters/projects/kubernetes-public/aaa/00-inputs.tf
@@ -7,7 +7,7 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 0.14.0"
+  required_version = "~> 0.15.0"
 
   backend "gcs" {
     bucket = "k8s-infra-tf-public-clusters"

--- a/infra/gcp/prow/ensure-e2e-projects.sh
+++ b/infra/gcp/prow/ensure-e2e-projects.sh
@@ -47,13 +47,6 @@ BOSKOS_JANITOR_SVCACCT=$(svc_acct_email "${BUILD_CLUSTER_PROJECT}" "boskos-janit
 mapfile -t E2E_PROJECTS < <(k8s_infra_projects "e2e")
 readonly E2E_PROJECTS
 
-# prow build cluster services that expose metrics endpoints to be scraped
-# by monitoring.prow.k8s.io; they each get a regional address
-readonly PROW_BUILD_CLUSTER_METRICS_SERVICES=(
-    "boskos-metrics"
-    "greenhouse-metrics"
-)
-
 function ensure_e2e_project() {
     if [ $# != 1 ] || [ -z "$1" ]; then
         echo "${FUNCNAME[0]}(project) requires 1 argument" >&2
@@ -142,21 +135,6 @@ function ensure_e2e_project() {
         --metadata-from-file ssh-keys="${ssh_keys_after}"
       diff_colorized "${ssh_keys_before}" "${ssh_keys_after}"
     fi
-}
-
-# TODO: this should be moved to the terraform responsible for k8s-infra-prow-build
-function ensure_prow_build_cluster_metrics_endpoints() {
-    local project="${BUILD_CLUSTER_PROJECT}"
-    local region="us-central1"
-    for service in "${PROW_BUILD_CLUSTER_METRICS_SERVICES[@]}"; do
-        color 6 "Ensuring monitoring.prow.k8s.io can scrape ${service} for: ${project}"
-        ensure_regional_address \
-          "${project}" \
-          "${region}" \
-          "${service}" \
-          "to allow monitoring.k8s.prow.io to scrape ${service}" \
-          2>&1 | indent
-    done
 }
 
 # TODO: this should be moved to the terraform responsible for k8s-infra-prow-build-trusted


### PR DESCRIPTION
Migration was performed by editing required versions, then running:

    terraform init -reconfigure
    terraform apply

The following folders have been migrated

- modules/gke-cluster
- modules/gke-nodepool
- modules/gke-project
- projects/k8s-infra-ii-sandbox
- projects/k8s-infra-prow-build
- projects/k8s-infra-prow-build-trusted

The one folder not migrated is projects/k8s-infra-public-pii since
that's still being deployed. However, since it doesn't depend on
modules/ it can be done as a followup