### PR TITLE
terraform: add roles to workload-identity-service-account

### DIFF
--- a/infra/gcp/terraform/modules/workload-identity-service-account/main.tf
+++ b/infra/gcp/terraform/modules/workload-identity-service-account/main.tf
@@ -20,8 +20,8 @@ limitations under the License.
 // running as cluster_serviceaccount_name
 
 locals {
-  description = var.description != "" ? var.description : var.name
-  cluster_project_id = var.cluster_project_id != "" ? var.cluster_project_id : var.project_id
+  description                 = var.description != "" ? var.description : var.name
+  cluster_project_id          = var.cluster_project_id != "" ? var.cluster_project_id : var.project_id
   cluster_serviceaccount_name = var.cluster_serviceaccount_name != "" ? var.cluster_serviceaccount_name : var.name
 }
 
@@ -42,4 +42,11 @@ data "google_iam_policy" "workload_identity" {
 resource "google_service_account_iam_policy" "serviceaccount_iam" {
   service_account_id = google_service_account.serviceaccount.name
   policy_data        = data.google_iam_policy.workload_identity.policy_data
+}
+// optional: roles to grant the serviceaccount on the project
+resource "google_project_iam_member" "project_roles" {
+  for_each = toset(var.project_roles)
+  project  = var.project_id
+  role     = each.value
+  member   = "serviceAccount:${google_service_account.serviceaccount.email}"
 }

--- a/infra/gcp/terraform/modules/workload-identity-service-account/variables.tf
+++ b/infra/gcp/terraform/modules/workload-identity-service-account/variables.tf
@@ -46,3 +46,9 @@ variable "cluster_namespace" {
   description = "The namespace of the kubernetes service account that will bind to the service account, eg: my-namespace"
   type        = string
 }
+
+variable "project_roles" {
+  description = "A list of roles to bind to the serviceaccount in its project, eg: [ \"roles/bigquery.user\" ]"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
First part of an attempt to for_each the sundry workload-identity-service-account modules created in k8s-infra-prow and k8s-infra-prow-build

Add a `project_roles` attribute that will optionally bind the service account to those roles in the project hosting the service account