### PR TITLE
[ISSUE-2651] [Digital Ocean] Add zone file for new subdomain for e2e kops digitial ocean tests

### DIFF
--- a/dns/zone-configs/k8s.io._1_do.yaml
+++ b/dns/zone-configs/k8s.io._1_do.yaml
@@ -1,0 +1,7 @@
+# kops testing e2e for digital ocean.
+test-cncf-do:
+  type: NS
+  values:
+  - ns1.digitalocean.com.
+  - ns2.digitalocean.com.
+  - ns3.digitalocean.com.


### PR DESCRIPTION
Adding a new zone file for e2e kops testing in digital ocean.
Reference Issue - https://github.com/kubernetes/k8s.io/issues/2651

FYI - @rifelpet @timoreimann 