### PR TITLE
releng: Update references to sigs.k8s.io/promo-tools

### DIFF
--- a/artifacts/README.md
+++ b/artifacts/README.md
@@ -117,10 +117,10 @@ To promote a set of artifacts, follow these steps:
       schedule (currently every 4 hours)
 7. Published artifacts will appear artifacts.k8s.io
 
-[generate-manifest]: https://sigs.k8s.io/k8s-container-image-promoter/cmd/kpromo#generating-a-file-promotion-manifest
+[generate-manifest]: https://sigs.k8s.io/promo-tools/cmd/kpromo#generating-a-file-promotion-manifest
 [google-groups]: /groups/README.md
 [infra.yaml]: /infra/gcp/infra.yaml
-[kpromo]: https://sigs.k8s.io/k8s-container-image-promoter/cmd/kpromo
+[kpromo]: https://sigs.k8s.io/promo-tools/cmd/kpromo
 [periodic]: https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/ci-k8sio-file-promo
 [postsubmit]: https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/post-k8sio-file-promo
 [presubmit]: https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-k8sio-file-promo

--- a/infra/gcp/bash/backup_tools/backup_test.sh
+++ b/infra/gcp/bash/backup_tools/backup_test.sh
@@ -30,12 +30,14 @@ set -o xtrace
 export GCRANE_CHECKOUT_DIR="${GOPATH}/src/github.com/google/go-containerregistry"
 GCRANE="${GCRANE_CHECKOUT_DIR}/cmd/gcrane/gcrane"
 
-export CIP_CHECKOUT_DIR="${GOPATH}/src/sigs.k8s.io/k8s-container-image-promoter"
-CIP_SNAPSHOT_CMD="${CIP_CHECKOUT_DIR}/cip -minimal-snapshot -output-format=CSV -snapshot"
-# CIP_REF is the commit SHA to use for building the cip binary (used only for
+export PROMO_TOOLS_CHECKOUT_DIR="${GOPATH}/src/sigs.k8s.io/promo-tools"
+SNAPSHOT_CMD="${PROMO_TOOLS_CHECKOUT_DIR}/cip -minimal-snapshot -output-format=CSV -snapshot"
+# PROMO_TOOLS_REF is the commit SHA to use for building the cip binary (used only for
 # testing; not used by the actual prod backup job).
+#
+# TODO(releng): Update me
 # Known-good commit from 2020-04-01
-CIP_REF="feb5dc08b2cbfa2c779c4c5d397dad40e669bc84"
+PROMO_TOOLS_REF="feb5dc08b2cbfa2c779c4c5d397dad40e669bc84"
 
 SCRIPT_ROOT="$(dirname "$(readlink -f "$0")")"
 # shellcheck disable=SC1090
@@ -47,9 +49,9 @@ build_cip()
 {
     local cip_path
 
-    git clone https://github.com/kubernetes-sigs/k8s-container-image-promoter "${CIP_CHECKOUT_DIR}"
-    pushd "${CIP_CHECKOUT_DIR}"
-    git reset --hard "${CIP_REF}"
+    git clone https://github.com/kubernetes-sigs/promo-tools "${PROMO_TOOLS_CHECKOUT_DIR}"
+    pushd "${PROMO_TOOLS_CHECKOUT_DIR}"
+    git reset --hard "${PROMO_TOOLS_REF}"
     make
     # Leave a symlink to the cip binary that was built from the above command.
     cip_path=$(find "$(bazel info bazel-bin)" -type f -name cip)
@@ -107,7 +109,7 @@ verify_repo()
 
     diff -u \
         <(cat "${TEST_IMAGES_FILE}") \
-        <(${CIP_SNAPSHOT_CMD} "${repo}")
+        <(${SNAPSHOT_CMD} "${repo}")
 }
 
 # Backup GCRs for prod.

--- a/infra/gcp/bash/lib.sh
+++ b/infra/gcp/bash/lib.sh
@@ -250,8 +250,8 @@ function empower_group_as_viewer() {
     ensure_project_role_binding "${project}" "group:${group}" "roles/viewer"
 }
 
-# Grant roles for running cip-auditor E2E test
-# (https://github.com/kubernetes-sigs/k8s-container-image-promoter/tree/master/test-e2e#cip-auditor-cip-auditor-e2ego).
+# Grant roles for running cip-auditor E2E tests
+# (https://sigs.k8s.io/promo-tools/test-e2e)
 
 # $1: The GCP project
 # $2: The service account
@@ -407,8 +407,6 @@ function empower_file_promoter() {
 
     ensure_service_account "${project}" "${FILE_PROMOTER_SVCACCT}" "artifact promoter"
 
-    # TODO(kpromo): Determine if admin access is required here.
-    #               ref: https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/413
     empower_svcacct_to_write_gcs_bucket "${acct}" "${bucket}"
 }
 

