### PR TITLE
PSC Rename

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -150,7 +150,7 @@ aliases:
     - karenhchu
     - tashimi
     - tpepper
-  committee-product-security:
+  committee-security-response:
     - cjcullen
     - cji
     - joelsmith

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -1,6 +1,6 @@
 # Defined below are the security contacts for this repo.
 #
-# They are the contact point for the Product Security Committee to reach out
+# They are the contact point for the Security Response Committee to reach out
 # to for triaging and handling of incoming issues.
 #
 # The below names agree to abide by the

--- a/groups/committee-product-security/OWNERS
+++ b/groups/committee-product-security/OWNERS
@@ -1,7 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- committee-product-security
+- committee-security-response
 
 labels:
-- committee/product-security
+- committee/security-response

--- a/groups/committee-product-security/groups.yaml
+++ b/groups/committee-product-security/groups.yaml
@@ -18,7 +18,7 @@ groups:
       - tabitha.c.sable@gmail.com
       - timallclair@gmail.com
     members:
-      # Associate PSC members
+      # Associate SRC members
       - mok@vmware.com
       - sfowler@redhat.com
       - taahm@google.com
@@ -70,9 +70,9 @@ groups:
   - email-id: security-discuss-private@kubernetes.io
     name: security-discuss-private
     description: |-
-      Private discussion forum for PSC members.
+      Private discussion forum for SRC members.
 
-      https://github.com/kubernetes/security#product-security-committee-psc
+      https://github.com/kubernetes/security#security-response-committee-psc
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"

--- a/groups/groups_test.go
+++ b/groups/groups_test.go
@@ -236,10 +236,10 @@ func TestK8sInfraRBACGroupConventions(t *testing.T) {
 	}
 }
 
-// Enforce conventions for PSC groups
+// Enforce conventions for SRC groups
 // - groups can't own other groups, so for groups that should be owned by
 //	 security@kubernetes.io should own, make sure the owners match
-func TestProductSecurityCommitteeGroups(t *testing.T) {
+func TestSecurityResponseCommitteeGroups(t *testing.T) {
 	pscGroups := []string{
 		"distributors-announce@kubernetes.io",
 		"security-discuss-private@kubernetes.io",

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -2,7 +2,7 @@ restrictions:
   - path: "committee-code-of-conduct/groups.yaml"
     allowedGroups:
       - "^conduct@kubernetes.io$"
-  - path: "committee-product-security/groups.yaml"
+  - path: "committee-security-response/groups.yaml"
     allowedGroups:
       - "^distributors-announce@kubernetes.io$"
       - "^security@kubernetes.io$"

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -296,7 +296,7 @@ groups:
     description: |-
       Private list for coordinating security releases.
 
-      Membership is restricted to the Product Security Committee,
+      Membership is restricted to the Security Response Committee,
       SIG Release Chairs, Patch Release Team, and Branch Managers.
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"


### PR DESCRIPTION
This is pull request is part of the process to rename the product
security commitee to the security response commmitee.

Please see [the community
issue](https://github.com/kubernetes/community/pull/5597/files)

Signed-off-by: Luke Hinds <lhinds@redhat.com>