### PR TITLE
Request new group for sig-security-tooling

### DIFF
--- a/groups/README.md
+++ b/groups/README.md
@@ -3,7 +3,6 @@
 ## Making changes
 
 - Edit `groups.yaml` to add a new group or update an existing group
-- All groups MUST start with "k8s-infra-" prefix for the reconcile.go to work
 - Use `make test` to ensure the changes meet conventions
 - Open a pull request
 - When the pull request merges, the [post-k8sio-groups] job will deploy the changes

--- a/groups/sig-security/OWNERS
+++ b/groups/sig-security/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-security-leads
+labels:
+  - sig/security

--- a/groups/sig-security/groups.yaml
+++ b/groups/sig-security/groups.yaml
@@ -1,0 +1,22 @@
+groups:
+  - email-id: security-tooling-private@kubernetes.io
+    name: security-tooling-private
+    description: |-
+      Private list for non-public (internal) triage of security vulnerabilities
+      identified via automated scans of artifacts in k/k
+
+      Membership is restricted to the SIG Security Chairs,
+      SIG Security Tooling Project Lead,
+      Product Security Committee / Security Response Committee,
+      SIG Release Chairs,  Patch Release Team, and Branch Managers.
+    settings:
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      ReconcileMembers: "true"
+    owners:
+      - contributors@kubernetes.io
+      - ian@coldwater.io
+      - tabitha.c.sable@gmail.com
+      - pushkarj.at.work@gmail.com
+    members:
+      - security-release-team@kubernetes.io
+


### PR DESCRIPTION
- Added `OWNERS` file and `groups.yaml` file for a security tooling group that is used for private triage of vulnerabilities identified via automated scans
- Removed a line in README, that does not reflect the current conventions tested
  
 Related PRs: https://github.com/kubernetes/community/pull/5853 and https://github.com/kubernetes/test-infra/pull/22833
  
 Relevant Slack threads: 
 [Question](https://kubernetes.slack.com/archives/C1TU9EB9S/p1626375603426800) 
 [Answer 1](https://kubernetes.slack.com/archives/C1TU9EB9S/p1626378312427400)
 [Answer 2](https://kubernetes.slack.com/archives/C1TU9EB9S/p1626379613431900)
  
/cc @IanColdwater @tabbysable @justaugustus 