### PR TITLE
Promote aws-ebs-csi-driver v1.2.1

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-provider-aws/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-provider-aws/images.yaml
@@ -26,6 +26,8 @@
     "sha256:56aabfb1d60effd888fd099886254d7492b4d359740d85163ca932f5fd109abd": ["v1.1.3-amazonlinux"]
     "sha256:25ece67112a267a2ccd6dc870b0dac4091cbcc2dc835e15c1f9492d6489ea906": ["v1.2.0"]
     "sha256:c1d7f2d06901c145a734cb97b444063ab9344b79a1e379b327014ecece4bd6b9": ["v1.2.0-amazonlinux"]
+    "sha256:732da7df530f4ad1923a7c71b927b0d964e596c622de68c1c6179fb7148704fd": ["v1.2.1"]
+    "sha256:6dda9d13dfe77e4440097c0aee379c703185fad7c01c4b96909f6bc28ea2dfd4": ["v1.2.1-amazonlinux"]
 - name: cloud-controller-manager
   dmap:
     "sha256:f900d8b4a358847cd311950c7802f938dad083f645eee784cd52b7aec0de8dfb": ["v1.18.0-alpha.0"]


### PR DESCRIPTION
1.1.4 is coming later, having trouble getting the build to succeed.
```
$ gcloud container images list-tags gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver --format='get(tags, digest)' --filter='tags:v1.2.1 AND tags!~rc'
v20210908-v1.2.1-amazonlinux	sha256:6dda9d13dfe77e4440097c0aee379c703185fad7c01c4b96909f6bc28ea2dfd4
v20210908-v1.2.1	sha256:732da7df530f4ad1923a7c71b927b0d964e596c622de68c1c6179fb7148704fd
```