### PR TITLE
apps/prow: Fix github rerun config

### DIFF
--- a/apps/prow/config.yaml
+++ b/apps/prow/config.yaml
@@ -100,9 +100,10 @@ deck:
         - podinfo.json
   tide_update_period: 1s
   rerun_auth_configs:
-    kubernetes/k8s.io:
-      github_users:
-      - wg-k8s-infra-leads
+    '*':
+      github_team_slugs:
+        - org: kubernetes
+          slug: wg-k8s-infra-leads
 
 presets:
 # enable GOPROXY by default


### PR DESCRIPTION
Fix incorrect config that specify who is able to trigger job reruns.
Doc: https://github.com/kubernetes/test-infra/blob/master/prow/config/prow-config-documented.yaml#L307-L317

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>