### PR TITLE
audit: refactor create-or-update-audit-pr.sh

### DIFF
--- a/audit/create-or-update-audit-pr.sh
+++ b/audit/create-or-update-audit-pr.sh
@@ -31,68 +31,157 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-GH_USER=cncf-ci
-GH_NAME="CNCF CI Bot"
-GH_EMAIL="cncf-ci@ii.coop"
-GH_TOKEN=$(cat /etc/github-token/token)
-FORK_GH_REPO=k8s.io
-FORK_GH_BRANCH=autoaudit-${PROW_INSTANCE_NAME:-prow}
-FORK_URI="https://github.com/${GH_USER}/${FORK_GH_REPO}"
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
 
-if [ -z "${GH_TOKEN}" ]; then
-  >&2 echo "ERROR: GH_TOKEN is empty"
-  exit 1
-fi
+#
+# config (overridable)
+#
 
-echo "Ensure git configured" >&2
-git config user.name "${GH_NAME}"
-git config user.email "${GH_EMAIL}"
+# paths used to build/install pr-creator if not present in PATH
+readonly TEST_INFRA_DIR="${TEST_INFRA_DIR:-${REPO_ROOT}/../test-infra}"
+readonly AUDIT_BIN_DIR="${AUDIT_BIN_DIR:-${REPO_ROOT}/tmp/bin}"
 
-echo "Ensure gcloud creds are working" >&2
-gcloud config list
+# git name/e-mail that will commit changes
+readonly GIT_NAME=${GIT_NAME:-"CNCF CI Bot"}
+readonly GIT_EMAIL=${GIT_EMAIL:-"cncf-ci@ii.coop"}
 
-echo "Ensure git creds are working" >&2
-git config --list
+# github user that will push and PR changes. They must have permissions to:
+# - push FORK_BRANCH to ${fork_public_url}
+# - open and update PRs made from ${fork_public_url}
+#
+# NB: since pr-creator requires a token path, this script does not support
+#     automatically picking up GITHUB_TOKEN from en
+readonly GITHUB_USER=${GITHUB_USER:-"cncf-ci"}
+readonly GITHUB_TOKEN_PATH=${GITHUB_TOKEN_PATH:-"/etc/github-token/token"}
+GITHUB_TOKEN=$(cat "${GITHUB_TOKEN_PATH}")
+readonly GITHUB_TOKEN
 
-echo "Running Audit Script to dump GCP configuration to yaml" >&2
-pushd ./audit
-bash ./audit-gcp.sh
-popd
+# github repo and branch where changes are pushed and PR'ed from
+readonly FORK_GITHUB_USER=${FORK_GITHUB_USER:-${GITHUB_USER}}
+readonly FORK_GITHUB_REPO=${FORK_GITHUB_REPO:-"k8s.io"}
+readonly FORK_BRANCH=${FORK_BRANCH:-"autoaudit-${PROW_INSTANCE_NAME:-"prow"}"}
+readonly FORK_REMOTE_NAME=${FORK_REMOTE_NAME:-"fork"}
 
-echo "Determining whether there are changes to push" >&2
-git add --all audit
-git commit -m "audit: update as of $(date +%Y-%m-%d)"
-if git remote get-url fork >/dev/null; then
-  git remote set-url fork "${FORK_URI}"
-else
-  git remote add fork "${FORK_URI}"
-fi
-if git fetch fork "${FORK_GH_BRANCH}"; then
-    if git diff --quiet HEAD "fork/${FORK_GH_BRANCH}" -- audit; then
-    echo "No new changes to push, exiting early..." >&2
-    exit
+# github repo where changes are PR'ed to
+readonly BASE_GITHUB_USER=${BASE_GITHUB_USER:-"kubernetes"}
+readonly BASE_GITHUB_REPO=${BASE_GITHUB_REPO:-"k8s.io"}
+# TODO: this could be excluded since pr-creator supports default branch
+readonly BASE_BRANCH=${BASE_BRANCH:-"main"}
+
+#
+# config (computed)
+#
+
+readonly audit_dir="./audit"
+readonly fork_public_url="https://github.com/${FORK_GITHUB_USER}/${FORK_GITHUB_REPO}"
+readonly fork_private_url="https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${FORK_GITHUB_USER}/${FORK_GITHUB_REPO}"
+
+#
+# functions
+#
+
+function cleanup() {
+    echo ""
+    echo "trapped EXIT, cleaning up ..."
+    echo "Removing fork remote '${FORK_REMOTE_NAME}' ..."
+    git remote rm fork
+    echo "Done cleaning up"
+}
+
+function ensure_dependencies() {
+    trap 'cleanup' EXIT
+
+    echo "Ensure git configured ..."
+    # Using env vars overrides system/global/local git config and does not
+    # persist if this script exits early
+    export GIT_AUTHOR_EMAIL="${GIT_EMAIL}"
+    export GIT_COMMITTER_EMAIL="${GIT_EMAIL}"
+    export GIT_AUTHOR_NAME="${GIT_NAME}"
+    export GIT_COMMITTER_NAME="${GIT_NAME}"
+
+    echo "Ensure fork remote '${FORK_REMOTE_NAME}' exists ..."
+    # setup the fork remote
+    # TODO: ideally we would use ssh to push instead; storing the token in the
+    #       url means we need to avoid leaking the remote url
+    if git remote get-url "${FORK_REMOTE_NAME}" 2>/dev/null; then
+        git remote set-url "${FORK_REMOTE_NAME}" "${fork_private_url}"
+    else
+        git remote add "${FORK_REMOTE_NAME}" "${fork_private_url}"
     fi
-fi
+    # TODO: this will fail if FORK_REMOTE_URL doesn't exist; use `gh fork` instead?
+    git fetch "${FORK_REMOTE_NAME}" "${FORK_BRANCH}"
 
-prcreator=pr-creator
-if ! command -v "${prcreator}" &>/dev/null; then
-    echo "Generating pr-creator binary from k/test-infra/robots" >&2
-    pushd ../../kubernetes/test-infra
-    go build -o /workspace/pr-creator robots/pr-creator/main.go
-    prcreator=/workspace/pr-creator
-    popd
-fi
+    echo "Ensure gcloud creds are working ..."
+    gcloud config list
 
-echo "Pushing commit to github.com/${GH_USER}/${FORK_GH_REPO}..." >&2
+    echo "Ensure GITHUB_TOKEN is non-empty ..."
+    if [ -z "${GITHUB_TOKEN}" ]; then
+      >&2 echo "ERROR: GITHUB_TOKEN is empty"
+      exit 1
+    fi
 
-git push -f "https://${GH_USER}:${GH_TOKEN}@github.com/${GH_USER}/${FORK_GH_REPO}" "HEAD:${FORK_GH_BRANCH}" 2>/dev/null
+    echo "Ensure pr-creator is installed ..."
+    if ! command -v "pr-creator" >/dev/null; then
+        pushd "${TEST_INFRA_DIR}"
+        mkdir -p "${AUDIT_BIN_DIR}"
+        go build -o "${AUDIT_BIN_DIR}/pr-creator" robots/pr-creator/main.go
+        export PATH="${AUDIT_BIN_DIR}:${PATH}"
+        popd
+    fi
+}
 
