### PR TITLE
releng: Temporary RM access for jimangel

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -59,6 +59,7 @@ groups:
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
       - georgedanielmangum@gmail.com
+      - jameswangel@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
       - saschagrunert@gmail.com


### PR DESCRIPTION
Jim Angel (@jimangel ) is a Release Manager Associate with SIG Release being granted
temporary elevated access to cut the v1.22.0-beta.2 release. Access will be
revoked after the 1.22.0-beta.2 release is cut.

https://github.com/kubernetes/sig-release/issues/1618

/assign @dims @cblecker @spiffxp
cc: @kubernetes/release-engineering 

/priority important-soon

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>