### PR TITLE
prow: add k8s-infra-test-pods ns to prow-build-trusted

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/k8s-infra-test-pods/build-serviceaccounts.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/k8s-infra-test-pods/build-serviceaccounts.yaml
@@ -3,6 +3,14 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
+    iam.gke.io/gcp-service-account: prow-build-trusted@k8s-infra-prow-build-trusted.iam.gserviceaccount.com
+  name: prow-build-trusted
+  namespace: k8s-infra-test-pods
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
     iam.gke.io/gcp-service-account: k8s-infra-prow@kubernetes-public.iam.gserviceaccount.com
   name: prowjob-default-sa
   namespace: k8s-infra-test-pods

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/k8s-infra-test-pods/cpu-limit-range_limitrange.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/k8s-infra-test-pods/cpu-limit-range_limitrange.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: cpu-limit-range
+  namespace: k8s-infra-test-pods
+spec:
+  limits:
+  - defaultRequest:
+      cpu: 250m
+    type: Container

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/k8s-infra-test-pods/mem-limit-range_limitrange.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/k8s-infra-test-pods/mem-limit-range_limitrange.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: mem-limit-range
+  namespace: k8s-infra-test-pods
+spec:
+  limits:
+  - defaultRequest:
+      memory: 1Gi
+    type: Container

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/staging-test-pods/.gitkeep
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/staging-test-pods/.gitkeep
@@ -1,1 +1,0 @@
-TODO: remove this file once real files are in this directory


### PR DESCRIPTION
Should stop deploys from failing

Fixes: https://github.com/kubernetes/k8s.io/issues/2552