### PR TITLE
Revert "Update infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/kubernetes-external-secrets/kubernetes-external-secrets.yaml"

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/kubernetes-external-secrets/kubernetes-external-secrets.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/kubernetes-external-secrets/kubernetes-external-secrets.yaml
@@ -57,9 +57,4 @@ spec:
             value: "60000"
           # Params for env vars populated from k8s secrets
       securityContext:
-        allowPrivilegeEscalation: false
-        capabilities:
-          drop:
-            - "ALL"
-        privileged: false
         runAsNonRoot: true


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/2220
- Followup to: https://github.com/kubernetes/k8s.io/pull/2827

This reverts commit 2d282ce0610353e2094422e935db3d6036493a11.

I'd rather get this back to a known-working state first, this will make
the deployment match what is used by k8s-infra-prow-build-trusted