### PR TITLE
infra/gcp/main: _actually_ use roles/container.admin

### DIFF
--- a/infra/gcp/ensure-main-project.sh
+++ b/infra/gcp/ensure-main-project.sh
@@ -214,7 +214,7 @@ function empower_cluster_admins_and_users() {
     prow_deployer_acct="prow-deployer@k8s-infra-prow-build-trusted.iam.gserviceaccount.com"
     # TODO(spiffxp): use container.deployer once we figure out why it isn't getting RBAC privileges
     old_prow_deployer_role=$(custom_org_role_name "container.deployer")
-    prow_deployer_role=$(custom_org_role_name "container.deployer")
+    prow_deployer_role="roles/container.admin"
     color 6 "Empowering ${prow_deployer_acct} to deploy to clusters in project: ${project}"
     ensure_removed_project_role_binding "${project}" "serviceAccount:${prow_deployer_acct}" "${old_prow_deployer_role}"
     ensure_project_role_binding "${project}" "serviceAccount:${prow_deployer_acct}" "${prow_deployer_role}"


### PR DESCRIPTION
Related:
- Followup to https://github.com/kubernetes/k8s.io/pull/2483
- Part of https://github.com/kubernetes/k8s.io/issues/2218