### PR TITLE
apps/k8s.io: flip go.k8s.io/triage to community-owned bucket

### DIFF
--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -264,7 +264,7 @@ data:
           rewrite ^/stuck-prs$       https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Aopen%20label%3Algtm%20label%3Aapproved%20-label%3Ado-not-merge%20-label%3Aneeds-rebase%20sort%3Aupdated-asc%20-status%3Asuccess redirect;
           rewrite ^/test-health$     http://velodrome.k8s.io/dashboard/db/bigquery-metrics redirect;
           rewrite ^/test-history$    https://storage.googleapis.com/kubernetes-test-history/static/index.html redirect;
-          rewrite ^/triage$          https://storage.googleapis.com/k8s-gubernator/triage/index.html redirect;
+          rewrite ^/triage$          https://storage.googleapis.com/k8s-triage/index.html redirect;
           rewrite ^/logo$            https://branding.cncf.io/projects/kubernetes/ redirect;
 
         }

--- a/infra/gcp/terraform/kubernetes-public/k8s-triage.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-triage.tf
@@ -34,7 +34,7 @@ data "google_iam_policy" "triage_bucket_iam_bindings" {
     ]
     role = "roles/storage.admin"
   }
-  // Preserve legacy storage bindings, give storage.admim members legacy bucket owner
+  // Preserve legacy storage bindings, give storage.admin members legacy bucket owner
   binding {
     members = [
       "group:${local.prow_owners}",
@@ -93,7 +93,7 @@ resource "google_project_iam_member" "triage_sa_bigquery_user" {
 resource "google_bigquery_dataset" "triage_dataset" {
   dataset_id  = "k8s_triage"
   project     = data.google_project.project.project_id
-  description = "Dataset for kubernetes/test-infra/triage to store temprorary results"
+  description = "Dataset for kubernetes/test-infra/triage to store temporary results"
   location    = "US"
 
   // Data is precious, make it difficult to delete by accident


### PR DESCRIPTION
Related:
- part of: https://github.com/kubernetes/k8s.io/issues/1305
- followup to: https://github.com/kubernetes/k8s.io/pull/2461 

/hold
Waiting to see successful triage run at: https://testgrid.k8s.io/wg-k8s-infra-canaries#triage

This also addresses some post-review nits from @sftim on https://github.com/kubernetes/k8s.io/pull/2461