### PR TITLE
promote csi-secrets-store driver:v0.2.0

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-csi-secrets-store/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-csi-secrets-store/images.yaml
@@ -13,6 +13,8 @@
     "sha256:1db2d1879a4ef656e3037a1d32be6bdb08cb10ea5800b6cca393361d6ac0330c": [ "v0.0.22" ]
     "sha256:e25d4daca186e8c3b26db395d67af56c7a5d0e3aaf61d36de39ea2f17b21ed98": [ "v0.0.23" ]
     "sha256:d6f02c93da117e5d56bd8beec0a10a0112c09c0257d219b07db32645c3f3cdb0": [ "v0.1.0" ]
+    "sha256:6ee985700ed7151290531bde375b92e64ae09a8587baf6b0c8f5bcf4da6dce93": [ "v0.2.0" ]
 - name: driver-crds
   dmap:
     "sha256:508f58321f8085877a8b8e7268e5a5efbca707ebe10e8c705124a5c9e1b5ceab": [ "v0.1.0" ]
+    "sha256:6b8740d237cb6c295bac93c7145c932d90f26c065c26886f28632fc6b4b6c9bf": [ "v0.2.0" ]


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

```
++ docker manifest push --purge gcr.io/k8s-staging-csi-secrets-store/driver:v0.2.0
sha256:6ee985700ed7151290531bde375b92e64ae09a8587baf6b0c8f5bcf4da6dce93
```

```
++ docker manifest push --purge gcr.io/k8s-staging-csi-secrets-store/driver-crds:v0.2.0
sha256:6b8740d237cb6c295bac93c7145c932d90f26c065c26886f28632fc6b4b6c9bf
```

Build - https://console.cloud.google.com/cloud-build/builds;region=global/d3a4c5bf-e1bc-4260-b26e-46f92bdce467?project=k8s-staging-csi-secrets-store

Generated by running -
```
➜ k8s.gcr.io/images/k8s-staging-csi-secrets-store/generate.sh > k8s.gcr.io/images/k8s-staging-csi-secrets-store/images.yaml
```

/assign @tam7t 