### PR TITLE
add sbom hostnames to cert SANs

### DIFF
--- a/k8s.io/certificate-canary.yaml
+++ b/k8s.io/certificate-canary.yaml
@@ -53,6 +53,8 @@ spec:
   - rel.kubernetes.io
   - releases.k8s.io
   - releases.kubernetes.io
+  - sbom.k8s.io
+  - sbom.kubernetes.io
   - sigs.k8s.io
   - sigs.kubernetes.io
   - submit-queue.k8s.io

--- a/k8s.io/certificate-prod.yaml
+++ b/k8s.io/certificate-prod.yaml
@@ -45,6 +45,8 @@ spec:
   - rel.kubernetes.io
   - releases.k8s.io
   - releases.kubernetes.io
+  - sbom.k8s.io
+  - sbom.kubernetes.io
   - sigs.k8s.io
   - sigs.kubernetes.io
   - submit-queue.k8s.io


### PR DESCRIPTION
This PR adds the `sbom.k8s.io` and `sbom.kubernetes.io` hostnames to the prod and canary
certificates SANs. These hostnames were recently added to the DNS and nginx configuration.

Follow-up to: https://github.com/kubernetes/k8s.io/pull/2447

/assign @spiffxp 

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>