### PR TITLE
infra/gcp/clusters: fix gke-nodepool ignore_changes

### DIFF
--- a/infra/gcp/clusters/modules/gke-nodepool/main.tf
+++ b/infra/gcp/clusters/modules/gke-nodepool/main.tf
@@ -65,7 +65,7 @@ resource "google_container_node_pool" "node_pool" {
     create_before_destroy = true
     # https://www.terraform.io/docs/providers/google/r/container_cluster.html#taint
     ignore_changes = [
-      node_config["taint"],
+      node_config[0].taint,
     ]
   }
 }


### PR DESCRIPTION
Followup to https://github.com/kubernetes/k8s.io/pull/2479

I suspect the syntax to ignore node taint changes was incorrect before,
causing terraform to ignore _all_ node_config changes

(confirmed `terraform plan` doesn't want to change k8s-infra-prow-build nodes, but does want to change k8s-infra-prow-build-trusted)