### PR TITLE
Add filter to good-first-issue and help-needed

### DIFF
--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -235,8 +235,8 @@ data:
           rewrite ^/bot-commands$    https://prow.k8s.io/command-help redirect;
           rewrite ^/calendar$        https://www.k8s.dev/calendar redirect;
           rewrite ^/github-labels$   https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md redirect;
-          rewrite ^/good-first-issue$ https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22&type=Issues redirect;
-          rewrite ^/help-wanted$     https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Aissue+label%3A%22help+wanted%22&type=Issues redirect;
+          rewrite ^/good-first-issue$ https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+no%3Aassignee&type=Issues redirect;
+          rewrite ^/help-wanted$     https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+no%3Aassignee&type=Issues redirect;
           rewrite ^/needs-ok-to-test$ https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Apr+label%3Aneeds-ok-to-test+label%3A%22cncf-cla%3A+yes%22+-label%3Aneeds-rebase&type=Issues redirect;
           rewrite ^/oncall$          https://storage.googleapis.com/test-infra-oncall/oncall.html redirect;
           rewrite ^/oncall-hotlist$  https://github.com/kubernetes/test-infra/search?q=label%3Akind%2Foncall-hotlist+is%3Aopen&type=Issues redirect;

--- a/k8s.io/test.py
+++ b/k8s.io/test.py
@@ -173,9 +173,9 @@ class RedirTest(HTTPTestCase):
             self.assert_temp_redirect(base + 'github-labels',
                 'https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md')
             self.assert_temp_redirect(base + 'good-first-issue',
-                'https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22&type=Issues')
+                'https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+no%3Aassignee&type=Issues')
             self.assert_temp_redirect(base + 'help-wanted',
-                'https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Aissue+label%3A%22help+wanted%22&type=Issues')
+                'https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+no%3Aassignee&type=Issues')
             self.assert_temp_redirect(
                 base + 'oncall',
                 'https://storage.googleapis.com/test-infra-oncall/oncall.html')


### PR DESCRIPTION
Fixes #2323

With the extra `no:assignee` filter in the GitHub link, it becomes easier to find un-assigned issues to work on.

/cc @dims 