### PR TITLE
apps/k8s-io: fix go.k8s.io/triage test

### DIFF
--- a/apps/k8s-io/test.py
+++ b/apps/k8s-io/test.py
@@ -195,7 +195,7 @@ class RedirTest(HTTPTestCase):
                 'https://storage.googleapis.com/kubernetes-test-history/static/index.html')
             self.assert_temp_redirect(
                 base + 'triage',
-                'https://storage.googleapis.com/k8s-gubernator/triage/index.html')
+                'https://storage.googleapis.com/k8s-triage/index.html')
             self.assert_temp_redirect(
                 base + 'logo',
                 'https://branding.cncf.io/projects/kubernetes/')


### PR DESCRIPTION
Related:
- part of: https://github.com/kubernetes/k8s.io/issues/1305
- followup to: https://github.com/kubernetes/k8s.io/pull/2544

Fix failed test case