### PR TITLE
bash/staging: prune unexpected services

### DIFF
--- a/infra/gcp/bash/ensure-staging-storage.sh
+++ b/infra/gcp/bash/ensure-staging-storage.sh
@@ -136,10 +136,17 @@ function ensure_staging_project() {
 
     # Enable services for staging projects and their direct dependencies; prune anything else
     color 6 "Ensuring necessary enabled services staging project: ${project}"
-    # TODO: this may eventually disable other services; for now it
-    #       only does so if an obnoxiously long environment var is set,
-    #       K8S_INFRA_ENSURE_ONLY_SERVICES_WILL_FORCE_DISABLE=true
-    ensure_only_services "${project}" "${STAGING_PROJECT_SERVICES[@]}"
+    # NOTE: horrible bash to allow special cases of staging projects needing
+    #       more services than the default set... since bash doesn't let us
+    #       pass around arrays, wrap an array in a function that echoes it,
+    #       and append the output of that function to the default set
+    local special_case_services="staging_special_case_services__${project//-/_}"
+    local enabled_services=("${STAGING_PROJECT_SERVICES[@]}")
+    if [ "$(type -t "${special_case_services}")" == "function" ]; then
+        mapfile -t -O "${#enabled_services[@]}" enabled_services < <(${special_case_services})
+    fi
+    K8S_INFRA_ENSURE_ONLY_SERVICES_WILL_FORCE_DISABLE=true \
+      ensure_only_services "${project}" "${enabled_services[@]}"
 
     color 6 "Ensuring disabled services for staging project: ${project}"
     ensure_disabled_services "${project}" "${STAGING_PROJECT_DISABLED_SERVICES[@]}"
@@ -377,27 +384,26 @@ function staging_special_case__k8s_staging_ci_images() {
     empower_svcacct_to_write_gcr "${PROW_BUILD_SERVICE_ACCOUNT}" "k8s-staging-ci-images"
 }
 
-# In order for pull-release-image-* to run on k8s-infra-prow-build,
-# it needs write access to gcr.io/k8s-staging-releng-test. We are
-# wary of what untrusted code is allowed to do, so we don't allow
-# presubmits to run on k8s-infra-prow-build-trusted.
-function staging_special_case__k8s_staging_releng_test() {
-    ensure_staging_gcb_builder_service_account "releng-test" "k8s-infra-prow-build"
-}
-
 # In order to build the node images using image-builder it needs
 # the compute api to be enabled because it will create a VM
 # to build the node image.
-function staging_special_case__k8s_staging_cluster_api_gcp() {
-    readonly STAGING_PROJECT="k8s-staging-cluster-api-gcp"
-    local serviceaccount
-    serviceaccount="$(svc_acct_email "${STAGING_PROJECT}" "gcb-builder-cluster-api-gcp")"
-
-    ensure_services "${STAGING_PROJECT}" compute.googleapis.com
-    ensure_project_role_binding "${STAGING_PROJECT}" "serviceAccount:${serviceaccount}" "roles/compute.instanceAdmin.v1"
-    ensure_serviceaccount_role_binding "${serviceaccount}" "serviceAccount:${serviceaccount}" "roles/iam.serviceAccountUser"
-    ensure_staging_gcb_builder_service_account "cluster-api-gcp" "k8s-infra-prow-build-trusted"
+function staging_special_case_services__k8s_staging_cluster_api_gcp() {
+    # needed to build images using packer via image-builder
+    echo compute.googleapis.com
+    # dependency of compute
+    echo oslogin.googleapis.com
 }
+function staging_special_case__k8s_staging_cluster_api_gcp() {
+    readonly suffix="cluster-api-gcp"
+    readonly project="k8s-staging-${suffix}"
+    local serviceaccount
+    serviceaccount="$(svc_acct_email "${project}" "gcb-builder-cluster-api-gcp")"
+
+    ensure_project_role_binding "${project}" "serviceAccount:${serviceaccount}" "roles/compute.instanceAdmin.v1"
+    ensure_serviceaccount_role_binding "${serviceaccount}" "serviceAccount:${serviceaccount}" "roles/iam.serviceAccountUser"
+    ensure_staging_gcb_builder_service_account "${suffix}" "k8s-infra-prow-build-trusted"
+}
+
 
 # In order to build the release artifacts, the group needs to be
 # able to create and manage a keyring to encrypt a secret token
@@ -417,6 +423,21 @@ function staging_special_case__k8s_staging_kustomize() {
     principal="serviceAccount:${cloudbuild_sa_email}"
     ensure_project_role_binding "${project}" "${principal}" "roles/cloudkms.cryptoKeyDecrypter"
     ensure_project_role_binding "${project}" "${principal}" "roles/secretmanager.secretAccessor"
+}
+
+# In order for pull-release-image-* to run on k8s-infra-prow-build,
+# it needs write access to gcr.io/k8s-staging-releng-test. We are
+# wary of what untrusted code is allowed to do, so we don't allow
+# presubmits to run on k8s-infra-prow-build-trusted.
+function staging_special_case__k8s_staging_releng_test() {
+    ensure_staging_gcb_builder_service_account "releng-test" "k8s-infra-prow-build"
+}
+
+# sig-storage has these enabled
+function staging_special_case_services__k8s_staging_sig_storage() {
+    echo compute.googleapis.com
+    # dependency of compute
+    echo oslogin.googleapis.com
 }
 
 #


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1675

Specifically

- add a mechanism for staging projects to specify special case services
  that they expect to have enabled
- use that mechanism for cluster-api-gcp and sig-storage
- set obnoxious env var that causes ensure_only_services to disable any
  service not explicitly requested as enabled
- cleanup: order special case functions by project name

Last step before I call https://github.com/kubernetes/k8s.io/issues/1675
done will be to run `ensure-staging-storage.sh` for all staging projects
just to ensure we've pruned all unexpected services.