### PR TITLE
apps/k8s-io: fix x-k8s.io redirect

### DIFF
--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -66,7 +66,7 @@ data:
       # ref: https://git.k8s.io/community/sig-architecture/api-review-process.md#voluntary
       server {
         server_name x-k8s.io;
-        listen 80 default_server;
+        listen 80;
         location / {
           return 301 https://kubernetes.io;
         }


### PR DESCRIPTION
So I was wondering why the deploy job for https://github.com/kubernetes/k8s.io/pull/2427 was taking so long

It's because the canary deployment was in a crashloop, because the nginx config was failing to load

I reverted the configmap change manually and watched the deploy job finish. Then I manually deployed this to canary, and it's happy, so I'll the deploy job handle rollout to prod