### PR TITLE
remove references to kubernetes-release-dev

### DIFF
--- a/apps/gcsweb/deployment.yaml
+++ b/apps/gcsweb/deployment.yaml
@@ -33,7 +33,7 @@ spec:
             # buckets owned by google.com
             - -b=kubernetes-jenkins
             - -b=kubernetes-release
-            - -b=kubernetes-release-dev
+            - -b=kubernetes-release-dev # TODO: remove when v1.22 unsupported, or no more builds exist her
             - -b=sig-scalability-logs
             - -p=8080
           ports:

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/README.md
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/README.md
@@ -78,15 +78,4 @@ gsutil iam ch \
 gsutil iam ch \
   serviceAccount:prow-build-trusted@k8s-infra-prow-build-trusted.iam.gserviceaccount.com:objectAdmin \
   gs://kubernetes-release-pull
-# TODO: this isn't working, the bucket is in google-containers project which has
-#       a ban on non-google.com accounts being added to iam
-gsutil iam ch \
-  serviceAccount:prow-build-trusted@k8s-infra-prow-build-trusted.iam.gserviceaccount.com:objectAdmin \
-  gs://kubernetes-release-dev
 ```
-
-## TODO
-
-- figure out whether this build cluster needs write access to gs://kubernetes-release-dev
-- deploy ghproxy to this cluster (does this need its own nodepool/instance?)
-- try out a dry-run peribolos job on this cluster

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/README.md
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/README.md
@@ -43,7 +43,7 @@ There was some manual work in bringing this up fully:
 # get k8s.io on here, for this example we'll assume everything's pushed to git
 git clone git://github.com/kubernetes/k8s.io
 
-# deploy the resources; note boskos-resources.yaml isn't a configmap
+# deploy the resources
 cd k8s.io/infra/gcp/clusters/k8s-infra-prow-build
 ./deploy.sh
 
@@ -139,7 +139,7 @@ gsutil iam ch \
 
 ## Known Issues / TODO
 
-- some jobs can't be migrated until we use a bucket other than gs://kubernetes-release-dev
+- jobs are not segmented into separate nodepools
 - setup an autobump jump for all components installed to this build cluster
 - try using local SSD for the node pools for faster IOPS
 

--- a/infra/gcp/ensure-release-projects.sh
+++ b/infra/gcp/ensure-release-projects.sh
@@ -182,7 +182,7 @@ function ensure_kubernetes_ci_gcs_bucket() {
     ensure_gcs_bucket_logging "${bucket}"
 
     # TODO(spiffxp): I'm not actually sure this makes sense. These groups don't
-    #                have permissions to do this with gs://kubernetes-release-dev
+    #                have permissions to do this with the google.com-owned bucket
     #                today. These buckets should be strictly-CI unless there are
     #                very exceptional circumstances (which is when I'd suggest we
     #                escalate to the admins above)
@@ -198,7 +198,7 @@ function special_case_kubernetes_ci_buckets() {
   ensure_kubernetes_ci_gcs_bucket "k8s-release" "gs://k8s-release-dev"
   # TODO: we're squatting on these bucket names until we decide what to do:
   # - these buckets aren't setup as regional buckets in ASIA and EU -> delete and recreate properly?
-  # - the kubernetes-release-dev-asia and -eu buckets are unpopulated -> forget the whole thing?
+  # - the google.com-owned -asia and -eu buckets are unpopulated -> forget the whole thing?
   ensure_kubernetes_ci_gcs_bucket "k8s-release" "gs://k8s-release-dev-asia"
   ensure_kubernetes_ci_gcs_bucket "k8s-release" "gs://k8s-release-dev-eu"
   # TODO(https://github.com/kubernetes/test-infra/issues/18789) remove this bucket when no longer needed


### PR DESCRIPTION
The one exception is gcsweb.k8s.io, which should continue serving the
bucket for as long as we have deprecated builds living in it. It should
stop serving once v1.22 has aged out of support, or when there are no
more builds being written to the bucket, whichever comes first

Part of https://github.com/kubernetes/k8s.io/issues/2318