### PR TITLE
Add SA and RoleBinding for ASN ETL pipeline

### DIFF
--- a/infra/gcp/terraform/k8s-infra-ii-sandbox/main.tf
+++ b/infra/gcp/terraform/k8s-infra-ii-sandbox/main.tf
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
- locals {
-     project_id = "k8s-infra-ii-sandbox"
- }
+locals {
+  project_id = "k8s-infra-ii-sandbox"
+}
 
 
 data "google_billing_account" "account" {
@@ -28,10 +28,10 @@ data "google_organization" "org" {
 }
 
 resource "google_project" "project" {
-    name = local.project_id
-    project_id = local.project_id
-    org_id = data.google_organization.org.org_id
-    billing_account = data.google_billing_account.account.id
+  name            = local.project_id
+  project_id      = local.project_id
+  org_id          = data.google_organization.org.org_id
+  billing_account = data.google_billing_account.account.id
 }
 
 
@@ -60,7 +60,7 @@ resource "google_project_iam_member" "k8s_infra_ii_coop" {
 // to the BQ dataset riaan_data_store.
 data "google_service_account" "bq_data_transfer" {
   account_id = "bq-data-transfer"
-  project = "k8s-infra-public-pii"
+  project    = "k8s-infra-public-pii"
 }
 
 resource "google_bigquery_dataset_iam_member" "bq_data_transfer_binding" {
@@ -68,4 +68,10 @@ resource "google_bigquery_dataset_iam_member" "bq_data_transfer_binding" {
   dataset_id = "riaan_data_store"
   role       = "roles/bigquery.admin"
   member     = "serviceAccount:${data.google_service_account.bq_data_transfer.email}"
+}
+
+resource "google_service_account" "asn_etl" {
+  project      = local.project_id
+  account_id   = "asn-etl"
+  display_name = "asn-etl"
 }

--- a/infra/gcp/terraform/k8s-infra-public-pii/main.tf
+++ b/infra/gcp/terraform/k8s-infra-public-pii/main.tf
@@ -93,12 +93,6 @@ resource "google_service_account" "asn_etl" {
 }
 
 // service account for running ASN etl pipeline job
-data "google_service_account" "public_pii_asn_etl" {
-  account_id = "asn-etl"
-  project    = local.project_id
-}
-
-// service account for running ASN etl pipeline job
 data "google_service_account" "ii_sandbox_asn_etl" {
   account_id = "asn-etl"
   project    = "k8s-infra-ii-sandbox"
@@ -121,13 +115,13 @@ data "google_iam_policy" "audit_logs_gcs_bindings" {
   binding {
     role = "roles/storage.legacyBucketReader"
     members = [
-      "serviceAccount:${data.google_service_account.public_pii_asn_etl}",
+      "serviceAccount:${google_service_account.public_pii_asn_etl.email}",
     ]
   }
   binding {
     role = "roles/storage.legacyBucketReader"
     members = [
-      "serviceAccount:${data.google_service_account.ii_sandbox_asn_etl}",
+      "serviceAccount:${data.google_service_account.ii_sandbox_asn_etl.email}",
     ]
   }
 }

--- a/infra/gcp/terraform/k8s-infra-public-pii/main.tf
+++ b/infra/gcp/terraform/k8s-infra-public-pii/main.tf
@@ -86,6 +86,19 @@ resource "google_storage_bucket" "audit-logs-gcs" {
 }
 
 // service account for running ASN etl pipeline job
+resource "google_service_account" "asn_etl" {
+  project      = local.project_id
+  account_id   = "asn-etl"
+  display_name = "asn-etl"
+}
+
+// service account for running ASN etl pipeline job
+data "google_service_account" "public_pii_asn_etl" {
+  account_id = "asn-etl"
+  project    = local.project_id
+}
+
+// service account for running ASN etl pipeline job
 data "google_service_account" "ii_sandbox_asn_etl" {
   account_id = "asn-etl"
   project    = "k8s-infra-ii-sandbox"
@@ -103,6 +116,12 @@ data "google_iam_policy" "audit_logs_gcs_bindings" {
     role = "roles/storage.legacyBucketWriter"
     members = [
       "group:cloud-storage-analytics@google.com",
+    ]
+  }
+  binding {
+    role = "roles/storage.legacyBucketReader"
+    members = [
+      "serviceAccount:${data.google_service_account.public_pii_asn_etl}",
     ]
   }
   binding {

--- a/infra/gcp/terraform/k8s-infra-public-pii/main.tf
+++ b/infra/gcp/terraform/k8s-infra-public-pii/main.tf
@@ -85,6 +85,12 @@ resource "google_storage_bucket" "audit-logs-gcs" {
   }
 }
 
+// service account for running ASN etl pipeline job
+data "google_service_account" "ii_sandbox_asn_etl" {
+  account_id = "asn-etl"
+  project    = "k8s-infra-ii-sandbox"
+}
+
 //grants role WRITER to cloud-storage-analytics@google.com
 data "google_iam_policy" "audit_logs_gcs_bindings" {
   binding {
@@ -97,6 +103,12 @@ data "google_iam_policy" "audit_logs_gcs_bindings" {
     role = "roles/storage.legacyBucketWriter"
     members = [
       "group:cloud-storage-analytics@google.com",
+    ]
+  }
+  binding {
+    role = "roles/storage.legacyBucketReader"
+    members = [
+      "serviceAccount:${data.google_service_account.ii_sandbox_asn_etl}",
     ]
   }
 }


### PR DESCRIPTION
Ensures that the asn-etl ServiceAccount is managed using k8s infra Terraform.
Adds a RoleBinding to ensure that the asn-etl ServiceAccount has access to the pii bucket for logs to consume.