--- a/k8s.gcr.io/Vanity-Domain-Flip.md
+++ b/k8s.gcr.io/Vanity-Domain-Flip.md
@@ -245,17 +245,17 @@ auditor service. Its members are listed [here](../groups/groups.yaml).
 - GCR: Google Container Registry
 - GCS: Google Cloud Storage
 
-[CIP]:https://github.com/kubernetes-sigs/k8s-container-image-promoter
-[internal-promoter]:http://go/registry-promoter
-[k8sio]:https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io
-[k8sio-manifests]:https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io/manifests
-[k8sio-backup]:https://github.com/kubernetes/k8s.io/tree/main/infra/gcp/backup_tools
-[staging-subproject]:https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io#staging-repos
-[prow]:https://github.com/kubernetes/test-infra/tree/master/prow
-[golangci-lint]:https://github.com/golangci/golangci-lint
-[groups]:https://github.com/kubernetes/k8s.io/blob/main/groups/groups.yaml
-[CIP-e2e]:https://github.com/kubernetes-sigs/k8s-container-image-promoter/tree/master/test-e2e
-[CIP-e2e-promotion]:https://github.com/kubernetes-sigs/k8s-container-image-promoter/tree/master/test-e2e/cip
-[CIP-e2e-auditor]:https://github.com/kubernetes-sigs/k8s-container-image-promoter/tree/master/test-e2e/cip-auditor
-[CIP-auditor-code]:https://github.com/kubernetes-sigs/k8s-container-image-promoter/blob/master/lib/audit/auditor.go
-[ci-k8sio-backup-code]:https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+[CIP]: https://sigs.k8s.io/promo-tools
+[internal-promoter]: http://go/registry-promoter
+[k8sio]: https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io
+[k8sio-manifests]: https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io/manifests
+[k8sio-backup]: https://github.com/kubernetes/k8s.io/tree/main/infra/gcp/backup_tools
+[staging-subproject]: https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io#staging-repos
+[prow]: https://github.com/kubernetes/test-infra/tree/master/prow
+[golangci-lint]: https://github.com/golangci/golangci-lint
+[groups]: https://github.com/kubernetes/k8s.io/blob/main/groups/groups.yaml
+[CIP-e2e]: https://sigs.k8s.io/promo-tools/test-e2e
+[CIP-e2e-promotion]: https://sigs.k8s.io/promo-tools/test-e2e/cip
+[CIP-e2e-auditor]: https://sigs.k8s.io/promo-tools/test-e2e/cip-auditor
+[CIP-auditor-code]: https://sigs.k8s.io/promo-tools/lib/audit/auditor.go
+[ci-k8sio-backup-code]: https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml

--- a/k8s.gcr.io/archived/images/DO-NOT-MODIFY-legacy-backfill/README.md
+++ b/k8s.gcr.io/archived/images/DO-NOT-MODIFY-legacy-backfill/README.md
@@ -7,7 +7,7 @@ Flip][VDF].
 
 **As such, these images are effectively FROZEN. New changes to them WILL BE
 REJECTED, and any new promotions MUST happen through individual sub-project
-staging repos, as detailed in the policy [here][official-policy].**
+staging repos, as detailed [here][staging-repos].**
 
-[VDF]: https://github.com/kubernetes/k8s.io/blob/main/k8s.gcr.io/Vanity-Domain-Flip.md
-[official-policy]: https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io#creating-staging-repos
+[staging-repos]: /k8s.gcr.io/README.md#staging-repos
+[VDF]: /k8s.gcr.io/Vanity-Domain-Flip.md

--- a/k8s.gcr.io/archived/images/DO-NOT-MODIFY-legacy-backfill/images.yaml
+++ b/k8s.gcr.io/archived/images/DO-NOT-MODIFY-legacy-backfill/images.yaml
@@ -7,11 +7,8 @@
 # It was generated automatically by running "cip-mm". To
 # reproduce, run:
 #
-# $ cd
-# $ git clone https://github.com/kubernetes-sigs/k8s-container-image-promoter go/src/sigs.k8s.io/k8s-container-image-promoter
-# $ cd go/src/sigs.k8s.io/k8s-container-image-promoter
-# $ make install
-# $ cip-mm -base_dir PATH/TO/k8s.gcr.io -staging_repo gcr.io/google-containers
+# $ go install sigs.k8s.io/promo-tools/cmd/cip-mm
+# $ $(go env GOPATH)/bin/cip-mm --base_dir k8s.gcr.io/archived --staging_repo gcr.io/google-containers
 
 - name: addon-builder
   dmap:


### PR DESCRIPTION
- releng: Update references to sigs.k8s.io/promo-tools (ref: https://github.com/kubernetes-sigs/promo-tools/issues/424)
- k8s.gcr.io/Vanity-Domain-Flip.md: Cleanup links

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @puerco @cpanato @ameukam @Verolop 
cc: @kubernetes/release-engineering 
