### PR TITLE
Add k8s-io-prod namespace to certificat-prod YAML file

### DIFF
--- a/apps/k8s-io/certificate-prod.yaml
+++ b/apps/k8s-io/certificate-prod.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.gke.io/v1
 kind: ManagedCertificate
 metadata:
   name: k8s-io-prod
+  namespace: k8s-io-prod
   labels:
     app: k8s-io
 spec:


### PR DESCRIPTION
This commit adds the `k8s-io-prod` namespace to the ManagedCertificate yaml file.

Ref: https://github.com/kubernetes/k8s.io/pull/2458#issuecomment-892544376

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>