### PR TITLE
apps/perfdash: migrate ingress to v1

### DIFF
--- a/apps/perfdash/ingress.yaml
+++ b/apps/perfdash/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: perfdash
@@ -10,6 +10,8 @@ metadata:
     kubernetes.io/ingress.global-static-ip-name: perf-dash-k8s-io-ingress-prod
     networking.gke.io/managed-certificates: perfdash-k8s-io
 spec:
-  backend:
-    serviceName: perfdash-status
-    servicePort: status
+  defaultBackend:
+    service:
+      name: perfdash-status
+      port:
+        name: status


### PR DESCRIPTION
Changed fields per https://kubernetes.io/docs/reference/using-api/deprecation-guide/

Part of issue https://github.com/kubernetes/k8s.io/issues/2316