### PR TITLE
apps: Switch jobs to ClusterIP and NEG

### DIFF
--- a/apps/sippy/service.yaml
+++ b/apps/sippy/service.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: sippy
   labels:
     app: sippy
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
 spec:
   ports:
     - port: 9080
@@ -13,4 +15,4 @@ spec:
   selector:
     app: sippy
   sessionAffinity: None
-  type: NodePort
+  type: ClusterIP

--- a/apps/slack-infra/resources/slack-event-log/service.yaml
+++ b/apps/slack-infra/resources/slack-event-log/service.yaml
@@ -2,10 +2,12 @@ kind: Service
 apiVersion: v1
 metadata:
   name: slack-event-log
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
 spec:
   selector:
     app: slack-event-log
-  type: NodePort
+  type: ClusterIP
   ports:
   - protocol: TCP
     port: 80

--- a/apps/slack-infra/resources/slack-moderator-words/service.yaml
+++ b/apps/slack-infra/resources/slack-moderator-words/service.yaml
@@ -2,10 +2,12 @@ kind: Service
 apiVersion: v1
 metadata:
   name: slack-moderator-words
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
 spec:
   selector:
     app: slack-moderator-words
-  type: NodePort
+  type: ClusterIP
   ports:
   - protocol: TCP
     port: 80

--- a/apps/slack-infra/resources/slack-moderator/service.yaml
+++ b/apps/slack-infra/resources/slack-moderator/service.yaml
@@ -2,10 +2,12 @@ kind: Service
 apiVersion: v1
 metadata:
   name: slack-moderator
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
 spec:
   selector:
     app: slack-moderator
-  type: NodePort
+  type: ClusterIP
   ports:
   - protocol: TCP
     port: 80

--- a/apps/slack-infra/resources/slack-post-message/service.yaml
+++ b/apps/slack-infra/resources/slack-post-message/service.yaml
@@ -2,10 +2,12 @@ kind: Service
 apiVersion: v1
 metadata:
   name: slack-post-message
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
 spec:
   selector:
     app: slack-post-message
-  type: NodePort
+  type: ClusterIP
   ports:
   - protocol: TCP
     port: 80

--- a/apps/slack-infra/resources/slack-welcomer/service.yaml
+++ b/apps/slack-infra/resources/slack-welcomer/service.yaml
@@ -2,10 +2,12 @@ kind: Service
 apiVersion: v1
 metadata:
   name: slack-welcomer
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
 spec:
   selector:
     app: slack-welcomer
-  type: NodePort
+  type: ClusterIP
   ports:
   - protocol: TCP
     port: 80

--- a/apps/slack-infra/resources/slackin/service.yaml
+++ b/apps/slack-infra/resources/slackin/service.yaml
@@ -2,10 +2,12 @@ kind: Service
 apiVersion: v1
 metadata:
   name: slackin2
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
 spec:
   selector:
     app: slackin2
-  type: NodePort
+  type: ClusterIP
   ports:
   - protocol: TCP
     port: 80

--- a/apps/triageparty-release/service.yaml
+++ b/apps/triageparty-release/service.yaml
@@ -5,8 +5,10 @@ metadata:
   namespace: triageparty-release
   labels:
     app: triage-party
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
     - port: 8080
       protocol: TCP


### PR DESCRIPTION
Ref: https://github.com/kubernetes/k8s.io/issues/2488.

Convert kubernetes services for world-accessible from NodePort to
ClusterIP.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>