### PR TITLE
apps/cert-manager: match what is deployed

### DIFF
--- a/apps/cert-manager/deploy.sh
+++ b/apps/cert-manager/deploy.sh
@@ -47,4 +47,8 @@ fi
 
 # deploy kubernetes resources
 pushd "${SCRIPT_ROOT}" >/dev/null
-kubectl --context="${context}" --namespace="${namespace}" apply -f .
+
+echo "Deploying ${app} to ${namespace}"
+# NOTE: cert-manager has resources in kube-system, and cluster-scoped resources, so we trust
+#       that the namespaces as defined in the resources are as they should be
+kubectl --context="${context}" apply -f .

--- a/apps/cert-manager/letsencrypt-prod.yaml
+++ b/apps/cert-manager/letsencrypt-prod.yaml
@@ -29,7 +29,7 @@ spec:
         - k8s.io
       http01:
         ingress:
-          name: k8s-io
+          name: k8s-io-v6
 
     # If any new services/ingresses are added, a new entry will need to be
     # added here.


### PR DESCRIPTION
Followup to https://github.com/kubernetes/k8s.io/pull/2374

Update the deploy.sh script to assume the resources have the correct namespace defined within them

Update letsencrypt-prod to match what I found in production. It might be wrong! But if it's been there this long without complaint, I don't want to change it just because we're shuffling an app's resource files around.