### PR TITLE
terraform/kubernetes-public-pii: fix permissions for gs://k8s-infra-artifacts-logs

### DIFF
--- a/infra/gcp/terraform/k8s-infra-public-pii/main.tf
+++ b/infra/gcp/terraform/k8s-infra-public-pii/main.tf
@@ -99,6 +99,14 @@ data "google_service_account" "ii_sandbox_asn_etl" {
 }
 
 data "google_iam_policy" "audit_logs_gcs_bindings" {
+  // Allow GCP org admins to admin this bucket
+  binding {
+    role = "roles/storage.admin"
+    members = [
+      "group:k8s-infra-gcp-org-admins@google.com",
+    ]
+  }
+  // Allow GCS access logs to be written to this bucket
   binding {
     role = "roles/storage.objectAdmin"
     members = [
@@ -111,6 +119,7 @@ data "google_iam_policy" "audit_logs_gcs_bindings" {
       "group:cloud-storage-analytics@google.com",
     ]
   }
+  // Allow read-only access to authorized service accounts
   binding {
     role = "roles/storage.legacyObjectReader"
     members = [


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/904
- Part of: https://github.com/kubernetes/k8s.io/issues/1968
- Noticed via: https://github.com/kubernetes/k8s.io/issues/904#issuecomment-891443463

See commits for details.  I'm not sure the permissions have ever been quite correct on this bucket.  This should get them to a place where folks authorized for PII can read the bucket, and org admins can write to the bucket (at least for long enough to complete migration from the old gcslogs bucket)