### PR TITLE
Promote aws-ebs-csi-driver:v1.3.1

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-provider-aws/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-provider-aws/images.yaml
@@ -31,6 +31,7 @@
     "sha256:732da7df530f4ad1923a7c71b927b0d964e596c622de68c1c6179fb7148704fd": ["v1.2.1"]
     "sha256:6dda9d13dfe77e4440097c0aee379c703185fad7c01c4b96909f6bc28ea2dfd4": ["v1.2.1-amazonlinux"]
     "sha256:b39ea6bb1496aa57a50898d1c94c24abf7f0a02c4077aa2285ad24449734b804": ["v1.3.0"]
+    "sha256:e2073961c0ba1ac67eeb3361a6c6f4c5e2e80af6cc3bea0a39e647dffb3b5fd8": ["v1.3.1"]
 - name: cloud-controller-manager
   dmap:
     "sha256:f900d8b4a358847cd311950c7802f938dad083f645eee784cd52b7aec0de8dfb": ["v1.18.0-alpha.0"]


### PR DESCRIPTION
this is a manifest list.

$ gcloud container images list-tags gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver --format='get(tags, digest)' --filter='tags:v1.3.1 AND tags!~rc'
v20211005-v1.3.1-windows-amd64-20H2	sha256:0231afaa97beac1b0e65f3be416f9ef6d2f35c6cb092512a965e4f401d94a3f5
v20211005-v1.3.1-windows-amd64-2004	sha256:46fe7c31195b091c93acfe46f3e0eda55965a09eea1c468f1d4d182fe3f8089b
v20211005-v1.3.1-windows-amd64-1809	sha256:c157bcd2296c048dc0872d657379358a52e009bf9b082c84e7903167db279863
v20211005-v1.3.1-linux-arm64-amazon	sha256:879bbf22e0d4ee7eeda639e68fc786179fbe0d6e6aefc9b280297c464f3316b3
v20211005-v1.3.1-linux-amd64-amazon	sha256:7ef05ab78ccc346cc9b45609ef53ac17958087aa3f9d976777f6c76f22f2b264
v20211005-v1.3.1	sha256:e2073961c0ba1ac67eeb3361a6c6f4c5e2e80af6cc3bea0a39e647dffb3b5fd8