### PR TITLE
releng: Temporary RM access for ameukam

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -57,6 +57,7 @@ groups:
     members:
       - k8s-infra-release-admins@kubernetes.io
       - adolfo.garcia@uservers.net
+      - ameukam@gmail.com
       - ctadeu@gmail.com
       - georgedanielmangum@gmail.com
       - k8s@auggie.dev


### PR DESCRIPTION
Arnaud (@ameukam) is a Release Manager Associate with SIG Release being granted
temporary elevated access to cut the v1.22.0-beta.1 release. Access will be
revoked after the 1.22.0-beta.1 release is cut.

SIG Release issue: kubernetes/sig-release#1614

/assign @dims @cblecker @spiffxp
cc: @kubernetes/release-engineering 

/priority important-soon

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>