### PR TITLE
Release-1.23: Add 1.23 RT Leads to relevant groups

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -49,7 +49,6 @@ groups:
       - ahg@google.com
       - alarcj137@gmail.com
       - ameukam@gmail.com
-      - antheabjung@gmail.com
       - augustus@cisco.com
       - bentheelder@google.com
       - caniszczyk@linuxfoundation.org
@@ -68,8 +67,6 @@ groups:
       - ddebroy@gmail.com
       - deads@redhat.com
       - decarr@redhat.com
-      - dcampau1@gmail.com
-      - divya.mohan0209@gmail.com
       - eddiezane@gmail.com
       - ehashman@redhat.com
       - fabrizio.pandini@gmail.com
@@ -99,7 +96,6 @@ groups:
       - k8s@auggie.dev
       - kaitlynbarnard10@gmail.com
       - kbhawkey@gmail.com
-      - kikis.github@gmail.com
       - kim.andrewsy@gmail.com
       - klaus1982.cn@gmail.com
       - ksemenov@vmware.com
@@ -123,7 +119,6 @@ groups:
       - rlejano@gmail.com
       - saadali@google.com
       - saschagrunert@gmail.com
-      - saveetha13@gmail.com
       - seans@google.com
       - shu.mutow@gmail.com
       - siarkowicz@google.com

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -83,6 +83,7 @@ groups:
       - hweicdl@gmail.com
       - ian@coldwater.io
       - irvi.fa@gmail.com
+      - james.laverack@jetstack.io
       - jameswangel@gmail.com
       - jayunit100.apache@gmail.com
       - jbelamaric@google.com
@@ -90,6 +91,7 @@ groups:
       - jeremy.r.rickard@gmail.com
       - jeremyot@google.com
       - jonathan.berkhahn@gmail.com
+      - joseph.r.sandoval@gmail.com
       - jsafrane@redhat.com
       - jshubheksha@gmail.com
       - jsturtevant@gmail.com
@@ -107,8 +109,10 @@ groups:
       - marosset@microsoft.com
       - maszulik@redhat.com
       - matt.farina@gmail.com
+      - max@koerbaecher.io
       - michmike@gmail.com
       - mikedanese@google.com
+      - monmonmsc@gmail.com
       - msau@google.com
       - mwielgus@google.com
       - neolit123@gmail.com
@@ -116,6 +120,7 @@ groups:
       - prydonius@gmail.com
       - phil.wittrock@gmail.com
       - quinton@hoole.biz
+      - rlejano@gmail.com
       - saadali@google.com
       - saschagrunert@gmail.com
       - saveetha13@gmail.com

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -49,6 +49,7 @@ groups:
       - ahg@google.com
       - alarcj137@gmail.com
       - ameukam@gmail.com
+      - antheabjung@gmail.com
       - augustus@cisco.com
       - bentheelder@google.com
       - caniszczyk@linuxfoundation.org
@@ -67,6 +68,8 @@ groups:
       - ddebroy@gmail.com
       - deads@redhat.com
       - decarr@redhat.com
+      - dcampau1@gmail.com
+      - divya.mohan0209@gmail.com
       - eddiezane@gmail.com
       - ehashman@redhat.com
       - fabrizio.pandini@gmail.com
@@ -80,7 +83,6 @@ groups:
       - hweicdl@gmail.com
       - ian@coldwater.io
       - irvi.fa@gmail.com
-      - james.laverack@jetstack.io
       - jameswangel@gmail.com
       - jayunit100.apache@gmail.com
       - jbelamaric@google.com
@@ -88,7 +90,6 @@ groups:
       - jeremy.r.rickard@gmail.com
       - jeremyot@google.com
       - jonathan.berkhahn@gmail.com
-      - joseph.r.sandoval@gmail.com
       - jsafrane@redhat.com
       - jshubheksha@gmail.com
       - jsturtevant@gmail.com
@@ -96,6 +97,7 @@ groups:
       - k8s@auggie.dev
       - kaitlynbarnard10@gmail.com
       - kbhawkey@gmail.com
+      - kikis.github@gmail.com
       - kim.andrewsy@gmail.com
       - klaus1982.cn@gmail.com
       - ksemenov@vmware.com
@@ -105,10 +107,8 @@ groups:
       - marosset@microsoft.com
       - maszulik@redhat.com
       - matt.farina@gmail.com
-      - max@koerbaecher.io
       - michmike@gmail.com
       - mikedanese@google.com
-      - monmonmsc@gmail.com
       - msau@google.com
       - mwielgus@google.com
       - neolit123@gmail.com
@@ -116,9 +116,9 @@ groups:
       - prydonius@gmail.com
       - phil.wittrock@gmail.com
       - quinton@hoole.biz
