### PR TITLE
releng: Add sbom.[k8s, kubernetes].io to certificate SANs

### DIFF
--- a/apps/k8s-io/certificate-canary.yaml
+++ b/apps/k8s-io/certificate-canary.yaml
@@ -55,6 +55,8 @@ spec:
   - rel.kubernetes.io
   - releases.k8s.io
   - releases.kubernetes.io
+  - sbom.k8s.io
+  - sbom.kubernetes.io
   - sigs.k8s.io
   - sigs.kubernetes.io
   - submit-queue.k8s.io

--- a/apps/k8s-io/certificate-prod.yaml
+++ b/apps/k8s-io/certificate-prod.yaml
@@ -47,6 +47,8 @@ spec:
   - rel.kubernetes.io
   - releases.k8s.io
   - releases.kubernetes.io
+  - sbom.k8s.io
+  - sbom.kubernetes.io
   - sigs.k8s.io
   - sigs.kubernetes.io
   - submit-queue.k8s.io


### PR DESCRIPTION
This commit adds the sbom.k8s.io and sbom.kubernetes.io hostnames to the prod and canary
certificate SANs. These hostnames were recently added to the DNS and nginx configuration.

Follow-up to: #2447
Part of: https://github.com/kubernetes/release/issues/1837

/assign @ameukam 

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>