### PR TITLE
Promote kube-webhook-certgen v1.1.1 image

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -116,6 +116,7 @@
   dmap:
     "sha256:f3b6b39a6062328c095337b4cadcefd1612348fdd5190b1dcbcb9b9e90bd8068": ["v1.0"]
     "sha256:cdc56f415500de9a6342be4f8703850dab9eae8870e9f33d9b8598232abd6ac0": ["v1.1"]
+    "sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660": ["v1.1.1"]
 
 # nginx-errors
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/custom-error-pages


### PR DESCRIPTION
Version v1.1 introduced an regression which has been fixed in
https://github.com/kubernetes/ingress-nginx/pull/7801, this commit
promotes fixed version.

Signed-off-by: Mateusz Gozdek <mgozdek@microsoft.com>