### PR TITLE
terraform: setup experimental nodepool with ephemeral local ssd for k8s-infra-prow-build

### DIFF
--- a/infra/gcp/terraform/modules/gke-nodepool/main.tf
+++ b/infra/gcp/terraform/modules/gke-nodepool/main.tf
@@ -50,6 +50,13 @@ resource "google_container_node_pool" "node_pool" {
     service_account = var.service_account
     oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
 
+    dynamic "ephemeral_storage_config" {
+      for_each = var.ephemeral_local_ssd_count > 0 ? [var.ephemeral_local_ssd_count] : [] 
+      content {
+        local_ssd_count = ephemeral_storage_config.value
+      }
+    }
+
     // Needed for workload identity
     workload_metadata_config {
       node_metadata = "GKE_METADATA_SERVER"

--- a/infra/gcp/terraform/modules/gke-nodepool/variables.tf
+++ b/infra/gcp/terraform/modules/gke-nodepool/variables.tf
@@ -70,6 +70,12 @@ variable "disk_type" {
   type        = string
 }
 
+variable "ephemeral_local_ssd_count" {
+  description = "Number of local SSDs to provision for ephemeral storage. If 0, ephemeral storage is backed by boot disk"
+  type        = string
+  default     = 0
+}
+
 variable "labels" {
   description = "The labels to apply to this node_pool"
   type        = map(string)


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1187

Add terraform to provision a new nodepool with ephemeral storage backed by local SSDs, ref:
- https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/local-ssd
- https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#ephemeral_storage_config

Taint the nodepool such that only jobs that tolerate `ephemeral-ssd-experiment=true` will schedule to the new nodepool

Use this to experiment with some canary jobs to see if everything behaves as expected