### PR TITLE
releng: Drop onlydole temporary RM access

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -61,7 +61,6 @@ groups:
       - georgedanielmangum@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
-      - onlydole@gmail.com
       - saschagrunert@gmail.com
 
   - email-id: k8s-infra-release-viewers@kubernetes.io


### PR DESCRIPTION
Taylor (@onlydole) is a Release Manager Associate with SIG Release who was granted temporary access to cut the v1.22.0-beta.0 release.

The release is out so we drop the temporary access.

k/sig-release issue: https://github.com/kubernetes/sig-release/issues/1601

/assign @dims @cblecker
cc: @kubernetes/release-engineering

Signed-off-by: Adolfo García Veytia (Puerco) adolfo.garcia@uservers.net

