### PR TITLE
SBOM domain redirects: nginx + DNS config

### DIFF
--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -313,6 +313,14 @@ data:
       }
 
       server {
+        server_name sbom.k8s.io sbom.kubernetes.io
+        listen 80;
+
+        rewrite ^/(.*)?/release$ https://storage.googleapis.com/kubernetes-release/release/$1/kubernetes-release.spdx redirect;
+        rewrite ^/(.*)?/source$  https://storage.googleapis.com/kubernetes-release/release/$1/kubernetes-source.spdx redirect;
+      }
+
+      server {
         server_name submit-queue.k8s.io submit-queue.kubernetes.io;
         listen 80;
 

--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -213,6 +213,9 @@ prs:
 relnotes:
   type: CNAME
   value: kubernetes-sigs-release-notes.netlify.app.
+sbom:
+  type: CNAME
+  value: redirect.k8s.io.
 sigs:
   type: CNAME
   value: redirect.k8s.io.

--- a/dns/zone-configs/kubernetes.io._0_base.yaml
+++ b/dns/zone-configs/kubernetes.io._0_base.yaml
@@ -153,6 +153,9 @@ prs:
 release.triage:
   type: CNAME
   value: release.triage.k8s.io.
+sbom:
+  type: CNAME
+  value: redirect.k8s.io.
 sigs:
   type: CNAME
   value: sigs.k8s.io.


### PR DESCRIPTION
This pull request adds two commits to enable publishing the Kubernetes Bill of Materials (SBOM) via redirects to the release bucket.

SIG Release SBOM issue:  https://github.com/kubernetes/release/issues/1837

Changes are split into two commits:

* The first one adds the redirect configuration that sends traffic from `sbom.k8s.io` to the release bucket locations where the SPDX documents live (same in `sbom.kubernetes.io`). 
* The second commit defined the DNS configuration for the `sbom.k8s.io` and `sbom.kubernetes.io` hostnames as CNAMEs pointing to `redirect.k8s.io.`.

If we decide this is the way to go, we still need a follow-up PR in `k/release` to match the namespaces in the documents to the new URIs.

/cc  @ameukam  and @kubernetes/release-engineering 
/hold for discussion in the releng meeting