### PR TITLE
prow: use pre-provisioned ghproxy-metrics address

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
@@ -165,6 +165,14 @@ resource "google_compute_address" "kubernetes_external_secrets_metrics_address" 
   address_type = "EXTERNAL"
 }
 
+resource "google_compute_address" "ghproxy_metrics_address" {
+  name         = "ghproxy-metrics"
+  description  = "to allow monitoring.k8s.prow.io to scrape ghproxy metrics"
+  project      = local.project_id
+  region       = local.cluster_location
+  address_type = "EXTERNAL"
+}
+
 module "prow_build_cluster" {
   source = "../../../modules/gke-cluster"
   project_name      = local.project_id

--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/default/ghproxy-service.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/default/ghproxy-service.yaml
@@ -29,4 +29,5 @@ spec:
   ports:
     - name: metrics
       port: 9090
+  loadBalancerIP: 34.121.239.242 # k8s-infra-prow-build-trusted/ghproxy-metrics
   type: LoadBalancer


### PR DESCRIPTION
Prep for the transfer of more jobs that consume GitHub tokens by exposing the metrics IP of ghproxy to be scraped by something.  Likely monitoring.prow.k8s.io

We'll want to do something similar for the ghproxy running in aaa, to help get a sense of things like triageparty github token usage.