### PR TITLE
apps/prow: Fix postsubmit failures.

### DIFF
--- a/apps/prow/cluster/deck_deployment.yaml
+++ b/apps/prow/cluster/deck_deployment.yaml
@@ -50,14 +50,14 @@ spec:
         - --github-endpoint=http://ghproxy.prow.svc.cluster.local
         - --github-endpoint=https://api.github.com
         - --github-oauth-config-file=/etc/githuboauth/secret
-        - --hook-url=http://hook:8888/plugin-help
+        - --hook-url=http://hook.prow.svc.cluster.local:8888/plugin-help
         - --job-config-path=/etc/job-config
         - --oauth-url=/github-login
         - --plugin-config=/etc/plugins/plugins.yaml
         - --redirect-http-to=k8s-infra-prow.k8s.io
         - --rerun-creates-job
         - --spyglass=true
-        - --tide-url=http://tide/
+        - --tide-url=http://tide.prow.svc.cluster.local/
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG

--- a/apps/prow/deploy.sh
+++ b/apps/prow/deploy.sh
@@ -25,15 +25,17 @@ set -o pipefail
 
 SCRIPT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
 
-app=$(basename "${SCRIPT_ROOT}")
+#TODO(ameukam): drop usage of it.
+#app=$(basename "${SCRIPT_ROOT}")
 
 # coordinates to locate the target cluster in gke
 cluster_name="aaa"
 cluster_project="kubernetes-public"
 cluster_region="us-central1"
 
+#TODO(ameukam): drop usage of it.
 # coordinates to locate the app on the target cluster
-namespace="${app}"
+#namespace="${app}"
 
 # well known name set by `gcloud container clusters get-credentials`
 gke_context="gke_${cluster_project}_${cluster_region}_${cluster_name}"
@@ -57,4 +59,4 @@ make update-plugins
 echo "Update k8s-infra-prow prowjobs"
 make update-prowjobs
 
-kubectl --context="${context}" --namespace="${namespace}" apply -Rf cluster/
+kubectl --context="${context}" apply -Rf cluster/


### PR DESCRIPTION
The namespace `k8s-infra-test-pods` is now part of the resources
deployed by the `deploy.sh` script.
We pass the incorrect namespace for this resource.
Drop the flag `--namespace` should fix the failures we get:
https://storage.googleapis.com/kubernetes-jenkins/logs/post-k8sio-deploy-app-prow/1425519080953090048/build-log.txt

Also use FQDN for prow services consumed by deck.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>

/label tide/merge-method-squash