### PR TITLE
aaa: Add namespace for Elekto

### DIFF
--- a/apps/elekto/OWNERS
+++ b/apps/elekto/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - alisondy # Election Officer
+  - ameukam # sig-k8s-infra Liaison
+  - jberkus # Election Officer
+  - coderanger # Election Officer
+
+labels:
+- sig/contributor-experience

--- a/apps/elekto/README.md
+++ b/apps/elekto/README.md
@@ -1,0 +1,3 @@
+# elekto
+
+[elekto](https://elekto.dev/) is a voting platform used to run elections for the Kubernetes community.

--- a/groups/committee-steering/groups.yaml
+++ b/groups/committee-steering/groups.yaml
@@ -52,6 +52,6 @@ groups:
       MembersCanPostAsTheGroup: "true"
       ReconcileMembers: "true"
     owners:
-      - ihor@cncf.io
+      - alison@alisondowdney.com
       - josh@berkus.org
-      - jdumars@gmail.com
+      - noah@coderanger.net

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -86,6 +86,7 @@ restrictions:
       - "^lwkd@kubernetes.io$"
       - "^moderators@kubernetes.io$"
       - "^stream-team@kubernetes.io$"
+      - "^k8s-infra-rbac-elekto@kubernetes.io$"
       - "^k8s-infra-rbac-slack-infra@kubernetes.io$"
       - "^k8s-infra-staging-slack-infra@kubernetes.io$"
   - path: "sig-docs/groups.yaml"

--- a/groups/sig-contributor-experience/groups.yaml
+++ b/groups/sig-contributor-experience/groups.yaml
@@ -158,6 +158,16 @@ groups:
   # - must have WhoCanViewMemberShip: "ALL_MEMBERS_CAN_VIEW"
   # - must be members of gke-security-groups@kubernetes.io
 
+  - email-id: k8s-infra-rbac-elekto@kubernetes.io
+    name: k8s-infra-rbac-elekto
+    description: |-
+      Grants access to the `namespace-user` role in the `elekto` namespace on the `aaa` cluster
+    settings:
+      ReconcileMembers: "true"
+      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # required
+    members:
+      - election@kubernetes.io
+
   - email-id: k8s-infra-rbac-slack-infra@kubernetes.io
     name: k8s-infra-rbac-slack-infra
     description: |-

--- a/groups/wg-k8s-infra/groups.yaml
+++ b/groups/wg-k8s-infra/groups.yaml
@@ -102,6 +102,7 @@ groups:
       WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # needed for RBAC
     members:
       - k8s-infra-rbac-cert-manager@kubernetes.io
+      - k8s-infra-rbac-elekto@kubernetes.io
       - k8s-infra-rbac-gcsweb@kubernetes.io
       - k8s-infra-rbac-kettle@kubernetes.io
       - k8s-infra-rbac-k8s-io-canary@kubernetes.io

--- a/infra/gcp/bash/namespaces/ensure-namespaces.sh
+++ b/infra/gcp/bash/namespaces/ensure-namespaces.sh
@@ -143,6 +143,7 @@ parse_args "$@";
 #
 
 ALL_APPS=(
+    elekto
     gcsweb
     kettle
     k8s-io-prod


### PR DESCRIPTION
Ref: https://github.com/kubernetes/k8s.io/issues/2575.

Create a kubernetes namespace for Elekto in GKE cluster `aaa`.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>