### PR TITLE
Allow Service Account admin access to dataset

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-ii-sandbox/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-ii-sandbox/main.tf
@@ -67,6 +67,6 @@ data "google_service_account" "bq_data_transfer" {
 resource "google_bigquery_dataset_iam_member" "bq_data_transfer_binding" {
   project    = local.project_id
   dataset_id = "riaan_data_store"
-  role       = "roles/bigquery.dataViewer"
+  role       = "roles/bigquery.admin"
   member     = "serviceAccount:${data.google_service_account.bq_data_transfer.email}"
 }


### PR DESCRIPTION
permissions added to bq-data-transfer were not enough to make the data
transfer job successful.
Use a predefined role instead of a custom role should fix it.

Got: 

```shell
1_etl_test_distinct_ip_org with error PERMISSION_DENIED: 
Access Denied: Project 226195303281: User does not have bigquery.jobs.create permission in project 226195303281.;
JobID: 226195303281:bqts_6208b112-0000-23fe-91dd-94eb2c0569f4
```

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>