### PR TITLE
artifacts: Add RelEng/WG K8s Infra as approvers/reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -173,7 +173,7 @@ aliases:
     - BenTheElder
     - MushuEE
     - spiffxp
-  cip-approvers:
+  promo-tools-approvers:
     - cpanato
     - jeremyrickard
     - justaugustus
@@ -181,7 +181,7 @@ aliases:
     - puerco
     - saschagrunert
     - thockin
-  cip-reviewers:
+  promo-tools-reviewers:
     - cpanato
     - jeremyrickard
     - justaugustus

--- a/artifacts/OWNERS
+++ b/artifacts/OWNERS
@@ -1,4 +1,21 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+options:
+  # Root approvers for this repo include contributors who are not involved
+  # in artifact promotion. We're blocking root approvals here to ensure
+  # manifests are reviewed by Release Engineering and/or WG K8s Infra
+  # approvers.
+  #
+  # Long-term, a separate repo has been proposed for these artifact promotion
+  # manifests: https://github.com/kubernetes/org/issues/2342
+  no_parent_owners: true
+approvers:
+  - promo-tools-approvers
+  - release-engineering-approvers
+  - wg-k8s-infra-leads
+reviewers:
+  - promo-tools-reviewers
+  - release-engineering-reviewers
+
 labels:
 - area/artifacts

--- a/infra/gcp/bash/backup_tools/OWNERS
+++ b/infra/gcp/bash/backup_tools/OWNERS
@@ -1,11 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- cip-approvers
+- promo-tools-approvers
 - release-engineering-approvers
 - wg-k8s-infra-leads
 reviewers:
-- cip-reviewers
+- promo-tools-reviewers
 - release-engineering-reviewers
 
 labels:

--- a/infra/gcp/bash/cip-auditor/OWNERS
+++ b/infra/gcp/bash/cip-auditor/OWNERS
@@ -1,11 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- cip-approvers
+- promo-tools-approvers
 - release-engineering-approvers
 - wg-k8s-infra-leads
 reviewers:
-- cip-reviewers
+- promo-tools-reviewers
 - release-engineering-reviewers
 
 labels:

--- a/k8s.gcr.io/images/k8s-staging-artifact-promoter/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-artifact-promoter/OWNERS
@@ -3,10 +3,10 @@
 options:
   no_parent_owners: true
 approvers:
-  - cip-approvers
+  - promo-tools-approvers
   - release-engineering-approvers
 reviewers:
-  - cip-reviewers
+  - promo-tools-reviewers
   - release-engineering-reviewers
 
 labels:


### PR DESCRIPTION
(Part of https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/413)

Adding the following teams as...
approvers:
  - promo-tools-approvers
  - release-engineering-approvers
  - wg-k8s-infra-leads
reviewers:
  - promo-tools-reviewers
  - release-engineering-reviewers

/assign @ameukam @dims @spiffxp 
cc: @kubernetes/release-engineering @kubernetes/wg-k8s-infra-leads 