### PR TITLE
tf/k8s-infra-prow-build-trusted: add ExternalSecrets

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-externalsecrets.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-externalsecrets.yaml
@@ -1,5 +1,19 @@
 # This is a place holder for adding kubernetes external secrets, please add the
 # ExternalSecret CR here, separated by `---`.
+#
+# e.g.
+# apiVersion: kubernetes-client.io/v1
+# kind: ExternalSecret
+# metadata:
+#   name: kubernetes-secret-name
+#   namespace: test-pods
+# spec:
+#   backendType: gcpSecretsManager
+#   projectId: k8s-infra-prow-build-trusted
+#   data:
+#   - key: google-secret-manager-secret-name
+#     name: key-in-kubernetes-secret
+#     version: latest
 ---
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
@@ -10,9 +24,9 @@ spec:
   backendType: gcpSecretsManager
   projectId: k8s-infra-prow-build-trusted
   data:
-  - key: cncf-ci-github-token # The name of the GSM Secret
-    name: token               # The key to write to in the Kubernetes Secret
-    version: latest           # The version of the GSM Secret
+  - key: cncf-ci-github-token
+    name: token
+    version: latest
 ---
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
@@ -22,9 +36,9 @@ metadata:
 spec:
   backendType: gcpSecretsManager
   data:
-  - key: snyk-token   # The name of the GSM Secret
-    name: SNYK_TOKEN  # The key to write to in the Kubernetes Secret
-    version: latest   # The version of the GSM Secret
+  - key: snyk-token
+    name: SNYK_TOKEN
+    version: latest
 ---
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
@@ -35,9 +49,9 @@ spec:
   backendType: gcpSecretsManager
   projectId: k8s-infra-prow-build-trusted
   data:
-  - key: k8s-triage-robot-github-token # The name of the GSM Secret
-    name: token                        # The key to write to in the Kubernetes Secret
-    version: latest                    # The version of the GSM Secret
+  - key: k8s-triage-robot-github-token
+    name: token
+    version: latest
 ---
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
@@ -48,6 +62,58 @@ spec:
   backendType: gcpSecretsManager
   projectId: kubernetes-public
   data:
-  - key: k8s-infra-ci-robot-github-token # The name of the GSM Secret
-    name: token                          # The key to write to in the Kubernetes Secret
-    version: latest                      # The version of the GSM Secret
+  - key: k8s-infra-ci-robot-github-token
+    name: token
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: k8s-cip-test-prod-service-account
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-public
+  data:
+  - key: k8s-cip-test-prod-service-account
+    name: service-account.json
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: k8s-gcr-audit-test-prod-service-account
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-public
+  data:
+  - key: k8s-gcr-audit-test-prod-service-account
+    name: service-account.json
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: service-account
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-public
+  data:
+  - key: service-account
+    name: service-account.json
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: slack-tempelis-auth
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-public
+  data:
+  - key: slack-tempelis-auth
+    name: auth.json
+    version: latest

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/secrets.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/secrets.tf
@@ -28,10 +28,6 @@ locals {
       group = "sig-release"
       owners = "k8s-infra-release-admins@kubernetes.io"
     }
-    k8s-infra-kops-e2e-tests-aws-ssh-key = {
-      group  = "sig-cluster-lifecycle"
-      owners = "k8s-infra-kops-maintainers@kubernetes.io"
-    }
     k8s-triage-robot-github-token = {
       group  = "sig-contributor-experience"
       owners = "github@kubernetes.io"


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/2220
- Followup to: https://github.com/kubernetes/k8s.io/pull/2859

The GSM secrets have been populated with values from the cluster, so these ExternalSecrets should be a no-op