### PR TITLE
k8s-infra-prow: Ingress for IpV6

### DIFF
--- a/apps/prow/cluster/prow_ingress.yaml
+++ b/apps/prow/cluster/prow_ingress.yaml
@@ -26,3 +26,32 @@ spec:
             name: hook
             port:
               number: 8888
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: k8s-infra-prow-k8s-io-v6
+  namespace: prow
+  annotations:
+    kubernetes.io/ingress.class: "gce"
+    kubernetes.io/ingress.global-static-ip-name: k8s-infra-prow-v6
+    networking.gke.io/managed-certificates: k8s-infra-prow-k8s-io-v6
+spec:
+  rules:
+  - host: k8s-infra-prow.k8s.io
+    http:
+      paths:
+      - path: /*
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: deck
+            port:
+              number: 80
+      - path: /hook
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: hook
+            port:
+              number: 8888

--- a/apps/prow/cluster/prow_managedcertificate.yaml
+++ b/apps/prow/cluster/prow_managedcertificate.yaml
@@ -6,3 +6,12 @@ metadata:
 spec:
   domains:
   - k8s-infra-prow.k8s.io
+---
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: k8s-infra-prow-k8s-io-v6
+  namespace: prow
+spec:
+  domains:
+  - k8s-infra-prow.k8s.io

--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -170,10 +170,13 @@ issue:
 issues:
   type: CNAME
   value: redirect.k8s.io.
-#sig-k8s-infra
+# sig-k8s-infra
+# Hosted on GKE cluster aaa
 k8s-infra-prow:
-  type: A
-  value: 34.117.224.94 # Hosted on GKE cluster aaa
+  - type: A
+    value: 34.117.224.94
+  - type: AAAA
+    value: "2600:1901:0:b267::"
 kep:
   type: CNAME
   value: redirect.k8s.io.


### PR DESCRIPTION
Ref: https://github.com/kubernetes/k8s.io/issues/1394
Expose k8s-infra-prow.k8s.io using IPv6.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>