### PR TITLE
infra/gcp: mv k8s-releng-prod to its own folder

### DIFF
--- a/infra/gcp/ensure-releng.sh
+++ b/infra/gcp/ensure-releng.sh
@@ -36,10 +36,8 @@ function usage() {
     echo > /dev/stderr
 }
 
-# NB: Please keep this sorted.
-PROJECTS=(
-    k8s-releng-prod
-)
+mapfile -t PROJECTS < <(k8s_infra_projects "releng")
+readonly PROJECTS
 
 if [ $# = 0 ]; then
     # default to all release projects
@@ -47,6 +45,12 @@ if [ $# = 0 ]; then
 fi
 
 for PROJECT; do
+
+    if ! k8s_infra_project "releng" "${PROJECT}" >/dev/null; then
+        color 1 "Skipping unrecognized release project name: ${PROJECT}"
+        continue
+    fi
+
     color 3 "Configuring: ${PROJECT}"
 
     # Make the project, if needed

--- a/infra/gcp/infra.yaml
+++ b/infra/gcp/infra.yaml
@@ -241,6 +241,9 @@ infra:
     projects:
       k8s-release:
       k8s-release-test-prod: # TODO: should this be prod or release?:
+
+  releng:
+    projects:
       k8s-releng-prod:
         managed_by: infra/gcp/ensure-releng-project.sh
 


### PR DESCRIPTION
k8s-releng-prod may be a release-related project, but it should not be handled by `ensure-release-projects.sh`

Move it to its own folder/group in infra.yaml to prevent https://github.com/kubernetes/k8s.io/pull/2322#discussion_r670713886 from happening again