### PR TITLE
infra/gcp: allow prow trusted cluster use of k8s-infra-ci-robot

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-externalsecrets.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-externalsecrets.yaml
@@ -38,3 +38,16 @@ spec:
   - key: k8s-triage-robot-github-token # The name of the GSM Secret
     name: token                        # The key to write to in the Kubernetes Secret
     version: latest                    # The version of the GSM Secret
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: k8s-infra-ci-robot-github-token
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-public
+  data:
+  - key: k8s-infra-ci-robot-github-token # The name of the GSM Secret
+    name: token                          # The key to write to in the Kubernetes Secret
+    version: latest                      # The version of the GSM Secret


### PR DESCRIPTION
Related:
- Part of https://github.com/kubernetes/k8s.io/issues/1742
- Followup to https://github.com/kubernetes/k8s.io/pull/2402

This will allow jobs in k8s-infra-prow-build-trusted to use k8s-infra-ci-robot-github-token to be able to open up PRs as k8s-infra-ci-robot