### PR TITLE
artifacts: Update manifests to use file promotion service account

### DIFF
--- a/artifacts/filestores/k8s-staging-kops/filepromoter-manifest.yaml
+++ b/artifacts/filestores/k8s-staging-kops/filepromoter-manifest.yaml
@@ -3,4 +3,4 @@ filestores:
 - base: gs://k8s-staging-kops/kops/releases/
   src: true
 - base: gs://k8s-artifacts-prod/binaries/kops/
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  service-account: k8s-infra-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
A service account for file promotion was created in https://github.com/kubernetes/k8s.io/pull/2700, so let's utilize it in the existing manifests.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @spiffxp @ameukam @justinsb 
cc: @kubernetes/release-engineering @kubernetes/kops-maintainers 

(I expect the file promotion presubmit to fail, since it's not running in a trusted env.)