### PR TITLE
prow: match prow-build-trusted nodepool to prow-build

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
@@ -256,10 +256,12 @@ module "prow_build_nodepool" {
   name            = "trusted-pool1"
   initial_count   = 1
   min_count       = 1
-  max_count       = 3
-  machine_type    = "n1-standard-8"
+  max_count       = 6
+  # image/machine/disk match prow-build for consistency's sake
+  image_type      = "UBUNTU_CONTAINERD"
+  machine_type    = "n1-highmem-8"
   disk_size_gb    = 200
-  disk_type       = "pd-standard"
+  disk_type       = "pd-ssd"
   service_account = module.prow_build_cluster.cluster_node_sa.email
 }
 


### PR DESCRIPTION
the motivating factor here is trying to run the triage job on this
cluster, which asks for more memory than an n1-standard-8 can provide

but in general I can't think of a good reason to restrict this cluster
to less resources than the regular prow-build cluster, while having it
match the cluster would create less surprises when transferring a job
from one to the other for whatever reason