### PR TITLE
groups: abs-path auto-detected groups-path

### DIFF
--- a/groups/reconcile.go
+++ b/groups/reconcile.go
@@ -153,7 +153,10 @@ func main() {
 	}
 
 	// rootDir contains groups.yaml files
-	rootDir := filepath.Dir(*configFilePath)
+	rootDir, err := filepath.Abs(filepath.Dir(*configFilePath))
+	if err != nil {
+		log.Fatalf("unable to convert config path '%v' into absolute path: %v", *configFilePath, err)
+	}
 	if config.GroupsPath != nil {
 		if !filepath.IsAbs(*config.GroupsPath) {
 			log.Fatalf("groups-path \"%s\" must be an absolute path", *config.GroupsPath)


### PR DESCRIPTION
Related:
- followup to: https://github.com/kubernetes/k8s.io/pull/2401
- part of: https://github.com/kubernetes/k8s.io/issues/460

This is the quick fix I figured out after playing with it live for a bit.

I started doing my typical thing of refactoring and adding some tests... which I will PR, but let's not block on that.