### PR TITLE
apps/cert-manager: move ixdy to emeritus_approvers

### DIFF
--- a/apps/cert-manager/OWNERS
+++ b/apps/cert-manager/OWNERS
@@ -1,7 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - ixdy
   - munnerz
+emeritus_approvers:
+  - ixdy
 labels:
   - area/infra/cert-manager


### PR DESCRIPTION
Not sure whether we should find other folks to add to the approvers list, or just rely on the top-level approvers.