### PR TITLE
apps: move prow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Kubernetes project infrastructure, managed by the kubernetes comunity via [wg-k8
     - `kubernetes-external-secrets`: instance of [kubernetes-external-secrets] - owned by [sig-testing]
     - `node-perf-dash`: instance of [node-perf-dash] - owned by [sig-node]
     - `perfdash`: instance of [perfdash] - owned by [sig-scalability]
+    - `prow`: work-in-pogress instance of [prow] - owned by [sig-testing]
     - `publishing-bot`: instance of [publishing-bot] - owned by [sig-release]
     - `sippy`: instance of [sippy] at https://sippy.k8s.io - owned by [sig-architecture] (on behalf of [wg-reliability])
     - `slack-infra`: instance of [slack-infra] including https://slack.k8s.io - owned by [sig-contributor-experience]
@@ -22,7 +23,6 @@ Kubernetes project infrastructure, managed by the kubernetes comunity via [wg-k8
     - `clusters/projects`: terraform to manage (parts of) GCP projects
 - `k8s.gcr.io`: container images published by the project, promoted from `gcr.io/k8s-staging-*` repos
 - `k8s.io`: instance of nginx that provides redirects/reverse-proxying for k8s.io and its subdomains - owned by [sig-contributor-experience] and [sig-testing] (TODO(https://github.com/kubernetes/k8s.io/issues/2150) migrate to apps/)
-- `prow`: work-in-pogress instance of [prow] - owned by [sig-testing] (TODO(https://github.com/kubernetes/k8s.io/issues/2150) migrate to apps/)
 - `registry.k8s.io`: work-in-progress to support cross-cloud mirroring/hosting of containers and binaries
 
 TODO: are these actively in use or should they be retired?

--- a/apps/prow/OWNERS
+++ b/apps/prow/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+required_reviewers:
+  - bentheelder
+  - cblecker
+  - spiffxp
+
+labels:
+- area/prow/bump
+- sig/testing

--- a/apps/prow/deploy.sh
+++ b/apps/prow/deploy.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Deploys this app to the aaa cluster, or whatever cluster is pointed to
+# by KUBECTL_CONTEXT if set. Assumes the app's namespace already exists.
+#
+# Members of k8s-infra-rbac-prow@kubernetes.io can run this.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+
+app=$(basename "${SCRIPT_ROOT}")
+
+# coordinates to locate the target cluster in gke
+cluster_name="aaa"
+cluster_project="kubernetes-public"
+cluster_region="us-central1"
+
+# coordinates to locate the app on the target cluster
+namespace="${app}"
+
+# well known name set by `gcloud container clusters get-credentials`
+gke_context="gke_${cluster_project}_${cluster_region}_${cluster_name}"
+context="${KUBECTL_CONTEXT:-${gke_context}}"
+
+# ensure we have a context to talk to the target cluster
+if ! kubectl config get-contexts "${context}" >/dev/null 2>&1; then
+  gcloud container clusters get-credentials "${cluster_name}" --project="${cluster_project}" --region="${cluster_region}"
+  context="${gke_context}"
+fi
+
+# deploy kubernetes resources
+pushd "${SCRIPT_ROOT}" >/dev/null
+kubectl --context="${context}" --namespace="${namespace}" apply -f .

--- a/apps/prow/ghproxy_deployment.yaml
+++ b/apps/prow/ghproxy_deployment.yaml
@@ -17,7 +17,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   labels:
-    app: ghproxy
+    app: prow
+    component: ghproxy
   name: ghproxy
   namespace: prow
 spec:
@@ -32,18 +33,19 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: ghproxy
+    app: prow
+    component: ghproxy
   name: ghproxy
   namespace: prow
 spec:
   selector:
     matchLabels:
-      app: ghproxy
+      component: ghproxy
   replicas: 1
   template:
     metadata:
       labels:
-        app: ghproxy
+        component: ghproxy
     spec:
       containers:
         - name: ghproxy
@@ -76,7 +78,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: ghproxy
+    app: prow
+    component: ghproxy
   name: ghproxy
   namespace: prow
 spec:
@@ -87,5 +90,5 @@ spec:
     - name: metrics
       port: 9090
   selector:
-    app: ghproxy
+    component: ghproxy
   type: ClusterIP

--- a/apps/prow/ghproxy_rbac.yaml
+++ b/apps/prow/ghproxy_rbac.yaml
@@ -18,3 +18,6 @@ apiVersion: v1
 metadata:
   name: ghproxy
   namespace: prow
+  labels:
+    app: prow
+    component: ghproxy

--- a/apps/prow/prow-externalsecrets.yaml
+++ b/apps/prow/prow-externalsecrets.yaml
@@ -6,6 +6,8 @@ kind: ExternalSecret
 metadata:
   name: k8s-infra-ci-robot-github-token
   namespace: prow
+  labels:
+    app: prow
 spec:
   backendType: gcpSecretsManager
   projectId: kubernetes-public


### PR DESCRIPTION
Part of https://github.com/kubernetes/k8s.io/issues/2150

move prow(ghproxy) to apps
Ensure script `deploy.sh` is present
Ensure OWNERS is present.
Update k8s.io/README.md to refect changes

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>