### PR TITLE
capz: update reviewers to match capz repo

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cluster-api-azure/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api-azure/OWNERS
@@ -2,13 +2,14 @@
 # Should always mirror the maintainers/reviewers in https://sigs.k8s.io/cluster-api-provider-azure/OWNERS_ALIASES
 
 approvers:
+- alexeldeib
 - CecileRobertMichon
 - devigned
 - nader-ziada
 reviewers:
-- alexeldeib
 - cpanato
 - juan-lee
+- mboersma
 - shysank
 
 labels:


### PR DESCRIPTION
Syncs up with recent changes to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES

cc: @alexeldeib 