### PR TITLE
Grant jobUser role for bq-data-transfer Service Account

### DIFF
--- a/infra/gcp/terraform/k8s-infra-public-pii/bigquery.tf
+++ b/infra/gcp/terraform/k8s-infra-public-pii/bigquery.tf
@@ -21,7 +21,16 @@ resource "google_service_account" "bq_data_transfer_writer" {
   project     = google_project.project.project_id
 }
 
-// grant bigquery dataEditor role to the service account so that scheduled query can run
+// grant bigquery jobUser role to the service account
+// so the scheduled job transfer can launch BigQuery jobs
+resource "google_project_iam_member" "bq_data_transfer_jobuser_binding" {
+  project = google_project.project.project_id
+  role    = "roles/bigquery.jobUser"
+  member  = "serviceAccount:${google_service_account.bq_data_transfer_writer.email}"
+}
+
+// grant bigquery dataEditor role to the service account so
+// that scheduled job transfer can access the source dataset
 resource "google_project_iam_member" "bq_data_transfer_writer_binding" {
   project = google_project.project.project_id
   role    = "roles/bigquery.dataEditor"
@@ -29,7 +38,7 @@ resource "google_project_iam_member" "bq_data_transfer_writer_binding" {
 }
 
 resource "google_bigquery_data_transfer_config" "bq_data_transfer" {
-  display_name           = "BigQuey data transfer to ${google_bigquery_dataset.audit-logs-gcs.dataset_id}"
+  display_name           = "BigQuery data transfer to ${google_bigquery_dataset.audit-logs-gcs.dataset_id}"
   project                = google_project.project.project_id
   data_source_id         = "cross_region_copy"
   schedule               = "every 24 hours" #Times are in UTC
@@ -45,10 +54,10 @@ resource "google_bigquery_data_transfer_config" "bq_data_transfer" {
 
   schedule_options {
     disable_auto_scheduling = false
-    start_time              = "2021-07-29T15:00:00Z"
+    start_time              = "2021-08-18T15:00:00Z"
   }
 
   email_preferences {
-    enable_failure_email = true
+    enable_failure_email = false
   }
 }


### PR DESCRIPTION
Ref: https://github.com/kubernetes/k8s.io/issues/1968

Grant this role allow the BigQuery Data transfer `BigQuery Data Transfer
to k8s_infra_artifacts_gcslogs` to run successfully.

By fixing the typo in the name of the transfer job, I'm forced to
recreate the job which means change the start date.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>