### PR TITLE
Promote ingress-nginx test-runner

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -65,6 +65,7 @@
     "sha256:f84dcddc84e5cba220260f315e18cd47fc8c6b7f3f4f57b7b3e9cc2ea25324b7": ["v20210601-g96a87c79b"]
     "sha256:0f3c0d0bda953aa7f1164c452cc0165ce8a0c72469b550988a9601c539f61608": ["v20210806-g26768e957"]
     "sha256:7d7393a8c6c72d76145282df53ea0679a5b769211fd1cd6b8910b6dda1bd986d": ["v20210810-g820a21a74"]
+    "sha256:55c568d9e35e15d94b3ab41fe549b8ee4cd910cc3e031ddcccd06256755c5d89": ["v20210822-g5e5faa24d"]
 
 # custom cfssl image for e2e tests
 # https://github.com/kubernetes/ingress-nginx/tree/master/images/cfssl


### PR DESCRIPTION
Promote the test-runner image to contain go v1.17

Part of https://github.com/kubernetes/ingress-nginx/issues/7520