### PR TITLE
Add tab to Triage Party for SIG Node BSP

### DIFF
--- a/triage-party/release-team/configmap.yaml
+++ b/triage-party/release-team/configmap.yaml
@@ -76,6 +76,15 @@ data:
           - kind-flake
           - kind-failing-test
 
+      ### For SIG Node BSP June 24-25, 2021 ###
+      - id: sig-node-bsp
+        name: SIG Node Bug Scrub
+        dedup: true
+        description: >
+          Dashboard tracking open SIG Node issues.
+        rules:
+          - kind-node-bsp
+
     rules:
       ### Milestone ###
       milestone-issues:
@@ -497,3 +506,11 @@ data:
       open-prs:
         name: "Open PRs"
         type: pull_request
+
+      ### For SIG Node BSP June 24-25, 2021 ###
+      kind-node-bsp:
+        name: "issues for Node Bug Scrub"
+        type: issue
+        resolution: Categorize, clean up, and close
+        filters:
+          - label: "sig/node"


### PR DESCRIPTION
Fixes #2205.
Fixes https://github.com/kubernetes/org/issues/2786.

/assign @justaugustus 
/cc @ameukam @cblecker 

I think this is all SIG Node will need if we can reuse the existing SIG Release Triage party. Is this okay?

/sig node