### PR TITLE
Fix typo in service account name.

### DIFF
--- a/infra/gcp/terraform/k8s-infra-public-pii/main.tf
+++ b/infra/gcp/terraform/k8s-infra-public-pii/main.tf
@@ -115,7 +115,7 @@ data "google_iam_policy" "audit_logs_gcs_bindings" {
   binding {
     role = "roles/storage.legacyBucketReader"
     members = [
-      "serviceAccount:${google_service_account.public_pii_asn_etl.email}",
+      "serviceAccount:${google_service_account.asn_etl.email}",
     ]
   }
   binding {


### PR DESCRIPTION
Followup of https://github.com/kubernetes/k8s.io/pull/2569

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>