### PR TITLE
Add Vallery and Nabarun to CoCC mailing list, remove Tasha and Aeva

### DIFF
--- a/groups/committee-code-of-conduct/groups.yaml
+++ b/groups/committee-code-of-conduct/groups.yaml
@@ -7,8 +7,8 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
-      - aeva.online@gmail.com
       - celeste@cncf.io
       - chu.karen.h@gmail.com
-      - tasha.drew@gmail.com
+      - pal.nabarun95@gmail.com
       - tpepper@vmware.com
+      - vallery@zeitgeistlabs.io


### PR DESCRIPTION
We thank @tashimi and @AevaOnline so much for their excellent service on the Code of Conduct Committee, and welcome @vllry and @palnabarun to the group!