### PR TITLE
prow: remove prow-build* SAs from k8s-infra-test-pods NS

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/k8s-infra-test-pods/build-serviceaccounts.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/k8s-infra-test-pods/build-serviceaccounts.yaml
@@ -3,14 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    iam.gke.io/gcp-service-account: prow-build-trusted@k8s-infra-prow-build-trusted.iam.gserviceaccount.com
-  name: prow-build-trusted
-  namespace: k8s-infra-test-pods
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
     iam.gke.io/gcp-service-account: k8s-infra-prow@kubernetes-public.iam.gserviceaccount.com
   name: prowjob-default-sa
   namespace: k8s-infra-test-pods

--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/k8s-infra-test-pods/build-serviceaccounts.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/k8s-infra-test-pods/build-serviceaccounts.yaml
@@ -3,14 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
-    iam.gke.io/gcp-service-account: prow-build@k8s-infra-prow-build.iam.gserviceaccount.com
-  name: prow-build
-  namespace: k8s-infra-test-pods
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
     iam.gke.io/gcp-service-account: k8s-infra-prow@kubernetes-public.iam.gserviceaccount.com
   name: prowjob-default-sa
   namespace: k8s-infra-test-pods


### PR DESCRIPTION
Related:
- part of: https://github.com/kubernetes/k8s.io/issues/1475
- part of: https://github.com/kubernetes/k8s.io/issues/1394
- Followup to address: https://github.com/kubernetes/k8s.io/pull/2551#discussion_r689801611

These service accounts have rights to push to `gs://kubernetes-jenkins` which is something we want to explicitly disallow for jobs triggered by `k8s-infra-prow.k8s.io`

/cc @ameukam