### PR TITLE
Auditor HotFix

### DIFF
--- a/infra/gcp/cip-auditor/deploy.sh
+++ b/infra/gcp/cip-auditor/deploy.sh
@@ -46,7 +46,7 @@ deploy_cip_auditor()
 
     gcloud run deploy "${AUDITOR_SERVICE_NAME}" \
         --image="us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip-auditor@sha256:${CIP_AUDITOR_DIGEST}" \
-        --update-env-vars="CIP_AUDIT_MANIFEST_REPO_URL=https://github.com/kubernetes/k8s.io,CIP_AUDIT_MANIFEST_REPO_BRANCH=master,CIP_AUDIT_MANIFEST_REPO_MANIFEST_DIR=k8s.gcr.io,CIP_AUDIT_GCP_PROJECT_ID=k8s-artifacts-prod" \
+        --update-env-vars="CIP_AUDIT_MANIFEST_REPO_URL=https://github.com/kubernetes/k8s.io,CIP_AUDIT_MANIFEST_REPO_BRANCH=main,CIP_AUDIT_MANIFEST_REPO_MANIFEST_DIR=k8s.gcr.io,CIP_AUDIT_GCP_PROJECT_ID=k8s-artifacts-prod" \
         --platform=managed \
         --no-allow-unauthenticated \
         --region=us-central1 \


### PR DESCRIPTION
This changes the environment variable `CIP_AUDIT_MANIFEST_REPO_BRANCH` that defines which repo branch the CIP auditor should clone from. Since the repo to audit is set to: `https://github.com/kubernetes/k8s.io`, and there is no longer a `master` branch, each attempt to clone the repository is met with the error: "reference not found".

Since the auditor attempts to clone this repo on every pub/sub message, indicating a GCR state change, this failure was repeating and causing the auditor to restart multiple times.

Simply by setting `CIP_AUDIT_MANIFEST_REPO_BRANCH=main` should resolve this issue #2364 

cc: @listx @amwat @spiffxp @kubernetes-sigs/release-engineering
 