### PR TITLE
Manifests for promotion of CSI-proxy

### DIFF
--- a/artifacts/filestores/k8s-staging-sig-storage/filepromoter-manifest.yaml
+++ b/artifacts/filestores/k8s-staging-sig-storage/filepromoter-manifest.yaml
@@ -1,0 +1,6 @@
+# google group for gcr.io/k8s-staging-sig-storage is kubernetes-sig-storage@kubernetes.io
+filestores:
+- base: gs://k8s-staging-sig-storage/csiproxy/
+  src: true
+- base: gs://k8s-artifacts-prod/binaries/storage/csiproxy
+  service-account: k8s-infra-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/artifacts/manifests/k8s-staging-sig-storage/master.yaml
+++ b/artifacts/manifests/k8s-staging-sig-storage/master.yaml
@@ -1,0 +1,3 @@
+files:
+- name: 1.0.2/csi-proxy.exe
+  sha256: 2d7f4c5665bf1e572a56f431bd6ecce816640953dea43985dba565f68e5ddb9d


### PR DESCRIPTION
This describes the non-image artifacts that should be published as
part of csiproxy.

The automated promotion job is not yet in place, so promotion will be
done manually or will have to wait for the prow job.