### PR TITLE
apps/prow: Fix URL for jobs results

### DIFF
--- a/apps/prow/cluster/prow_controller_manager_rbac.yaml
+++ b/apps/prow/cluster/prow_controller_manager_rbac.yaml
@@ -15,6 +15,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: k8s-infra-prow@kubernetes-public.iam.gserviceaccount.com
   namespace: prow
   name: "prow-controller-manager"
 ---

--- a/apps/prow/config.yaml
+++ b/apps/prow/config.yaml
@@ -24,7 +24,7 @@ plank:
       gcs_configuration:
         bucket: k8s-infra-prow-results
         path_strategy: explicit
-      gcs_credentials_secret: "k8s-infra-prow-sa-key"
+      gcs_credentials_secret: "" # Use GKE Workload identity
       resources:
         clonerefs:
           requests:

--- a/apps/prow/config.yaml
+++ b/apps/prow/config.yaml
@@ -8,7 +8,7 @@ plank:
   report_templates:
     '*': '[Full PR test history](https://k8s-infra-prow.k8s.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://k8s-infra-prow.k8s.io/pr?query=is%3Apr%20state%3Aopen%20author%3A{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).'
   job_url_prefix_config:
-    '*': https://k8s-infra-prow.k8s.io/view/gs/
+    '*': https://k8s-infra-prow.k8s.io/view/
   pod_pending_timeout: 15m
   pod_unscheduled_timeout: 5m
   default_decoration_configs:


### PR DESCRIPTION
- Fix URL for job results
- Switch to GKE Workload Identity for the prow-controller-manager

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>