### PR TITLE
terraform/kubernetes-public: add k8s-prod-readiness dataset and group

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -37,6 +37,7 @@ restrictions:
       - "^k8s-infra-staging-apisnoop@kubernetes.io$"
       - "^k8s-infra-code-organization@kubernetes.io$"
       - "^k8s-infra-rbac-sippy@kubernetes.io$"
+      - "^k8s-infra-prod-readiness@kubernetes.io$"
   - path: "sig-auth/groups.yaml"
     allowedGroups:
       - "^k8s-infra-staging-csi-secrets-store@kubernetes.io$"

--- a/groups/sig-architecture/groups.yaml
+++ b/groups/sig-architecture/groups.yaml
@@ -65,6 +65,19 @@ groups:
       - liggitt@google.com
       - shaikhnavid14@gmail.com
 
+  - email-id: k8s-infra-prod-readiness@kubernetes.io
+    name: k8s-infra-prod-readiness
+    description: |-
+      ACL for managing access to prod-readiness-related infrastructure such as
+      the k8s-prod-readiness bigquery dataset
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - jbelamaric@google.com
+      - deads@redhat.com
+      - wojtekt@google.com
+      - ehashman@redhat.com
+
   # RBAC groups:
   # - grant access to the `namespace-user` role for a single namespace on the `aaa` cluster
   # - must have WhoCanViewMemberShip: "ALL_MEMBERS_CAN_VIEW"

--- a/infra/gcp/terraform/kubernetes-public/k8s-prod-readiness.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-prod-readiness.tf
@@ -1,0 +1,51 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+ 
+/*
+This file defines:
+- A BigQuery dataset for prod-readiness reporting
+- IAM bindings on that dataset
+*/
+
+locals {
+  prod_readiness_owners = "k8s-infra-prod-readiness@kubernetes.io"
+}
+
+// BigQuery dataset for PRR analysis
+resource "google_bigquery_dataset" "prod_readiness_dataset" {
+  dataset_id  = "k8s_prod_readiness"
+  project     = data.google_project.project.project_id
+  description = "Dataset for prod-readiness approvers to use for reporting purposes"
+  location    = "US"
+
+  // Data is precious, make it difficult to delete by accident
+  delete_contents_on_destroy = false
+}
+
+data "google_iam_policy" "prod_readiness_dataset_iam_policy" {
+  binding {
+    members = [
+      "group:${local.prod_readiness_owners}",
+    ]
+    role = "roles/bigquery.dataOwner"
+  }
+}
+
+resource "google_bigquery_dataset_iam_policy" "prod_readiness_dataset" {
+  dataset_id  = google_bigquery_dataset.prod_readiness_dataset.dataset_id
+  project = google_bigquery_dataset.prod_readiness_dataset.project
+  policy_data = data.google_iam_policy.prod_readiness_dataset_iam_policy.policy_data
+}


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/2619

Adds a `k8s-prod-readiness` bigquery dataset owned by a new `k8s-infra-prod-readiness@kubernetes.io` group that is populated by the current PRR approvers (I happened to find an e-mail for each person in other groups already(