### PR TITLE
terraform/k8s-infra-prow-build: add kubernetes-external-secrets namespace

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/namespaces.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/namespaces.yaml
@@ -8,3 +8,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: test-pods
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubernetes-external-secrets


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/2220
- Followup to: https://github.com/kubernetes/k8s.io/pull/2830

Having a kubernetes-external-secrets namespace present might help when attempting to deploy things into said namespace