### PR TITLE
Promote nginx error pages

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -1,5 +1,5 @@
 # ingress-nginx controller image
-# https://github.com/kubernetes/ingress-nginx/tree/master/rootfs
+# https://github.com/kubernetes/ingress-nginx/tree/main/rootfs
 - name: controller
   dmap:
     "sha256:56633bd00dab33d92ba14c6e709126a762d54a75a6e72437adefeaaca0abb069": ["v0.34.0"]
@@ -26,7 +26,7 @@
     "sha256:0851b34f69f69352bf168e6ccf30e1e20714a264ab1ecd1933e4d8c0fc3215c6": ["v1.0.0"]
 
 # custom base NGINX image
-# https://github.com/kubernetes/ingress-nginx/tree/master/images/nginx
+# https://github.com/kubernetes/ingress-nginx/tree/main/images/nginx
 - name: nginx
   dmap:
     "sha256:35da1d3e00f5e763e59cb59159bf88ba0f0b6e8835885ac9d8b63029a478dba7": ["v20200625-g1813d1c56"]
@@ -49,7 +49,7 @@
     "sha256:fac972a7e43b18408ecb9e87da868df519428294e2e988c16be72479ee873c0e": ["v20210904-gb7c973dce"]
 
 # image to run tests
-# https://github.com/kubernetes/ingress-nginx/tree/master/images/test-runner
+# https://github.com/kubernetes/ingress-nginx/tree/main/images/test-runner
 - name: e2e-test-runner
   dmap:
     "sha256:7dece116c5cc1a51496095de97cc9249a07e9f1a4ed0dc378630074c6857ff46": ["v20200630-g2bff8ed3b"]
@@ -70,13 +70,13 @@
     "sha256:55c568d9e35e15d94b3ab41fe549b8ee4cd910cc3e031ddcccd06256755c5d89": ["v20210822-g5e5faa24d"]
     "sha256:cf7079b5c05b8b1b108b16752c6ff4ca312cf96700e91eef6088b9e0c4a7aff1": ["v20210906-g7d577d976"]
 # custom cfssl image for e2e tests
-# https://github.com/kubernetes/ingress-nginx/tree/master/images/cfssl
+# https://github.com/kubernetes/ingress-nginx/tree/main/images/cfssl
 - name: e2e-test-cfssl
   dmap:
     "sha256:be2f69024f7b7053f35b86677de16bdaa5d3ff0f81b17581ef0b0c6804188b03": ["v20200627-g1fcf4444c"]
 
 # custom echo HTTP server image for e2e tests
-# https://github.com/kubernetes/ingress-nginx/tree/master/images/echo
+# https://github.com/kubernetes/ingress-nginx/tree/main/images/echo
 - name: e2e-test-echo
   dmap:
     "sha256:41c043188a499d460e7425883a3b196e13f10bf40c395895dbdf06caf3324536": ["v20200627-g35e992fe0"]
@@ -89,20 +89,20 @@
     "sha256:131ece0637b29231470cfaa04690c2966a2e0b147d3c9df080a0857b78982410": ["v20210810-g820a21a74"]
 
 # fastcgi HTTP server image for e2e tests
-# https://github.com/kubernetes/ingress-nginx/tree/master/images/fastcgi-helloserver
+# https://github.com/kubernetes/ingress-nginx/tree/main/images/fastcgi-helloserver
 - name: e2e-test-fastcgi-helloserver
   dmap:
     "sha256:723b8187e1768d199b93fd939c37c1ce9427dcbca72ec6415f4d890bca637fcc": ["v20200627-g1fcf4444c"]
 
 # httpbin image for e2e tests
-# https://github.com/kubernetes/ingress-nginx/tree/master/images/httpbin
+# https://github.com/kubernetes/ingress-nginx/tree/main/images/httpbin
 - name: e2e-test-httpbin
   dmap:
     "sha256:c6372ef57a775b95f18e19d4c735a9819f2e7bb4641e5e3f27287d831dfeb7e8": ["v20200627-gfc91afac8"]
     "sha256:12f18b0ce1fa12e40a29b4b142cbfc6b909b65a0be02421bc3d1889c824747f7": ["v20200808-gc500bd4b3"]
 
 # kube-webhook-certgen
-# https://github.com/kubernetes/ingress-nginx/tree/master/images/kube-webhook-certgen
+# https://github.com/kubernetes/ingress-nginx/tree/main/images/kube-webhook-certgen
 - name: kube-webhook-certgen
   dmap:
     "sha256:f3b6b39a6062328c095337b4cadcefd1612348fdd5190b1dcbcb9b9e90bd8068": ["v1.0"]

--- a/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -106,3 +106,9 @@
 - name: kube-webhook-certgen
   dmap:
     "sha256:f3b6b39a6062328c095337b4cadcefd1612348fdd5190b1dcbcb9b9e90bd8068": ["v1.0"]
+
+# custom-error-pages
+# https://github.com/kubernetes/ingress-nginx/tree/main/images/custom-error-pages
+- name: kube-webhook-certgen
+  dmap:
+    "sha256:5530c7fc1fa75b49e068d6b7b4f8f1c13a5834c155ba7abd5943b9057c3b925b": ["0.48.1"]

--- a/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -109,6 +109,6 @@
 
 # custom-error-pages
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/custom-error-pages
-- name: kube-webhook-certgen
+- name: nginx-errors
   dmap:
     "sha256:5530c7fc1fa75b49e068d6b7b4f8f1c13a5834c155ba7abd5943b9057c3b925b": ["0.48.1"]

--- a/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -107,7 +107,7 @@
   dmap:
     "sha256:f3b6b39a6062328c095337b4cadcefd1612348fdd5190b1dcbcb9b9e90bd8068": ["v1.0"]
 
-# custom-error-pages
+# nginx-errors
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/custom-error-pages
 - name: nginx-errors
   dmap:


### PR DESCRIPTION
The custom-error-pages images are already on the staging repo and have to be promoted to also be pushed to the main repository.  
In this PR I added the required entry to the images.yml to do so.

I also took the liberty of updating the old links in this file to point to the correct (main) branch of the ingress-nginx repo.