### PR TITLE
infra/gcp: enable GCS access logs for staging project GCS and GCR

### DIFF
--- a/infra/gcp/ensure-staging-storage.sh
+++ b/infra/gcp/ensure-staging-storage.sh
@@ -189,6 +189,9 @@ function ensure_staging_gcs_bucket() {
 
     color 6 "Ensuring ${writers} can write to ${bucket} in project: ${project}"
     empower_group_to_write_gcs_bucket "${writers}" "${bucket}"
+
+    # Ensure logging is turned on
+    ensure_gcs_bucket_logging "${bucket}"
 }
 
 # Ensure a GCR repo is provisioned in the given staging project, with
@@ -205,6 +208,7 @@ function ensure_staging_gcr_repo() {
     fi
     local project="${1}"
     local writers="${2}"
+    local gcr_bucket="gs://artifacts.${1}.appspot.com"
 
     color 6 "Ensuring a GCR repo exists for project: ${project}"
     ensure_gcr_repo "${project}"
@@ -214,6 +218,9 @@ function ensure_staging_gcr_repo() {
 
     color 6 "Ensuring GCR admins can admin GCR for project: ${project}"
     empower_gcr_admins "${project}"
+    
+    color 6 "Ensuring logging on ${gcr_bucket} for GCR project: ${project}"
+    ensure_gcs_bucket_logging "${gcr_bucket}"
 }
 
 # Ensure GCB is setup for the given staging project, by ensuring the

--- a/infra/gcp/lib.sh
+++ b/infra/gcp/lib.sh
@@ -52,6 +52,9 @@ trap 'cleanup_tmpdir' EXIT
 # Useful organization-wide constants
 #
 
+# Set up logs bucket
+export K8S_INFRA_GCSLOGS_BUCKET="gs://k8s-infra-artifacts-gcslogs"
+
 # The GCP org stuff needed to turn it all on.
 readonly GCP_ORG="758905017065" # kubernetes.io
 readonly GCP_BILLING="018801-93540E-22A20E"


### PR DESCRIPTION
Addresses:
https://github.com/kubernetes/k8s.io/issues/904#issuecomment-859932423
Intent:                                                                                                                                                                                                                                                       
- Ensure a bucket exist for the logs inside each project                                                                                                                                                                                                        
- Enable logging for k8s-staging-* buckets                                                                                                                                                                                                                      
- Ensure access is gated to limit access per #2031     
Research:
https://github.com/ii/org/blob/main/research/k8sio-ensure-staging-pii-gcs.org 