### PR TITLE
gcp-compute-persistent-disk-csi-drive: promote image release v1.3.0

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cloud-provider-gcp/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-cloud-provider-gcp/images.yaml
@@ -1,9 +1,10 @@
 - name: gcp-compute-persistent-disk-csi-driver
   dmap:
     "sha256:23d2fe20c5307c3ef2580ed035084d9a57866717bd8b80bdc2dabd2097591227": ["v1.2.1"]
+    "sha256:8e04ffa8060e46b5e07d70990f80ad15446b2f27b286df4a47569e1c818dcce7": ["v1.3.0"]
     "sha256:e9c355dd1ce57de91a0f9164bd2fe688938723e7f9bd40bb13652d603f41d25a": ["v1.2.2"]
 - name: gcp-filestore-csi-driver
   dmap:
+    "sha256:10ae6b591a3db0adf727f09a8581f4624fce5b6feda0b10cdfbc86db5022e3b0": ["v0.5.0"]
     "sha256:351548ca4bb0556e717c27309e1e559f65c9ae5826e60d48e0215f267835b80f": ["v0.3.1"]
     "sha256:3c1571074aab73f430aae43a35cb7ad81148248aa1807cb75df640f09368ed71": ["v0.4.0"]
-    "sha256:10ae6b591a3db0adf727f09a8581f4624fce5b6feda0b10cdfbc86db5022e3b0": ["v0.5.0"]


### PR DESCRIPTION
release v1.3.0 is out https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/releases/tag/v1.3.0
and image `gcr.io/k8s-staging-cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.3.0` is available in the staging repo.

```
$ crane manifest gcr.io/k8s-staging-cloud-provider-gcp/gcp-compute-persistent-disk-csi-driver:v1.3.0
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 956,
         "digest": "sha256:e0dd03a16f42be5000b30fed2f2680ce2114c942149d0b6c323283c37c2781af",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.18363.1556"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 957,
         "digest": "sha256:caa17408862b3ae2f94692d041869ddd76d3c053be132e8725f85a80d18b5fdb",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.19041.1110"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 957,
         "digest": "sha256:cd2b11b1b0fbbf78eee62f43d0558dce86aaadaa10e44d0d3be733bf9f285ed6",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.19042.1110"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1162,
         "digest": "sha256:baf5c0bd8215da02bb7e157ec05dc1a05c58e57b1caec0d81696c3d09a27d5db",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1162,
         "digest": "sha256:b8664f511546e1fb3166b9f0c37eaa8372ef22f4b6132de5816eabe2b7d59fbd",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 956,
         "digest": "sha256:e69a0b8570c1eb94cd56d7fc0af4712c08bff933eca95c2c71b53422fa348d9d",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.17763.2061"
         }
      }
   ]
}
```

/assign @spiffxp @msau42 @mattcary @saad-ali 