### PR TITLE
terraform/kubernetes-public: shorten external-ips

### DIFF
--- a/infra/gcp/terraform/kubernetes-public/external-ips.tf
+++ b/infra/gcp/terraform/kubernetes-public/external-ips.tf
@@ -18,90 +18,54 @@ limitations under the License.
 This file defines all the external IP addresses in kubernetes-public
 */
 
-resource "google_compute_global_address" "k8s_io" {
-  project       = data.google_project.project.project_id
-  for_each = {
-    // used by gcsweb.k8s.io
+locals {
+  external_ips = {
     gcsweb = {
       name = "gcsweb-k8s-io",
-      description = null
-      address_type = "EXTERNAL",
-      ip_version = "IPV4"
     },
-    // used by canary.k8s.io
     canary = {
       name = "k8s-io-ingress-canary",
-      description = null
-      address_type = "EXTERNAL",
-      ip_version = "IPV4"
     },
-    // used by canary.k8s.io (IPv6)
     canary-v6 = {
       name = "k8s-io-ingress-canary-v6",
-      description = null
-      address_type = "EXTERNAL",
-      ip_version = "IPV6"
+      ipv6 = true
     },
-    // used by k8s-infra-prow.k8s.io
     infra-prow = {
       name = "k8s-infra-prow",
-      description = null
-      address_type = "EXTERNAL",
-      ip_version = "IPV4"
     },
-    // used by k8s-infra-prow.k8s.io (IPv6)
     infra-prow-v6 = {
       name = "k8s-infra-prow-v6",
-      description = null
-      address_type = "EXTERNAL",
-      ip_version = "IPV6"
+      ipv6 = true
     },
-    // used by k8s.io
     ingress-prod = {
       name = "k8s-io-ingress-prod",
-      description = null
-      address_type = "EXTERNAL",
-      ip_version = "IPV4"
     },
-    // used by k8s.io (IPv6)
     ingress-prod-v6 = {
       name = "k8s-io-ingress-prod-v6",
-      description = null
-      address_type = "EXTERNAL",
-      ip_version = "IPV6"
+      ipv6 = true
     },
-    // used by perf-dash.k8s.io
     perf-dash = {
       name = "perf-dash-k8s-io-ingress-prod",
-      description = null
-      address_type = "EXTERNAL",
-      ip_version = "IPV4"
     },
-    // used by sippy.k8s.io
     sippy = {
       name = "sippy-ingress-prod",
       description  = "IP for aaa cluster Ingress"
-      address_type = "EXTERNAL",
-      ip_version = "IPV4"
     },
-    // used by slack.k8s.io
     slack = {
       name = "slack-infra-ingress-prod",
-      description = null
-      address_type = "EXTERNAL",
-      ip_version = "IPV4"
     },
-    // used by release.triage.k8s.io
     triage-party-release = {
       name = "triage-party-release-ingress-prod",
       description  = "IP for aaa cluster Ingress"
-      address_type = "EXTERNAL",
-      ip_version = "IPV4"
     },
   }
+}
 
+resource "google_compute_global_address" "k8s_io" {
+  project       = data.google_project.project.project_id
+  for_each      = local.external_ips
   name          = each.value.name
-  description   = each.value.description
-  address_type  = each.value.address_type
-  ip_version    = each.value.ip_version
+  description   = lookup(each.value, "description", null)
+  address_type  = "EXTERNAL"
+  ip_version    = lookup(each.value, "ipv6", false) ? "IPV6" : "IPV4"
 }


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/2275
- Followup to: https://github.com/kubernetes/k8s.io/pull/2724

My ideal would be getting this to a set (or two, one per address type)
that matched the external ip names. Another alternative would be a
naming scheme that matched app names, like
`{app}-ingress-{canary,prod}{-v6}`

But getting there requires some destructive actions (terraform state mv,
recreating ips and then updating DNS) that I'm not willing to spend time
on at the moment.

I'm approaching this from the perspective of "could I allow people to
edit a YAML for self-service vs. forcing them to make terraform changes"

e.g. of what this would look like in yaml now:
```yaml
canary:
  name: k8s-io-ingress-canary
canary-v6:
  name: k8s-io-ingress-canary-v6
  ipv6: true
```