### PR TITLE
releng: RM temporary access por Nabarun Pal

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -61,6 +61,7 @@ groups:
       - georgedanielmangum@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
+      - pal.nabarun95@gmail.com
       - saschagrunert@gmail.com
 
   - email-id: k8s-infra-release-viewers@kubernetes.io


### PR DESCRIPTION
Nabarun Pal (@palnabarun) is a Release Manager Associate with SIG Release being granted
temporary elevated access to cut the v1.22.1 and v1.23.0-alpha.1 releases. Access will be
revoked after the releases are cut.

SIG Release Issue: kubernetes/sig-release#1665

/assign @dims @cblecker @spiffxp
cc: @kubernetes/release-engineering

/priority important-soon

Signed-off-by: Adolfo García Veytia (Puerco) adolfo.garcia@uservers.net
