### PR TITLE
apps/elekto: Fix ingress

### DIFF
--- a/apps/elekto/ingress.yaml
+++ b/apps/elekto/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     app: elekto
   annotations:
     kubernetes.io/ingress.class: gce
-    kubernetes.io/ingress.global-static-ip-name: elekto-k8s-io-ingress-prod
+    kubernetes.io/ingress.global-static-ip-name: k8s-io-elections
     networking.gke.io/managed-certificates: elections-k8s-io
 spec:
   defaultBackend:


### PR DESCRIPTION
Related:
  - Part of : https://github.com/kubernetes/k8s.io/issues/2575
  - Followup of : https://github.com/kubernetes/k8s.io/pull/2774

Error in the name of global IP address (loadbalancer) used by the
ingress.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>