### PR TITLE
DNS entries for k8s-infra-prow.k8s.io

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -163,6 +163,12 @@ issue:
 issues:
   type: CNAME
   value: redirect.k8s.io.
+#wg-k8s-infra
+k8s-infra-prow:
+  - type: A
+    value: 34.117.224.94 # Hosted on GKE cluster aaa
+  - type: AAAA
+    value: "2600:1901:0:b267::" # Hosted on GKE cluster aaa
 kep:
   type: CNAME
   value: redirect.k8s.io.
@@ -203,10 +209,6 @@ prow-canary:
 monitoring.prow-canary:
   type: A
   value: 34.102.128.31
-#wg-k8s-infra (@ameukam)
-prow-staging:
-  type: A
-  value: 35.190.121.209
 prs:
   type: CNAME
   value: redirect.k8s.io.

--- a/infra/gcp/clusters/projects/kubernetes-public/aaa/external-ips.tf
+++ b/infra/gcp/clusters/projects/kubernetes-public/aaa/external-ips.tf
@@ -24,6 +24,21 @@ resource "google_compute_global_address" "k8s_io_ingress_canary_v6" {
   ip_version    = "IPV6"
 }
 
+// used by k8s-infra-prow.k8s.io
+resource "google_compute_global_address" "k8s_infra_prow" {
+  project      = data.google_project.project.project_id
+  name         = "k8s-infra-prow"
+  address_type = "EXTERNAL"
+}
+
+// used by k8s-infra-prow.k8s.io (IPv6)
+resource "google_compute_global_address" "k8s_infra_prow_v6" {
+  project      = data.google_project.project.project_id
+  name         = "k8s-infra-prow-v6"
+  address_type = "EXTERNAL"
+  ip_version   = "IPV6"
+}
+
 // used by k8s.io
 resource "google_compute_global_address" "k8s_io_ingress_prod" {
   project       = data.google_project.project.project_id


### PR DESCRIPTION
Ref: https://github.com/kubernetes/k8s.io/issues/1394

This is required by https://github.com/kubernetes/k8s.io/pull/2235 to be able to create the Google SSL certificate for `k8s-infra-prow.k8s.io`.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>