### PR TITLE
terraform/kubernetes-public: add k8s-keps

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -35,6 +35,7 @@ restrictions:
       - "^k8s-infra-code-organization@kubernetes.io$"
       - "^k8s-infra-rbac-sippy@kubernetes.io$"
       - "^k8s-infra-prod-readiness@kubernetes.io$"
+      - "^k8s-infra-keps@kubernetes.io$"
   - path: "sig-auth/groups.yaml"
     allowedGroups:
       - "^k8s-infra-staging-csi-secrets-store@kubernetes.io$"

--- a/groups/sig-architecture/groups.yaml
+++ b/groups/sig-architecture/groups.yaml
@@ -78,6 +78,19 @@ groups:
       - wojtekt@google.com
       - ehashman@redhat.com
 
+  - email-id: k8s-infra-keps@kubernetes.io
+    name: k8s-infra-keps
+    description: |-
+      ACL for access to KEP related infrastructure
+    settings:
+      ReconcileMembers: "true"
+    members:
+    - jeremy.r.rickard@gmail.com
+    - jbelamaric@google.com
+    - k8s@auggie.dev
+    - killen.bob@gmail.com
+    - pal.nabarun95@gmail.com
+
   # RBAC groups:
   # - grant access to the `namespace-user` role for a single namespace on the `aaa` cluster
   # - must have WhoCanViewMemberShip: "ALL_MEMBERS_CAN_VIEW"

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-serviceaccounts.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-serviceaccounts.yaml
@@ -15,6 +15,8 @@ metadata:
     iam.gke.io/gcp-service-account: prow-deployer@k8s-infra-prow-build-trusted.iam.gserviceaccount.com
   name: prow-deployer
   namespace: test-pods
+
+# Specialized infrastructure access service accounts
 ---
 kind: ServiceAccount
 apiVersion: v1
@@ -30,6 +32,14 @@ metadata:
   annotations:
     iam.gke.io/gcp-service-account: k8s-triage@k8s-infra-prow-build-trusted.iam.gserviceaccount.com
   name: k8s-triage
+  namespace: test-pods
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: k8s-keps@k8s-infra-prow-build-trusted.iam.gserviceaccount.com
+  name: k8s-keps
   namespace: test-pods
 
 # Infrastructure management service accounts

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/serviceaccounts.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/serviceaccounts.tf
@@ -36,6 +36,11 @@ locals {
       description   = "deploys k8s resources to k8s clusters"
       project_roles = ["roles/container.admin"]
     }
+    // also assigned roles by:
+    // - terraform/kubernetes-public
+    k8s-keps = {
+      description   = "write to gs://k8s-keps"
+    }
     k8s-metrics = {
       description   = "read bigquery and write to gs://k8s-metrics"
       project_roles = ["roles/bigquery.user"]


### PR DESCRIPTION
Related:
- Implements: https://github.com/kubernetes/k8s.io/issues/2490
- In support of: https://github.com/kubernetes/contributor-site/pull/222

Add a world-readable bucket gs://k8s-keps along with a service account
and dedicated k8s-infra-keps@kubernetes.io group with privileged access
to the bucket and its contents.

/hold
I would like eyes on this before attempting to deploy anything to make
sure we're agreed this is the right pattern / set of infrastructure for
this use case