### PR TITLE
Update SIG Release group members

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -39,6 +39,7 @@ groups:
       - k8s-infra-release-admins@kubernetes.io
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
+      - gveronicalg@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
       - saschagrunert@gmail.com
@@ -54,7 +55,6 @@ groups:
       - k8s-infra-release-editors@kubernetes.io
       - k8s-infra-google-build-admins@kubernetes.io
       - ameukam@gmail.com
-      - gveronicalg@gmail.com
       - james.laverack@jetstack.io
       - jameswangel@gmail.com
       - jeremy.r.rickard@gmail.com

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -222,6 +222,7 @@ groups:
       - saschagrunert@gmail.com
     members:
       - augustus@cisco.com
+      - gveronicalg@gmail.com
       - mudrinic.mare@gmail.com
 
   - email-id: release-managers@kubernetes.io

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -38,7 +38,6 @@ groups:
     members:
       - k8s-infra-release-admins@kubernetes.io
       - adolfo.garcia@uservers.net
-      - ameukam@gmail.com
       - ctadeu@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com


### PR DESCRIPTION
This PR deals with two pending updates to the SIG Release groups:

1. It drops the temporary Release Manager access granted to @ameukam to cut the v1.23.0-alpha.3 release: https://github.com/kubernetes/k8s.io/pull/2837
2. It adds @Verolop to the `k8s-infra-release-editors` and  `release-managers-private` groups as part of her Release Manager onboarding: https://github.com/kubernetes/sig-release/issues/1713

Fixes: https://github.com/kubernetes/sig-release/issues/1716
/assign @justaugustus @cpanato @jeremyrickard 
