### PR TITLE
infra/clusters: upgrade to terraform 1.0

### DIFF
--- a/infra/gcp/clusters/modules/gke-cluster/versions.tf
+++ b/infra/gcp/clusters/modules/gke-cluster/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.15.0"
+  required_version = "~> 1.0.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/infra/gcp/clusters/modules/gke-nodepool/versions.tf
+++ b/infra/gcp/clusters/modules/gke-nodepool/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.15.0"
+  required_version = "~> 1.0.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/infra/gcp/clusters/modules/gke-project/versions.tf
+++ b/infra/gcp/clusters/modules/gke-project/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.15.0"
+  required_version = "~> 1.0.0"
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/infra/gcp/clusters/projects/k8s-infra-ii-sandbox/versions.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-ii-sandbox/versions.tf
@@ -4,5 +4,5 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 0.15"
+  required_version = "~> 1.0.0"
 }

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/versions.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/versions.tf
@@ -4,5 +4,5 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 0.15.0"
+  required_version = "~> 1.0.0"
 }

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/versions.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/versions.tf
@@ -4,5 +4,5 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 0.15.0"
+  required_version = "~> 1.0.0"
 }

--- a/infra/gcp/clusters/projects/k8s-infra-public-pii/versions.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-public-pii/versions.tf
@@ -4,5 +4,5 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 0.14.0"
+  required_version = "~> 1.0.0"
 }

--- a/infra/gcp/clusters/projects/kubernetes-public/aaa/00-inputs.tf
+++ b/infra/gcp/clusters/projects/kubernetes-public/aaa/00-inputs.tf
@@ -7,7 +7,7 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 0.15.0"
+  required_version = "~> 1.0.0"
 
   backend "gcs" {
     bucket = "k8s-infra-tf-public-clusters"


### PR DESCRIPTION
All changes have been deployed for the following in infra/gcp/projects:

- k8s-infra-ii-sandbox
- k8s-infra-prow-build/prow-build
- k8s-infra-prow-build-trusted/prow-build-trusted
- k8s-infra-public-pii
- kubernetes-public/aaa

k8s-infra-public-pii was upgraded to v0.15 before upgrading to 1.0

All changes were no-ops; terraform suggested `apply -refresh-only`
but I ran a full `terraform apply` anyway

Upgrading terraform ref: https://github.com/kubernetes/k8s.io/issues/2020