### PR TITLE
promote csi-secrets-store driver:v0.1.0

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-csi-secrets-store/generate.sh
+++ b/k8s.gcr.io/images/k8s-staging-csi-secrets-store/generate.sh
@@ -22,6 +22,7 @@ readonly repo="gcr.io/k8s-staging-csi-secrets-store"
 readonly tag_filter="tags~^v[0-9]+.[0-9]+.[0-9]+$ AND NOT tags=v0.0.11"
 readonly images=(
     driver
+    driver-crds
 )
 
 for image in "${images[@]}"; do

--- a/k8s.gcr.io/images/k8s-staging-csi-secrets-store/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-csi-secrets-store/images.yaml
@@ -12,3 +12,7 @@
     "sha256:b1f7286ba11aa8045dc01b0ef62ddac5c966c2600bab8f02ddb96169ea228b5a": [ "v0.0.21" ]
     "sha256:981d4a484d156273a673b3d4e130ce6a7e09d25d8275b4acef78df697a67d7b2": [ "v0.0.22" ]
     "sha256:e25d4daca186e8c3b26db395d67af56c7a5d0e3aaf61d36de39ea2f17b21ed98": [ "v0.0.23" ]
+    "sha256:d6f02c93da117e5d56bd8beec0a10a0112c09c0257d219b07db32645c3f3cdb0": [ "v0.1.0" ]
+- name: driver-crds
+  dmap:
+    "sha256:508f58321f8085877a8b8e7268e5a5efbca707ebe10e8c705124a5c9e1b5ceab": [ "v0.1.0" ]


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

```
++ docker manifest push --purge gcr.io/k8s-staging-csi-secrets-store/driver:v0.1.0
sha256:d6f02c93da117e5d56bd8beec0a10a0112c09c0257d219b07db32645c3f3cdb0
```

```
++ docker manifest push --purge gcr.io/k8s-staging-csi-secrets-store/driver-crds:v0.1.0
sha256:508f58321f8085877a8b8e7268e5a5efbca707ebe10e8c705124a5c9e1b5ceab
```

Build - https://console.cloud.google.com/cloud-build/builds;region=global/21deb903-9852-4d5e-9066-7e418c638e2a?project=k8s-staging-csi-secrets-store

Generated by running -
```
➜ k8s.gcr.io/images/k8s-staging-csi-secrets-store/generate.sh > k8s.gcr.io/images/k8s-staging-csi-secrets-store/images.yaml
```

/assign @tam7t 