### PR TITLE
Define min and max instances for cip-auditor

### DIFF
--- a/infra/gcp/cip-auditor/deploy.sh
+++ b/infra/gcp/cip-auditor/deploy.sh
@@ -51,7 +51,9 @@ deploy_cip_auditor()
         --no-allow-unauthenticated \
         --region=us-central1 \
         --project="${PROJECT_ID}" \
-        --service-account="${CLOUD_RUN_SERVICE_ACCOUNT}"
+        --service-account="${CLOUD_RUN_SERVICE_ACCOUNT}" \
+        --min-instances=1 \
+        --max-instances=1
 }
 
 usage()


### PR DESCRIPTION
This change prevents Cloud Run from reducing the number of instances for the cip-auditor. Naturally, when cloud run notices low CPU usage, it scaled down the number of instances. This behavior occurs too often, since the auditor should always be running.

Here is a view of the current cip-auditor running in the GCP project: `k8s-artifacts-prod`.
![pantheon corp google com_run_detail_us-central1_cip-auditor_metrics_project=k8s-artifacts-prod (1)](https://user-images.githubusercontent.com/20875599/126414019-6e1a614f-52a8-4738-a586-5fb79fb2486f.png)


However, by explicitly setting `--min-instances` and `--max-instances` during deployment, we can be sure that the auditor will always be running.

Related to CIP issue: [#353](https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/353)

cc: @listx @amwat @justaugustus @kubernetes-sigs/release-engineering