### PR TITLE
apps/prow: set default service account

### DIFF
--- a/apps/prow/config.yaml
+++ b/apps/prow/config.yaml
@@ -20,6 +20,7 @@ plank:
         initupload: "gcr.io/k8s-prow/initupload:v20210816-7054447c7a"
         entrypoint: "gcr.io/k8s-prow/entrypoint:v20210816-7054447c7a"
         sidecar: "gcr.io/k8s-prow/sidecar:v20210816-7054447c7a"
+      default_service_account_name: "prowjob-default-sa"
       gcs_configuration:
         bucket: k8s-infra-prow-results
         path_strategy: explicit


### PR DESCRIPTION
Followup of https://github.com/kubernetes/k8s.io/pull/2549/.
Set default service account for prow-controller-manager.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>