### PR TITLE
Use test prow-controller-manager for k8s-infra-prow debugging

### DIFF
--- a/apps/prow/cluster/prow_controller_manager_deployment.yaml
+++ b/apps/prow/cluster/prow_controller_manager_deployment.yaml
@@ -34,7 +34,8 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20210902-01e03305a2
+        # image: gcr.io/k8s-prow/prow-controller-manager:v20210902-01e03305a2
+        image: public.ecr.aws/ezaneski/prow-controller-manager:v20210923-fef59c14ed-dirty
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false


### PR DESCRIPTION
ref: https://kubernetes.slack.com/archives/CCK68P2Q2/p1632350923083000

This PR swaps out the k8s-infra-prow prow-controller-manager image for one built from [this commit](https://github.com/eddiezane/test-infra/commit/6fa637e31e5e22bb3d0419e0b9ba4181d5db9b01) which adds extra debug logging.

Not sure if we want to manually edit this image on the cluster or merge this and revert after.

/assign @spiffxp @ameukam 