### PR TITLE
apps/slack-infra: use ExternalSecrets to manage secrets

### DIFF
--- a/apps/slack-infra/resources/slack-event-log/externalsecrets.yaml
+++ b/apps/slack-infra/resources/slack-event-log/externalsecrets.yaml
@@ -1,0 +1,14 @@
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: slack-event-log-config  # The name of the Kubernetes Secret
+  namespace: slack-infra
+  labels:
+    app: slack-event-log
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-public
+  data:
+  - key: slack-event-log-config # The name of the GSM secret
+    name: config.json           # The key to write to in the Kubernetes Secret
+    version: latest             # The version of the GSM secret

--- a/apps/slack-infra/resources/slack-moderator-words/externalsecrets.yaml
+++ b/apps/slack-infra/resources/slack-moderator-words/externalsecrets.yaml
@@ -1,0 +1,14 @@
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: slack-moderator-words-config  # The name of the Kubernetes Secret
+  namespace: slack-infra
+  labels:
+    app: slack-moderator-words
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-public
+  data:
+  - key: slack-moderator-words-config # The name of the GSM secret
+    name: config.json                 # The key to write to in the Kubernetes Secret
+    version: latest                   # The version of the GSM secret

--- a/apps/slack-infra/resources/slack-moderator/externalsecrets.yaml
+++ b/apps/slack-infra/resources/slack-moderator/externalsecrets.yaml
@@ -1,0 +1,14 @@
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: slack-moderator-config  # The name of the Kubernetes Secret
+  namespace: slack-infra
+  labels:
+    app: slack-moderator
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-public
+  data:
+  - key: slack-moderator-config # The name of the GSM secret
+    name: config.json           # The key to write to in the Kubernetes Secret
+    version: latest             # The version of the GSM secret

--- a/apps/slack-infra/resources/slack-post-message/externalsecrets.yaml
+++ b/apps/slack-infra/resources/slack-post-message/externalsecrets.yaml
@@ -1,0 +1,14 @@
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: slack-post-message-config   # The name of the Kubernetes Secret
+  namespace: slack-infra
+  labels:
+    app: slack-post-message
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-public
+  data:
+  - key: slack-post-message-config  # The name of the GSM secret
+    name: config.json               # The key to write to in the Kubernetes Secret
+    version: latest                 # The version of the GSM secret

--- a/apps/slack-infra/resources/slack-welcomer/externalsecrets.yaml
+++ b/apps/slack-infra/resources/slack-welcomer/externalsecrets.yaml
@@ -1,0 +1,14 @@
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: slack-welcomer-config   # The name of the Kubernetes Secret
+  namespace: slack-infra
+  labels:
+    app: slack-welcomer
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-public
+  data:
+  - key: slack-welcomer-config  # The name of the GSM secret
+    name: config.json           # The key to write to in the Kubernetes Secret
+    version: latest             # The version of the GSM secret

--- a/apps/slack-infra/resources/slackin/externalsecrets.yaml
+++ b/apps/slack-infra/resources/slackin/externalsecrets.yaml
@@ -1,0 +1,32 @@
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: recaptcha             # The name of the Kubernetes Secret
+  namespace: slack-infra
+  labels:
+    app: slackin
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-public
+  data:
+  - key: recaptcha-secret-key # The name of the GSM secret
+    name: secret-key          # The key to write to in the Kubernetes Secret
+    version: latest           # The version of the GSM secret
+  - key: recaptcha-site-key   # The name of the GSM secret
+    name: site-key            # The key to write to in the Kubernetes Secret
+    version: latest           # The version of the GSM secret
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: slackin-token   # The name of the Kubernetes Secret
+  namespace: slack-infra
+  labels:
+    app: slackin
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-public
+  data:
+  - key: slackin-token  # The name of the GSM secret
+    name: token         # The key to write to in the Kubernetes Secret
+    version: latest     # The version of the GSM secret

--- a/infra/gcp/bash/ensure-main-project.sh
+++ b/infra/gcp/bash/ensure-main-project.sh
@@ -375,10 +375,12 @@ function ensure_aaa_external_secrets() {
         publishing-bot-github-token
     )
     local slack_infra_secrets=(
-        recaptcha
+        recaptcha-secret-key
+        recaptcha-site-key
         slack-event-log-config
         slack-moderator-config
         slack-moderator-words-config
+        slack-post-message-config
         slack-welcomer-config
         slackin-token
     )


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/2220

I have already deployed the `ensure-main-project.sh` changes to provision the new secrets, removed the old `recaptcha` secret, and populated all of the GSM secrets with values that will work with the added `ExternalSecret` resources this adds

As-is this will be a no-op for the existing deployments. I'll watch the secrets to confirm no change in value