### PR TITLE
releng: Drop jimangel temporary access

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -59,7 +59,6 @@ groups:
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
       - georgedanielmangum@gmail.com
-      - jameswangel@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
       - saschagrunert@gmail.com


### PR DESCRIPTION
Jim Angel (@jimangel ) is a Release Manager Associate who was granted temporary elevated access to cut the v1.22.0-beta.2 release.

The release is out so we drop the elevated privileges.

SIG Release issue: https://github.com/kubernetes/sig-release/issues/1618

/assign @dims @cblecker @spiffxp
cc: @kubernetes/release-engineering

/priority important-soon

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>