### PR TITLE
k8s.io: use /issues or /pulls for GH queries

### DIFF
--- a/k8s.io/configmap-nginx.yaml
+++ b/k8s.io/configmap-nginx.yaml
@@ -235,9 +235,9 @@ data:
           rewrite ^/bot-commands$    https://prow.k8s.io/command-help redirect;
           rewrite ^/calendar$        https://www.k8s.dev/calendar redirect;
           rewrite ^/github-labels$   https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md redirect;
-          rewrite ^/good-first-issue$ https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+no%3Aassignee&type=Issues redirect;
-          rewrite ^/help-wanted$     https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+no%3Aassignee&type=Issues redirect;
-          rewrite ^/needs-ok-to-test$ https://github.com/search?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Apr+label%3Aneeds-ok-to-test+label%3A%22cncf-cla%3A+yes%22+-label%3Aneeds-rebase&type=Issues redirect;
+          rewrite ^/good-first-issue$ https://github.com/issues?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+no%3Aassignee redirect;
+          rewrite ^/help-wanted$     https://github.com/issues?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+no%3Aassignee redirect;
+          rewrite ^/needs-ok-to-test$ https://github.com/pulls?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Apr+label%3Aneeds-ok-to-test+label%3A%22cncf-cla%3A+yes%22+-label%3Aneeds-rebase redirect;
           rewrite ^/oncall$          https://storage.googleapis.com/test-infra-oncall/oncall.html redirect;
           rewrite ^/oncall-hotlist$  https://github.com/kubernetes/test-infra/search?q=label%3Akind%2Foncall-hotlist+is%3Aopen&type=Issues redirect;
           rewrite ^/owners$          https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md redirect;


### PR DESCRIPTION
It took me deploying the previous change to finally use one of these
redirects, so here's my spin on it.

I prefer to use /issues instead of /search when I'm trying find GitHub
Issues, ditto /pulls for Pull Requests. It gets me a UI that's sort of
like /issues for a given repo, where I can quickly jump between
open/closed, sort order, see labels as they're colored in-repo, etc.

I find /search is useful when what I'm looking for might be something
other than an Issue or Pull Request.

Followup to https://github.com/kubernetes/k8s.io/pull/2324

---

go.k8s.io/help-wanted before:
![Screen Shot 2021-07-13 at 3 53 25 PM](https://user-images.githubusercontent.com/49258/125535401-a6e0198b-a017-4c48-9792-45e9004323c1.png)

go.k8s.io/help-wanted after:
![Screen Shot 2021-07-13 at 3 54 34 PM](https://user-images.githubusercontent.com/49258/125535449-269719ed-60de-49b5-8421-84a5d3a01d3d.png)