### PR TITLE
Migrate k8s-triage, k8s-metrics to terraform, setup k8s-triage dataset

### DIFF
--- a/infra/gcp/ensure-main-project.sh
+++ b/infra/gcp/ensure-main-project.sh
@@ -432,33 +432,6 @@ function ensure_prow_special_cases {
       # k8s-infra-prow-build-trusted can charge bigquery usage to this project
       ensure_project_role_binding "${project}" "${principal}" "roles/bigquery.user"
     ) 2>&1 | indent
-
-    color 6 "Special case: ensuring gs://k8s-triage exists"
-    (
-      local bucket="gs://k8s-triage"
-      local owners="k8s-infra-prow-oncall@kubernetes.io"
-      local old_service_account="triage@k8s-gubernator.iam.gserviceaccount.com"
-
-      ensure_public_gcs_bucket "${project}" "${bucket}"
-      # GCS admins can admin all GCS buckets
-      empower_gcs_admins "${project}" "${bucket}"
-      # bucket owners can admin this bucket
-      empower_group_to_admin_gcs_bucket "${owners}" "${bucket}"
-      # TODO(spiffxp): remove once bindings have been removed
-      # k8s-prow-builds can no longer write to this bucket
-      principal="serviceAccount:${old_service_account}"
-      ensure_gcs_role_binding "${bucket}" "${principal}" "objectAdmin"
-      ensure_gcs_role_binding "${bucket}" "${principal}" "legacyBucketWriter"
-      # k8s-infra-prow-build-trusted can write to this bucket
-      principal="serviceAccount:$(svc_acct_email "k8s-infra-prow-build-trusted" "k8s-triage")"
-      ensure_gcs_role_binding "${bucket}" "${principal}" "objectAdmin"
-      ensure_gcs_role_binding "${bucket}" "${principal}" "legacyBucketWriter"
-      # TODO(spiffxp): this is a test to confirm we _can_ charge bigquery usage elsewhere
-      #                and might prove convenient since there are datasets in this project,
-      #                but this should probably not be the long-term home of usage billing
-      # k8s-infra-prow-build-trusted can charge bigquery usage to this project
-      ensure_project_role_binding "${project}" "${principal}" "roles/bigquery.user"
-    ) 2>&1 | indent
 }
 
 function ensure_main_project() {

--- a/infra/gcp/ensure-main-project.sh
+++ b/infra/gcp/ensure-main-project.sh
@@ -433,14 +433,13 @@ function ensure_prow_special_cases {
       ensure_project_role_binding "${project}" "${principal}" "roles/bigquery.user"
     ) 2>&1 | indent
 
-    color 6 "Special case: ensuring gs://k8s-project-triage exists"
+    color 6 "Special case: ensuring gs://k8s-triage exists"
     (
-      local bucket="gs://k8s-project-triage"
+      local bucket="gs://k8s-triage"
       local owners="k8s-infra-prow-oncall@kubernetes.io"
       local old_service_account="triage@k8s-gubernator.iam.gserviceaccount.com"
 
       ensure_public_gcs_bucket "${project}" "${bucket}"
-      ensure_gcs_bucket_auto_deletion "${bucket}" "365" # match gs://k8s-metrics
       # GCS admins can admin all GCS buckets
       empower_gcs_admins "${project}" "${bucket}"
       # bucket owners can admin this bucket
@@ -526,4 +525,8 @@ function ensure_main_project() {
     color 6 "Done"
 }
 
-ensure_main_project "${PROJECT}"
+project="${PROJECT}"
+color 6 "Ensuring prow special cases for: ${project}"
+ensure_prow_special_cases "${project}" 2>&1 | indent
+
+# ensure_main_project "${PROJECT}"

--- a/infra/gcp/ensure-main-project.sh
+++ b/infra/gcp/ensure-main-project.sh
@@ -409,29 +409,6 @@ function ensure_prow_special_cases {
     principal="serviceAccount:$(svc_acct_email "k8s-infra-prow-build-trusted" "kubernetes-external-secrets")"
     secret=$(secret_full_name "${project}" "k8s-infra-ci-robot-github-token")
     ensure_secret_role_binding "${secret}" "${principal}" "roles/secretmanager.secretAccessor" 2>&1 | indent
-
-    color 6 "Special case: ensuring gs://k8s-metrics exists"
-    (
-      local bucket="gs://k8s-metrics"
-      local owners="k8s-infra-prow-oncall@kubernetes.io"
-      local old_service_account="triage@k8s-gubernator.iam.gserviceaccount.com"
-
-      ensure_public_gcs_bucket "${project}" "${bucket}"
-      ensure_gcs_bucket_auto_deletion "${bucket}" "365" # match gs://k8s-metrics
-      # GCS admins can admin all GCS buckets
-      empower_gcs_admins "${project}" "${bucket}"
-      # bucket owners can admin this bucket
-      empower_group_to_admin_gcs_bucket "${owners}" "${bucket}"
-      # k8s-infra-prow-build-trusted can write to this bucket
-      principal="serviceAccount:$(svc_acct_email "k8s-infra-prow-build-trusted" "k8s-metrics")"
-      ensure_gcs_role_binding "${bucket}" "${principal}" "objectAdmin"
-      ensure_gcs_role_binding "${bucket}" "${principal}" "legacyBucketWriter"
-      # TODO(spiffxp): this is a test to confirm we _can_ charge bigquery usage elsewhere
-      #                and might prove convenient since there are datasets in this project,
-      #                but this should probably not be the long-term home of usage billing
-      # k8s-infra-prow-build-trusted can charge bigquery usage to this project
-      ensure_project_role_binding "${project}" "${principal}" "roles/bigquery.user"
-    ) 2>&1 | indent
 }
 
 function ensure_main_project() {

--- a/infra/gcp/terraform/kubernetes-public/00-inputs.tf
+++ b/infra/gcp/terraform/kubernetes-public/00-inputs.tf
@@ -6,6 +6,10 @@ This file defines:
 - GCP project configuration
 */
 
+locals {
+  prow_owners = "k8s-infra-prow-oncall@kubernetes.io"
+}
+
 terraform {
   required_version = "~> 1.0.0"
 

--- a/infra/gcp/terraform/kubernetes-public/k8s-infra-prow.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-infra-prow.tf
@@ -90,12 +90,12 @@ resource "google_storage_bucket_iam_member" "k8s_infra_prow_public_access" {
   member = "allUsers"
 }
 
-// Allow read access to members of k8s-infra-prow-oncall@kubernetes.io
-resource "google_storage_bucket_iam_member" "k8s_infra_prow_oncall" {
+// Allow read access to prow owners
+resource "google_storage_bucket_iam_member" "k8s_infra_prow_owners" {
   bucket = google_storage_bucket.k8s_infra_prow_bucket.name
   role   = "roles/storage.objectViewer"
   //TODO(ameukam): switch to allUsers when https://github.com/kubernetes/k8s.io/issues/752 is closed.
-  member = "group:k8s-infra-prow-oncall@kubernetes.io"
+  member = "group:${local.prow_owners}"
 }
 
 // Create a secret for GCP Service Account key of k8s-infra-prow
@@ -114,13 +114,13 @@ resource "google_secret_manager_secret_version" "k8s_infra_prow_key_version" {
   secret_data = base64decode(google_service_account_key.k8s_infra_prow.private_key)
 }
 
-// Allow read access to members of k8s-infra-prow-oncall@kubernetes.io
+// Allow read access to prow owners
 resource "google_secret_manager_secret_iam_binding" "name" {
   project   = data.google_project.project.project_id
   secret_id = google_secret_manager_secret.k8s_infra_prow_key.id
   role      = "roles/secretmanager.admin"
   members = [
-    "group:k8s-infra-prow-oncall@kubernetes.io"
+    "group:${local.prow_owners}"
   ]
 }
 

--- a/infra/gcp/terraform/kubernetes-public/k8s-metrics.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-metrics.tf
@@ -5,10 +5,6 @@ This file defines:
 - IAM bindings
 */
 
-locals {
-  prow_owners                  = "k8s-infra-prow-oncall@kubernetes.io"
-}
-
 // Use a data source for the service account
 // NB: we can't do this for triage_legacy_sa_email as we lack sufficient privileges
 data "google_service_account" "metrics_sa" {
@@ -22,7 +18,7 @@ resource "google_storage_bucket" "metrics_bucket" {
   location                    = "us-central1"
   storage_class               = "REGIONAL"
   uniform_bucket_level_access = true
-  
+
   lifecycle_rule {
     condition {
       age = 365 // days
@@ -35,7 +31,7 @@ resource "google_storage_bucket" "metrics_bucket" {
 }
 
 data "google_iam_policy" "metrics_bucket_iam_bindings" {
-  // Ensure k8s-infra-prow-oncall has admin privileges, and keep existing
+  // Ensure prow owners have admin privileges, and keep existing
   // legacy bindings since we're overwriting all existing bindings below
   binding {
     members = [
@@ -84,7 +80,7 @@ data "google_iam_policy" "metrics_bucket_iam_bindings" {
 }
 
 // Authoritative iam-policy: replaces any existing policy attached to the bucket
-resource "google_storage_bucket_iam_policy" "triage_bucket_iam_policy" {
+resource "google_storage_bucket_iam_policy" "metrics_bucket_iam_policy" {
   bucket      = google_storage_bucket.metrics_bucket.name
   policy_data = data.google_iam_policy.metrics_bucket_iam_bindings.policy_data
 }

--- a/infra/gcp/terraform/kubernetes-public/k8s-metrics.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-metrics.tf
@@ -15,8 +15,8 @@ data "google_service_account" "metrics_sa" {
 resource "google_storage_bucket" "metrics_bucket" {
   name                        = "k8s-metrics"
   project                     = data.google_project.project.project_id
-  location                    = "us-central1"
-  storage_class               = "REGIONAL"
+  location                    = "US"
+  storage_class               = "STANDARD"
   uniform_bucket_level_access = true
 
   lifecycle_rule {

--- a/infra/gcp/terraform/kubernetes-public/k8s-metrics.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-metrics.tf
@@ -1,0 +1,97 @@
+/*
+This file defines:
+- bigquery dataset for triage to store temp results
+- GCS bucket to serve go.k8s.io/triage results
+- IAM bindings
+*/
+
+locals {
+  prow_owners                  = "k8s-infra-prow-oncall@kubernetes.io"
+}
+
+// Use a data source for the service account
+// NB: we can't do this for triage_legacy_sa_email as we lack sufficient privileges
+data "google_service_account" "metrics_sa" {
+  account_id = "k8s-metrics@k8s-infra-prow-build-trusted.iam.gserviceaccount.com"
+}
+
+// Create a GCS bucket for triage results
+resource "google_storage_bucket" "metrics_bucket" {
+  name                        = "k8s-metrics"
+  project                     = data.google_project.project.project_id
+  location                    = "us-central1"
+  storage_class               = "REGIONAL"
+  uniform_bucket_level_access = true
+  
+  lifecycle_rule {
+    condition {
+      age = 365 // days
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+}
+
+data "google_iam_policy" "metrics_bucket_iam_bindings" {
+  // Ensure k8s-infra-prow-oncall has admin privileges, and keep existing
+  // legacy bindings since we're overwriting all existing bindings below
+  binding {
+    members = [
+      "group:${local.prow_owners}",
+    ]
+    role = "roles/storage.admin"
+  }
+  // Preserve legacy storage bindings, give storage.admim members legacy bucket owner
+  binding {
+    members = [
+      "group:${local.prow_owners}",
+      "projectEditor:${data.google_project.project.project_id}",
+      "projectOwner:${data.google_project.project.project_id}",
+    ]
+    role = "roles/storage.legacyBucketOwner"
+  }
+  // Ensure triage service accounts have write access to the bucket
+  binding {
+    members = [
+      "serviceAccount:${data.google_service_account.triage_sa.email}",
+    ]
+    role = "roles/storage.legacyBucketWriter"
+  }
+  // Preserve legacy storage bindings
+  binding {
+    members = [
+      "projectViewer:${data.google_project.project.project_id}",
+    ]
+    role = "roles/storage.legacyBucketReader"
+  }
+  // Ensure triage service accounts have write/update/delete access to objects
+  binding {
+    role = "roles/storage.objectAdmin"
+    members = [
+      "group:${local.prow_owners}",
+      "serviceAccount:${data.google_service_account.triage_sa.email}",
+    ]
+  }
+  // Ensure bucket contents are world readable
+  binding {
+    role = "roles/storage.objectViewer"
+    members = [
+      "allUsers"
+    ]
+  }
+}
+
+// Authoritative iam-policy: replaces any existing policy attached to the bucket
+resource "google_storage_bucket_iam_policy" "triage_bucket_iam_policy" {
+  bucket      = google_storage_bucket.metrics_bucket.name
+  policy_data = data.google_iam_policy.metrics_bucket_iam_bindings.policy_data
+}
+
+// Ensure triage service account can run bigquery jobs by billing to this project
+resource "google_project_iam_member" "k8s_metrics_sa_bigquery_user" {
+  project = data.google_project.project.project_id
+  role    = "roles/bigquery.user"
+  member  = "serviceAccount:${data.google_service_account.metrics_sa.email}"
+}

--- a/infra/gcp/terraform/kubernetes-public/k8s-triage.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-triage.tf
@@ -1,0 +1,92 @@
+/*
+This file defines:
+- bigquery dataset for triage to store temp results
+- GCS bucket to serve go.k8s.io/triage results
+- IAM bindings
+*/
+
+locals {
+  // TODO(spiffxp): remove legacy serviceaccount when migration completed
+  triage_legacy_sa_email = "triage@k8s-gubernator.iam.gserviceaccount.com"
+  triage_dataset               = "k8s-triage"
+  prow_owners                  = "k8s-infra-prow-oncall@kubernetes.io"
+}
+
+// Use a data source for the service account
+// NB: we can't do this for triage_legacy_sa_email as we lack sufficient privileges
+data "google_service_account" "triage_sa" {
+  account_id = "k8s-triage@k8s-infra-prow-build-trusted.iam.gserviceaccount.com"
+}
+
+// Create a GCS bucket for triage results
+resource "google_storage_bucket" "triage_bucket" {
+  name                        = "k8s-triage"
+  project                     = data.google_project.project.project_id
+  location                    = "us-central1"
+  storage_class               = "REGIONAL"
+  uniform_bucket_level_access = true
+}
+
+data "google_iam_policy" "triage_bucket_iam_bindings" {
+  // Ensure k8s-infra-prow-oncall has admin privileges, and keep existing
+  // legacy bindings since we're overwriting all existing bindings below
+  binding {
+    members = [
+      "group:${local.prow_owners}",
+    ]
+    role = "roles/storage.admin"
+  }
+  // Preserve legacy storage bindings, give storage.admim members legacy bucket owner
+  binding {
+    members = [
+      "group:${local.prow_owners}",
+      "projectEditor:${data.google_project.project.project_id}",
+      "projectOwner:${data.google_project.project.project_id}",
+    ]
+    role = "roles/storage.legacyBucketOwner"
+  }
+  // Ensure triage service accounts have write access to the bucket
+  binding {
+    members = [
+      "serviceAccount:${data.google_service_account.triage_sa.email}",
+      "serviceAccount:${local.triage_legacy_sa_email}"
+    ]
+    role = "roles/storage.legacyBucketWriter"
+  }
+  // Preserve legacy storage bindings
+  binding {
+    members = [
+      "projectViewer:${data.google_project.project.project_id}",
+    ]
+    role = "roles/storage.legacyBucketReader"
+  }
+  // Ensure triage service accounts have write/update/delete access to objects
+  binding {
+    role = "roles/storage.objectAdmin"
+    members = [
+      "group:${local.prow_owners}",
+      "serviceAccount:${data.google_service_account.triage_sa.email}",
+      "serviceAccount:${local.triage_legacy_sa_email}"
+    ]
+  }
+  // Ensure bucket contents are world readable
+  binding {
+    role = "roles/storage.objectViewer"
+    members = [
+      "allUsers"
+    ]
+  }
+}
+
+// Authoritative iam-policy: replaces any existing policy attached to the bucket
+resource "google_storage_bucket_iam_policy" "triage_bucket_iam_policy" {
+  bucket      = google_storage_bucket.triage_bucket.name
+  policy_data = data.google_iam_policy.triage_bucket_iam_bindings.policy_data
+}
+
+// Ensure triage service account can run bigquery jobs by billing to this project
+resource "google_project_iam_member" "k8s_triage_sa_bigquery_user" {
+  project = data.google_project.project.project_id
+  role    = "roles/bigquery.user"
+  member  = "serviceAccount:${data.google_service_account.triage_sa.email}"
+}

--- a/infra/gcp/terraform/kubernetes-public/k8s-triage.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-triage.tf
@@ -20,8 +20,8 @@ data "google_service_account" "triage_sa" {
 resource "google_storage_bucket" "triage_bucket" {
   name                        = "k8s-triage"
   project                     = data.google_project.project.project_id
-  location                    = "us-central1"
-  storage_class               = "REGIONAL"
+  location                    = "US"
+  storage_class               = "STANDARD"
   uniform_bucket_level_access = true
 }
 
@@ -91,7 +91,7 @@ resource "google_project_iam_member" "triage_sa_bigquery_user" {
 
 // BigQuery dataset for triage to store temporary results
 resource "google_bigquery_dataset" "triage_dataset" {
-  dataset_id  = "k8s-triage"
+  dataset_id  = "k8s_triage"
   project     = data.google_project.project.project_id
   description = "Dataset for kubernetes/test-infra/triage to store temprorary results"
   location    = "US"
@@ -116,6 +116,7 @@ data "google_iam_policy" "triage_dataset_iam_policy" {
 }
 
 resource "google_bigquery_dataset_iam_policy" "triage_dataset" {
-  dataset_id  = google_bigquery_dataset.triage_dataset
+  dataset_id  = google_bigquery_dataset.triage_dataset.dataset_id
+  project = google_bigquery_dataset.triage_dataset.project
   policy_data = data.google_iam_policy.triage_dataset_iam_policy.policy_data
 }

--- a/infra/gcp/terraform/kubernetes-public/k8s-triage.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-triage.tf
@@ -9,7 +9,6 @@ locals {
   // TODO(spiffxp): remove legacy serviceaccount when migration completed
   triage_legacy_sa_email = "triage@k8s-gubernator.iam.gserviceaccount.com"
   triage_dataset               = "k8s-triage"
-  prow_owners                  = "k8s-infra-prow-oncall@kubernetes.io"
 }
 
 // Use a data source for the service account
@@ -28,7 +27,7 @@ resource "google_storage_bucket" "triage_bucket" {
 }
 
 data "google_iam_policy" "triage_bucket_iam_bindings" {
-  // Ensure k8s-infra-prow-oncall has admin privileges, and keep existing
+  // Ensure prow owners have admin privileges, and keep existing
   // legacy bindings since we're overwriting all existing bindings below
   binding {
     members = [

--- a/infra/gcp/terraform/kubernetes-public/prowjob-buckets.tf
+++ b/infra/gcp/terraform/kubernetes-public/prowjob-buckets.tf
@@ -41,17 +41,17 @@ resource "google_storage_bucket" "scalability_tests_logs" {
 }
 
 data "google_iam_policy" "scalability_tests_logs_bindings" {
-  // Ensure k8s-infra-prow-oncall has admin privileges, and keep existing
+  // Ensure prow owners have admin privileges, and keep existing
   // legacy bindings since we're overwriting all existing bindings below
   binding {
     members = [
-      "group:k8s-infra-prow-oncall@kubernetes.io",
+      "group:${local.prow_owners}",
     ]
     role = "roles/storage.admin"
   }
   binding {
     members = [
-      "group:k8s-infra-prow-oncall@kubernetes.io",
+      "group:${local.prow_owners}",
       "projectEditor:${data.google_project.project.project_id}",
       "projectOwner:${data.google_project.project.project_id}",
     ]


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1305
- Followup to: https://github.com/kubernetes/k8s.io/pull/2454
- Depends on: https://github.com/kubernetes/test-infra/pull/23126

Since converting go.k8s.io/triage to triage.k8s.io is going to be more involved than I thought, setup to migrate gs://k8s-gubernator/triage to gs://k8s-triage.  The bucket is currently populated with whatever it contained a while ago (which is basically as fresh as it's going to get since kettle has been down this whole time)

The dependency test-infra PR sets up a job that runs in k8s-infra-prow-build-trusted to update gs://k8s-triage

While I initially did all the provisioning for this via ensure-main-project.sh, I have since updated the PR to do all of this via terraform.  I migrated all of the setup code for gs://k8s-metrics while doing so.

This also adds a bigquery dataset `kubernetes-public:k8s-triage` for the ci-test-infra-triage-canary job to be able to write to.  A future test-infra PR will configure the job to write to it instead of currently failing to write to `k8s-gubernator:temp.triage`

In setting up the dataset, I'm trying out use of IAM roles instead of basic access (ref: https://cloud.google.com/bigquery/docs/access-control-basic-roles)