### PR TITLE
terraform: provision prow-related secrets via terraform

### DIFF
--- a/infra/gcp/bash/prow/ensure-e2e-projects.sh
+++ b/infra/gcp/bash/prow/ensure-e2e-projects.sh
@@ -35,7 +35,6 @@ function usage() {
 ## projects hosting prow build clusters managed by sig-k8s-infra
 
 BUILD_CLUSTER_PROJECT=$(k8s_infra_project "prow" "k8s-infra-prow-build")
-TRUSTED_BUILD_CLUSTER_PROJECT=$(k8s_infra_project "prow" "k8s-infra-prow-build-trusted")
 
 ## setup service accounts and ips for the prow build cluster
 
@@ -137,37 +136,6 @@ function ensure_e2e_project() {
     fi
 }
 
-# TODO: this should be moved to the terraform responsible for k8s-infra-prow-build-trusted
-function ensure_trusted_prow_build_cluster_secrets() {
-    local project="${TRUSTED_BUILD_CLUSTER_PROJECT}"
-    local secret_specs=(
-        k8s-infra-kops-e2e-tests-aws-ssh-key/sig-cluster-lifecycle/k8s-infra-kops-maintainers@kubernetes.io
-        k8s-triage-robot-github-token/sig-contributor-experience/github@kubernetes.io
-        cncf-ci-github-token/sig-testing/k8s-infra-ii-coop@kubernetes.io
-        snyk-token/sig-architecture/k8s-infra-code-organization@kubernetes.io
-    )
-
-    for spec in "${secret_specs[@]}"; do
-        local secret k8s_group admin_group
-        secret="$(echo "${spec}" | cut -d/ -f1)"
-        k8s_group="$(echo "${spec}" | cut -d/ -f2)"
-        admin_group="$(echo "${spec}" | cut -d/ -f3)"
-
-        local admins=("k8s-infra-prow-oncall@kubernetes.io" "${admin_group}")
-        local labels=("group=${k8s_group}")
-
-        color 6 "Ensuring secret '${secret}' exists in '${project}' and is owned by '${admin_group}'"
-        ensure_secret "${project}" "${secret}"
-        ensure_secret_labels "${project}" "${secret}" "${labels[@]}"
-        for group in "${admins[@]}"; do
-            ensure_secret_role_binding \
-                "$(secret_full_name "${project}" "${secret}")" \
-                "group:${group}" \
-                "roles/secretmanager.admin"
-        done
-    done
-}
-
 # Disable OS Login at the project level
 # $1 The GCP Project
 function disable_project_oslogin() {
@@ -210,9 +178,6 @@ function ensure_e2e_projects() {
 #
 
 function main() {
-  color 6 "Ensuring external secrets exist for use by k8s-infra-prow-build-trusted"
-  ensure_trusted_prow_build_cluster_secrets 2>&1 | indent
-
   color 6 "Ensuring e2e projects used by prow..."
   ensure_e2e_projects "${@}" 2>&1 | indent
 

--- a/infra/gcp/terraform/k8s-infra-prow-build/main.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/main.tf
@@ -117,6 +117,42 @@ resource "google_compute_address" "kubernetes_external_secrets_metrics" {
   address_type = "EXTERNAL"
 }
 
+locals {
+  build_cluster_secrets = {
+    prow-build-service-account = {
+      group  = "sig-testing"
+      owners = "k8s-infra-prow-oncall@kubernetes.io"
+    }
+    prow-build-ssh-key-secret = {
+      group  = "sig-testing"
+      owners = "k8s-infra-prow-oncall@kubernetes.io"
+    }
+  }
+}
+
+resource "google_secret_manager_secret" "build_cluster_secrets" {
+  for_each  = local.build_cluster_secrets
+  project   = local.project_id
+  secret_id = each.key
+  labels = {
+    group = each.value.group
+  }
+  replication {
+    automatic = true
+  }
+}
+
+resource "google_secret_manager_secret_iam_binding" "build_cluster_secret_admins" {
+  for_each  = local.build_cluster_secrets
+  project   = local.project_id
+  secret_id = each.key
+  role      = "roles/secretmanager.admin"
+  members = [
+    "group:k8s-infra-prow-oncall@kubernetes.io",
+    "group:${each.value.owners}"
+  ]
+}
+
 module "prow_build_cluster" {
   source             = "../modules/gke-cluster"
   project_name       = local.project_id


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/2220
- Part of: https://github.com/kubernetes/k8s.io/issues/1731

This moves management of k8s-infra-prow-build-trusted's secrets to terraform

Then follows a similar pattern to setup secrets for k8s-infra-prow-build that will be populated and hooked up to ExternalSecret CRDs as followup

This was written with separate locals blocks to avoid merge conflicts with outstanding terraform PRs for prow