### PR TITLE
OWNERS: mv wg-k8s-infra sig-k8s-infra

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -48,6 +48,11 @@ aliases:
     - dashpole
     - ehashman
     - logicalhan
+  sig-k8s-infra-leads:
+    - ameukam
+    - dims
+    - spiffxp
+    - thockin
   sig-multicluster-leads:
     - jeremyot
     - pmorie
@@ -111,10 +116,6 @@ aliases:
     - cantbewong
     - cindyxing
     - dejanb
-  wg-k8s-infra-leads:
-    - ameukam
-    - dims
-    - spiffxp
   wg-lts-leads:
     - imkin
     - quinton-hoole

--- a/apps/kubernetes-external-secrets/OWNERS
+++ b/apps/kubernetes-external-secrets/OWNERS
@@ -5,7 +5,7 @@ approvers:
 - spiffxp
 
 reviewers:
-- wg-k8s-infra-leads
+- sig-k8s-infra-leads
 
 labels:
 - wg/k8s-infra

--- a/artifacts/OWNERS
+++ b/artifacts/OWNERS
@@ -12,7 +12,7 @@ options:
 approvers:
   - promo-tools-approvers
   - release-engineering-approvers
-  - wg-k8s-infra-leads
+  - sig-k8s-infra-leads
 reviewers:
   - promo-tools-reviewers
   - release-engineering-reviewers

--- a/groups/wg-k8s-infra/OWNERS
+++ b/groups/wg-k8s-infra/OWNERS
@@ -1,9 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- wg-k8s-infra-leads
+- sig-k8s-infra-leads
 reviewers:
-- wg-k8s-infra-leads
+- sig-k8s-infra-leads
 
 labels:
 - wg/k8s-infra

--- a/infra/gcp/bash/backup_tools/OWNERS
+++ b/infra/gcp/bash/backup_tools/OWNERS
@@ -3,7 +3,7 @@
 approvers:
 - promo-tools-approvers
 - release-engineering-approvers
-- wg-k8s-infra-leads
+- sig-k8s-infra-leads
 reviewers:
 - promo-tools-reviewers
 - release-engineering-reviewers

--- a/infra/gcp/bash/cip-auditor/OWNERS
+++ b/infra/gcp/bash/cip-auditor/OWNERS
@@ -3,7 +3,7 @@
 approvers:
 - promo-tools-approvers
 - release-engineering-approvers
-- wg-k8s-infra-leads
+- sig-k8s-infra-leads
 reviewers:
 - promo-tools-reviewers
 - release-engineering-reviewers

--- a/k8s.gcr.io/images/k8s-staging-ci-images/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-ci-images/OWNERS
@@ -5,7 +5,7 @@ options:
 approvers:
   - release-engineering-approvers
   - sig-testing-leads
-  - wg-k8s-infra-leads
+  - sig-k8s-infra-leads
 reviewers:
   - release-engineering-reviewers
 

--- a/k8s.gcr.io/images/k8s-staging-infra-tools/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-infra-tools/OWNERS
@@ -2,11 +2,11 @@
 
 approvers:
   - munnerz
-  - wg-k8s-infra-leads
+  - sig-k8s-infra-leads
 
 reviewers:
   - munnerz
-  - wg-k8s-infra-leads
+  - sig-k8s-infra-leads
 
 emeritus-approvers:
   - bartsmykla

--- a/k8s.gcr.io/images/k8s-staging-mirror/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-mirror/OWNERS
@@ -6,7 +6,7 @@ approvers:
   - sig-release-leads
   - sig-testing-leads
   - release-engineering-approvers
-  - wg-k8s-infra-leads
+  - sig-k8s-infra-leads
   - build-admins
 reviewers:
   - release-engineering-reviewers


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/community/issues/6036

Excluded everything a blanket search-replace caught, don't yet want to rename mailing lists or github teams

Labels used in owners files will be renamed in a followup PR once sig/k8s-infra has rolled out