### PR TITLE
apps/prow: drop tide queries

### DIFF
--- a/apps/prow/cluster/prow_controller_manager_deployment.yaml
+++ b/apps/prow/cluster/prow_controller_manager_deployment.yaml
@@ -41,7 +41,10 @@ spec:
         - --dry-run=false
         - --enable-controller=plank
         - --job-config-path=/etc/job-config
-        - --kubeconfig=/etc/kubeconfig/kubeconfig
+        env:
+        # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
+        - name: KUBECONFIG
+          value: "/etc/kubeconfig/kubeconfig"
         ports:
         - name: metrics
           containerPort: 9090

--- a/apps/prow/config.yaml
+++ b/apps/prow/config.yaml
@@ -52,16 +52,6 @@ github_reporter:
 
 tide:
   sync_period: 1m
-  queries:
-  - repos:
-    - kubernetes/k8s.io
-    labels:
-    - lgtm
-    - approved
-    - a-label-that-does-not-exist
-    missingLabels:
-    - do-not-merge/hold
-    - do-not-merge/work-in-progress
   pr_status_base_urls:
     '*': https://k8s-infra-prow.k8s.io/pr
 


### PR DESCRIPTION
Related to:
  - Umbrella issue : #752 
  - Part of #1394 

Suggestion of spiffxp:
https://github.com/kubernetes/k8s.io/pull/2800#issuecomment-926191017.

Tide is not required for the moment.

Also testing usage of `KUBECONFIG` as an attempt to address https://github.com/kubernetes/k8s.io/issues/2559.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>