### PR TITLE
promote aws-ebs-csi-driver v1.3.0

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-provider-aws/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-provider-aws/images.yaml
@@ -30,6 +30,7 @@
     "sha256:c1d7f2d06901c145a734cb97b444063ab9344b79a1e379b327014ecece4bd6b9": ["v1.2.0-amazonlinux"]
     "sha256:732da7df530f4ad1923a7c71b927b0d964e596c622de68c1c6179fb7148704fd": ["v1.2.1"]
     "sha256:6dda9d13dfe77e4440097c0aee379c703185fad7c01c4b96909f6bc28ea2dfd4": ["v1.2.1-amazonlinux"]
+    "sha256:b39ea6bb1496aa57a50898d1c94c24abf7f0a02c4077aa2285ad24449734b804": ["v1.3.0"]
 - name: cloud-controller-manager
   dmap:
     "sha256:f900d8b4a358847cd311950c7802f938dad083f645eee784cd52b7aec0de8dfb": ["v1.18.0-alpha.0"]


### PR DESCRIPTION
➜  k8s.io git:(main) gcloud container images list-tags gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver --format='get(tags, digest)' --filter='tags:v1.3.0 AND tags!~rc'
v20210916-v1.3.0-windows-amd64-20H2	sha256:243126f73559877c0198f84a5f0d01d36ac3ee66bc9a5b90f8d38c076252ec23
v20210916-v1.3.0-windows-amd64-2004	sha256:03083388a6857d637dab51727d2f12d98315da4c9963eeb00a713bead68b68aa
v20210916-v1.3.0-windows-amd64-1809	sha256:2f4f3eb6190e8cb06cbde4ec2baab54ee9b0ab0fa8967b3ef31debecf0222aa3
v20210916-v1.3.0-linux-arm64-amazon	sha256:2af951c971c359d2e3c95eb95819bd1936fc7377f952e487021d4c6e2e70c6bc
v20210916-v1.3.0-linux-amd64-amazon	sha256:ebcbf282aa7a6c5a042c95b60dce1f6ad4f2f4c696cfd39049641f3bc20cde38
v20210916-v1.3.0	sha256:b39ea6bb1496aa57a50898d1c94c24abf7f0a02c4077aa2285ad24449734b804