### PR TITLE
Add k8s-infra-scale-golang-builds bucket for CI.

### DIFF
--- a/infra/gcp/clusters/projects/kubernetes-public/aaa/10-cluster-configuration.tf
+++ b/infra/gcp/clusters/projects/kubernetes-public/aaa/10-cluster-configuration.tf
@@ -8,10 +8,11 @@ Note that it does not configure any node pools; this is done in a separate file.
 */
 
 locals {
-  cluster_name                       = "aaa"         // This is the name of the cluster defined in this file
-  cluster_location                   = "us-central1" // This is the GCP location (region or zone) where the cluster should be created
-  bigquery_location                  = "US"          // This is the bigquery specific location where the dataset should be created
-  scalability_tests_logs_bucket_name = "k8s-infra-scalability-tests-logs" // Name of the bucket for the scalability test results
+  cluster_name                          = "aaa"                              // This is the name of the cluster defined in this file
+  cluster_location                      = "us-central1"                      // This is the GCP location (region or zone) where the cluster should be created
+  bigquery_location                     = "US"                               // This is the bigquery specific location where the dataset should be created
+  scalability_tests_logs_bucket_name    = "k8s-infra-scalability-tests-logs" // Name of the bucket for the scalability test results
+  scalability_golang_builds_bucket_name = "k8s-infra-scale-golang-builds"    // Name of the bucket for the scalability golang builds
 }
 
 // Create SA for nodes
@@ -230,4 +231,57 @@ data "google_iam_policy" "scalability_tests_logs_bindings" {
 resource "google_storage_bucket_iam_policy" "scalability_tests_logs_policy" {
   bucket      = google_storage_bucket.scalability_tests_logs.name
   policy_data = data.google_iam_policy.scalability_tests_logs_bindings.policy_data
+}
+
+// Bucket used for Golang Scalability builds
+resource "google_storage_bucket" "scalability_golang_builds" {
+  project = data.google_project.project.project_id
+  name    = local.scalability_golang_builds_bucket_name
+
+  uniform_bucket_level_access = true
+}
+
+data "google_iam_policy" "scalability_golang_builds_bindings" {
+  // Ensure k8s-infra-sig-scalability-oncall has admin privileges
+  binding {
+    members = [
+      "group:k8s-infra-sig-scalability-oncall@kubernetes.io",
+    ]
+    role = "roles/storage.admin"
+  }
+  // Maintain legacy admins privilegies
+  binding {
+    members = [
+      "group:k8s-infra-sig-scalability-oncall@kubernetes.io",
+      "projectEditor:${data.google_project.project.project_id}",
+      "projectOwner:${data.google_project.project.project_id}",
+    ]
+    role = "roles/storage.legacyBucketOwner"
+  }
+  binding {
+    members = [
+      "projectViewer:${data.google_project.project.project_id}",
+    ]
+    role = "roles/storage.legacyBucketReader"
+  }
+  // Ensure prow-build serviceaccount can write to bucket
+  binding {
+    role = "roles/storage.objectAdmin"
+    members = [
+      "serviceAccount:prow-build@k8s-infra-prow-build.iam.gserviceaccount.com",
+    ]
+  }
+  // Ensure bucket is world readable
+  binding {
+    role = "roles/storage.objectViewer"
+    members = [
+      "allUsers"
+    ]
+  }
+}
+
+// Authoritative iam-policy: replaces any existing policy attached to the bucket
+resource "google_storage_bucket_iam_policy" "scalability_golang_builds_policy" {
+  bucket      = google_storage_bucket.scalability_golang_builds.name
+  policy_data = data.google_iam_policy.scalability_golang_builds_bindings.policy_data
 }


### PR DESCRIPTION
We add a community-owned bucket equivalent to k8s-scale-golang-build
and give prow(SA prow-build) write access to this bucket.

Ref: https://github.com/kubernetes/k8s.io/issues/2268

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>