### PR TITLE
groups: update spiffxp membership

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -450,7 +450,6 @@ groups:
       - ktbry@google.com
       - nikitaraghunath@gmail.com
       - rajula96reddy@gmail.com
-      - spiffxp@google.com
       - spiffxp@gmail.com
       - thockin@google.com
 
@@ -465,7 +464,6 @@ groups:
       - deads@redhat.com
       - wojtekt@google.com
       - skuznets@redhat.com
-      - spiffxp@gmail.com
 
   - email-id: k8s-infra-sig-scalability-oncall@kubernetes.io
     name: k8s-infra-sig-scalability-oncall
@@ -958,7 +956,6 @@ groups:
       - davanum@gmail.com
       - james@munnelly.eu
       - thockin@google.com
-      - spiffxp@google.com
       - spiffxp@gmail.com
 
   - email-id: k8s-infra-staging-kas-network-proxy@kubernetes.io
@@ -985,7 +982,6 @@ groups:
       - ihor@cncf.io
       - justinsb@google.com
       - thockin@google.com
-      - spiffxp@gmail.com
 
   - email-id: k8s-infra-staging-kubeadm@kubernetes.io
     name: k8s-infra-staging-kubeadm

--- a/groups/sig-testing/groups.yaml
+++ b/groups/sig-testing/groups.yaml
@@ -58,7 +58,6 @@ groups:
     - davanum@gmail.com
     - justinsb@google.com
     - thockin@google.com
-    - spiffxp@google.com
     - spiffxp@gmail.com
 
   - email-id: k8s-infra-staging-k8s-gsm-tools@kubernetes.io
@@ -70,7 +69,6 @@ groups:
     members:
     - bentheelder@google.com
     - shanefu@google.com
-    - spiffxp@google.com
     - spiffxp@gmail.com
 
   - email-id: k8s-infra-staging-kind@kubernetes.io
@@ -94,7 +92,7 @@ groups:
     members:
     - amwat@google.com
     - bentheelder@google.com
-    - spiffxp@google.com
+    - spiffxp@gmail.com
 
   - email-id: k8s-infra-staging-test-infra@kubernetes.io
     name: k8s-infra-staging-test-infra

--- a/groups/wg-k8s-infra/groups.yaml
+++ b/groups/wg-k8s-infra/groups.yaml
@@ -108,7 +108,6 @@ groups:
       - jdagostino2@gmail.com
       - justinsb@google.com
       - k8s-infra-ii-coop@kubernetes.io
-      - spiffxp@gmail.com
       - spiffxp@google.com
       - thockin@google.com
 
@@ -128,7 +127,6 @@ groups:
       - ihor@cncf.io
       - jdagostino2@gmail.com
       - k8s-infra-ii-coop@kubernetes.io
-      - spiffxp@google.com
       - spiffxp@gmail.com
       - thockin@google.com
       - tjferrara@google.com


### PR DESCRIPTION
Broadly:
- drop spiffxp google.com from groups unless they're admin groups
  - k8s-infra-rbac-slack-infra
  - k8s-infra-staging-infra-tools
  - k8s-infra-staging-e2e-test-images
  - k8s-infra-staging-k8s-gsm-tools
  - k8s-infra-gcp-auditors
- drop spiffxp gmail.com from groups spiffxp doesn't work in
  - k8s-infra-rbac-sippy
  - k8s-infra-staging-kops
- drop spiffxp gmail.com from admin groups
  - k8s-infra-gcp-accounting
- swap google.com for gmail.com in non-admin groups spiffxp does work in
  - k8s-infra-staging-kubetest2

Motivated by trying to make my gmail.com account as read-only as
possible for purposes of experimenting with data studio, while giving
appropriate admin access for sig testing subprojects