### PR TITLE
apps/prow: drop DNS record for k8s-infra-prow.k8s.io

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -165,10 +165,8 @@ issues:
   value: redirect.k8s.io.
 #wg-k8s-infra
 k8s-infra-prow:
-  - type: A
-    value: 34.117.224.94 # Hosted on GKE cluster aaa
-  - type: AAAA
-    value: "2600:1901:0:b267::" # Hosted on GKE cluster aaa
+  type: A
+  value: 34.117.224.94 # Hosted on GKE cluster aaa
 kep:
   type: CNAME
   value: redirect.k8s.io.


### PR DESCRIPTION
Ref: https://github.com/kubernetes/k8s.io/issues/2505

Drop the AAAA record to ensure the certificate for k8s-infra-prow.k8s.io
can be provisioned.
I'm still not sure how managed-certificate-controller is failing to
provide the certificate. This DNS record is not a hard requirement for
this prow instance.
I also keep the IPv6 IP address so we can use once we understood the
issue.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>