### PR TITLE
triage-party/relase: update ExternalSecret

### DIFF
--- a/apps/triageparty-release/secret.yaml
+++ b/apps/triageparty-release/secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
-  name: github-token
+  name: triage-party-github-token
   namespace: triageparty-release
   labels:
     app: triage-party
@@ -10,5 +10,5 @@ spec:
   projectId: kubernetes-public
   data:
   - key: triage-party-github-token
-    name: triage-party-github-token
+    name: token
     version: latest


### PR DESCRIPTION
Update the kubernetes ExternalSecret to pull Github token from GCP Secret
manager.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>