### PR TITLE
releng: Drop palnabarun temporary access

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -41,7 +41,6 @@ groups:
       - ctadeu@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
-      - pal.nabarun95@gmail.com
       - saschagrunert@gmail.com
 
   - email-id: k8s-infra-release-viewers@kubernetes.io


### PR DESCRIPTION
Nabarun Pal is a Release Manager Associate who was granted temporary elevated access to cut the v1.23.0-alpha.2 release.

The release is out, so we drop the elevated privileges.

/assign @dims @spiffxp @ameukam 
cc: @kubernetes/release-engineering

SIG Release issue: kubernetes/sig-release#1700

Closes kubernetes/sig-release#1700

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>