### PR TITLE
infra/gcp/aaa: Change image type for the node pools.

### DIFF
--- a/infra/gcp/clusters/projects/kubernetes-public/aaa/11-pool1-configuration.tf
+++ b/infra/gcp/clusters/projects/kubernetes-public/aaa/11-pool1-configuration.tf
@@ -36,6 +36,7 @@ resource "google_container_node_pool" "pool1" {
     machine_type = "n1-standard-2"
     disk_size_gb = 100
     disk_type    = "pd-standard"
+    image_type   = "COS_CONTAINERD"
 
     service_account = google_service_account.cluster_node_sa.email
     oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]

--- a/infra/gcp/clusters/projects/kubernetes-public/aaa/11-pool2-configuration.tf
+++ b/infra/gcp/clusters/projects/kubernetes-public/aaa/11-pool2-configuration.tf
@@ -36,6 +36,7 @@ resource "google_container_node_pool" "pool2" {
     machine_type = "n1-standard-4"
     disk_size_gb = 100
     disk_type    = "pd-standard"
+    image_type   = "COS_CONTAINERD"
 
     service_account = google_service_account.cluster_node_sa.email
     oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]


### PR DESCRIPTION
Ref: https://github.com/kubernetes/k8s.io/issues/2013

The default image was `COS` and it's now deprecated.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>