### PR TITLE
terraform: invoke workload-identity-service-account module via for_each

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/tf-state-mv.sh
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/tf-state-mv.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+terraform state mv 'module.gcb_builder_sa.google_service_account.serviceaccount' 'module.workload_identity_service_accounts["gcb-builder"].google_service_account.serviceaccount'
+terraform state mv 'module.gcb_builder_sa.google_service_account_iam_policy.serviceaccount_iam' 'module.workload_identity_service_accounts["gcb-builder"].google_service_account_iam_policy.serviceaccount_iam'
+terraform state mv 'module.k8s_metrics_sa.google_service_account.serviceaccount' 'module.workload_identity_service_accounts["k8s-metrics"].google_service_account.serviceaccount'
+terraform state mv 'module.k8s_metrics_sa.google_service_account_iam_policy.serviceaccount_iam' 'module.workload_identity_service_accounts["k8s-metrics"].google_service_account_iam_policy.serviceaccount_iam'
+terraform state mv 'module.k8s_triage_sa.google_service_account.serviceaccount' 'module.workload_identity_service_accounts["k8s-triage"].google_service_account.serviceaccount'
+terraform state mv 'module.k8s_triage_sa.google_service_account_iam_policy.serviceaccount_iam' 'module.workload_identity_service_accounts["k8s-triage"].google_service_account_iam_policy.serviceaccount_iam'
+terraform state mv 'module.prow_deployer_sa.google_service_account.serviceaccount' 'module.workload_identity_service_accounts["prow-deployer"].google_service_account.serviceaccount'
+terraform state mv 'module.prow_deployer_sa.google_service_account_iam_policy.serviceaccount_iam' 'module.workload_identity_service_accounts["prow-deployer"].google_service_account_iam_policy.serviceaccount_iam'
+terraform state mv 'module.kubernetes_external_secrets_sa.google_service_account.serviceaccount' 'module.workload_identity_service_accounts["kubernetes-external-secrets"].google_service_account.serviceaccount'
+terraform state mv 'module.kubernetes_external_secrets_sa.google_service_account_iam_policy.serviceaccount_iam' 'module.workload_identity_service_accounts["kubernetes-external-secrets"].google_service_account_iam_policy.serviceaccount_iam'
+terraform state mv 'module.prow_build_cluster_sa.google_service_account.serviceaccount' 'module.workload_identity_service_accounts["prow-build-trusted"].google_service_account.serviceaccount'
+terraform state mv 'module.prow_build_cluster_sa.google_service_account_iam_policy.serviceaccount_iam' 'module.workload_identity_service_accounts["prow-build-trusted"].google_service_account_iam_policy.serviceaccount_iam'

--- a/infra/gcp/terraform/k8s-infra-prow-build/tf-state-mv.sh
+++ b/infra/gcp/terraform/k8s-infra-prow-build/tf-state-mv.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+terraform state mv 'module.boskos_janitor_sa.google_service_account.serviceaccount' 'module.workload_identity_service_accounts["boskos-janitor"].google_service_account.serviceaccount'
+terraform state mv 'module.boskos_janitor_sa.google_service_account_iam_policy.serviceaccount_iam' 'module.workload_identity_service_accounts["boskos-janitor"].google_service_account_iam_policy.serviceaccount_iam'
+terraform state mv 'module.kubernetes_external_secrets_sa.google_service_account.serviceaccount' 'module.workload_identity_service_accounts["kubernetes-external-secrets"].google_service_account.serviceaccount'
+terraform state mv 'module.kubernetes_external_secrets_sa.google_service_account_iam_policy.serviceaccount_iam' 'module.workload_identity_service_accounts["kubernetes-external-secrets"].google_service_account_iam_policy.serviceaccount_iam'
+terraform state mv 'module.prow_build_cluster_sa.google_service_account.serviceaccount' 'module.workload_identity_service_accounts["prow-build"].google_service_account.serviceaccount'
+terraform state mv 'module.prow_build_cluster_sa.google_service_account_iam_policy.serviceaccount_iam' 'module.workload_identity_service_accounts["prow-build"].google_service_account_iam_policy.serviceaccount_iam'


### PR DESCRIPTION
Related:
- Followup to: https://github.com/kubernetes/k8s.io/pull/2843

This DRYs things up a bit.

Now when we want to add/edit a service account that is usable via workload identity, instead of looking at this:
```terraform
module "prow_build_cluster_sa" {
  source            = "../modules/workload-identity-service-account"
  project_id        = local.project_id
  name              = local.cluster_sa_name
  description       = "default service account for pods in ${local.cluster_name}"
  cluster_namespace = local.pod_namespace
}

module "boskos_janitor_sa" {
  source            = "../modules/workload-identity-service-account"
  project_id        = local.project_id
  name              = local.boskos_janitor_sa_name
  description       = "used by boskos-janitor in ${local.cluster_name}"
  cluster_namespace = local.pod_namespace
}

module "kubernetes_external_secrets_sa" {
  source            = "../modules/workload-identity-service-account"
  project_id        = local.project_id
  name              = local.kubernetes_external_secrets_sa_name
  description       = "sync K8s secrets from GSM in this and other projects"
  cluster_namespace = "kubernetes-external-secrets"
  project_roles     = ["roles/secretmanager.secretAccessor"]
}
```

We look at this:
```terraform
workload_identity_service_accounts = [
  {
    name        = "prow-build",
    description = "default service account for pods in ${local.cluster_name}",
  },
  {
    name        = "boskos-janitor",
    description = "uesd by boskos-janitor in ${local.cluster_name}",
  },
  {
    name          = "kubernetes-external-secrets",
    description   = "sync K8s secrets from GSM in this and other projects",
    project_roles = ["roles/secretmanager.secretAccessor"]
  }
]
```

It's the sort of data that could come from a YAML/JSON file, though I'm not inclined to go that far since I can't see an obvious place to put such a thing.

This requires terraform state surgery to deploy without destroying/recreating some resources. I've included shell scripts `tf-state-mv.sh` in each module to do the needful, which can be reverted out once deployed