### PR TITLE
bash/staging: update expected services

### DIFF
--- a/infra/gcp/bash/ensure-staging-storage.sh
+++ b/infra/gcp/bash/ensure-staging-storage.sh
@@ -61,6 +61,15 @@ readonly STAGING_PROJECT_SERVICES=(
     secretmanager.googleapis.com
     # These projects may host binaries in GCS
     storage-component.googleapis.com
+
+    # Dependencies (gcloud services used to encode these in its response)
+
+    # logging used by: cloudbuild
+    logging.googleapis.com
+    # pubsub used by: cloudbuild, containerregistry
+    pubsub.googleapis.com
+    # storage-api used by: cloudbuild, containerregistry
+    storage-api.googleapis.com
 )
 
 readonly STAGING_PROJECT_DISABLED_SERVICES=(


### PR DESCRIPTION
Related:
- part of: https://github.com/kubernetes/k8s.io/issues/1675

At some point in the past few months, `gcloud services` stopped returning dependency information. This means our scripts don't implicitly expect those services anymore, and list them under `to_disable`.

I manually discovered and encoded the dependencies by trying to remove a service our scripts log as unexpected, and seeing what the error returned.