### PR TITLE
terraform/k8s-infra-prow-build: migrate to localssd nodepool

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/main.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/main.tf
@@ -134,6 +134,8 @@ module "prow_build_cluster" {
   cloud_shell_access = false
 }
 
+# TODO(spiffxp): remove this once all jobs/pods have fully migrated over to
+#                pool5
 module "prow_build_nodepool_n1_highmem_8_maxiops" {
   source        = "../modules/gke-nodepool"
   project_name  = local.project_id
@@ -154,20 +156,15 @@ module "prow_build_nodepool_n1_highmem_8_maxiops" {
   service_account = module.prow_build_cluster.cluster_node_sa.email
 }
 
-# TODO(spiffxp): intent is to replace pool4 with this after scheduling a few select
-#                jobs to this pool to confirm things work as expected; this will
-#                involve dropping the taints, raising the max_count
 module "prow_build_nodepool_n1_highmem_8_localssd" {
   source        = "../modules/gke-nodepool"
   project_name  = local.project_id
   cluster_name  = module.prow_build_cluster.cluster.name
   location      = module.prow_build_cluster.cluster.location
   name          = "pool5"
-  # NOTE: taints are only applied during creation and ignored after that, see module docs
-  taints        = [{ key = "ephemeral-ssd-experiment", value = "true", effect = "NO_SCHEDULE" }]
   initial_count = 1
   min_count     = 1
-  max_count     = 5
+  max_count     = 80
   # kind-ipv6 jobs need an ipv6 stack; COS doesn't provide one, so we need to
   # use an UBUNTU image instead. Keep parity with the existing google.com
   # k8s-prow-builds/prow cluster by using the CONTAINERD variant

--- a/infra/gcp/terraform/k8s-infra-prow-build/main.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/main.tf
@@ -134,28 +134,6 @@ module "prow_build_cluster" {
   cloud_shell_access = false
 }
 
-# TODO(spiffxp): remove this once all jobs/pods have fully migrated over to
-#                pool5
-module "prow_build_nodepool_n1_highmem_8_maxiops" {
-  source        = "../modules/gke-nodepool"
-  project_name  = local.project_id
-  cluster_name  = module.prow_build_cluster.cluster.name
-  location      = module.prow_build_cluster.cluster.location
-  name          = "pool4"
-  initial_count = 1
-  min_count     = 1
-  max_count     = 80
-  # kind-ipv6 jobs need an ipv6 stack; COS doesn't provide one, so we need to
-  # use an UBUNTU image instead. Keep parity with the existing google.com
-  # k8s-prow-builds/prow cluster by using the CONTAINERD variant
-  image_type   = "UBUNTU_CONTAINERD"
-  machine_type = "n1-highmem-8"
-  # Use an ssd volume sized to allow the max IOPS supported by n1 instances w/ 8 vCPU
-  disk_size_gb    = 500
-  disk_type       = "pd-ssd"
-  service_account = module.prow_build_cluster.cluster_node_sa.email
-}
-
 module "prow_build_nodepool_n1_highmem_8_localssd" {
   source        = "../modules/gke-nodepool"
   project_name  = local.project_id


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1187
- Followup to: https://github.com/kubernetes/k8s.io/pull/2835

See https://github.com/kubernetes/k8s.io/issues/1187#issuecomment-929162495 for rationale

Deploying this is going to require some manual recreation of resources