### PR TITLE
Aggregate errors rather than exiting reconcile loop per error

### DIFF
--- a/groups/reconcile.go
+++ b/groups/reconcile.go
@@ -227,37 +227,31 @@ func (r *Reconciler) ReconcileGroups(groups []GoogleGroup) error {
 	for _, g := range groups {
 		if g.EmailId == "" {
 			errs = append(errs, fmt.Errorf("group has no email-id: %#v", g))
-			continue
 		}
 
 		err := r.AdminSvc.CreateOrUpdateGroupIfNescessary(g)
 		if err != nil {
 			errs = append(errs, err)
-			continue
 		}
 
 		err = r.GroupSvc.UpdateGroupSettings(g)
 		if err != nil {
 			errs = append(errs, err)
-			continue
 		}
 
 		err = r.AdminSvc.AddOrUpdateGroupMembers(g, OwnerRole, g.Owners)
 		if err != nil {
 			errs = append(errs, err)
-			continue
 		}
 
 		err = r.AdminSvc.AddOrUpdateGroupMembers(g, ManagerRole, g.Managers)
 		if err != nil {
 			errs = append(errs, err)
-			continue
 		}
 
 		err = r.AdminSvc.AddOrUpdateGroupMembers(g, MemberRole, g.Members)
 		if err != nil {
 			errs = append(errs, err)
-			continue
 		}
 
 		if g.Settings["ReconcileMembers"] == "true" {

--- a/groups/reconcile.go
+++ b/groups/reconcile.go
@@ -290,7 +290,7 @@ func (r *Reconciler) printGroupMembersAndSettings() error {
 
 	g, err := asClient.ListGroups()
 	if err != nil {
-		return fmt.Errorf("unable to retrieve users in domain: %v", err)
+		return fmt.Errorf("unable to retrieve users in domain: %w", err)
 	}
 
 	if len(g.Groups) == 0 {
@@ -307,7 +307,7 @@ func (r *Reconciler) printGroupMembersAndSettings() error {
 		}
 		g2, err := gsClient.Get(g.Email)
 		if err != nil {
-			return fmt.Errorf("unable to retrieve group info for group %s: %v", g.Email, err)
+			return fmt.Errorf("unable to retrieve group info for group %s: %w", g.Email, err)
 		}
 		group.Settings = make(map[string]string)
 		group.Settings["AllowExternalMembers"] = g2.AllowExternalMembers
@@ -324,7 +324,7 @@ func (r *Reconciler) printGroupMembersAndSettings() error {
 
 		l, err := asClient.ListMembers(g.Email)
 		if err != nil {
-			return fmt.Errorf("unable to retrieve members in group : %v", err)
+			return fmt.Errorf("unable to retrieve members in group : %w", err)
 		}
 
 		if len(l.Members) == 0 {
@@ -353,7 +353,7 @@ func (r *Reconciler) printGroupMembersAndSettings() error {
 	cm := genyaml.NewCommentMap("reconcile.go")
 	yamlSnippet, err := cm.GenYaml(groupsConfig)
 	if err != nil {
-		return fmt.Errorf("unable to generate yaml for groups : %v", err)
+		return fmt.Errorf("unable to generate yaml for groups : %w", err)
 	}
 
 	fmt.Println(yamlSnippet)
@@ -364,10 +364,10 @@ func (c *Config) Load(configFilePath string, confirmChanges bool) error {
 	log.Printf("reading config file: %s", configFilePath)
 	content, err := ioutil.ReadFile(configFilePath)
 	if err != nil {
-		return fmt.Errorf("error reading config file %s: %v", configFilePath, err)
+		return fmt.Errorf("error reading config file %s: %w", configFilePath, err)
 	}
 	if err = yaml.Unmarshal(content, &c); err != nil {
-		return fmt.Errorf("error parsing config file %s: %v", configFilePath, err)
+		return fmt.Errorf("error parsing config file %s: %w", configFilePath, err)
 	}
 
 	if c.GroupsPath == "" {
@@ -394,10 +394,10 @@ func (rc *RestrictionsConfig) Load(path string) error {
 	log.Printf("reading restrictions config file: %s", path)
 	content, err := ioutil.ReadFile(path)
 	if err != nil {
-		return fmt.Errorf("error reading restrictions config file %s: %v", path, err)
+		return fmt.Errorf("error reading restrictions config file %s: %w", path, err)
 	}
 	if err = yaml.Unmarshal(content, &rc); err != nil {
-		return fmt.Errorf("error parsing restrictions config file %s: %v", path, err)
+		return fmt.Errorf("error parsing restrictions config file %s: %w", path, err)
 	}
 
 	ret := make([]Restriction, 0, len(rc.Restrictions))
@@ -406,7 +406,7 @@ func (rc *RestrictionsConfig) Load(path string) error {
 		for _, g := range r.AllowedGroups {
 			re, err := regexp.Compile(g)
 			if err != nil {
-				return fmt.Errorf("error parsing group pattern %q for path %q: %v", g, r.Path, err)
+				return fmt.Errorf("error parsing group pattern %q for path %q: %w", g, r.Path, err)
 			}
 			r.AllowedGroupsRe = append(r.AllowedGroupsRe, re)
 		}
@@ -436,16 +436,16 @@ func (gc *GroupsConfig) Load(rootDir string, restrictions *RestrictionsConfig) e
 			)
 
 			if content, err = ioutil.ReadFile(path); err != nil {
-				return fmt.Errorf("error reading groups config file %s: %v", path, err)
+				return fmt.Errorf("error reading groups config file %s: %w", path, err)
 			}
 			if err = yaml.Unmarshal(content, &groupsConfigAtPath); err != nil {
-				return fmt.Errorf("error parsing groups config at %s: %v", path, err)
+				return fmt.Errorf("error parsing groups config at %s: %w", path, err)
 			}
 
 			r := restrictions.GetRestrictionForPath(path, rootDir)
 			mergedGroups, err := mergeGroups(gc.Groups, groupsConfigAtPath.Groups, r)
 			if err != nil {
-				return fmt.Errorf("couldn't merge groups: %v", err)
+				return fmt.Errorf("couldn't merge groups: %w", err)
 			}
 			gc.Groups = mergedGroups
 		}
@@ -500,7 +500,7 @@ func accessSecretVersion(secretVersion string) ([]byte, error) {
 	ctx := context.Background()
 	client, err := secretmanager.NewClient(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create secretmanager client: %v", err)
+		return nil, fmt.Errorf("failed to create secretmanager client: %w", err)
 	}
 
 	req := &secretmanagerpb.AccessSecretVersionRequest{
@@ -509,7 +509,7 @@ func accessSecretVersion(secretVersion string) ([]byte, error) {
 
 	result, err := client.AccessSecretVersion(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to access secret version: %v", err)
+		return nil, fmt.Errorf("failed to access secret version: %w", err)
 	}
 
 	return result.Payload.Data, nil

--- a/groups/service.go
+++ b/groups/service.go
@@ -91,7 +91,7 @@ func (as *adminService) AddOrUpdateGroupMembers(group GoogleGroup, role string, 
 			log.Printf("skipping adding members to group %q as it has not yet been created\n", group.EmailId)
 			return nil
 		}
-		return fmt.Errorf("unable to retrieve members in group %q: %v", group.EmailId, err)
+		return fmt.Errorf("unable to retrieve members in group %q: %w", group.EmailId, err)
 	}
 
 	// aggregate the errors that occured and return them together in the end.
@@ -112,7 +112,7 @@ func (as *adminService) AddOrUpdateGroupMembers(group GoogleGroup, role string, 
 				if config.ConfirmChanges {
 					_, err := as.client.UpdateMember(group.EmailId, member.Email, member)
 					if err != nil {
-						errs = append(errs, fmt.Errorf("unable to update %s in %q as %s : %v", memberEmailId, group.EmailId, role, err))
+						errs = append(errs, fmt.Errorf("unable to update %s in %q as %s : %w", memberEmailId, group.EmailId, role, err))
 						continue
 					}
 					log.Printf("Updated %s to %q as a %s\n", memberEmailId, group.EmailId, role)
@@ -131,7 +131,7 @@ func (as *adminService) AddOrUpdateGroupMembers(group GoogleGroup, role string, 
 		if config.ConfirmChanges {
 			_, err := as.client.InsertMember(group.EmailId, member)
 			if err != nil {
-				errs = append(errs, fmt.Errorf("unable to add %s to %q as %s : %v", memberEmailId, group.EmailId, role, err))
+				errs = append(errs, fmt.Errorf("unable to add %s to %q as %s : %w", memberEmailId, group.EmailId, role, err))
 				continue
 			}
 			log.Printf("Added %s to %q as a %s\n", memberEmailId, group.EmailId, role)
@@ -169,12 +169,12 @@ func (as *adminService) CreateOrUpdateGroupIfNescessary(group GoogleGroup) error
 				}
 				g4, err := as.client.InsertGroup(&g)
 				if err != nil {
-					return fmt.Errorf("unable to add new group %q: %v", group.EmailId, err)
+					return fmt.Errorf("unable to add new group %q: %w", group.EmailId, err)
 				}
 				log.Printf("> Successfully created group %s\n", g4.Email)
 			}
 		} else {
-			return fmt.Errorf("unable to fetch group %q: %#v", group.EmailId, err.Error())
+			return fmt.Errorf("unable to fetch group %q: %w", group.EmailId, err)
 		}
 	} else {
 		if group.Name != "" && grp.Name != group.Name ||
@@ -194,7 +194,7 @@ func (as *adminService) CreateOrUpdateGroupIfNescessary(group GoogleGroup) error
 				}
 				g4, err := as.client.UpdateGroup(group.EmailId, &g)
 				if err != nil {
-					return fmt.Errorf("unable to update group %q: %v", group.EmailId, err)
+					return fmt.Errorf("unable to update group %q: %w", group.EmailId, err)
 				}
 				log.Printf("> Successfully updated group %s\n", g4.Email)
 			}
@@ -209,7 +209,7 @@ func (as *adminService) CreateOrUpdateGroupIfNescessary(group GoogleGroup) error
 func (as *adminService) DeleteGroupsIfNecessary() error {
 	g, err := as.client.ListGroups()
 	if err != nil {
-		return fmt.Errorf("unable to retrieve users in domain: %v", err)
+		return fmt.Errorf("unable to retrieve users in domain: %w", err)
 	}
 
 	// aggregate the errors that occured and return them together in the end.
@@ -233,7 +233,7 @@ func (as *adminService) DeleteGroupsIfNecessary() error {
 			}
 			err := as.client.DeleteGroup(g.Email)
 			if err != nil {
-				errs = append(errs, fmt.Errorf("unable to remove group %s : %v", g.Email, err))
+				errs = append(errs, fmt.Errorf("unable to remove group %s : %w", g.Email, err))
 				continue
 			}
 			log.Printf("Removing group %s\n", g.Email)
@@ -259,7 +259,7 @@ func (as *adminService) RemoveOwnerOrManagersFromGroup(group GoogleGroup, member
 			log.Printf("skipping removing members group %q as group has not yet been created\n", group.EmailId)
 			return nil
 		}
-		return fmt.Errorf("unable to retrieve members in group %q: %v", group.EmailId, err)
+		return fmt.Errorf("unable to retrieve members in group %q: %w", group.EmailId, err)
 	}
 
 	// aggregate the errors that occured and return them together in the end.
@@ -284,7 +284,7 @@ func (as *adminService) RemoveOwnerOrManagersFromGroup(group GoogleGroup, member
 		if config.ConfirmChanges {
 			err := as.client.DeleteMember(group.EmailId, m.Id)
 			if err != nil {
-				errs = append(errs, fmt.Errorf("unable to remove %s from %q as OWNER or MANAGER : %v", m.Email, group.EmailId, err))
+				errs = append(errs, fmt.Errorf("unable to remove %s from %q as OWNER or MANAGER : %w", m.Email, group.EmailId, err))
 				continue
 			}
 			log.Printf("Removing %s from %q as OWNER or MANAGER\n", m.Email, group.EmailId)
@@ -310,7 +310,7 @@ func (as *adminService) RemoveMembersFromGroup(group GoogleGroup, members []stri
 			log.Printf("skipping removing members group %q as group has not yet been created\n", group.EmailId)
 			return nil
 		}
-		return fmt.Errorf("unable to retrieve members in group %q: %v", group.EmailId, err)
+		return fmt.Errorf("unable to retrieve members in group %q: %w", group.EmailId, err)
 	}
 
 	// aggregate the errors that occured and return them together in the end.
@@ -331,7 +331,7 @@ func (as *adminService) RemoveMembersFromGroup(group GoogleGroup, members []stri
 		if config.ConfirmChanges {
 			err := as.client.DeleteMember(group.EmailId, m.Id)
 			if err != nil {
-				errs = append(errs, fmt.Errorf("unable to remove %s from %q as a %s : %v", m.Email, group.EmailId, m.Role, err))
+				errs = append(errs, fmt.Errorf("unable to remove %s from %q as a %s : %w", m.Email, group.EmailId, m.Role, err))
 				continue
 			}
 			log.Printf("Removing %s from %q as a %s\n", m.Email, group.EmailId, m.Role)
@@ -366,7 +366,7 @@ func (gs *groupService) UpdateGroupSettings(group GoogleGroup) error {
 			log.Printf("skipping updating group settings as group %q has not yet been created\n", group.EmailId)
 			return nil
 		}
-		return fmt.Errorf("unable to retrieve group info for group %q: %v", group.EmailId, err)
+		return fmt.Errorf("unable to retrieve group info for group %q: %w", group.EmailId, err)
 	}
 
 	var (
@@ -420,7 +420,7 @@ func (gs *groupService) UpdateGroupSettings(group GoogleGroup) error {
 		if config.ConfirmChanges {
 			_, err := gs.client.Patch(group.EmailId, &wantSettings)
 			if err != nil {
-				return fmt.Errorf("unable to update group info for group %q: %v", group.EmailId, err)
+				return fmt.Errorf("unable to update group info for group %q: %w", group.EmailId, err)
 			}
 			log.Printf("> Successfully updated group settings for %q to allow external members and other security settings\n", group.EmailId)
 		} else {


### PR DESCRIPTION
Following up on https://github.com/kubernetes/k8s.io/pull/2713

Instead of returning a slice of errors, the aggregation utils defined by apimachienry utils is used mainly in accordance with how peribolos does it

As a slightly related fix - change format specifiers of error types in `fmt.Errorf()` from `%v` to `%w`

Fixes #2772 

/priority important-soon
/assign @spiffxp 