### PR TITLE
bash/main: fix cherrypick secret iam

### DIFF
--- a/infra/gcp/bash/ensure-main-project.sh
+++ b/infra/gcp/bash/ensure-main-project.sh
@@ -409,12 +409,14 @@ function ensure_prow_special_cases {
     color 6 "Special case: ensuring k8s-infra-ci-robot-github-token accessible by k8s-infra-prow-build-trusted"
     principal="serviceAccount:$(svc_acct_email "k8s-infra-prow-build-trusted" "kubernetes-external-secrets")"
     secret=$(secret_full_name "${project}" "k8s-infra-ci-robot-github-token")
+    ensure_secret_role_binding "${secret}" "${principal}" "roles/secretmanager.viewer" 2>&1 | indent
     ensure_secret_role_binding "${secret}" "${principal}" "roles/secretmanager.secretAccessor" 2>&1 | indent
 
     # TODO: remove when cherrypicker is running solely on k8s-infra-prow.k8s.io
     color 6 "Special case: ensuring k8s-infra-cherrypicker-github-token accessible by k8s-prow"
-    principal="kubernetes-external-secrets-sa@k8s-prow.iam.gserviceaccount.com"
+    principal="serviceAccount:kubernetes-external-secrets-sa@k8s-prow.iam.gserviceaccount.com"
     secret=$(secret_full_name "${project}" "k8s-infra-cherrypick-robot-github-token")
+    ensure_secret_role_binding "${secret}" "${principal}" "roles/secretmanager.viewer" 2>&1 | indent
     ensure_secret_role_binding "${secret}" "${principal}" "roles/secretmanager.secretAccessor" 2>&1 | indent
 }
 


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/test-infra/issues/23469
- Followup to: https://github.com/kubernetes/test-infra/pull/23551

Fix a typo and also fix permissions to include ability to view the secret being accessed