### PR TITLE
kubernetes-public: Allow write access to prow-build-trusted SA

### DIFF
--- a/infra/gcp/terraform/kubernetes-public/prowjob-buckets.tf
+++ b/infra/gcp/terraform/kubernetes-public/prowjob-buckets.tf
@@ -174,7 +174,7 @@ data "google_iam_policy" "kops_ci_bucket_bindings" {
   binding {
     role = "roles/storage.objectAdmin"
     members = [
-      "serviceAccount:prow-build@k8s-infra-prow-build.iam.gserviceaccount.com",
+      "serviceAccount:prow-build-trusted@k8s-infra-prow-build-trusted.iam.gserviceaccount.com",
     ]
   }
   // Ensure bucket is world readable


### PR DESCRIPTION
Ref: https://github.com/kubernetes/k8s.io/issues/2625

Allow prow-build-trusted SA to write to k8s-infra-kops-ci-results
bucket.
This is required by prowjobs pushing version markers for kops.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>