### PR TITLE
terraform: update secret iam to depend on secrets

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/main.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/main.tf
@@ -173,8 +173,8 @@ resource "google_secret_manager_secret" "build_cluster_secrets" {
 
 resource "google_secret_manager_secret_iam_binding" "build_cluster_secret_admins" {
   for_each  = local.build_cluster_secrets
-  project   = local.project_id
-  secret_id = each.key
+  project   = google_secret_manager_secret.build_cluster_secrets[each.key].project
+  secret_id = google_secret_manager_secret.build_cluster_secrets[each.key].id
   role      = "roles/secretmanager.admin"
   members = [
     "group:k8s-infra-prow-oncall@kubernetes.io",

--- a/infra/gcp/terraform/k8s-infra-prow-build/main.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/main.tf
@@ -144,8 +144,8 @@ resource "google_secret_manager_secret" "build_cluster_secrets" {
 
 resource "google_secret_manager_secret_iam_binding" "build_cluster_secret_admins" {
   for_each  = local.build_cluster_secrets
-  project   = local.project_id
-  secret_id = each.key
+  project   = google_secret_manager_secret.build_cluster_secrets[each.key].project
+  secret_id = google_secret_manager_secret.build_cluster_secrets[each.key].id
   role      = "roles/secretmanager.admin"
   members = [
     "group:k8s-infra-prow-oncall@kubernetes.io",


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/2220
- Part of: https://github.com/kubernetes/k8s.io/issues/1731
- Followup to: https://github.com/kubernetes/k8s.io/pull/2845

This is a subtle ordering bug that appears to only surface when new
secrets are created. The workaround was to just keep re-running
`terraform apply` until it worked

The first time I ran `terraform apply` for k8s-infra-prow-build, there
were secrets to be created, and then iam bindings to be applied on those
secrets. But terraform didn't know about that ordering, because the
iam bindings depended on the same locals that the secrets did, so
terraform tried to create them all in parallel.

This resulted in terraform erroring out on first run, because it was
trying to create iam bindings on secrets that didn't yet exist. When I
reran `terraform apply` the secrets had been created, so the iam
bindings succeeded.

One way to let terraform know about an ordering like this is to have one
terraform resource use the value of another. Another way would be an
explicit `depends_on`, but that's described as a last resort, and we're
not out of options here.