### PR TITLE
prow: force namespace in deploy.sh

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/k8s-infra-test-pods/build-serviceaccounts.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/k8s-infra-test-pods/build-serviceaccounts.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: prow-build@k8s-infra-prow-build.iam.gserviceaccount.com
+  name: prow-build
+  namespace: k8s-infra-test-pods

--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/k8s-infra-test-pods/cpu-limit-range_limitrange.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/k8s-infra-test-pods/cpu-limit-range_limitrange.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: cpu-limit-range
+  namespace: k8s-infra-test-pods
+spec:
+  limits:
+  - defaultRequest:
+      cpu: 250m
+    type: Container

--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/k8s-infra-test-pods/mem-limit-range_limitrange.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/k8s-infra-test-pods/mem-limit-range_limitrange.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: mem-limit-range
+  namespace: k8s-infra-test-pods
+spec:
+  limits:
+  - defaultRequest:
+      memory: 1Gi
+    type: Container


### PR DESCRIPTION
Related:
- https://github.com/kubernetes/k8s.io/pull/2520#discussion_r687820370 - in suggesting this change for another deploy script I realized we're not doing it for our build clusters
- https://github.com/kubernetes/k8s.io/issues/1475 - this change also adds service account and limit ranges for the `k8s-infra-test-pods` namespace to support `k8s-infra-prow` scheduling pods in `k8s-infra-prow-build`
- https://github.com/kubernetes/k8s.io/issues/1394

since resources are split into dir-per-namespace for our prow build
clusters, use the --namespace flag to make extra sure we don't
accidentally deploy a resource into a different namespace