### PR TITLE
infra/gcp: prow-deployer as container.admin

### DIFF
--- a/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
+++ b/infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/main.tf
@@ -132,12 +132,12 @@ resource "google_service_account_iam_policy" "prow_deployer_sa_iam" {
 // roles: prow-deployer (there are also some assigned in ensure-main-project.sh)
 resource "google_project_iam_member" "prow_deployer_for_prow_build_trusted" {
   project = local.project_id
-  role    = "${data.google_organization.org.name}/roles/container.deployer"
+  role    = "roles/container.admin"
   member  = "serviceAccount:${local.prow_deployer_sa_name}@${local.project_id}.iam.gserviceaccount.com"
 }
 resource "google_project_iam_member" "prow_deployer_for_prow_build" {
   project = "k8s-infra-prow-build"
-  role    = "${data.google_organization.org.name}/roles/container.deployer"
+  role    = "roles/container.admin"
   member  = "serviceAccount:${local.prow_deployer_sa_name}@${local.project_id}.iam.gserviceaccount.com"
 }
 

--- a/infra/gcp/ensure-main-project.sh
+++ b/infra/gcp/ensure-main-project.sh
@@ -212,8 +212,11 @@ function empower_cluster_admins_and_users() {
     # TODO(spiffxp): consider replacing this with a service account per namespace
     local prow_deployer_acct prow_deployer_role
     prow_deployer_acct="prow-deployer@k8s-infra-prow-build-trusted.iam.gserviceaccount.com"
+    # TODO(spiffxp): use container.deployer once we figure out why it isn't getting RBAC privileges
+    old_prow_deployer_role=$(custom_org_role_name "container.deployer")
     prow_deployer_role=$(custom_org_role_name "container.deployer")
     color 6 "Empowering ${prow_deployer_acct} to deploy to clusters in project: ${project}"
+    ensure_removed_project_role_binding "${project}" "serviceAccount:${prow_deployer_acct}" "${old_prow_deployer_role}"
     ensure_project_role_binding "${project}" "serviceAccount:${prow_deployer_acct}" "${prow_deployer_role}"
 
     color 6 "Empowering cluster users"


### PR DESCRIPTION
The custom container.deployer role isn't getting privileges to deploy RBAC and I'd rather not leave our postsubmit deploy process broken while I continue to not have time to figure out why.

Related:
- part of https://github.com/kubernetes/k8s.io/issues/2218
- should unblock auto deploy of https://github.com/kubernetes/k8s.io/pull/2235