### PR TITLE
apps/slack-infra: change pathtype for Ingresses

### DIFF
--- a/apps/slack-infra/resources/ingress.yaml
+++ b/apps/slack-infra/resources/ingress.yaml
@@ -15,35 +15,35 @@ spec:
   rules:
   - http:
       paths:
-      - pathType: Prefix
+      - pathType: ImplementationSpecific
         path: "/infra/event-log/*"
         backend:
           service:
             name: slack-event-log
             port:
               number: 80
-      - pathType: Prefix
+      - pathType: ImplementationSpecific
         path: "/infra/moderator/*"
         backend:
           service:
             name: slack-moderator
             port:
               number: 80
-      - pathType: Prefix
+      - pathType: ImplementationSpecific
         path: "/infra/welcomer/*"
         backend:
           service:
             name: slack-welcomer
             port:
               number: 80
-      - pathType: Prefix
+      - pathType: ImplementationSpecific
         path: "/infra/post-message/*"
         backend:
           service:
             name: slack-post-message
             port:
               number: 80
-      - pathType: Prefix
+      - pathType: ImplementationSpecific
         path: "/infra/moderator-words/*"
         backend:
           service:


### PR DESCRIPTION
Ingresses is now GA since GKE 1.19 and only `ImplementationSpecific`
is supported in the `pathType`.

Currently the ingress returns :

```shell
Translation failed: invalid ingress spec: only "ImplementationSpecific" path type is supported
```

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>