### PR TITLE
Adding tjferrara to k8s-infra-gcp-auditors

### DIFF
--- a/groups/wg-k8s-infra/groups.yaml
+++ b/groups/wg-k8s-infra/groups.yaml
@@ -132,6 +132,7 @@ groups:
       - spiffxp@google.com
       - spiffxp@gmail.com
       - thockin@google.com
+      - tjferrara@google.com
 
   - email-id: k8s-infra-gcp-org-admins@kubernetes.io
     name: k8s-infra-gcp-org-admins


### PR DESCRIPTION
Looking for access to the `us.gcr.io/k8s-artifacts-prod` repo for work on this CIP auditor scaling issue: https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/259

cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering