### PR TITLE
[aaa] Drop usage of RBAC v1beta1

### DIFF
--- a/infra/gcp/namespaces/namespace-user-role-binding.yml
+++ b/infra/gcp/namespaces/namespace-user-role-binding.yml
@@ -1,6 +1,6 @@
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: namespace-user
   namespace: {{namespace}}

--- a/infra/gcp/namespaces/namespace-user-role.yml
+++ b/infra/gcp/namespaces/namespace-user-role.yml
@@ -1,6 +1,6 @@
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: namespace-user
   namespace: {{namespace}}


### PR DESCRIPTION
RBAC is GA since kubernetes 1.8 :
https://kubernetes.io/blog/2017/10/using-rbac-generally-available-18/.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>