### PR TITLE
SIG Release cleanups

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -174,13 +174,19 @@ aliases:
     - MushuEE
     - spiffxp
   cip-approvers:
+    - cpanato
+    - jeremyrickard
     - justaugustus
     - listx
+    - puerco
     - saschagrunert
     - thockin
   cip-reviewers:
+    - cpanato
+    - jeremyrickard
     - justaugustus
     - listx
+    - puerco
     - saschagrunert
     - thockin
   provider-aws:
@@ -205,14 +211,14 @@ aliases:
     - frapposelli
   release-engineering-approvers:
     - cpanato # subproject owner / Release Manager / SIG Technical Lead
-    - jeremyrickard # SIG Technical Lead
+    - jeremyrickard # subproject owner / SIG Technical Lead
     - justaugustus # subproject owner / Release Manager / SIG Chair
     - puerco # subproject owner / Release Manager / SIG Technical Lead
     - saschagrunert # subproject owner / Release Manager / SIG Chair
     - xmudrii # Release Manager
   release-engineering-reviewers:
     - cpanato # subproject owner / Release Manager / SIG Technical Lead
-    - jeremyrickard # SIG Technical Lead
+    - jeremyrickard # subproject owner / SIG Technical Lead
     - justaugustus # subproject owner / Release Manager / SIG Chair
     - puerco # subproject owner / Release Manager / SIG Technical Lead
     - saschagrunert # subproject owner / Release Manager / SIG Chair

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -61,7 +61,6 @@ aliases:
     - derekwaynecarr
   sig-release-leads:
     - cpanato
-    - hasheddan
     - jeremyrickard
     - justaugustus
     - puerco
@@ -175,13 +174,11 @@ aliases:
     - MushuEE
     - spiffxp
   cip-approvers:
-    - hasheddan
     - justaugustus
     - listx
     - saschagrunert
     - thockin
   cip-reviewers:
-    - hasheddan
     - justaugustus
     - listx
     - saschagrunert
@@ -208,7 +205,6 @@ aliases:
     - frapposelli
   release-engineering-approvers:
     - cpanato # subproject owner / Release Manager / SIG Technical Lead
-    - hasheddan # subproject owner / Release Manager / SIG Technical Lead
     - jeremyrickard # SIG Technical Lead
     - justaugustus # subproject owner / Release Manager / SIG Chair
     - puerco # subproject owner / Release Manager / SIG Technical Lead
@@ -216,7 +212,6 @@ aliases:
     - xmudrii # Release Manager
   release-engineering-reviewers:
     - cpanato # subproject owner / Release Manager / SIG Technical Lead
-    - hasheddan # subproject owner / Release Manager / SIG Technical Lead
     - jeremyrickard # SIG Technical Lead
     - justaugustus # subproject owner / Release Manager / SIG Chair
     - puerco # subproject owner / Release Manager / SIG Technical Lead

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -76,7 +76,6 @@ groups:
       - fbongiovanni@google.com
       - fbranczyk@gmail.com
       - frapposelli@vmware.com
-      - georgedanielmangum@gmail.com
       - guyjtempleton@googlemail.com
       - hankang@google.com
       - hpandey@pivotal.io
@@ -1260,7 +1259,6 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
-      - georgedanielmangum@gmail.com
       - pjbgf@linux.com
       - saschagrunert@gmail.com
 

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -45,12 +45,12 @@ groups:
       - paris.pittman@gmail.com
       - spiffxp@gmail.com
     members:
-      - adolfo.garcia@uservers.net
+      - adolfo.garcia@uservers.net # SIG Release
       - ahg@google.com
       - alarcj137@gmail.com
       - ameukam@gmail.com
       - antheabjung@gmail.com
-      - augustus@cisco.com
+      - augustus@cisco.com # SIG Release
       - bentheelder@google.com
       - caniszczyk@linuxfoundation.org
       - casey@tigera.io
@@ -58,7 +58,7 @@ groups:
       - chiachenk@google.com
       - cncf-speakers@linuxfoundation.org
       - community@kubernetes.io
