### PR TITLE
Adding tjferrara to k8s-infra-gcp-accounting

### DIFF
--- a/groups/wg-k8s-infra/groups.yaml
+++ b/groups/wg-k8s-infra/groups.yaml
@@ -112,6 +112,7 @@ groups:
       - spiffxp@gmail.com
       - spiffxp@google.com
       - thockin@google.com
+      - tjferrara@google.com
 
   - email-id: k8s-infra-gcp-auditors@kubernetes.io
     name: k8s-infra-gcp-auditors


### PR DESCRIPTION
This change is an attempt to gain access to k8s-artifacts-prod's `cip-auditor` logs within cloud run.

Such access will allow me to continue working on CIP's [auditor scaling issue](https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/259). This is NOT a blocker at the moment, so please let me know if there is a better group to join in order to gain such access.

cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering
