### PR TITLE
Revert "Use test prow-controller-manager for k8s-infra-prow debugging"

### DIFF
--- a/apps/prow/cluster/prow_controller_manager_deployment.yaml
+++ b/apps/prow/cluster/prow_controller_manager_deployment.yaml
@@ -34,8 +34,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        # image: gcr.io/k8s-prow/prow-controller-manager:v20210902-01e03305a2
-        image: public.ecr.aws/ezaneski/prow-controller-manager:v20210923-fef59c14ed-dirty
+        image: gcr.io/k8s-prow/prow-controller-manager:v20210902-01e03305a2
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false


### PR DESCRIPTION
https://github.com/kubernetes/k8s.io/issues/2559 is solved and we can revert from the debugging image. I will upstream some of the logging that uncovered this.