### PR TITLE
Check max. length for groups description

### DIFF
--- a/groups/groups_test.go
+++ b/groups/groups_test.go
@@ -115,6 +115,32 @@ func TestStagingEmailLength(t *testing.T) {
 	}
 }
 
+// TestDescriptionLength tests that the number of characters in the
+// google groups description does not exceed 300.
+//
+// This validation is needed because gcloud allows apps:description
+// with length no greater than 300
+func TestDescriptionLength(t *testing.T) {
+	var errs []error
+	for _, g := range cfg.Groups {
+		description := g.Description
+
+		len := utf8.RuneCountInString(description)
+		//Ref: https://developers.google.com/admin-sdk/groups-settings/v1/reference/groups
+		if len > 300 {
+			errs = append(errs,
+				fmt.Errorf("Number of characters in description \"%s\" for group name \"%s\" "+
+					"should not exceed 300; is: %d", description, g.Name, len))
+		}
+	}
+
+	if errs != nil {
+		for _, err := range errs {
+			t.Error(err)
+		}
+	}
+}
+
 // Enforce conventions for all groups
 func TestGroupConventions(t *testing.T) {
 	for _, g := range cfg.Groups {

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -127,21 +127,9 @@ groups:
   - email-id: k8s-infra-staging-cip-test@kubernetes.io
     name: k8s-infra-staging-cip-test
     description: |-
-      ACL for staging cip-test buckets, also the test-only backup and auditing
-      jobs for the promoter. The associated test-only GCP Project IDs are:
-
-        - k8s-cip-test-prod: This is used for testing the promoter to see that
-          it can still promote things, as part of an E2E test.
-
-        - k8s-staging-cip-test: Also used for the promotion E2E test.
-
-        - k8s-gcr-backup-test-prod: Used for testing the backup script in
-          infra/gcr/backup_tools.
-
-        - k8s-gcr-backup-test-prod-bak: Same as above.
-
-        - k8s-gcr-audit-test-prod: Used for an E2E test for the cip-auditor
-          Cloud Run service.
+      ACL for staging cip-test buckets, the test-only backup, and auditing
+      jobs for the promoter. See infra/gcp/ensure-prod-storage.sh for more
+      details.
     settings:
       ReconcileMembers: "true"
     members:

--- a/groups/sig-security/groups.yaml
+++ b/groups/sig-security/groups.yaml
@@ -6,9 +6,8 @@ groups:
       identified via automated scans of artifacts in k/k
 
       Membership is restricted to the SIG Security Chairs,
-      SIG Security Tooling Project Lead,
-      Product Security Committee / Security Response Committee,
-      SIG Release Chairs,  Patch Release Team, and Branch Managers.
+      SIG Security Tooling Lead, Security Response Committee,
+      SIG Release Chairs, Patch Release Team, and Branch Managers.
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"


### PR DESCRIPTION
- Google groups API imposes group description length to be no greater than 300
- New test checks the length and fails when description greater than 300 is attempted
- It ignores the description of an existing group for backwards compatability even though it exceeds this limit

Fixes https://github.com/kubernetes/k8s.io/issues/2345

Related: https://github.com/kubernetes/k8s.io/pull/2342

/sig security
/area access
/kind bug 
/cc @spiffxp 