### PR TITLE
apps/prow: drop FQDN for prow components

### DIFF
--- a/apps/prow/cluster/deck_deployment.yaml
+++ b/apps/prow/cluster/deck_deployment.yaml
@@ -49,17 +49,17 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --cookie-secret=/etc/cookie/secret
         - --github-token-path=/etc/github/token
-        - --github-endpoint=http://ghproxy.prow.svc.cluster.local
+        - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --github-oauth-config-file=/etc/githuboauth/secret
-        - --hook-url=http://hook.prow.svc.cluster.local:8888/plugin-help
+        - --hook-url=http://hook:8888/plugin-help
         - --job-config-path=/etc/job-config
         - --oauth-url=/github-login
         - --plugin-config=/etc/plugins/plugins.yaml
         - --redirect-http-to=k8s-infra-prow.k8s.io
         - --rerun-creates-job
         - --spyglass=true
-        - --tide-url=http://tide.prow.svc.cluster.local/
+        - --tide-url=http://tide/
         env:
         # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
         - name: KUBECONFIG


### PR DESCRIPTION
Drop FDQN in deck deployment.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>