-      - rlejano@gmail.com
       - saadali@google.com
       - saschagrunert@gmail.com
+      - saveetha13@gmail.com
       - seans@google.com
       - shu.mutow@gmail.com
       - siarkowicz@google.com

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -78,12 +78,16 @@ groups:
       - dcampau1@gmail.com
       - divya.mohan0209@gmail.com
       - gveronicalg@gmail.com
+      - james.laverack@jetstack.io
       - jameswangel@gmail.com
       - jeremy.r.rickard@gmail.com
+      - joseph.r.sandoval@gmail.com
       - kikis.github@gmail.com
       - max@koerbaecher.io
+      - monmonmsc@gmail.com
       - onlydole@gmail.com
       - pal.nabarun95@gmail.com
+      - rlejano@gmail.com
       - saveetha13@gmail.com
       - sethpmccombs@gmail.com
       - thejoycekung@gmail.com
@@ -225,12 +229,17 @@ groups:
       - dcampau1@gmail.com # 1.22 RT Lead Shadow
       - divya.mohan0209@gmail.com # 1.22 RT Lead Shadow
       - guineveresaenger@gmail.com # 1.22 Emeritus Advisor
+      - james.laverack@jetstack.io # 1.23 RT Lead Shadow
       - jeeves.butler@gmail.com # 1.22 Comms Lead
+      - joseph.r.sandoval@gmail.com # 1.23 RT Lead Shadow
       - kikis.github@gmail.com # 1.22 RT Lead Shadow
       - klkfr@amazon.com # 1.22 Comms Shadow
       - kunalkushwaha453@gmail.com # 1.22 Comms Shadow
       - lauri.d.apple@gmail.com
+      - max@koerbaecher.io # 1.23 RT Lead Shadow
+      - monmonmsc@gmail.com # RT Lead Shadow
       - rajula96reddy@gmail.com # 1.22 Comms Shadow
+      - rlejano@gmail.com # 1.23 RT Lead
       - saveetha13@gmail.com # 1.22 RT Lead
 
   - email-id: release-managers-private@kubernetes.io
@@ -280,13 +289,17 @@ groups:
       - divya.mohan0209@gmail.com
       - gmccloskey@google.com
       - gveronicalg@gmail.com
+      - james.laverack@jetstack.io
       - jameswangel@gmail.com
+      - joseph.r.sandoval@gmail.com
       - kikis.github@gmail.com
       - lauri.d.apple@gmail.com
       - max@koerbaecher.io
+      - monmonmsc@gmail.com
       - mudrinic.mare@gmail.com
       - pal.nabarun95@gmail.com
       - onlydole@gmail.com
+      - rlejano@gmail.com
       - saveetha13@gmail.com
       - sethpmccombs@gmail.com
       - spiffxp@google.com
@@ -341,6 +354,11 @@ groups:
       - dcampau1@gmail.com # 1.22 RT Lead Shadow
       - divya.mohan0209@gmail.com # 1.22 RT Lead Shadow
       - kikis.github@gmail.com # 1.22 RT Lead Shadow
+      - james.laverack@jetstack.io # 1.23 RT Lead Shadow
+      - joseph.r.sandoval@gmail.com # 1.23 RT Lead Shadow
+      - max@koerbaecher.io # 1.23 RT Lead Shadow
+      - monmonmsc@gmail.com # 1.23 RT Lead Shadow
+      - rlejano@gmail.com # 1.23 RT Lead
       - saveetha13@gmail.com # 1.22 RT Lead
     members:
       - sig-release-leads@kubernetes.io
@@ -353,16 +371,12 @@ groups:
       - james@jameslaverack.com # 1.22 Enhancements Lead
       - jeeves.butler@gmail.com # 1.22 Comms Lead
       - jgavinray@linux.com # 1.22 Bug Triage Shadow
-      - joseph.r.sandoval@gmail.com # 1.22 Enhancements Shadow
       - klkfr@amazon.com # 1.22 Comms Shadow
       - kunalkushwaha453@gmail.com # 1.22 Comms Shadow
-      - max@koerbaecher.io # 1.22 CI Signal Lead
-      - menna.elmasry@suse.com # 1.22 Bug Triage Lead
       - nng.grace@gmail.com # 1.22 Enhancements Shadow
       - pmmalinov01@gmail.com # 1.22 Release Notes Lead
       - rajula96reddy@gmail.com # 1.22 Comms Shadow
       - ramses.green.2@gmail.com # 1.22 CI Signal Shadow
