### PR TITLE
Remove extra label from k8s-infra-prow tide

### DIFF
--- a/apps/prow/config.yaml
+++ b/apps/prow/config.yaml
@@ -58,7 +58,6 @@ tide:
     labels:
     - lgtm
     - approved
-    - a-label-that-does-not-exist
     missingLabels:
     - do-not-merge/hold
     - do-not-merge/work-in-progress


### PR DESCRIPTION
I noticed an extra label at the bottom of the GitHub PR checks for Tide. I am assuming this was accidentally added.

This PR removes that label.