### PR TITLE
images/k8s-infra: Bump dependencies

### DIFF
--- a/images/k8s-infra/Dockerfile
+++ b/images/k8s-infra/Dockerfile
@@ -26,17 +26,17 @@ FROM debian:bullseye
 # latest at the time, and package-based installs from debian-maintained repos
 # are not pinned to a specific version
 
-ARG CONFTEST_VERSION=0.27.0
-ARG GCLOUD_VERSION=355.0.0
+ARG CONFTEST_VERSION=0.28.1
+ARG GCLOUD_VERSION=360.0.0
 ARG GH_VERSION=2.0.0
-ARG GO_VERSION=1.17
+ARG GO_VERSION=1.17.2
 ARG JQ_VERSION=1.6
 # K8S_VERSION should be within +/- 1 minor version of our clusters
 # ref: https://kubernetes.io/releases/version-skew-policy/#kubectl
-ARG K8S_VERSION=1.21.4
-ARG OPA_VERSION=0.32.0
+ARG K8S_VERSION=1.21.5
+ARG OPA_VERSION=0.33.1
 ARG SHELLCHECK_VERSION=0.7.2
-ARG TFSWITCH_VERSION=0.12.1119
+ARG TFSWITCH_VERSION=0.12.1168
 
 # build everything in /build
 WORKDIR /build


### PR DESCRIPTION
Conftest: https://github.com/open-policy-agent/conftest/releases/tag/v0.28.1
Gcloud: https://cloud.google.com/sdk/docs/release-notes#36000_2021-10-05
Go 1.17.2: https://groups.google.com/g/golang-announce/c/AEBu9j7yj5A/m/1D54lOxkAwAJ
Kubectl 1.21.5: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md#v1215
OPA: https://github.com/open-policy-agent/opa/releases/tag/v0.33.1
Tfswitch: https://github.com/warrensbox/terraform-switcher/releases/tag/0.12.1168

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>