-      - ctadeu@gmail.com
+      - ctadeu@gmail.com # SIG Release
       - davanum@gmail.com
       - davidopp@google.com
       - dawnchen@google.com
@@ -86,14 +86,14 @@ groups:
       - jayunit100.apache@gmail.com
       - jbelamaric@google.com
       - jeef111x@gmail.com
-      - jeremy.r.rickard@gmail.com
+      - jeremy.r.rickard@gmail.com # SIG Release
       - jeremyot@google.com
       - jonathan.berkhahn@gmail.com
       - jsafrane@redhat.com
       - jshubheksha@gmail.com
       - jsturtevant@gmail.com
       - justin@fathomdb.com
-      - k8s@auggie.dev
+      - k8s@auggie.dev # SIG Release
       - kaitlynbarnard10@gmail.com
       - kbhawkey@gmail.com
       - kikis.github@gmail.com
@@ -101,7 +101,7 @@ groups:
       - klaus1982.cn@gmail.com
       - ksemenov@vmware.com
       - lachlan.evenson@gmail.com
-      - lauri.d.apple@gmail.com
+      - lauri.d.apple@gmail.com # SIG Release
       - liggitt@google.com
       - marosset@microsoft.com
       - maszulik@redhat.com
@@ -116,7 +116,7 @@ groups:
       - phil.wittrock@gmail.com
       - quinton@hoole.biz
       - saadali@google.com
-      - saschagrunert@gmail.com
+      - saschagrunert@gmail.com # SIG Release
       - saveetha13@gmail.com
       - seans@google.com
       - shu.mutow@gmail.com

--- a/groups/sig-release/OWNERS
+++ b/groups/sig-release/OWNERS
@@ -2,7 +2,6 @@
 
 reviewers:
 - sig-release-leads
-- release-engineering-approvers
 
 labels:
 - sig/release

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -43,7 +43,6 @@ groups:
     members:
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
-      - georgedanielmangum@gmail.com
       - k8s@auggie.dev
       - saschagrunert@gmail.com
 
@@ -58,7 +57,6 @@ groups:
       - k8s-infra-release-admins@kubernetes.io
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
-      - georgedanielmangum@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
       - pal.nabarun95@gmail.com
@@ -216,7 +214,6 @@ groups:
     owners:
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
-      - georgedanielmangum@gmail.com
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
       - saschagrunert@gmail.com
@@ -244,7 +241,6 @@ groups:
     owners:
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
-      - georgedanielmangum@gmail.com
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
       - saschagrunert@gmail.com
@@ -264,7 +260,6 @@ groups:
     owners:
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
-      - georgedanielmangum@gmail.com
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
       - saschagrunert@gmail.com
@@ -320,7 +315,6 @@ groups:
     owners:
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
-      - georgedanielmangum@gmail.com
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
       - lauri.d.apple@gmail.com
@@ -335,7 +329,6 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
-      - georgedanielmangum@gmail.com
       - k8s@auggie.dev
       - lauri.d.apple@gmail.com
       - saschagrunert@gmail.com
@@ -383,7 +376,6 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
-      - georgedanielmangum@gmail.com
       - k8s@auggie.dev
       - lauri.d.apple@gmail.com
       - saschagrunert@gmail.com

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -329,6 +329,9 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
+      - adolfo.garcia@uservers.net
+      - ctadeu@gmail.com
+      - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
       - lauri.d.apple@gmail.com
       - saschagrunert@gmail.com
@@ -376,6 +379,9 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
+      - adolfo.garcia@uservers.net
+      - ctadeu@gmail.com
+      - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
       - lauri.d.apple@gmail.com
       - saschagrunert@gmail.com

--- a/groups/sig-testing/groups.yaml
+++ b/groups/sig-testing/groups.yaml
@@ -152,7 +152,6 @@ groups:
     - antonio.ojea.garcia@gmail.com
     - bartek@smykla.com
     - eddiezane@gmail.com
