### PR TITLE
Revert "Remove extra label from k8s-infra-prow"

### DIFF
--- a/apps/prow/config.yaml
+++ b/apps/prow/config.yaml
@@ -58,6 +58,7 @@ tide:
     labels:
     - lgtm
     - approved
+    - a-label-that-does-not-exist
     missingLabels:
     - do-not-merge/hold
     - do-not-merge/work-in-progress


### PR DESCRIPTION
Revert
https://github.com/kubernetes/k8s.io/commit/dd1509e8d8f46cbfadf78e7233f16624bf83d8c4.

This prevent k8s-infra-ci-robot to merge PRs and conflict with
k8s-ci-robot.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>