### PR TITLE
infra/terraform: Bump Terraform provider

### DIFF
--- a/infra/gcp/terraform/k8s-infra-ii-sandbox/provider.tf
+++ b/infra/gcp/terraform/k8s-infra-ii-sandbox/provider.tf
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
- 
+
 /*
 This file defines:
 - Required provider versions
@@ -33,11 +33,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.74.0"
+      version = "~> 3.87.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.74.0"
+      version = "~> 3.87.0"
     }
   }
 }

--- a/infra/gcp/terraform/k8s-infra-ii-sandbox/versions.tf
+++ b/infra/gcp/terraform/k8s-infra-ii-sandbox/versions.tf
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
- 
+
 /*
 This file defines:
 - Required Terraform version

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/00-provider.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/00-provider.tf
@@ -30,11 +30,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.74.0"
+      version = "~> 3.87.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.74.0"
+      version = "~> 3.87.0"
     }
   }
 }

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/main.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/main.tf
@@ -62,14 +62,14 @@ module "prow_build_cluster" {
 
 // The image/machine/disk match prow-build for consistency's sake
 module "prow_build_nodepool" {
-  source        = "../modules/gke-nodepool"
-  project_name  = module.project.project_id
-  cluster_name  = module.prow_build_cluster.cluster.name
-  location      = module.prow_build_cluster.cluster.location
-  name          = "trusted-pool1"
-  initial_count = 1
-  min_count     = 1
-  max_count     = 6
+  source          = "../modules/gke-nodepool"
+  project_name    = module.project.project_id
+  cluster_name    = module.prow_build_cluster.cluster.name
+  location        = module.prow_build_cluster.cluster.location
+  name            = "trusted-pool1"
+  initial_count   = 1
+  min_count       = 1
+  max_count       = 6
   image_type      = "UBUNTU_CONTAINERD"
   machine_type    = "n1-highmem-8"
   disk_size_gb    = 200

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/secrets.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/secrets.tf
@@ -21,11 +21,11 @@ locals {
       owners = "k8s-infra-ii-coop@kubernetes.io"
     }
     k8s-cip-test-prod-service-account = {
-      group = "sig-release"
+      group  = "sig-release"
       owners = "k8s-infra-release-admins@kubernetes.io"
     }
     k8s-gcr-audit-test-prod-service-account = {
-      group = "sig-release"
+      group  = "sig-release"
       owners = "k8s-infra-release-admins@kubernetes.io"
     }
     k8s-triage-robot-github-token = {
@@ -33,11 +33,11 @@ locals {
       owners = "github@kubernetes.io"
     }
     service-account = {
-      group = "sig-testing"
+      group  = "sig-testing"
       owners = "k8s-infra-prow-oncall@kubernetes.io"
     }
     slack-tempelis-auth = {
-      group = "sig-contributor-experience"
+      group  = "sig-contributor-experience"
       owners = "k8s-infra-rbac-slack-infra@kubernetes.io"
     }
     snyk-token = {

--- a/infra/gcp/terraform/k8s-infra-prow-build/00-provider.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/00-provider.tf
@@ -30,11 +30,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.74.0"
+      version = "~> 3.87.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.74.0"
+      version = "~> 3.87.0"
     }
   }
 }

--- a/infra/gcp/terraform/k8s-infra-public-pii/bigquery.tf
+++ b/infra/gcp/terraform/k8s-infra-public-pii/bigquery.tf
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
- 
+
 // Service account dedicated for BigQuery Data Transfer
 resource "google_service_account" "bq_data_transfer_writer" {
   account_id  = "bq-data-transfer"

--- a/infra/gcp/terraform/k8s-infra-public-pii/provider.tf
+++ b/infra/gcp/terraform/k8s-infra-public-pii/provider.tf
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
- 
+
 /*
 This file defines:
 - Required provider versions
@@ -31,11 +31,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.74.0"
+      version = "~> 3.87.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.74.0"
+      version = "~> 3.87.0"
     }
   }
 }

--- a/infra/gcp/terraform/k8s-infra-public-pii/versions.tf
+++ b/infra/gcp/terraform/k8s-infra-public-pii/versions.tf
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
- 
+
 /*
 This file defines:
 - Required Terraform version

--- a/infra/gcp/terraform/kubernetes-public/00-inputs.tf
+++ b/infra/gcp/terraform/kubernetes-public/00-inputs.tf
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
- 
+
 /*
 This file defines:
 - Required Terraform version
@@ -36,10 +36,10 @@ terraform {
 
   required_providers {
     google = {
-      version = "~> 3.74.0"
+      version = "~> 3.87.0"
     }
     google-beta = {
-      version = "~> 3.74.0"
+      version = "~> 3.87.0"
     }
   }
 }

--- a/infra/gcp/terraform/kubernetes-public/10-cluster-configuration.tf
+++ b/infra/gcp/terraform/kubernetes-public/10-cluster-configuration.tf
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
- 
+
 /*
 This file defines:
 - GCP Service Account for nodes

--- a/infra/gcp/terraform/kubernetes-public/11-pool1-configuration.tf
+++ b/infra/gcp/terraform/kubernetes-public/11-pool1-configuration.tf
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
- 
+
 /*
 This file defines:
 - Node pool for pool1

--- a/infra/gcp/terraform/kubernetes-public/11-pool2-configuration.tf
+++ b/infra/gcp/terraform/kubernetes-public/11-pool2-configuration.tf
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
- 
+
 /*
 This file defines:
 - Node pool for pool2

--- a/infra/gcp/terraform/kubernetes-public/k8s-infra-prow.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-infra-prow.tf
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
- 
+
 /*
 This file defines:
 - a bucket for k8s-infra-prow

--- a/infra/gcp/terraform/kubernetes-public/k8s-metrics.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-metrics.tf
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
- 
+
 /*
 This file defines:
 - GCS bucket to serve metrics bigquery results

--- a/infra/gcp/terraform/kubernetes-public/k8s-triage.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-triage.tf
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
- 
+
 /*
 This file defines:
 - bigquery dataset for triage to store temp results
@@ -133,6 +133,6 @@ data "google_iam_policy" "triage_dataset_iam_policy" {
 
 resource "google_bigquery_dataset_iam_policy" "triage_dataset" {
   dataset_id  = google_bigquery_dataset.triage_dataset.dataset_id
-  project = google_bigquery_dataset.triage_dataset.project
+  project     = google_bigquery_dataset.triage_dataset.project
   policy_data = data.google_iam_policy.triage_dataset_iam_policy.policy_data
 }

--- a/infra/gcp/terraform/modules/gke-cluster/versions.tf
+++ b/infra/gcp/terraform/modules/gke-cluster/versions.tf
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.74.0"
+      version = "~> 3.87.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.74.0"
+      version = "~> 3.87.0"
     }
   }
 }

--- a/infra/gcp/terraform/modules/gke-nodepool/versions.tf
+++ b/infra/gcp/terraform/modules/gke-nodepool/versions.tf
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.74.0"
+      version = "~> 3.87.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.74.0"
+      version = "~> 3.87.0"
     }
   }
 }

--- a/infra/gcp/terraform/modules/gke-project/versions.tf
+++ b/infra/gcp/terraform/modules/gke-project/versions.tf
@@ -21,11 +21,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.74.0"
+      version = "~> 3.87.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.74.0"
+      version = "~> 3.87.0"
     }
   }
 }

--- a/infra/gcp/terraform/modules/workload-identity-service-account/versions.tf
+++ b/infra/gcp/terraform/modules/workload-identity-service-account/versions.tf
@@ -18,11 +18,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.74.0"
+      version = "~> 3.87.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.74.0"
+      version = "~> 3.87.0"
     }
   }
 }


### PR DESCRIPTION
Bump provider to 3.87.0 for google and google-beta

Changelog: https://github.com/hashicorp/terraform-provider-google-beta/blob/master/CHANGELOG.md

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>