### PR TITLE
kubernetes-public: Create private service access

### DIFF
--- a/infra/gcp/bash/ensure-main-project.sh
+++ b/infra/gcp/bash/ensure-main-project.sh
@@ -107,6 +107,8 @@ readonly MAIN_PROJECT_SERVICES=(
     monitoring.googleapis.com
     # We host secrets in this project for use by prow and other apps
     secretmanager.googleapis.com
+    # We create internal IP addresses for GCP managed services
+    servicenetworking.googleapis.com
     # We store elections results in Cloud SQL databases
     sql-component.googleapis.com
     # We host public-facing and private GCS buckets in this project

--- a/infra/gcp/terraform/kubernetes-public/variables.tf
+++ b/infra/gcp/terraform/kubernetes-public/variables.tf
@@ -101,7 +101,7 @@ variable "cloudsql_tier" {
 
 variable "cloudsql_disk_size_gb" {
   type    = number
-  default = 5
+  default = 10
 
   description = "Size of the Cloud SQL disk, in GB."
 }


### PR DESCRIPTION
Ref: https://github.com/kubernetes/k8s.io/issues/2575
Followup of : https://github.com/kubernetes/k8s.io/pull/2587

Cloud SQL instance with internal IP needs private service access. This a
private connection between in the VPC network used and the Cloud SQL's
VPC network.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>