### PR TITLE
SIG-CLI: KnVerey to lead, pwittrock to emeritus

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -22,7 +22,7 @@ aliases:
     - mwielgus
   sig-cli-leads:
     - eddiezane
-    - pwittrock
+    - KnVerey
     - seans3
     - soltysh
   sig-cloud-provider-leads:

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -80,6 +80,7 @@ groups:
       - kikis.github@gmail.com
       - kim.andrewsy@gmail.com
       - klaus1982.cn@gmail.com
+      - kn.verey@gmail.com # SIG CLI
       - ksemenov@vmware.com
       - lachlan.evenson@gmail.com
       - lauri.d.apple@gmail.com # SIG Release
@@ -94,7 +95,6 @@ groups:
       - neolit123@gmail.com
       - nospam.wong@gmail.com
       - prydonius@gmail.com
-      - phil.wittrock@gmail.com
       - quinton@hoole.biz
       - saadali@google.com
       - saschagrunert@gmail.com # SIG Release


### PR DESCRIPTION
Part of kubernetes/community#6102

/hold on that merging
/cc @eddiezane @pwittrock @soltysh @seans3