### PR TITLE
infra(releng): Create service account for file promotions

### DIFF
--- a/infra/gcp/bash/ensure-prod-storage.sh
+++ b/infra/gcp/bash/ensure-prod-storage.sh
@@ -114,7 +114,7 @@ function ensure_prod_gcr() {
         empower_gcr_admins "${project}" "${region}"
         
         color 6 "Empowering image promoter for region: ${region} in project: ${project}"
-        empower_artifact_promoter "${project}" "${region}"
+        empower_image_promoter "${project}" "${region}"
 
         color 6 "Ensuring GCS access logs enabled for GCR bucket in region: ${region} in project: ${project}"
         ensure_gcs_bucket_logging "${gcr_bucket}"
@@ -315,13 +315,13 @@ function ensure_all_prod_special_cases() {
 
     # Special case: create/add-permissions for necessary service accounts for the auditor.
     color 6 "Empowering artifact auditor"
-    empower_artifact_auditor "${PROD_PROJECT}"
-    empower_artifact_auditor_invoker "${PROD_PROJECT}"
+    empower_image_auditor "${PROD_PROJECT}"
+    empower_image_auditor_invoker "${PROD_PROJECT}"
 
     # Special case: give Cloud Run Admin privileges to the group that will
     # administer the cip-auditor (so that they can deploy the auditor to Cloud Run).
     color 6 "Empowering artifact-admins to release prod auditor"
-    empower_group_to_admin_artifact_auditor \
+    empower_group_to_admin_image_auditor \
         "${PROD_PROJECT}" \
         "k8s-infra-artifact-admins@kubernetes.io"
 

--- a/infra/gcp/bash/ensure-prod-storage.sh
+++ b/infra/gcp/bash/ensure-prod-storage.sh
@@ -41,8 +41,8 @@ PROD_PROJECT=$(k8s_infra_project "prod" "k8s-artifacts-prod")
 PRODBAK_PROJECT=$(k8s_infra_project "prod" "${PROD_PROJECT}-bak")
 
 # These are for testing the image promoter's promotion process.
-PROMOTER_TEST_PROD_PROJECT=$(k8s_infra_project "prod" "k8s-cip-test-prod")
-PROMOTER_TEST_STAGING_PROJECT=$(k8s_infra_project "staging" "k8s-staging-cip-test")
+IMAGE_PROMOTER_TEST_PROD_PROJECT=$(k8s_infra_project "prod" "k8s-cip-test-prod")
+IMAGE_PROMOTER_TEST_STAGING_PROJECT=$(k8s_infra_project "staging" "k8s-staging-cip-test")
 
 # These are for testing the GCR backup/restore process.
 GCR_BACKUP_TEST_PROD_PROJECT=$(k8s_infra_project "prod" "k8s-gcr-backup-test-prod")
@@ -249,10 +249,10 @@ function ensure_all_prod_special_cases() {
     # prod projects.
     color 6 "Empowering staging-cip-test group to fake-prod"
     empower_group_to_fake_prod \
-        "${PROMOTER_TEST_PROD_PROJECT}" \
+        "${IMAGE_PROMOTER_TEST_PROD_PROJECT}" \
         "k8s-infra-staging-cip-test@kubernetes.io"
     empower_group_to_fake_prod \
-        "${PROMOTER_TEST_STAGING_PROJECT}" \
+        "${IMAGE_PROMOTER_TEST_STAGING_PROJECT}" \
         "k8s-infra-staging-cip-test@kubernetes.io"
     empower_group_to_fake_prod \
         "${GCR_BACKUP_TEST_PROD_PROJECT}" \
@@ -268,15 +268,15 @@ function ensure_all_prod_special_cases() {
     # staging, to allow e2e tests to run as that account, instead of yet another.
     color 6 "Empowering test-prod promoter to promoter staging GCR"
     empower_svcacct_to_admin_gcr \
-        "$(svc_acct_email "${PROMOTER_TEST_PROD_PROJECT}" "${PROMOTER_SVCACCT}")" \
-        "${PROMOTER_TEST_STAGING_PROJECT}"
+        "$(svc_acct_email "${IMAGE_PROMOTER_TEST_PROD_PROJECT}" "${IMAGE_PROMOTER_SVCACCT}")" \
+        "${IMAGE_PROMOTER_TEST_STAGING_PROJECT}"
 
     # Special case: grant the image promoter test service account access to
     # their testing project (used for running e2e tests for the promoter auditing
     # mechanism).
     color 6 "Empowering test-prod promoter to test-prod auditor"
     empower_service_account_for_cip_auditor_e2e_tester \
-        "$(svc_acct_email "${GCR_AUDIT_TEST_PROD_PROJECT}" "${PROMOTER_SVCACCT}")" \
+        "$(svc_acct_email "${GCR_AUDIT_TEST_PROD_PROJECT}" "${IMAGE_PROMOTER_SVCACCT}")" \
         "${GCR_AUDIT_TEST_PROD_PROJECT}"
 
     # Special case: grant the GCR backup-test svcacct access to the "backup-test
@@ -289,7 +289,7 @@ function ensure_all_prod_special_cases() {
     for r in "${PROD_REGIONS[@]}"; do
         color 3 "region $r"
         empower_svcacct_to_write_gcr \
-            "$(svc_acct_email "${GCR_BACKUP_TEST_PRODBAK_PROJECT}" "${PROMOTER_SVCACCT}")" \
+            "$(svc_acct_email "${GCR_BACKUP_TEST_PRODBAK_PROJECT}" "${IMAGE_PROMOTER_SVCACCT}")" \
             "${GCR_BACKUP_TEST_PROD_PROJECT}" \
             "${r}"
     done 2>&1 | indent
@@ -329,7 +329,7 @@ function ensure_all_prod_special_cases() {
     color 6 "Ensuring prod promoter vuln scanning svcacct exists"
     ensure_service_account \
         "${PROD_PROJECT}" \
-        "${PROMOTER_VULN_SCANNING_SVCACCT}" \
+        "${IMAGE_PROMOTER_VULN_SCANNING_SVCACCT}" \
         "k8s-infra container image vuln scanning"
 
     # Special case: allow prow trusted build clusters to run jobs as
@@ -337,21 +337,21 @@ function ensure_all_prod_special_cases() {
     color 6 "Empowering trusted prow build clusters to use prod-related GCP service accounts"
     for project in "${PROW_TRUSTED_BUILD_CLUSTER_PROJECTS[@]}"; do
         # Grant write access to k8s-artifacts-prod GCR
-        serviceaccount="$(svc_acct_email "${PROD_PROJECT}" "${PROMOTER_SVCACCT}")"
+        serviceaccount="$(svc_acct_email "${PROD_PROJECT}" "${IMAGE_PROMOTER_SVCACCT}")"
         color 6 "Ensuring GKE clusters in '${project}' can run pods in '${PROWJOB_POD_NAMESPACE}' as '${serviceaccount}'"
         empower_gke_for_serviceaccount \
             "${project}" "${PROWJOB_POD_NAMESPACE}" \
             "${serviceaccount}" "k8s-infra-gcr-promoter"
 
         # Grant write access to k8s-artifacts-prod-bak GCR (for backups)
-        serviceaccount="$(svc_acct_email "${PRODBAK_PROJECT}" "${PROMOTER_SVCACCT}")"
+        serviceaccount="$(svc_acct_email "${PRODBAK_PROJECT}" "${IMAGE_PROMOTER_SVCACCT}")"
         color 6 "Ensuring GKE clusters in '${project}' can run pods in '${PROWJOB_POD_NAMESPACE}' as '${serviceaccount}'"
         empower_gke_for_serviceaccount \
             "${project}" "${PROWJOB_POD_NAMESPACE}" \
             "${serviceaccount}" "k8s-infra-gcr-promoter-bak"
 
         # TODO: Grant ??? acccess to k8s-artifacts-prod ???
-        serviceaccount="$(svc_acct_email "${PROD_PROJECT}" "${PROMOTER_VULN_SCANNING_SVCACCT}")"
+        serviceaccount="$(svc_acct_email "${PROD_PROJECT}" "${IMAGE_PROMOTER_VULN_SCANNING_SVCACCT}")"
         color 6 "Ensuring GKE clusters in '${project}' can run pods in '${PROWJOB_POD_NAMESPACE}' as '${serviceaccount}'"
         empower_gke_for_serviceaccount \
             "${project}" "${PROWJOB_POD_NAMESPACE}" \
@@ -368,7 +368,7 @@ function ensure_all_prod_special_cases() {
     # NOTE: This is granted to prow build clusters that run untrusted code,
     #       such as presubmit jobs using PRs.
     color 6 "Empowering promoter-test namespace to use backup-test-prod-bak promoter svcacct"
-    serviceaccount="$(svc_acct_email "${GCR_BACKUP_TEST_PRODBAK_PROJECT}" "${PROMOTER_SVCACCT}")"
+    serviceaccount="$(svc_acct_email "${GCR_BACKUP_TEST_PRODBAK_PROJECT}" "${IMAGE_PROMOTER_SVCACCT}")"
     for project in "${PROW_UNTRUSTED_BUILD_CLUSTER_PROJECTS[@]}"; do
         color 6 "Ensuring GKE clusters in '${project}' can run pods in '${PROWJOB_POD_NAMESPACE}' as '${serviceaccount}'"
         empower_gke_for_serviceaccount \

--- a/infra/gcp/bash/ensure-prod-storage.sh
+++ b/infra/gcp/bash/ensure-prod-storage.sh
@@ -339,6 +339,13 @@ function ensure_all_prod_special_cases() {
     # prod-related GCP service accounts
     color 6 "Empowering trusted prow build clusters to use prod-related GCP service accounts"
     for project in "${PROW_TRUSTED_BUILD_CLUSTER_PROJECTS[@]}"; do
+        # Grant write access to k8s-artifacts-prod GCS
+        serviceaccount="$(svc_acct_email "${PROD_PROJECT}" "${FILE_PROMOTER_SVCACCT}")"
+        color 6 "Ensuring GKE clusters in '${project}' can run pods in '${PROWJOB_POD_NAMESPACE}' as '${serviceaccount}'"
+        empower_gke_for_serviceaccount \
+            "${project}" "${PROWJOB_POD_NAMESPACE}" \
+            "${serviceaccount}" "k8s-infra-promoter"
+
         # Grant write access to k8s-artifacts-prod GCR
         serviceaccount="$(svc_acct_email "${PROD_PROJECT}" "${IMAGE_PROMOTER_SVCACCT}")"
         color 6 "Ensuring GKE clusters in '${project}' can run pods in '${PROWJOB_POD_NAMESPACE}' as '${serviceaccount}'"

--- a/infra/gcp/bash/ensure-prod-storage.sh
+++ b/infra/gcp/bash/ensure-prod-storage.sh
@@ -148,6 +148,9 @@ function ensure_prod_gcs_bucket() {
     color 6 "Empowering GCS admins"
     empower_gcs_admins "${project}" "${bucket}"
 
+    color 6 "Empowering file promoter in project: ${project}"
+    empower_file_promoter "${project}" "${bucket}"
+
     color 6 "Ensuring GCS access logs enabled for ${bucket} in project: ${project}"
     ensure_gcs_bucket_logging "${bucket}"
 

--- a/infra/gcp/bash/ensure-staging-storage.sh
+++ b/infra/gcp/bash/ensure-staging-storage.sh
@@ -94,8 +94,8 @@ readonly AUTO_DELETION_DAYS=60
 
 readonly PROD_PROJECT="k8s-artifacts-prod"
 
-PROD_PROMOTER_SCANNING_SERVICE_ACCOUNT="$(svc_acct_email "${PROD_PROJECT}" "${PROMOTER_VULN_SCANNING_SVCACCT}")"
-readonly PROD_PROMOTER_SCANNING_SERVICE_ACCOUNT
+PROD_IMAGE_PROMOTER_SCANNING_SERVICE_ACCOUNT="$(svc_acct_email "${PROD_PROJECT}" "${IMAGE_PROMOTER_VULN_SCANNING_SVCACCT}")"
+readonly PROD_IMAGE_PROMOTER_SCANNING_SERVICE_ACCOUNT
 
 #
 # Staging functions
@@ -127,7 +127,7 @@ function ensure_staging_project() {
     local staging_bucket="gs://${project}" # used by humans
     local gcb_bucket="gs://${project}-gcb" # used by GCB
 
-    local cip_principal="serviceAccount:${PROD_PROMOTER_SCANNING_SERVICE_ACCOUNT}"
+    local cip_principal="serviceAccount:${PROD_IMAGE_PROMOTER_SCANNING_SERVICE_ACCOUNT}"
 
     color 6 "Ensuring project exists: ${project}"
     ensure_project "${project}"

--- a/infra/gcp/bash/lib.sh
+++ b/infra/gcp/bash/lib.sh
@@ -80,11 +80,11 @@ readonly AUDITOR_INVOKER_SVCACCT="k8s-infra-gcr-auditor-invoker"
 readonly AUDITOR_SERVICE_NAME="cip-auditor"
 
 # The service account name for the image promoter.
-readonly PROMOTER_SVCACCT="k8s-infra-gcr-promoter"
+readonly IMAGE_PROMOTER_SVCACCT="k8s-infra-gcr-promoter"
 
 # The service account name for the image promoter's vulnerability check.
 # used in: ensure-prod-storage.sh ensure-staging-storage.sh
-export PROMOTER_VULN_SCANNING_SVCACCT="k8s-infra-gcr-vuln-scanning"
+export IMAGE_PROMOTER_VULN_SCANNING_SVCACCT="k8s-infra-gcr-vuln-scanning"
 
 # Release Engineering umbrella groups
 # - admins - edit and KMS access (Release Engineering subproject owners)
@@ -400,12 +400,12 @@ function empower_artifact_promoter() {
     local project="$1"
     local region="${2:-}"
     local acct=
-    acct=$(svc_acct_email "${project}" "${PROMOTER_SVCACCT}")
+    acct=$(svc_acct_email "${project}" "${IMAGE_PROMOTER_SVCACCT}")
 
     if ! gcloud --project "${project}" iam service-accounts describe "${acct}" >/dev/null 2>&1; then
         gcloud --project "${project}" \
             iam service-accounts create \
-            "${PROMOTER_SVCACCT}" \
+            "${IMAGE_PROMOTER_SVCACCT}" \
             --display-name="k8s-infra container image promoter"
     fi
 

--- a/infra/gcp/bash/lib.sh
+++ b/infra/gcp/bash/lib.sh
@@ -357,9 +357,9 @@ function empower_gcs_admins() {
 # Grant Cloud Run privileges to a group.
 # $1: The GCP project
 # $2: The googlegroups group
-function empower_group_to_admin_artifact_auditor() {
+function empower_group_to_admin_image_auditor() {
     if [ $# != 2 ]; then
-        echo "empower_group_to_admin_artifact_auditor(project, group_name) requires 2 arguments" >&2
+        echo "empower_group_to_admin_image_auditor(project, group_name) requires 2 arguments" >&2
         return 1
     fi
     local project="$1"
@@ -392,9 +392,9 @@ function empower_group_to_admin_artifact_auditor() {
 # Grant full privileges to the GCR promoter bot
 # $1: The GCP project
 # $2: The GCR region (optional)
-function empower_artifact_promoter() {
+function empower_image_promoter() {
     if [ $# -lt 1 ] || [ $# -gt 2 ] || [ -z "$1" ]; then
-        echo "empower_artifact_promoter(project, [region]) requires 1 or 2 arguments" >&2
+        echo "empower_image_promoter(project, [region]) requires 1 or 2 arguments" >&2
         return 1
     fi
     local project="$1"
@@ -414,9 +414,9 @@ function empower_artifact_promoter() {
 
 # Ensure the auditor service account exists and has the ability to write logs and fire alerts to Stackdriver Error Reporting.
 # $1: The GCP project
-function empower_artifact_auditor() {
+function empower_image_auditor() {
     if [ $# -lt 1 ] || [ -z "$1" ]; then
-        echo "empower_artifact_auditor(project) requires 1 argument" >&2
+        echo "empower_image_auditor(project) requires 1 argument" >&2
         return 1
     fi
     local project="$1"
@@ -452,9 +452,9 @@ function empower_artifact_auditor() {
 # subscription getting its messages from the GCR topic "gcr", where changes to
 # GCR are posted).
 # $1: The GCP project
-function empower_artifact_auditor_invoker() {
+function empower_image_auditor_invoker() {
     if [ $# -lt 1 ] || [ -z "$1" ]; then
-        echo "empower_artifact_auditor_invoker(project) requires 1 argument" >&2
+        echo "empower_image_auditor_invoker(project) requires 1 argument" >&2
         return 1
     fi
     local project="$1"

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-serviceaccounts.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-serviceaccounts.yaml
@@ -75,6 +75,14 @@ metadata:
     iam.gke.io/gcp-service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod-bak.iam.gserviceaccount.com
   name: k8s-infra-gcr-promoter-bak
   namespace: test-pods
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: k8s-infra-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  name: k8s-infra-promoter
+  namespace: test-pods
 
 # Staging service accounts
 ---


### PR DESCRIPTION
Part of https://github.com/kubernetes/k8s.io/issues/2624, https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/413.

- infra/gcp/bash: Prepend `IMAGE_` to image promoter svc account vars
  ...in preparation for adding file promoter service account configs
- infra/gcp/bash: s/artifact_/image_ 
- infra/gcp/bash: Add `empower_file_promoter`
- infra/gcp: Add service account bindings for file promotion

Signed-off-by: Stephen Augustus <foo@auggie.dev>