-echo "Creating or updating PR to merge ${GH_USER}:${FORK_GH_BRANCH} into kubernetes:main..." >&2
-"${prcreator}" \
-    --github-token-path=/etc/github-token/token \
-    --org=kubernetes --repo=k8s.io --branch=main \
-    --source="${GH_USER}:${FORK_GH_BRANCH}" \
-    --head-branch="${FORK_GH_BRANCH}" \
-    --title="audit: update as of $(date +%Y-%m-%d)" \
-    --body="Audit Updates wg-k8s-infra" \
-    --confirm
+function run_audit() {
+    echo "Running audit script to export GCP resources ..." >&2
+    "${audit_dir}/audit-gcp.sh" "$@"
+}
+
+function push_changes_if_any() {
+    echo "Identifying changes ..." >&2
+    git status --porcelain "${audit_dir}"
+    echo "Adding changes ..." >&2
+    # TODO: use a branch instead of HEAD?
+    git add "${audit_dir}"
+    echo "Committing changes ..." >&2
+    git commit -m "audit: update as of $(date +%Y-%m-%d)"
+    echo "Fetching fork remote '${FORK_REMOTE_NAME}' ..." >&2
+    if git fetch "${FORK_REMOTE_NAME}" "${FORK_BRANCH}"; then
+        echo "Verifying whether HEAD differs from ${fork_public_url}/tree/${FORK_BRANCH} ..."
+        if git diff --quiet HEAD "${FORK_REMOTE_NAME}/${FORK_BRANCH}" -- "${audit_dir}"; then
+            echo "No new changes to push, exiting early..." >&2
+            exit
+        fi
+    fi
+
+    echo "Pushing HEAD to ${FORK_BRANCH} in ${fork_public_url}..." >&2
+    git push -f "${FORK_REMOTE_NAME}" "HEAD:${FORK_BRANCH}" 2>/dev/null
+}
+
+function create_or_update_audit_pr() {
+    echo "Creating or updating PR to merge ${FORK_GITHUB_USER}:${FORK_BRANCH} into ${BASE_GITHUB_USER}:${BASE_BRANCH}..." >&2
+    local args=(
+        --github-token-path="${GITHUB_TOKEN_PATH}"
+        --org="${BASE_GITHUB_USER}"
+        --repo="${BASE_GITHUB_REPO}"
+        --branch="${BASE_BRANCH}"
+        --source="${FORK_GITHUB_USER}:${FORK_BRANCH}"
+        --head-branch="${FORK_BRANCH}"
+        --title="audit: update as of $(date +%Y-%m-%d)"
+        --body="Audit Updates wg-k8s-infra"
+        --confirm
+    )
+    pr-creator "${args[@]}"
+}
+
+#
+# main
+#
+
+function main() {
+    ensure_dependencies
+    run_audit "$@"
+    push_changes_if_any
+    create_or_update_audit_pr
+    echo "Done!"
+}
+
+main "$@"

--- a/images/k8s-infra/Makefile
+++ b/images/k8s-infra/Makefile
@@ -56,6 +56,7 @@ run:
 		--tty \
 		--volume $(HOME)/.config/gcloud:/root/.config/gcloud \
 		--volume $(HOME)/.gitconfig:/root/.gitconfig \
+		--volume $(HOME)/.gitignore_global:/root/.gitignore_global \
 		--volume $(HOME)/.secrets/github.token:/etc/github-token/token \
 		--volume $(repo_root):/workspace/kubernetes/k8s.io \
 		--workdir /workspace/kubernetes/k8s.io \


### PR DESCRIPTION
Mostly changes aimed at making local testing of this script easier:

- add config, aka extract hardcodes into (overridable) env vars
- add cleanup function to try avoiding pollution of local dev env
- refactor into functions for ease of local testing
- allow arg passthrough to audit-gcp.sh

The amount of configurable env vars seems like overkill, and mimics the 
surface area of pr-creator.

An example of running with some local overrides, from repo root:

    make -C images/k8s-infra run \
      WHAT="bash -c 'GIT_NAME=foo GIT_EMAIL=bar@baz.com
      ./audit/create-or-update-audit-pr.sh k8s-staging-kubetest2'"