-      - rlejano@gmail.com # 1.22 Enhancements Shadow
       - rpanjwani@vmware.com # 1.22 Release Docs Shadow
       - salahi.hossein@gmail.com # 1.22 CI Signal Shadow
       - simran.thind@outlook.com # 1.22 Release Notes Shadow

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -74,21 +74,16 @@ groups:
       - k8s-infra-release-editors@kubernetes.io
       - k8s-infra-google-build-admins@kubernetes.io
       - ameukam@gmail.com
-      - antheabjung@gmail.com
-      - dcampau1@gmail.com
-      - divya.mohan0209@gmail.com
       - gveronicalg@gmail.com
       - james.laverack@jetstack.io
       - jameswangel@gmail.com
       - jeremy.r.rickard@gmail.com
       - joseph.r.sandoval@gmail.com
-      - kikis.github@gmail.com
       - max@koerbaecher.io
       - monmonmsc@gmail.com
       - onlydole@gmail.com
       - pal.nabarun95@gmail.com
       - rlejano@gmail.com
-      - saveetha13@gmail.com
       - sethpmccombs@gmail.com
       - thejoycekung@gmail.com
       - wilsonehusin@gmail.com
@@ -225,22 +220,17 @@ groups:
       - k8s@auggie.dev
       - saschagrunert@gmail.com
     members:
-      - antheabjung@gmail.com # 1.22 RT Lead Shadow
-      - dcampau1@gmail.com # 1.22 RT Lead Shadow
-      - divya.mohan0209@gmail.com # 1.22 RT Lead Shadow
-      - guineveresaenger@gmail.com # 1.22 Emeritus Advisor
+      - jeremy.r.rickard@gmail.com # 1.23 Emeritus Advisor
       - james.laverack@jetstack.io # 1.23 RT Lead Shadow
       - jeeves.butler@gmail.com # 1.22 Comms Lead
       - joseph.r.sandoval@gmail.com # 1.23 RT Lead Shadow
-      - kikis.github@gmail.com # 1.22 RT Lead Shadow
       - klkfr@amazon.com # 1.22 Comms Shadow
       - kunalkushwaha453@gmail.com # 1.22 Comms Shadow
       - lauri.d.apple@gmail.com
       - max@koerbaecher.io # 1.23 RT Lead Shadow
-      - monmonmsc@gmail.com # RT Lead Shadow
+      - monmonmsc@gmail.com # 1.23 RT Lead Shadow
       - rajula96reddy@gmail.com # 1.22 Comms Shadow
       - rlejano@gmail.com # 1.23 RT Lead
-      - saveetha13@gmail.com # 1.22 RT Lead
 
   - email-id: release-managers-private@kubernetes.io
     name: release-managers-private
@@ -350,16 +340,11 @@ groups:
       - lauri.d.apple@gmail.com
       - saschagrunert@gmail.com
     managers:
-      - antheabjung@gmail.com # 1.22 RT Lead Shadow
-      - dcampau1@gmail.com # 1.22 RT Lead Shadow
-      - divya.mohan0209@gmail.com # 1.22 RT Lead Shadow
-      - kikis.github@gmail.com # 1.22 RT Lead Shadow
       - james.laverack@jetstack.io # 1.23 RT Lead Shadow
       - joseph.r.sandoval@gmail.com # 1.23 RT Lead Shadow
       - max@koerbaecher.io # 1.23 RT Lead Shadow
       - monmonmsc@gmail.com # 1.23 RT Lead Shadow
       - rlejano@gmail.com # 1.23 RT Lead
-      - saveetha13@gmail.com # 1.22 RT Lead
     members:
       - sig-release-leads@kubernetes.io
       - ania0102@gmail.com # 1.22 CI Signal Shadow

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -220,7 +220,6 @@ groups:
       - k8s@auggie.dev
       - saschagrunert@gmail.com
     members:
-      - jeremy.r.rickard@gmail.com # 1.23 Emeritus Advisor
       - james.laverack@jetstack.io # 1.23 RT Lead Shadow
       - jeeves.butler@gmail.com # 1.22 Comms Lead
       - joseph.r.sandoval@gmail.com # 1.23 RT Lead Shadow


### PR DESCRIPTION
**What this PR does / why we need it:**
Add @JamesLaverack @jrsapi @mkorbi @MonzElmasry @reylejano to the following:
- <strike>leads@</strike> - reverted change to leads
- release-managers@
- release-team@
- release-comms@

Offboard 1.22 RT Leads.

**Which issue(s) this PR fixes:**
Ref: https://github.com/kubernetes/sig-release/issues/1652

/assign
/sig release
/priority critical-urgent
/assign @justaugustus @saschagrunert @jeremyrickard @cpanato @puerco @hasheddan
/cc @JamesLaverack @jrsapi @mkorbi @MonzElmasry
