### PR TITLE
apps/prow: Use dedicated service account

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/k8s-infra-test-pods/build-serviceaccounts.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/k8s-infra-test-pods/build-serviceaccounts.yaml
@@ -3,14 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    iam.gke.io/gcp-service-account: prow-build@k8s-infra-prow-build.iam.gserviceaccount.com
-  name: prow-build
-  namespace: k8s-infra-test-pods
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
     iam.gke.io/gcp-service-account: k8s-infra-prow@kubernetes-public.iam.gserviceaccount.com
   name: prowjob-default-sa
   namespace: k8s-infra-test-pods

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/namespaces.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/namespaces.yaml
@@ -2,6 +2,11 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  name: k8s-infra-test-pods
+---
+apiVersion: v1
+kind: Namespace
+metadata:
   name: kubernetes-external-secrets
 ---
 apiVersion: v1

--- a/infra/gcp/terraform/kubernetes-public/k8s-infra-prow.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-infra-prow.tf
@@ -11,7 +11,7 @@ locals {
   bucket_location           = "us-central1"
   prow_service_account      = "k8s-infra-prow"
   test_pods_namespace       = "k8s-infra-test-pods"
-  test_pods_service_account = "default"
+  test_pods_service_account = "prowjob-default-sa"
 }
 
 


### PR DESCRIPTION
Use a dedicated kubernetes service account as default instead of use the default
service account for the namespace `k8s-infra-test-pods`.
(Mirroring the pratice done for prow.k8s.io :
https://github.com/kubernetes/test-infra/blob/master/prow/create-build-cluster.sh#L179)

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>