### PR TITLE
infra/gcp/main: add k8s-project-metrics special-case

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-serviceaccounts.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-serviceaccounts.yaml
@@ -1,3 +1,4 @@
+# Prow service accounts
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -7,20 +8,30 @@ metadata:
   name: prow-build-trusted
   namespace: test-pods
 ---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: prow-deployer@k8s-infra-prow-build-trusted.iam.gserviceaccount.com
+  name: prow-deployer
+  namespace: test-pods
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: k8s-metrics@k8s-infra-prow-build-trusted.iam.gserviceaccount.com
+  name: k8s-metrics
+  namespace: test-pods
+
+# Infrastructure management service accounts
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
     iam.gke.io/gcp-service-account: k8s-infra-gcp-auditor@kubernetes-public.iam.gserviceaccount.com
   name: k8s-infra-gcp-auditor
-  namespace: test-pods
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
-    iam.gke.io/gcp-service-account: gcb-builder@k8s-infra-prow-build-trusted.iam.gserviceaccount.com
-  name: gcb-builder
   namespace: test-pods
 ---
 kind: ServiceAccount
@@ -38,16 +49,9 @@ metadata:
     iam.gke.io/gcp-service-account: gsuite-groups-manager@k8s-gsuite.iam.gserviceaccount.com
   name: gsuite-groups-manager
   namespace: test-pods
----
-kind: ServiceAccount
-apiVersion: v1
-metadata:
-  annotations:
-    iam.gke.io/gcp-service-account: prow-deployer@k8s-infra-prow-build-trusted.iam.gserviceaccount.com
-  name: prow-deployer
-  namespace: test-pods
----
+
 # Image promotion service accounts
+---
 kind: ServiceAccount
 apiVersion: v1
 metadata:
@@ -62,6 +66,16 @@ metadata:
   annotations:
     iam.gke.io/gcp-service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod-bak.iam.gserviceaccount.com
   name: k8s-infra-gcr-promoter-bak
+  namespace: test-pods
+
+# Staging service accounts
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: gcb-builder@k8s-infra-prow-build-trusted.iam.gserviceaccount.com
+  name: gcb-builder
   namespace: test-pods
 ---
 kind: ServiceAccount


### PR DESCRIPTION
Related:
- Starts work on https://github.com/kubernetes/k8s.io/issues/1306
- Part of https://github.com/kubernetes/k8s.io/issues/1308

k8s-metrics is a low-traffic GCS bucket for the project, setup permissions to trial moving it from one org to the other. The steps for this process are going to look something like:

- allow google.com prow to write to the new bucket
- allow humans to own the new bucket
- sync contents from old bucket to new bucket
- setup canary job on k8s-infra-prow-build-trusted that writes to the new
  bucket to confirm permissions are correct for:
    - executing bigquery queries that use the k8s-gubernator:builds dataset
    - writing to the new bucket
- remove canary job / move old job to k8s-infra-prow-build-trusted
- delete old bucket
- rename new bucket to old bucket

If the rename fails, we'll use the new bucket name and look into a redirect from old files.