### PR TITLE
infra/gcp/roles: add cloudtrace to audit.viewer

### DIFF
--- a/infra/gcp/roles/audit.viewer.yaml
+++ b/infra/gcp/roles/audit.viewer.yaml
@@ -332,8 +332,12 @@ includedPermissions:
   - cloudtoolresults.executions.list
   - cloudtoolresults.histories.list
   - cloudtoolresults.steps.list
+  - cloudtrace.insights.get
   - cloudtrace.insights.list
+  - cloudtrace.stats.get
+  - cloudtrace.tasks.get
   - cloudtrace.tasks.list
+  - cloudtrace.traces.get
   - cloudtrace.traces.list
   - cloudtranslate.glossaries.list
   - cloudtranslate.locations.list

--- a/infra/gcp/roles/specs/audit.viewer.yaml
+++ b/infra/gcp/roles/specs/audit.viewer.yaml
@@ -19,6 +19,9 @@ include:
   # read access to cloudkms public keys
   # ref: https://cloud.google.com/kms/docs/reference/permissions-and-roles#access-control-guidelines
   - roles/cloudkms.publicKeyViewer
+  # full access to trace console, but is filtered back to read-only
+  # ref: https://cloud.google.com/trace/docs/iam#roles
+  - roles/cloudtrace.user
   # read access to compute
   - roles/compute.viewer
   # read access to compute


### PR DESCRIPTION
specifically add roles/cloudtrace.user, but rely on the permission
filtering to exclude create/delete/edit type permissions

this is equivalent to what would have been granted by roles/viewer,
which is making my wonder out loud again why we're not just using that

This is in service of fixing https://github.com/kubernetes/k8s.io/issues/2364#issuecomment-882767362