### PR TITLE
apps/prow: Allow deck service account to act as a GCP SA

### DIFF
--- a/infra/gcp/terraform/kubernetes-public/k8s-infra-prow.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-infra-prow.tf
@@ -42,6 +42,14 @@ resource "google_service_account_iam_member" "prow_build_trusted_cluster_sa_iam"
   member             = format("serviceAccount:%s.svc.id.goog[%s/%s]", "k8s-infra-prow-build-trusted", local.test_pods_namespace, local.test_pods_service_account)
 }
 
+// Allow deck (component of k8s-infra-prow) service account to use GCP SA k8s-infra-prow via workload identity
+// TODO (ameukam): move hardcoded value to terraform variables
+resource "google_service_account_iam_member" "aaa_cluster_sa_iam" {
+  role               = "roles/iam.workloadIdentityUser"
+  service_account_id = google_service_account.k8s_infra_prow.name
+  member             = format("serviceAccount:%s.svc.id.goog[%s/%s]", "kubernetes-public", "prow", "deck")
+}
+
 // Create a GCS bucket for ProwJobs logs and tide history
 resource "google_storage_bucket" "k8s_infra_prow_bucket" {
   name          = local.bucket_name

--- a/infra/gcp/terraform/kubernetes-public/k8s-infra-prow.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-infra-prow.tf
@@ -83,6 +83,13 @@ resource "google_storage_bucket_iam_member" "k8s_infra_prow_admin_legacy" {
   member = "serviceAccount:${google_service_account.k8s_infra_prow.email}"
 }
 
+// Allow the bucket k8s-infra-prow-results to be word-readable
+resource "google_storage_bucket_iam_member" "k8s_infra_prow_public_access" {
+  bucket = google_storage_bucket.k8s_infra_prow_bucket.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers"
+}
+
 // Allow read access to members of k8s-infra-prow-oncall@kubernetes.io
 resource "google_storage_bucket_iam_member" "k8s_infra_prow_oncall" {
   bucket = google_storage_bucket.k8s_infra_prow_bucket.name


### PR DESCRIPTION
Allow deck to act as GCP ServiceAccount
k8s-infra-prow@kubernetes-public.iam.gserviceaccount.com

Also make `gs://k8s-infra-prow-results` publicly accessible in read-only.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>