### PR TITLE
prow: add k8s-infra-gci-robot-github-token ExternalSecret

### DIFF
--- a/infra/gcp/ensure-main-project.sh
+++ b/infra/gcp/ensure-main-project.sh
@@ -331,6 +331,12 @@ function ensure_aaa_external_secrets() {
 
     # another sign that we should move to using YAML as source of intent;
     # bash and indirect array access don't play nice, so we get this...
+
+    # prow as in the k8s-infra-prow instance being stood up on aaa, not the
+    # build clusters managed via infra/gcp/clusters/k8s-infra-prow-build*
+    local prow_secrets=(
+        k8s-infra-ci-robot-github-token
+    )
     local slack_infra_secrets=(
         recaptcha
         slack-event-log-config
@@ -343,6 +349,7 @@ function ensure_aaa_external_secrets() {
         triage-party-github-token
     )
     mapfile -t secret_specs < <(
+        printf "%s/prow/sig-testing\n" "${prow_secrets[@]}"
         printf "%s/slack-infra/sig-contributor-experience\n" "${slack_infra_secrets[@]}"
         printf "%s/triageparty-release/sig-release\n" "${triageparty_release_secrets[@]}"
     )

--- a/prow/prow-externalsecrets.yaml
+++ b/prow/prow-externalsecrets.yaml
@@ -1,0 +1,15 @@
+# This is a place holder for adding kubernetes external secrets, please add the
+# ExternalSecret CR here, separated by `---`.
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: k8s-infra-ci-robot-github-token
+  namespace: prow
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-public
+  data:
+  - key: k8s-infra-ci-robot-github-token # The name of the GSM Secret
+    name: token                          # The key to write to in the Kubernetes Secret
+    version: latest                      # The version of the GSM Secret


### PR DESCRIPTION
Part of umbrella issue to setup a k8s-infra-prow instance on aaa, ref: https://github.com/kubernetes/k8s.io/issues/1394
Part of umbrella issue to migrate everything to ExternalSecrets, ref: https://github.com/kubernetes/k8s.io/issues/2220

Depends on https://github.com/kubernetes/k8s.io/pull/2226 to upgrade aaa's kubernetes-external-secrets to v8.x so we can use the v1 API.