### PR TITLE
Remove namespace, assume yaml calls it out

### DIFF
--- a/apps/cert-manager/deploy.sh
+++ b/apps/cert-manager/deploy.sh
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Deploys this app to the aaa cluster, or whatever cluster is pointed to
-# by KUBECTL_CONTEXT if set. Assumes the app's namespace already exists.
+# by KUBECTL_CONTEXT if set.
 #
 # Members of k8s-infra-rbac-${app}@kubernetes.io can run this.
 
@@ -32,9 +32,6 @@ cluster_name="aaa"
 cluster_project="kubernetes-public"
 cluster_region="us-central1"
 
-# coordinates to locate the app on the target cluster
-namespace="${app}"
-
 # well known name set by `gcloud container clusters get-credentials`
 gke_context="gke_${cluster_project}_${cluster_region}_${cluster_name}"
 context="${KUBECTL_CONTEXT:-${gke_context}}"
@@ -47,4 +44,4 @@ fi
 
 # deploy kubernetes resources
 pushd "${SCRIPT_ROOT}" >/dev/null
-kubectl --context="${context}" --namespace="${namespace}" apply -f .
+kubectl --context="${context}" apply -f .


### PR DESCRIPTION
Per the cert-manager docs, when applying `cert-manager.yaml` you do not need to specify namespace:
https://cert-manager.io/v0.13-docs/installation/kubernetes/#installing-with-regular-manifests

```
$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.13.1/cert-manager.yaml
```

Removing the `--namespace` flag from `deploy.sh`