### PR TITLE
terraform: Fix modules path

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/main.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/main.tf
@@ -186,4 +186,3 @@ module "prow_build_nodepool" {
   disk_type       = "pd-ssd"
   service_account = module.prow_build_cluster.cluster_node_sa.email
 }
-


### PR DESCRIPTION
Modules path was not changed after Terraform resources relocation done
in : https://github.com/kubernetes/k8s.io/pull/2482.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>