### PR TITLE
give kustomize admins key management permission

### DIFF
--- a/infra/gcp/bash/ensure-staging-storage.sh
+++ b/infra/gcp/bash/ensure-staging-storage.sh
@@ -401,6 +401,22 @@ function staging_special_case__k8s_staging_cluster_api_gcp() {
     ensure_staging_gcb_builder_service_account "cluster-api-gcp" "k8s-infra-prow-build-trusted"
 }
 
+# In order to build the release artifacts, the group needs to be
+# able to create and manage a keyring to encrypt a secret token
+# that will be accessed and decrypted by a cloud build job.
+function staging_special_case__k8s_staging_kustomize() {
+    readonly STAGING_PROJECT="k8s-staging-kustomize"
+
+    local sa_email_group="k8s-infra-staging-kustomize@kubernetes.io"
+    local principal_group="serviceAccount:${sa_email_group}"
+    ensure_project_role_binding "${STAGING_PROJECT}" "${principal_group}" "roles/cloudkms.admin"
+
+    local sa_email_cloudbuild="660796270509@cloudbuild.gserviceaccount.com"
+    local principal_cloudbuild="serviceAccount:${sa_email_cloudbuild}"
+    ensure_project_role_binding "${STAGING_PROJECT}" "${principal_cloudbuild}" "roles/cloudkms.cryptoKeyDecrypter"
+    ensure_project_role_binding "${STAGING_PROJECT}" "${principal_cloudbuild}" "roles/secretmanager.secretAccessor"
+}
+
 #
 # main
 #


### PR DESCRIPTION
We are trying to run a cloud build job in the k8s-staging-kustomize project. This PR is intended to:

1. Give the members listed here:

https://github.com/kubernetes/k8s.io/blob/7f720723206888b4bfb01036d5028f9852940b8f/groups/sig-cli/groups.yaml#L22-L34

permission to create and manage a keyring by giving it the role `Cloud KMS Admin`.

2. Give the cloud build project associated with k8s-staging-kustomize the roles `Cloud KMS CryptoKey Decrypter` and `Secret Manager Secret Accessor` so that it can read and decrypt the secret stored in our cloudbuild.yaml file. 

It would be helpful if the reviewer could confirm that this PR gives the correct service accounts and people the roles that I intend (since I am new here). 

I also noticed that there is a file here https://github.com/kubernetes/k8s.io/blob/main/audit/projects/k8s-staging-kustomize/iam.json which describes the IAM roles for each service account. Do I need to update that file as well? If so, is there an automated script I can run to do so?

Thank you in advance.

/cc @monopole @KnVerey @spiffxp 