### PR TITLE
Technical lead access for cpanato and puerco

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -45,6 +45,7 @@ groups:
       - paris.pittman@gmail.com
       - spiffxp@gmail.com
     members:
+      - adolfo.garcia@uservers.net
       - ahg@google.com
       - alarcj137@gmail.com
       - ameukam@gmail.com
@@ -57,6 +58,7 @@ groups:
       - chiachenk@google.com
       - cncf-speakers@linuxfoundation.org
       - community@kubernetes.io
+      - ctadeu@gmail.com
       - davanum@gmail.com
       - davidopp@google.com
       - dawnchen@google.com

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -41,6 +41,8 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
+      - adolfo.garcia@uservers.net
+      - ctadeu@gmail.com
       - georgedanielmangum@gmail.com
       - k8s@auggie.dev
       - saschagrunert@gmail.com

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -225,6 +225,8 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
+      - adolfo.garcia@uservers.net
+      - ctadeu@gmail.com
       - georgedanielmangum@gmail.com
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -328,6 +328,8 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
+      - adolfo.garcia@uservers.net
+      - ctadeu@gmail.com
       - georgedanielmangum@gmail.com
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -254,14 +254,14 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
+      - adolfo.garcia@uservers.net
+      - ctadeu@gmail.com
       - georgedanielmangum@gmail.com
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
       - saschagrunert@gmail.com
     members:
-      - adolfo.garcia@uservers.net
       - augustus@cisco.com
-      - ctadeu@gmail.com
       - mudrinic.mare@gmail.com
 
   - email-id: release-managers@kubernetes.io

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -274,6 +274,8 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
+      - adolfo.garcia@uservers.net
+      - ctadeu@gmail.com
       - georgedanielmangum@gmail.com
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
@@ -285,7 +287,6 @@ groups:
       - antheabjung@gmail.com
       - augustus@cisco.com
       - bentheelder@google.com
-      - ctadeu@gmail.com
       - dcampau1@gmail.com
       - divya.mohan0209@gmail.com
       - gmccloskey@google.com


### PR DESCRIPTION
This is the access part of the technical lead onboarding of @cpanato and @puerco. This PR takes care of adding/moving our emails to the following groups:

* leads (members)
* k8s-infra-release-admins (members)
* k8s-infra-release-editors (members)
* release-comms (owners)
* release-managers (owners)
* release-managers-private (owners)

Ref: https://github.com/kubernetes/sig-release/issues/1590

/assign @dims @cblecker
/cc @justaugustus @saschagrunert
cc: @kubernetes/release-engineering
