### PR TITLE
apps/kubernetes-external-secrets: update to 8.2.3

### DIFF
--- a/apps/kubernetes-external-secrets/kubernetes-external-secrets.yaml
+++ b/apps/kubernetes-external-secrets/kubernetes-external-secrets.yaml
@@ -35,7 +35,7 @@ spec:
       serviceAccountName: kubernetes-external-secrets
       containers:
         - name: kubernetes-external-secrets
-          image: "ghcr.io/external-secrets/kubernetes-external-secrets:8.1.2"
+          image: "ghcr.io/external-secrets/kubernetes-external-secrets:8.2.3"
           imagePullPolicy: IfNotPresent
           ports:
           - name: prometheus

--- a/apps/kubernetes-external-secrets/kubernetes-external-secrets_crd.yaml
+++ b/apps/kubernetes-external-secrets/kubernetes-external-secrets_crd.yaml
@@ -1,4 +1,4 @@
-# From https://github.com/external-secrets/kubernetes-external-secrets/blob/8.1.2/charts/kubernetes-external-secrets/crds/kubernetes-client.io_externalsecrets_crd.yaml
+# From https://github.com/external-secrets/kubernetes-external-secrets/blob/8.2.3/charts/kubernetes-external-secrets/crds/kubernetes-client.io_externalsecrets_crd.yaml
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -12,8 +12,6 @@ metadata:
 spec:
   group: kubernetes-client.io
   scope: Namespaced
-
-  preserveUnknownFields: false
 
   versions:
     - name: v1

--- a/apps/kubernetes-external-secrets/kubernetes-external-secrets_rbac.yaml
+++ b/apps/kubernetes-external-secrets/kubernetes-external-secrets_rbac.yaml
@@ -8,7 +8,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["create", "update"]
+    verbs: ["create", "update", "get"]
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "watch", "list"]


### PR DESCRIPTION
Related:
- Doing this to verify: https://github.com/kubernetes/k8s.io/issues/2151

This should net us some CVE fixes and fewer secret upserts

Changelogs:
- from: https://github.com/external-secrets/kubernetes-external-secrets/blob/master/CHANGELOG.md#812-2021-06-05
- to: https://github.com/external-secrets/kubernetes-external-secrets/blob/master/CHANGELOG.md#823-2021-07-30