### PR TITLE
apps/prow: fixes for k8s-infra-prow (part2)

### DIFF
--- a/apps/prow/Makefile
+++ b/apps/prow/Makefile
@@ -30,4 +30,4 @@ update-plugins: get-cluster-credentials
 	kubectl -n "$(NAMESPACE)" create configmap plugins --from-file=plugins.yaml=plugins.yaml --dry-run=client -o yaml | kubectl replace configmap plugins -f -
 
 update-prowjobs: get-cluster-credentials
-	kubectl -n "$(NAMESPACE)" create configmap job-config --from-file=$PWD/prowjobs/kubernetes/k8s.io/ --dry-run=client -o yaml | kubectl replace configmap job-config -f -
+	kubectl -n "$(NAMESPACE)" create configmap job-config --from-file=$(PWD)/prowjobs/kubernetes/k8s.io/ --dry-run=client -o yaml | kubectl replace configmap job-config -f -

--- a/apps/prow/cluster/tide_deployment.yaml
+++ b/apps/prow/cluster/tide_deployment.yaml
@@ -41,6 +41,7 @@ spec:
         - --github-endpoint=http://ghproxy.prow.svc.cluster.local
         - --github-endpoint=https://api.github.com
         - --github-token-path=/etc/github/token
+        - --gcs-credentials-file=/etc/gcs-credentials/service-account.json
         - --job-config-path=/etc/job-config
         - --history-uri=gs://k8s-infra-prow-results/tide-history.json
         - --status-path=gs://k8s-infra-prow-results/tide-status-checkpoint.yaml
@@ -63,11 +64,18 @@ spec:
         - name: job-config
           mountPath: /etc/job-config
           readOnly: true
+        - name: gcs-credentials
+          mountPath: /etc/gcs-credentials
+          readOnly: true
       volumes:
       - name: github-token
         secret:
           defaultMode: 420
           secretName: k8s-infra-ci-robot-github-token
+      - name: gcs-credentials
+        secret:
+          defaultMode: 420
+          secretName: k8s-infra-prow-sa-key
       - name: config
         configMap:
           name: config

--- a/apps/prow/deploy.sh
+++ b/apps/prow/deploy.sh
@@ -47,7 +47,14 @@ fi
 
 # deploy kubernetes resources
 pushd "${SCRIPT_ROOT}" >/dev/null
+
+echo "Update k8s-infra-prow config"
 make update-config
+
+echo "Update k8s-infra-prow plugins"
 make update-plugins
+
+echo "Update k8s-infra-prow prowjobs"
 make update-prowjobs
+
 kubectl --context="${context}" --namespace="${namespace}" apply -Rf cluster/

--- a/apps/prow/plugins.yaml
+++ b/apps/prow/plugins.yaml
@@ -14,17 +14,17 @@ lgtm:
 
 config_updater:
   maps:
-    prow/config.yaml:
+    apps/prow/config.yaml:
       name: config
       clusters:
         k8s-infra-prow-build-trusted:
           - prow
-    prow/plugins.yaml:
+    apps/prow/plugins.yaml:
       name: plugins
       clusters:
         k8s-infra-prow-build-trusted:
           - prow
-    prow/prowjobs/**/*.yaml:
+    apps/prow/prowjobs/**/*.yaml:
       name: job-config
       gzip: true
       clusters:


### PR DESCRIPTION
Followup of https://github.com/kubernetes/k8s.io/pull/2487.
Ref: https://github.com/kubernetes/k8s.io/issues/1394

- Use GCS legacy authentication for tide.
It's possible to use workloadIdentity for tide but prow components needs to
be bumped to a more recent version.
- Fix path for prowjobs update command.
- Fix path for config-updater plugin

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>