### PR TITLE
Add cli.triage dns

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -190,10 +190,14 @@ pr:
 pr-test:
   type: CNAME
   value: redirect.k8s.io.
-#sig-release
+# sig-release
 release.triage:
   type: A
   value: 35.186.239.70
+# sig-cli
+cli.triage:
+  type: A
+  value: 34.117.106.163
 # Running in a GKE cluster somewhere (@ixdy).
 prow:
   type: A


### PR DESCRIPTION
This PR adds a DNS record for cli.triage.k8s.io.

Closes https://github.com/kubernetes/k8s.io/issues/2621

/assign @ameukam
/sig cli
/sig k8s-infra