### PR TITLE
kubernetes-public: Enable billing service

### DIFF
--- a/infra/gcp/bash/ensure-main-project.sh
+++ b/infra/gcp/bash/ensure-main-project.sh
@@ -87,6 +87,8 @@ readonly TERRAFORM_STATE_BUCKET_ENTRIES=(
 #       graph here? ensure_only_services dynamically computes the set of
 #       expected services
 readonly MAIN_PROJECT_SERVICES=(
+    # We store budgets applied to projects of the kubernetes.io org
+    billingbudgets.googleapis.com
     # We export billing data to bigquery
     bigquery.googleapis.com
     # We use cloud asset inventory from this project to audit all projects


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/funding/issues/18

Enable `billingbudgets.googleapis.com` for GCP Billing budgets.
All budgets created will be centralised in `kubernetes-public` project.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>