### PR TITLE
apps/prow: Add additional kubernetes namespace

### DIFF
--- a/apps/prow/cluster/100_namespace.yaml
+++ b/apps/prow/cluster/100_namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: k8s-infra-test-pods

--- a/apps/prow/cluster/prow_controller_manager_rbac.yaml
+++ b/apps/prow/cluster/prow_controller_manager_rbac.yaml
@@ -90,3 +90,36 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "prow-controller-manager"
+### RBAC for namespace k8s-infra-test-pods
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "prow-controller-manager"
+  namespace: k8s-infra-test-pods
+rules:
+  - apiGroups:
+    - ""
+    resources:
+      - pods
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "prow-controller-manager"
+  namespace: k8s-infra-test-pods
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "prow-controller-manager"
+subjects:
+- kind: ServiceAccount
+  name: "prow-controller-manager"
+  namespace: prow

--- a/apps/prow/cluster/sinker_rbac.yaml
+++ b/apps/prow/cluster/sinker_rbac.yaml
@@ -75,3 +75,35 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "sinker"
+### RBAC for namespace k8s-infra-test-pods
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "sinker"
+  namespace: k8s-infra-test-pods
+rules:
+  - apiGroups:
+    - ""
+    resources:
+      - pods
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - watch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: "sinker"
+  namespace: k8s-infra-test-pods
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "sinker"
+subjects:
+- kind: ServiceAccount
+  name: "sinker"
+  namespace: prow


### PR DESCRIPTION
Followup of https://github.com/kubernetes/k8s.io/pull/2235.
Ref: https://github.com/kubernetes/k8s.io/issues/1394.

sinker & prow-controller-manager require a namespace is present and they
can list and update the pods present in this namespace:

```shell
E0807 22:07:54.495104       1 reflector.go:138] external/io_k8s_client_go/tools/cache/reflector.go:167: Failed to watch *v1.Pod: failed to list *v1.Pod: pods is forbidden: User "system:serviceaccount:prow:sinker" cannot list resource "pods" in API group "" in the namespace "k8s-infra-test-pods"
```

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>