### PR TITLE
Add Terraform subrepo for monitoring

### DIFF
--- a/infra/gcp/bash/ensure-main-project.sh
+++ b/infra/gcp/bash/ensure-main-project.sh
@@ -74,6 +74,7 @@ readonly DNS_GROUP="k8s-infra-dns-admins@kubernetes.io"
 readonly TERRAFORM_STATE_BUCKET_ENTRIES=(
     "${LEGACY_CLUSTER_TERRAFORM_BUCKET}:${CLUSTER_ADMINS_GROUP}"
     k8s-infra-tf-aws:k8s-infra-aws-admins@kubernetes.io
+    k8s-infra-tf-monitoring:"${CLUSTER_ADMINS_GROUP}"
     k8s-infra-tf-prow-clusters:k8s-infra-prow-oncall@kubernetes.io
     k8s-infra-tf-public-clusters:"${CLUSTER_ADMINS_GROUP}"
     k8s-infra-tf-public-pii:"${CLUSTER_ADMINS_GROUP}"
@@ -470,7 +471,7 @@ function ensure_main_project() {
     color 6 "Ensuring specific workload identity serviceaccounts exist in: ${project}"; (
         local svcacct_args cluster_args
 
-        color 6 "Ensuring GCP Auditor serviceaccount"
+        color 6 "Ensuring GCP Auditor service account"
         # roles/viewer on kubernetes-public is a bootstrap; the true purpose
         # is custom role audit.viewer on the kubernetes.io org, but that is
         # handled by ensure-organization.sh
@@ -478,19 +479,24 @@ function ensure_main_project() {
         cluster_args=("k8s-infra-prow-build-trusted" "${PROWJOB_POD_NAMESPACE}")
         ensure_workload_identity_serviceaccount "${svcacct_args[@]}" "${cluster_args[@]}" 2>&1 | indent
 
-        color 6 "Ensuring DNS Updater serviceaccount"
+        color 6 "Ensuring DNS Updater service account"
         svcacct_args=("${project}" "k8s-infra-dns-updater" "roles/dns.admin")
         cluster_args=("k8s-infra-prow-build-trusted" "${PROWJOB_POD_NAMESPACE}")
         ensure_workload_identity_serviceaccount "${svcacct_args[@]}" "${cluster_args[@]}" 2>&1 | indent
 
-        color 6 "Ensuring Monitoring Viewer serviceaccount"
+        color 6 "Ensuring Monitoring Viewer service account"
         svcacct_args=("${project}" "k8s-infra-monitoring-viewer" "roles/monitoring.viewer")
         cluster_args=("${project}" "monitoring")
         ensure_workload_identity_serviceaccount "${svcacct_args[@]}" "${cluster_args[@]}" 2>&1 | indent
 
-        color 6 "Ensuring Kubernetes External Secrets serviceaccount"
+        color 6 "Ensuring Kubernetes External Secrets service account"
         svcacct_args=("${project}" "kubernetes-external-secrets" "roles/secretmanager.secretAccessor")
         cluster_args=("${project}" "kubernetes-external-secrets")
+        ensure_workload_identity_serviceaccount "${svcacct_args[@]}" "${cluster_args[@]}" 2>&1 | indent
+
+        color 6 "Ensure Monitoring Admin service account for Terraform"
+        svcacct_args=("${project}" "tf-monitoring-deployer" "roles/monitoring.admin")
+        cluster_args=("${project}" "${PROWJOB_POD_NAMESPACE}")
         ensure_workload_identity_serviceaccount "${svcacct_args[@]}" "${cluster_args[@]}" 2>&1 | indent
     ) 2>&1 | indent
 

--- a/infra/gcp/terraform/k8s-infra-monitoring/deploy.sh
+++ b/infra/gcp/terraform/k8s-infra-monitoring/deploy.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# intended to be run by k8s-infra-prow-build-trusted or a member of
+# k8s-infra-oncall@kubernetes.io
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+
+readonly project=kubernetes-public
+readonly region=us-central1
+
+function deploy_terraform() {
+  pushd "${SCRIPT_ROOT}"
+  terraform init
+  terraform apply -auto-approve
+  popd
+}
+
+function main() {
+    echo "deploying resources in project ${project} and region ${region}"
+    deploy_terraform
+}
+
+main

--- a/infra/gcp/terraform/k8s-infra-monitoring/main.tf
+++ b/infra/gcp/terraform/k8s-infra-monitoring/main.tf
@@ -1,0 +1,27 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+data "google_project" "project" {
+  project_id = "kubernetes-public"
+}
+
+// Slack channel on https://kubernetes.slack.com used for alerting 
+data "google_monitoring_notification_channel" "slack_alerts" {
+  display_name = "#k8s-infra-alerts"
+  project      = data.google_project.project.project_id
+}
+
+

--- a/infra/gcp/terraform/k8s-infra-monitoring/provider.tf
+++ b/infra/gcp/terraform/k8s-infra-monitoring/provider.tf
@@ -1,0 +1,35 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This file defines:
+- Required provider versions
+- Storage backend details
+*/
+
+terraform {
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.87.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 3.87.0"
+    }
+  }
+}

--- a/infra/gcp/terraform/k8s-infra-monitoring/versions.tf
+++ b/infra/gcp/terraform/k8s-infra-monitoring/versions.tf
@@ -1,0 +1,24 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This file defines:
+- Required Terraform version
+*/
+
+terraform {
+  required_version = "~> 1.0.0"
+}

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-serviceaccounts.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-serviceaccounts.yaml
@@ -57,6 +57,14 @@ metadata:
     iam.gke.io/gcp-service-account: gsuite-groups-manager@k8s-gsuite.iam.gserviceaccount.com
   name: gsuite-groups-manager
   namespace: test-pods
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: tf-monitoring-deployer@kubernetes-public.iam.gserviceaccount.com
+  name: tf-monitoring-deployer
+  namespace: test-pods
 
 # Image promotion service accounts
 ---


### PR DESCRIPTION
Related to:
 - Ref: https://github.com/kubernetes/k8s.io/issues/2588

Bootstrap a new suberepo that will host the Terraform resources
consuming the GCP monitoring API.
I also bumped the terraform provider for this subrepo and will the other
declarations of the provider in a followup PR.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>