### PR TITLE
apps/elekto: SSL certificate for elections.k8s.io

### DIFF
--- a/apps/elekto/certificate.yaml
+++ b/apps/elekto/certificate.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: elections-k8s-io
+  namespace: elekto
+  labels:
+    app: elekto
+spec:
+  domains:
+    - elections.k8s.io

--- a/apps/elekto/ingress.yaml
+++ b/apps/elekto/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: gce
     kubernetes.io/ingress.global-static-ip-name: elekto-k8s-io-ingress-prod
-    networking.gke.io/managed-certificates: elekto-k8s-io
+    networking.gke.io/managed-certificates: elections-k8s-io
 spec:
   defaultBackend:
     service:


### PR DESCRIPTION
Related:
  - Part of : https://github.com/kubernetes/k8s.io/issues/2575
  - Followup of https://github.com/kubernetes/k8s.io/pull/2774

Request GKE SSL certificate for `elections.k8s.io`.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>