-    - georgedanielmangum@gmail.com
     - gmccloskey@google.com
     - helenfengzhi@gmail.com
     - liggitt@google.com

--- a/infra/gcp/backup_tools/OWNERS
+++ b/infra/gcp/backup_tools/OWNERS
@@ -2,10 +2,10 @@
 
 approvers:
 - cip-approvers
+- release-engineering-approvers
 - wg-k8s-infra-leads
 reviewers:
 - cip-reviewers
-- release-engineering-approvers
 - release-engineering-reviewers
 
 labels:

--- a/infra/gcp/cip-auditor/OWNERS
+++ b/infra/gcp/cip-auditor/OWNERS
@@ -2,10 +2,10 @@
 
 approvers:
 - cip-approvers
+- release-engineering-approvers
 - wg-k8s-infra-leads
 reviewers:
 - cip-reviewers
-- release-engineering-approvers
 - release-engineering-reviewers
 
 labels:

--- a/k8s.gcr.io/images/k8s-staging-artifact-promoter/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-artifact-promoter/OWNERS
@@ -4,12 +4,12 @@ options:
   no_parent_owners: true
 approvers:
   - cip-approvers
-  - wg-k8s-infra-leads
+  - release-engineering-approvers
 reviewers:
   - cip-reviewers
-  - release-engineering-approvers
   - release-engineering-reviewers
 
 labels:
   - sig/release
   - area/release-eng
+  - area/artifacts

--- a/k8s.gcr.io/images/k8s-staging-build-image/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-build-image/OWNERS
@@ -1,5 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+options:
+  no_parent_owners: true
 approvers:
   - release-engineering-approvers
 reviewers:

--- a/k8s.gcr.io/images/k8s-staging-experimental/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-experimental/OWNERS
@@ -4,10 +4,6 @@ options:
   no_parent_owners: true
 approvers:
   - release-engineering-approvers
-  - cblecker
-  - dims
-  - listx
-  - thockin
 reviewers:
   - release-engineering-reviewers
 

--- a/k8s.gcr.io/images/k8s-staging-kubernetes/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-kubernetes/OWNERS
@@ -4,10 +4,6 @@ options:
   no_parent_owners: true
 approvers:
   - release-engineering-approvers
-  - cblecker
-  - dims
-  - listx
-  - thockin
 reviewers:
   - release-engineering-reviewers
 

--- a/k8s.gcr.io/images/k8s-staging-releng/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-releng/OWNERS
@@ -4,10 +4,6 @@ options:
   no_parent_owners: true
 approvers:
   - release-engineering-approvers
-  - cblecker
-  - dims
-  - listx
-  - thockin
 reviewers:
   - release-engineering-reviewers
 

--- a/k8s.gcr.io/images/k8s-staging-sp-operator/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-sp-operator/OWNERS
@@ -2,7 +2,6 @@
 
 approvers:
   - JAORMX
-  - hasheddan
   - jhrozek
   - pjbgf
   - saschagrunert


### PR DESCRIPTION
This is roughly equivalent to the changes proposed in https://github.com/kubernetes/org/pull/2906.

I've opted to leave out any @kubernetes/release-team list updates as the 1.23 team is currently being built out and I'd like to prevent interruptions in their comms/access.

- @hasheddan is now Emeritus (https://github.com/kubernetes/sig-release/issues/1667)
  Emeritus overall from the project, so this covers all held roles.
- Update references for Chairs/Technical Leads
- Drop "promote the promoter" access for @kubernetes/wg-k8s-infra-leads 
  WG K8s Infra is transitioning to a SIG: https://github.com/kubernetes/community/pull/5928
  As part of that, we refine access to promote image-promoter images to
  CIP maintainers and @kubernetes/release-engineering subproject owners.
- OWNERS: Tidy Release Engineering areas
  - Prune extraneous OWNERS
  - Ensure approvers/reviewers are in correct sections
  - Add `no_parent_owners: true` to areas requiring RelEng approval

Signed-off-by: Stephen Augustus <foo@auggie.dev>