### PR TITLE
infra/gcp: setup k8s-project-triage special-case

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-serviceaccounts.yaml
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-serviceaccounts.yaml
@@ -23,6 +23,14 @@ metadata:
     iam.gke.io/gcp-service-account: k8s-metrics@k8s-infra-prow-build-trusted.iam.gserviceaccount.com
   name: k8s-metrics
   namespace: test-pods
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: k8s-triage@k8s-infra-prow-build-trusted.iam.gserviceaccount.com
+  name: k8s-triage
+  namespace: test-pods
 
 # Infrastructure management service accounts
 ---

--- a/infra/gcp/ensure-main-project.sh
+++ b/infra/gcp/ensure-main-project.sh
@@ -416,13 +416,36 @@ function ensure_prow_special_cases {
       empower_gcs_admins "${project}" "${bucket}"
       # bucket owners can admin this bucket
       empower_group_to_admin_gcs_bucket "${owners}" "${bucket}"
+      # k8s-infra-prow-build-trusted can write to this bucket
+      principal="serviceAccount:$(svc_acct_email "k8s-infra-prow-build-trusted" "k8s-metrics")"
+      ensure_gcs_role_binding "${bucket}" "${principal}" "objectAdmin"
+      ensure_gcs_role_binding "${bucket}" "${principal}" "legacyBucketWriter"
+      # TODO(spiffxp): this is a test to confirm we _can_ charge bigquery usage elsewhere
+      #                and might prove convenient since there are datasets in this project,
+      #                but this should probably not be the long-term home of usage billing
+      # k8s-infra-prow-build-trusted can charge bigquery usage to this project
+      ensure_project_role_binding "${project}" "${principal}" "roles/bigquery.user"
+    ) 2>&1 | indent
+
+    color 6 "Special case: ensuring gs://k8s-project-triage exists"
+    (
+      local bucket="gs://k8s-project-triage"
+      local owners="k8s-infra-prow-oncall@kubernetes.io"
+      local old_service_account="triage@k8s-gubernator.iam.gserviceaccount.com"
+
+      ensure_public_gcs_bucket "${project}" "${bucket}"
+      ensure_gcs_bucket_auto_deletion "${bucket}" "365" # match gs://k8s-metrics
+      # GCS admins can admin all GCS buckets
+      empower_gcs_admins "${project}" "${bucket}"
+      # bucket owners can admin this bucket
+      empower_group_to_admin_gcs_bucket "${owners}" "${bucket}"
       # TODO(spiffxp): remove once bindings have been removed
       # k8s-prow-builds can no longer write to this bucket
       principal="serviceAccount:${old_service_account}"
-      ensure_removed_gcs_role_binding "${bucket}" "${principal}" "objectAdmin"
-      ensure_removed_gcs_role_binding "${bucket}" "${principal}" "legacyBucketWriter"
+      ensure_gcs_role_binding "${bucket}" "${principal}" "objectAdmin"
+      ensure_gcs_role_binding "${bucket}" "${principal}" "legacyBucketWriter"
       # k8s-infra-prow-build-trusted can write to this bucket
-      principal="serviceAccount:$(svc_acct_email "k8s-infra-prow-build-trusted" "k8s-metrics")"
+      principal="serviceAccount:$(svc_acct_email "k8s-infra-prow-build-trusted" "k8s-triage")"
       ensure_gcs_role_binding "${bucket}" "${principal}" "objectAdmin"
       ensure_gcs_role_binding "${bucket}" "${principal}" "legacyBucketWriter"
       # TODO(spiffxp): this is a test to confirm we _can_ charge bigquery usage elsewhere


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1305
- Small followup to: https://github.com/kubernetes/k8s.io/pull/2451

Same steps as were done for k8s-project-metrics:
- add a gs://k8s-project-triage bucket to kubernetes-public
- give the google.com triage SA write access to this bucket
- add a k8s-triage SA
- give it roles/bigquery.user in k8s-infra-prow-build-trusted and
  kubernetes-public
- give it write access to gs://k8s-project-triage

While here, I removed the binding removal code for gs://k8s-metrics