### PR TITLE
Migrate to networking.k8s.io/v1

### DIFF
--- a/apps/gcsweb/ingress.yaml
+++ b/apps/gcsweb/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: gcsweb

--- a/apps/node-perf-dash/ingress.yaml
+++ b/apps/node-perf-dash/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: node-perf-dash

--- a/apps/perfdash/ingress.yaml
+++ b/apps/perfdash/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: perfdash

--- a/apps/sippy/ingress.yaml
+++ b/apps/sippy/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: sippy

--- a/apps/slack-infra/resources/ingress.yaml
+++ b/apps/slack-infra/resources/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: slack-infra

--- a/apps/triageparty-release/ingress.yaml
+++ b/apps/triageparty-release/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: triage-party-release

--- a/k8s.io/ingress-canary-v6.yaml
+++ b/k8s.io/ingress-canary-v6.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: k8s-io-v6

--- a/k8s.io/ingress-canary.yaml
+++ b/k8s.io/ingress-canary.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: k8s-io

--- a/k8s.io/ingress-prod-v6.yaml
+++ b/k8s.io/ingress-prod-v6.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: k8s-io-v6

--- a/k8s.io/ingress-prod.yaml
+++ b/k8s.io/ingress-prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: k8s-io


### PR DESCRIPTION
## Resolves:
* https://github.com/kubernetes/k8s.io/issues/2316 (First PR, more to come, maybe)

## Notes:
- Starting with the ingress version change as a starting point.
- I'll do some review on the NEG part of the request, and follow up with another PR if possible.
- I only have read-only access on the `aaa` cluster, so I'll need help getting the `deploy.sh` scripts run. 

## Changes:
* Update all k8s-infra `aaa` ingress objects to `networking.k8s.io/v1`