### PR TITLE
apps/elekto: disable http traffic

### DIFF
--- a/apps/elekto/ingress.yaml
+++ b/apps/elekto/ingress.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: elekto
   annotations:
+    kubernetes.io/ingress.allow-http: "false"
     kubernetes.io/ingress.class: gce
     kubernetes.io/ingress.global-static-ip-name: k8s-io-elections
     networking.gke.io/managed-certificates: elections-k8s-io


### PR DESCRIPTION
Related:
 - Ref: https://github.com/kubernetes/k8s.io/issues/2575
 - followup of : https://github.com/kubernetes/k8s.io/pull/2774

Allow HTTPS connections.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>