### PR TITLE
Update k8s-infra-prow to v20210806-86f0abc1dd and enable autobump

### DIFF
--- a/apps/prow/cluster/crier_deployment.yaml
+++ b/apps/prow/cluster/crier_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20210407-51f95c2d52
+        image: gcr.io/k8s-prow/crier:v20210806-86f0abc1dd
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml

--- a/apps/prow/cluster/deck_deployment.yaml
+++ b/apps/prow/cluster/deck_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20210407-51f95c2d52
+        image: gcr.io/k8s-prow/deck:v20210806-86f0abc1dd
         imagePullPolicy: Always
         ports:
           - name: http

--- a/apps/prow/cluster/ghproxy_deployment.yaml
+++ b/apps/prow/cluster/ghproxy_deployment.yaml
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20210318-ffb8032f91
+          image: gcr.io/k8s-prow/ghproxy:v20210806-86f0abc1dd
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/apps/prow/cluster/hook_deployment.yaml
+++ b/apps/prow/cluster/hook_deployment.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20210407-51f95c2d52
+        image: gcr.io/k8s-prow/hook:v20210806-86f0abc1dd
         imagePullPolicy: Always
         args:
         - --config-path=/etc/config/config.yaml

--- a/apps/prow/cluster/horologium_deployment.yaml
+++ b/apps/prow/cluster/horologium_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20210407-51f95c2d52
+        image: gcr.io/k8s-prow/horologium:v20210806-86f0abc1dd
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/apps/prow/cluster/prow_controller_manager_deployment.yaml
+++ b/apps/prow/cluster/prow_controller_manager_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20210407-51f95c2d52
+        image: gcr.io/k8s-prow/prow-controller-manager:v20210806-86f0abc1dd
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/apps/prow/cluster/sinker_deployment.yaml
+++ b/apps/prow/cluster/sinker_deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - --dry-run=false
         - --job-config-path=/etc/job-config
         - --kubeconfig=/etc/kubeconfig/kubeconfig
-        image: gcr.io/k8s-prow/sinker:v20210407-51f95c2d52
+        image: gcr.io/k8s-prow/sinker:v20210806-86f0abc1dd
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/apps/prow/cluster/statusreconciler_deployment.yaml
+++ b/apps/prow/cluster/statusreconciler_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20210407-51f95c2d52
+        image: gcr.io/k8s-prow/status-reconciler:v20210806-86f0abc1dd
         imagePullPolicy: Always
         args:
         - --config-path=/etc/config/config.yaml

--- a/apps/prow/cluster/tide_deployment.yaml
+++ b/apps/prow/cluster/tide_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20210407-51f95c2d52
+        image: gcr.io/k8s-prow/tide:v20210806-86f0abc1dd
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/hack/autobump-config.yaml
+++ b/hack/autobump-config.yaml
@@ -9,22 +9,30 @@ gitHubRepo: "k8s.io"
 remoteName: "k8s.io"
 upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/k8s.io/main"
 includedConfigPaths:
+  - "apps/prow/cluster"
   - "infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources"
   - "infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources"
 excludedConfigPaths:
   - "k8s.gcr.io"
 extraFiles:
   - "hack/verify-yamllint.sh"
+  - "apps/prow/config.yaml"
 targetVersion: "latest"
 prefixes:
+  - name: "boskos"
+    prefix: "gcr.io/k8s-staging-boskos/"
+    refConfigFile: "infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/boskos.yaml"
+    repo: "https://github.com/kubernetes-sigs/boskos"
+    summarise: false
+    consistentImages: true
   - name: "ghproxy"
     prefix: "gcr.io/k8s-prow/ghproxy"
     refConfigFile: "infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/ghproxy-deployment.yaml"
     repo: "https://github.com/kubernetes/test-infra"
     summarise: false
-  - name: "boskos"
-    prefix: "gcr.io/k8s-staging-boskos/"
-    refConfigFile: "infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/boskos.yaml"
-    repo: "https://github.com/kubernetes-sigs/boskos"
+  - name: "prow"
+    prefix: "gcr.io/k8s-prow/"
+    refConfigFile: "apps/prow/cluster/deck_deployment.yaml"
+    repo: "https://github.com/kubernetes/test-infra"
     summarise: false
     consistentImages: true


### PR DESCRIPTION
Bump prow components to `v20210806-86f0abc1dd` and enable autobump for
k8s-infra-prow.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>