### PR TITLE
bash/prod: fix static path

### DIFF
--- a/infra/gcp/bash/ensure-prod-storage.sh
+++ b/infra/gcp/bash/ensure-prod-storage.sh
@@ -237,7 +237,7 @@ function ensure_all_prod_special_cases() {
     color 6 "Copying static content into the prod bucket"
     upload_gcs_static_content \
         "gs://${PROD_PROJECT}" \
-        "${SCRIPT_DIR}/static/prod-storage"
+        "${SCRIPT_DIR}/../static/prod-storage"
 
     # Special case: enable people to read vulnerability reports.
     color 6 "Empowering artifact-security group to real vulnerability reports"


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/516
- Discovered via: https://github.com/kubernetes/k8s.io/pull/2700
- Followup to: https://github.com/kubernetes/k8s.io/pull/2632

this was missed when scripts got moved into infra/gcp/bash but static
files stayed behind in infra/gcp/static