### PR TITLE
Update k8s-infra-alerts@kubernetes.io

### DIFF
--- a/groups/wg-k8s-infra/groups.yaml
+++ b/groups/wg-k8s-infra/groups.yaml
@@ -12,13 +12,12 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     members:
+      - ameukam@gmail.com
       - amwat@google.com
       - bentheelder@google.com
       - cblecker@gmail.com
       - davanum@gmail.com
-      - ihor@cncf.io
-      - jgrafton@google.com
-      - mkumatag@in.ibm.com
+      - spiffxp@gmail.com
       - spiffxp@google.com
       - thockin@google.com
       - linusa@google.com


### PR DESCRIPTION
We started to add auto-deployments mechanisms for community-owned GKE
clusters with failures alerts directed to k8s-infra-alerts@kuberntes.io.
Update the list with people "actively" involved in the WG.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>