### PR TITLE
kubernetes-public: Add GCP secret for publishing-bot

### DIFF
--- a/infra/gcp/bash/ensure-main-project.sh
+++ b/infra/gcp/bash/ensure-main-project.sh
@@ -371,6 +371,9 @@ function ensure_aaa_external_secrets() {
         k8s-infra-prow-github-oauth-config
         k8s-infra-prow-hmac-token
     )
+    local publishing_bot_secrets=(
+        publishing-bot-github-token
+    )
     local slack_infra_secrets=(
         recaptcha
         slack-event-log-config
@@ -394,6 +397,7 @@ function ensure_aaa_external_secrets() {
     )
     mapfile -t secret_specs < <(
         printf "%s/prow/sig-testing\n" "${prow_secrets[@]}"
+        printf "%s/publishing-bot/sig-release\n" "${publishing_bot_secrets[@]}"
         printf "%s/slack-infra/sig-contributor-experience\n" "${slack_infra_secrets[@]}"
         printf "%s/triageparty-release/sig-release\n" "${triageparty_release_secrets[@]}"
         printf "%s/elekto/sig-contributor-experience\n" "${elekto_secrets[@]}"


### PR DESCRIPTION
Ref: https://github.com/kubernetes/k8s.io/issues/2220

Add a GCP secret that store the Github token used by publishing-bot

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>