### PR TITLE
k8s.io: use zero-arg deploy.sh

### DIFF
--- a/k8s.io/README.md
+++ b/k8s.io/README.md
@@ -72,8 +72,6 @@ How to deploy
    namespaces with `kubectl --context gke_kubernetes-public_us-central1_aaa get
    ns`.
 
-3) Run `./deploy.sh canary`.  This will push the configs to our canary namespace and
-   run the tests against it.
-
-4) Assuming the tests pass, run `./deploy.sh prod`.  This will push the configs
-   to our prod namespace and run the tests against it.
+3) Run `./deploy.sh`.  This will effectively run `./deploy.sh canary` to push
+   and test configs in the canary namespace, followed by `./deploy.sh prod` to
+   do the same in prod if tests pass against canary.

--- a/k8s.io/deploy.sh
+++ b/k8s.io/deploy.sh
@@ -18,58 +18,92 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ $# -ne 1 ] || [ -z "${1:-}" ]; then
-    echo "usage: $0 [ canary | prod ]"
-    exit 1
+SCRIPT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+
+app=$(basename "${SCRIPT_ROOT}")
+
+# coordinates to locate the target cluster in gke
+cluster_name="aaa"
+cluster_project="kubernetes-public"
+cluster_region="us-central1"
+
+# well known name set by `gcloud container clusters get-credentials`
+gke_context="gke_${cluster_project}_${cluster_region}_${cluster_name}"
+context="${KUBECTL_CONTEXT:-${gke_context}}"
+
+# ensure we have a context to talk to the target cluster
+if ! kubectl config get-contexts "${context}" >/dev/null 2>&1; then
+    gcloud container clusters get-credentials "${cluster_name}" --project="${cluster_project}" --region="${cluster_region}"
+    context="${gke_context}"
 fi
-if [ "$1" != "canary" ] && [ "$1" != "prod" ]; then
-    echo "unsupported target '$1'"
-    echo "usage: $0 [ canary | prod ]"
-    exit 1
-fi
 
-NS="k8s-io-$1"
-CONTEXT="gke_kubernetes-public_us-central1_aaa"
+function deploy() {
+    local target="$1"
+    if [ "${target}" != "prod" ] && [ "${target}" != "canary" ]; then
+        echo >&2 "ERROR: unknown target: ${target}; valid targets are: prod, canary"
+        return 1
+    fi
+    local namespace="k8s-io-$target"
 
-echo "Deploying to namespace $NS - ^C now to abort..."
-sleep 5
+    local kubectl=(
+        kubectl
+        --context="${context}"
+        --namespace="${namespace}"
+    )
 
-function kc() {
-  kubectl --context="${CONTEXT}" --namespace="${NS}" "$@"
+    echo "running kubectl apply..."
+    "${kubectl[@]}" apply \
+        -f configmap-nginx.yaml \
+        -f configmap-www-get.yaml \
+        -f deployment.yaml \
+        -f service.yaml
+
+    echo "restarting deployment..."
+    "${kubectl[@]}" rollout restart deployment k8s-io
+
+    echo "waiting for all replicas to be up..."
+    while true; do
+      sleep 3
+      read -r spec ready unavail < <( \
+          "${kubectl[@]}" get deployment k8s-io \
+              -o go-template='{{.spec.replicas}} {{.status.readyReplicas}} {{.status.unavailableReplicas}}{{"\n"}}'
+      )
+
+      if [ -z "${ready}" ] || [ "${ready}" == "<no value>" ]; then
+          ready=0
+      fi
+      if [ -z "${unavail}" ] || [ "${unavail}" == "<no value>" ]; then
+          unavail=0
+      fi
+      if [ -n "${spec}" ] && [ -n "${ready}" ] && [ "${spec}" == "${ready}" ] && [ "${unavail}" == 0 ]; then
+        break
+      fi
+      echo "  want ${spec}, found ${ready} ready and ${unavail} unavailable"
+    done
+
+    # We can only test IPv4 from within GCP.
+    all_ips=$("${kubectl[@]}" get ing k8s-io -o go-template='{{range .status.loadBalancer.ingress}}{{.ip}}{{end}}')
+
+    for ip in $all_ips; do
+        echo "Testing TARGET_IP=$ip"
+        make test TARGET_IP="$ip"
+    done
 }
 
-kc apply \
-    -f configmap-nginx.yaml \
-    -f configmap-www-get.yaml \
-    -f deployment.yaml \
-    -f service.yaml
+function main() {
+  pushd "${SCRIPT_ROOT}" >/dev/null
+  if [ $# == 1 ]; then
+      echo "Deploying ${app} to '$1' target - ^C now to abort..."
+      sleep 5
+      deploy "$1"
+  elif [ $# == 0 ]; then
+      echo "Auto-deploying ${app} to canary then prod targets - ^C now to abort..."
+      sleep 5
+      deploy canary
+      deploy prod
+  else
+      echo >&2 "Usage: $0 [canary|prod]"
+  fi 
+}
 
-kc rollout restart deployment k8s-io
-
-echo "waiting for all replicas to be up"
-while true; do
-  sleep 3
-  read -r WANT HAVE UNAVAIL < <( \
-      kc get deployment k8s-io \
-          -o go-template='{{.spec.replicas}} {{.status.readyReplicas}} {{.status.unavailableReplicas}}{{"\n"}}'
-  )
-
-  if [ -z "${HAVE}" ] || [ "${HAVE}" == "<no value>" ]; then
-      HAVE=0
-  fi
-  if [ -z "${UNAVAIL}" ] || [ "${UNAVAIL}" == "<no value>" ]; then
-      UNAVAIL=0
-  fi
-  if [ -n "${WANT}" ] && [ -n "${HAVE}" ] && [ "${WANT}" == "${HAVE}" ] && [ "${UNAVAIL}" == 0 ]; then
-    break
-  fi
-  echo "  want ${WANT}, found ${HAVE} ready and ${UNAVAIL} unavailable"
-done
-
-# We can only test IPv4 from within GCP.
-all_ips=$(kc get ing k8s-io -o go-template='{{range .status.loadBalancer.ingress}}{{.ip}}{{end}}')
-
-for ip in $all_ips; do
-    echo "Testing TARGET_IP=$ip"
-    make test TARGET_IP="$ip"
-done
+main "$@"


### PR DESCRIPTION
This is to get k8s.io in line with everything else in /apps that has a zero-arg deploy.sh script that can be used to deploy the app.

ref: https://github.com/kubernetes/k8s.io/issues/2150