### PR TITLE
apps/prow: Fix typo in crier service

### DIFF
--- a/apps/prow/cluster/crier_service.yaml
+++ b/apps/prow/cluster/crier_service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   labels:
     app: crier
-    namespace: prow
+  namespace: prow
   name: crier
 spec:
   ports:

--- a/apps/prow/cluster/ghproxy_deployment.yaml
+++ b/apps/prow/cluster/ghproxy_deployment.yaml
@@ -42,6 +42,8 @@ spec:
     matchLabels:
       component: ghproxy
   replicas: 1
+  strategy:
+    type: "Recreate"
   template:
     metadata:
       labels:


### PR DESCRIPTION
The namespace was defined as a label instead of a metadata field of the
object.

Also force the Deployment `ghproxy` to recreate his pods. We have a pod stuck for any rollout: 

```
ghproxy-55d56d7cf5-42mf2                  0/1     ContainerCreating   0          158m
ghproxy-74496ccddb-2qt78                  1/1     Running             0          10h
```

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>

