### PR TITLE
releng: drop ameukam temporary RM access

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -57,7 +57,6 @@ groups:
     members:
       - k8s-infra-release-admins@kubernetes.io
       - adolfo.garcia@uservers.net
-      - ameukam@gmail.com
       - ctadeu@gmail.com
       - georgedanielmangum@gmail.com
       - k8s@auggie.dev


### PR DESCRIPTION
@ameukam is a Relaese Manager Associate with SIG Release who was granted
temporary access to cut the v1.22.0-beta.1 release.

The release is out so we drop the temporary access.

k/sig-release issue: https://github.com/kubernetes/sig-release/issues/1614

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>