### PR TITLE
terraform/kubernetes-public: mv public k8s.io IPs to for_each

### DIFF
--- a/infra/gcp/terraform/kubernetes-public/external-ips.tf
+++ b/infra/gcp/terraform/kubernetes-public/external-ips.tf
@@ -18,84 +18,90 @@ limitations under the License.
 This file defines all the external IP addresses in kubernetes-public
 */
 
-// used by gcsweb.k8s.io
-resource "google_compute_global_address" "gcsweb_k8s_io" {
-  project      = data.google_project.project.project_id
-  name         = "gcsweb-k8s-io"
-  address_type = "EXTERNAL"
-}
+resource "google_compute_global_address" "k8s_io" {
+  project       = data.google_project.project.project_id
+  for_each = {
+    // used by gcsweb.k8s.io
+    gcsweb = {
+      name = "gcsweb-k8s-io",
+      description = null
+      address_type = "EXTERNAL",
+      ip_version = "IPV4"
+    },
+    // used by canary.k8s.io
+    canary = {
+      name = "k8s-io-ingress-canary",
+      description = null
+      address_type = "EXTERNAL",
+      ip_version = "IPV4"
+    },
+    // used by canary.k8s.io (IPv6)
+    canary-v6 = {
+      name = "k8s-io-ingress-canary-v6",
+      description = null
+      address_type = "EXTERNAL",
+      ip_version = "IPV6"
+    },
+    // used by k8s-infra-prow.k8s.io
+    infra-prow = {
+      name = "k8s-infra-prow",
+      description = null
+      address_type = "EXTERNAL",
+      ip_version = "IPV4"
+    },
+    // used by k8s-infra-prow.k8s.io (IPv6)
+    infra-prow-v6 = {
+      name = "k8s-infra-prow-v6",
+      description = null
+      address_type = "EXTERNAL",
+      ip_version = "IPV6"
+    },
+    // used by k8s.io
+    ingress-prod = {
+      name = "k8s-io-ingress-prod",
+      description = null
+      address_type = "EXTERNAL",
+      ip_version = "IPV4"
+    },
+    // used by k8s.io (IPv6)
+    ingress-prod-v6 = {
+      name = "k8s-io-ingress-prod-v6",
+      description = null
+      address_type = "EXTERNAL",
+      ip_version = "IPV6"
+    },
+    // used by perf-dash.k8s.io
+    perf-dash = {
+      name = "perf-dash-k8s-io-ingress-prod",
+      description = null
+      address_type = "EXTERNAL",
+      ip_version = "IPV4"
+    },
+    // used by sippy.k8s.io
+    sippy = {
+      name = "sippy-ingress-prod",
+      description  = "IP for aaa cluster Ingress"
+      address_type = "EXTERNAL",
+      ip_version = "IPV4"
+    },
+    // used by slack.k8s.io
+    slack = {
+      name = "slack-infra-ingress-prod",
+      description = null
+      address_type = "EXTERNAL",
+      ip_version = "IPV4"
+    },
+    // used by release.triage.k8s.io
+    triage-party-release = {
+      name = "triage-party-release-ingress-prod",
+      description  = "IP for aaa cluster Ingress"
+      address_type = "EXTERNAL",
+      ip_version = "IPV4"
+    },
+  }
 
-// used by canary.k8s.io
-resource "google_compute_global_address" "k8s_io_ingress_canary" {
-  project      = data.google_project.project.project_id
-  name         = "k8s-io-ingress-canary"
-  address_type = "EXTERNAL"
-}
-
-// used by canary.k8s.io (IPv6)
-resource "google_compute_global_address" "k8s_io_ingress_canary_v6" {
-  project      = data.google_project.project.project_id
-  name         = "k8s-io-ingress-canary-v6"
-  address_type = "EXTERNAL"
-  ip_version   = "IPV6"
-}
-
-// used by k8s-infra-prow.k8s.io
-resource "google_compute_global_address" "k8s_infra_prow" {
-  project      = data.google_project.project.project_id
-  name         = "k8s-infra-prow"
-  address_type = "EXTERNAL"
-}
-
-// used by k8s-infra-prow.k8s.io (IPv6)
-resource "google_compute_global_address" "k8s_infra_prow_v6" {
-  project      = data.google_project.project.project_id
-  name         = "k8s-infra-prow-v6"
-  address_type = "EXTERNAL"
-  ip_version   = "IPV6"
-}
-
-// used by k8s.io
-resource "google_compute_global_address" "k8s_io_ingress_prod" {
-  project      = data.google_project.project.project_id
-  name         = "k8s-io-ingress-prod"
-  address_type = "EXTERNAL"
-}
-
-// used by k8s.io (IPv6)
-resource "google_compute_global_address" "k8s_io_ingress_prod_v6" {
-  project      = data.google_project.project.project_id
-  name         = "k8s-io-ingress-prod-v6"
-  address_type = "EXTERNAL"
-  ip_version   = "IPV6"
-}
-
-// used by perf-dash.k8s.io
-resource "google_compute_global_address" "perf_dash" {
-  project      = data.google_project.project.project_id
-  name         = "perf-dash-k8s-io-ingress-prod"
-  address_type = "EXTERNAL"
-}
-
-// used by sippy.k8s.io
-resource "google_compute_global_address" "sippy" {
-  project      = data.google_project.project.project_id
-  name         = "sippy-ingress-prod"
-  description  = "IP for aaa cluster Ingress"
-  address_type = "EXTERNAL"
-}
-
-// used by slack.k8s.io
-resource "google_compute_global_address" "slack" {
-  project      = data.google_project.project.project_id
-  name         = "slack-infra-ingress-prod"
-  address_type = "EXTERNAL"
-}
-
-// used by release.triage.k8s.io
-resource "google_compute_global_address" "release_triage" {
-  project      = data.google_project.project.project_id
-  name         = "triage-party-release-ingress-prod"
-  description  = "IP for aaa cluster Ingress"
-  address_type = "EXTERNAL"
+  name          = each.value.name
+  description   = each.value.description
+  address_type  = each.value.address_type
+  ip_version    = each.value.ip_version
 }


### PR DESCRIPTION
Move public k8s.io IPs from individual google_compute_global_address resources to a single resource with for_each.

Ref: [#2275](https://github.com/kubernetes/k8s.io/issues/2275)

Manual steps must be made to merge PR. 

-  Backup tfstate and ensure no one else is modifying it.

```
terraform state pull > pulled-tfstate.json
```
-  Perform a terraform state mv dry run for each google_compute_global_address

```
terraform state mv -dry-run google_compute_global_address.k8s_io_ingress_prod 'google_compute_global_address.k8s_io["ingress-prod"]'
Would move "google_compute_global_address.k8s_io_ingress_prod" to "google_compute_global_address.k8s_io[\"ingress-prod\"]"
```

- Move each resource 

```
terraform state mv  google_compute_global_address.k8s_io_ingress_prod 'google_compute_global_address.k8s_io["ingress-prod"]'
Move "google_compute_global_address.k8s_io_ingress_prod" to "google_compute_global_address.k8s_io[\"ingress-prod\"]"
Successfully moved 1 object(s).
```

-  Perform a terraform plan until obtaining "No changes" output

Signed-off-by: Gabriel De Obieta deobieta@gmail.com