### PR TITLE
hack: verify-terraform no args == all *.tf paths

### DIFF
--- a/hack/verify-terraform.sh
+++ b/hack/verify-terraform.sh
@@ -20,46 +20,83 @@ set -o pipefail
 REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
 
 function usage() {
-  echo >&2 "Usage: $0 <PATH>"
-  exit 1
+    echo >&2 "Usage: $0 [path...]"
+    exit 1
+}
+
+function ensure_dependencies() {
+    if [ -z "$(which curl)" ]; then
+        echo "Please install curl"
+        exit 1
+    fi
+
+    if [ -z "$(which tfswitch)" ]; then
+        echo "Please install tfswitch"
+        exit 1
+    fi
 }
 
 function check_terraform() {
-  if [ $# != 1 ]; then
-    echo "check_terraform(path) requires 1 argument" >&2
-    exit 1
+  local path="${1}"
+
+  if [ ! -d "${path}" ]; then
+      echo "check_terraform: path '${path}' is not a directory (or does not exist)"
+      return 1
   fi
 
-  if [ ! -d "$1" ]; then
-    echo "path not found"
-    exit 1
-  fi
+  pushd "${path}" >/dev/null
 
-  cd "$1"
-  echo "Installing Terraform"
+  echo "# Installing terraform for path: ${path} ..."
   tfswitch
-  echo "Running terraform validate"
+
+  echo "# Running terraform validate for path: ${path} ..."
   terraform init -backend=false
   terraform validate
+
+  popd >/dev/null
 }
 
+function main() {
+    local paths=("$@")
+    local failures=()
 
-if [ $# != 1 ]; then
-    usage
-    exit 1
-fi
+    ensure_dependencies
 
-if [ -z "$(which curl)" ]; then
-  echo "Please install curl"
-  exit 1
-fi
+    # if no paths specified, default to all paths that contain *.tf,
+    # excluding modules/* since those are picked up by way of inclusion
+    # in the rest of our terraform
+    pushd "$REPO_ROOT"
+    if [ "${#paths[@]}" == 0 ]; then
+        mapfile -t paths < <(
+          find . -name '*.tf' -print0 \
+            | xargs -0 -n1 dirname \
+            | sort \
+            | uniq \
+            | grep -v ^./infra/gcp/clusters/modules/
+        )
+    fi
 
-if [ -z "$(which tfswitch)" ]; then
-  echo "Installing tfswitch locally"
-  curl -L https://raw.githubusercontent.com/warrensbox/terraform-switcher/release/install.sh | bash
-else
-tfswitch --version
-fi
+    # verify all terraform paths
+    for path in "${paths[@]}"; do
+        echo "# Verifying terraform for path: ${path} ..."
+        if ! check_terraform "${path}"; then
+            failures+=("${path}")
+        fi
+    done
 
-cd "$REPO_ROOT"
-check_terraform "$1"
+    # determine pass/fail
+    result="passed"
+    code=0
+    if [ ${#failures[@]} != 0 ]; then
+        result="failed"
+        code=1
+    fi
+
+    # report
+    echo "result: ${result}"
+    echo "failures:"
+    printf "%s\n" "${failures[@]/#/- }"
+    exit "${code}"
+}
+
+main "$@"


### PR DESCRIPTION
Not opting to have this run by default as part of verify.sh because:

- Errors when run against paths that had terraform init run with a
  backend the current user can't access (see below)
- Running no-args takes too long IMO; 15s locally for no changes

Working around "already init'ed with a bad backend" is hard because:

- terrafom init -from-source into a tmp dir fixes this (no backend to
  begin with), but breaks on loading modules from local relative paths
- terraform has a git_repository data source, but it needs a manually
  specified root (either in source, or via the GIT_DIR env var)
- so... not yet found a way to avoid having to hardcode a path or always
  invoking terraform with GIT_DIR