### PR TITLE
tf/k8s-infra-prow-build: add ExternalSecrets

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/test-pods/externalsecrets.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/test-pods/externalsecrets.yaml
@@ -1,0 +1,31 @@
+# This is a place holder for adding kubernetes external secrets, please add the
+# ExternalSecret CR here, separated by `---`.
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: service-account             # The name of the Kubernetes Secret
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-infra-prow-build
+  data:
+  - key: prow-build-service-account # The name of the GSM Secret
+    name: service-account.json      # The key to write to in the Kubernetes Secret
+    version: latest                 # The version of the GSM Secret
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: ssh-key-secret                          # The name of the Kubernetes Secret
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-infra-prow-build
+  data:
+  - key: prow-build-ssh-key-secret-ssh-public   # The name of the GSM Secret
+    name: ssh-public                            # The key to write to in the Kubernetes Secret
+    version: latest                             # The version of the GSM Secret
+  - key: prow-build-ssh-key-secret-ssh-private  # The name of the GSM Secret
+    name: ssh-private                           # The key to write to in the Kubernetes Secret
+    version: latest                             # The version of the GSM Secret

--- a/infra/gcp/terraform/k8s-infra-prow-build/secrets.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/secrets.tf
@@ -20,7 +20,11 @@ locals {
       group  = "sig-testing"
       owners = "k8s-infra-prow-oncall@kubernetes.io"
     }
-    prow-build-ssh-key-secret = {
+    prow-build-ssh-key-secret-ssh-private = {
+      group  = "sig-testing"
+      owners = "k8s-infra-prow-oncall@kubernetes.io"
+    }
+    prow-build-ssh-key-secret-ssh-public = {
       group  = "sig-testing"
       owners = "k8s-infra-prow-oncall@kubernetes.io"
     }


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/2220
- Followup to: https://github.com/kubernetes/k8s.io/pull/2845

Turns out the k8s secret has two fields: ssh-private and ssh-public, so we'll instead make a GSM secret per field

I populated the GSM secrets, and have added ExternalSecret CRDs to sync the values back to the Kubernetes secrets