### PR TITLE
gcp/bash: Add GCP secrets for kops ssh key

### DIFF
--- a/infra/gcp/bash/prow/ensure-e2e-projects.sh
+++ b/infra/gcp/bash/prow/ensure-e2e-projects.sh
@@ -141,6 +141,7 @@ function ensure_e2e_project() {
 function ensure_trusted_prow_build_cluster_secrets() {
     local project="${TRUSTED_BUILD_CLUSTER_PROJECT}"
     local secret_specs=(
+        k8s-infra-kops-e2e-tests-aws-ssh-key/sig-cluster-lifecycle/k8s-infra-kops-maintainers@kubernetes.io
         k8s-triage-robot-github-token/sig-contributor-experience/github@kubernetes.io
         cncf-ci-github-token/sig-testing/k8s-infra-ii-coop@kubernetes.io
         snyk-token/sig-architecture/k8s-infra-code-organization@kubernetes.io


### PR DESCRIPTION
Related:
  - https://github.com/kubernetes/k8s.io/issues/2625.

EDIT: The kops e2e tests needs a SSH key (passwordless is allowed) to be able to access to instances running on AWS. Add GCP secret for SSH key
The value of the secret will be accessible by `k8s-infra-kops-maintainers@kubernetes.io`.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>