### PR TITLE
apps/prow: few improvements of k8s-infra-prow

### DIFF
--- a/apps/prow/cluster/deck_deployment.yaml
+++ b/apps/prow/cluster/deck_deployment.yaml
@@ -43,6 +43,8 @@ spec:
         ports:
           - name: http
             containerPort: 8080
+          - name: metrics
+            containerPort: 9090
         args:
         - --config-path=/etc/config/config.yaml
         - --cookie-secret=/etc/cookie/secret

--- a/apps/prow/cluster/ghproxy_deployment.yaml
+++ b/apps/prow/cluster/ghproxy_deployment.yaml
@@ -57,7 +57,10 @@ spec:
             - --cache-sizeGB=99
             - --serve-metrics=true
           ports:
-            - containerPort: 8888
+            - name: main
+              containerPort: 8888
+            - name: metrics
+              containerPort: 9090
           resources:
             requests:
               cpu: 2

--- a/apps/prow/cluster/hook_service.yaml
+++ b/apps/prow/cluster/hook_service.yaml
@@ -29,3 +29,4 @@ spec:
     port: 8888
   - name: metrics
     port: 9090
+  type: ClusterIP

--- a/apps/prow/cluster/horologium_rbac.yaml
+++ b/apps/prow/cluster/horologium_rbac.yaml
@@ -17,6 +17,7 @@ rules:
     verbs:
       - create
       - list
+      - watch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/apps/prow/cluster/sinker_service.yaml
+++ b/apps/prow/cluster/sinker_service.yaml
@@ -25,3 +25,4 @@ spec:
       port: 9090
   selector:
     app: sinker
+  type: ClusterIP

--- a/apps/prow/cluster/tide_service.yaml
+++ b/apps/prow/cluster/tide_service.yaml
@@ -28,3 +28,4 @@ spec:
     targetPort: 8888
   - name: metrics
     port: 9090
+  type: ClusterIP


### PR DESCRIPTION
- Add a permission allowing horologium to watch pods.
- Add a dedicated port for metrics
- Explicitly set type for kubernetes services.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>