### PR TITLE
Promote aws-ebs-csi-driver:v1.4.0

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-provider-aws/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-provider-aws/images.yaml
@@ -32,6 +32,7 @@
     "sha256:6dda9d13dfe77e4440097c0aee379c703185fad7c01c4b96909f6bc28ea2dfd4": ["v1.2.1-amazonlinux"]
     "sha256:b39ea6bb1496aa57a50898d1c94c24abf7f0a02c4077aa2285ad24449734b804": ["v1.3.0"]
     "sha256:e2073961c0ba1ac67eeb3361a6c6f4c5e2e80af6cc3bea0a39e647dffb3b5fd8": ["v1.3.1"]
+    "sha256:5c03401df9e8fa384b66efc8bfd954a0371ad584a9430eca7d4d9338654d7fe0": ["v1.4.0"]
 - name: cloud-controller-manager
   dmap:
     "sha256:f900d8b4a358847cd311950c7802f938dad083f645eee784cd52b7aec0de8dfb": ["v1.18.0-alpha.0"]


### PR DESCRIPTION
```
~ $ gcloud container images list-tags gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver --format='get(tags, digest)' --filter='tags:v1.4.0 AND tags!~rc'
v20211012-v1.4.0-windows-amd64-20H2	sha256:31ebd3eb6c3aad58eabf9e19ea0dfea79c99b0570f643791750732b030efc53d
v20211012-v1.4.0-windows-amd64-2004	sha256:1bd4f654a91ef15fbdc512421029d37dae3110466006c6fe9a9fa576856f202d
v20211012-v1.4.0-windows-amd64-1809	sha256:aab515fd22abcd2cf38f4201b5516bda541107345eca480ab5e2e221de03fc93
v20211012-v1.4.0-linux-arm64-amazon	sha256:81e2698ecc8ccdeca67fbc743217024ab02554d23b788ffcfea123724b31d9c1
v20211012-v1.4.0-linux-amd64-amazon	sha256:af9b4b98976393b65496911090487a4c2911e3fef461b46e221028c60cfc9c7d
v20211012-v1.4.0	sha256:5c03401df9e8fa384b66efc8bfd954a0371ad584a9430eca7d4d9338654d7fe0
```

the last one above is the manifest list to promote.

pushed by https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/aws-ebs-csi-driver-push-images/1448035944807534592
