### PR TITLE
Add CoCC vanity redirect

### DIFF
--- a/apps/k8s-io/certificate-canary.yaml
+++ b/apps/k8s-io/certificate-canary.yaml
@@ -25,6 +25,8 @@ spec:
   - ci-test.kubernetes.io
   - code.k8s.io
   - code.kubernetes.io
+  - conduct.k8s.io
+  - conduct.kubernetes.io
   - dl.k8s.io
   - dl.kubernetes.io
   - docs.k8s.io

--- a/apps/k8s-io/certificate-prod.yaml
+++ b/apps/k8s-io/certificate-prod.yaml
@@ -18,6 +18,8 @@ spec:
   - ci-test.kubernetes.io
   - code.k8s.io
   - code.kubernetes.io
+  - conduct.k8s.io
+  - conduct.kubernetes.io
   - dl.k8s.io
   - dl.kubernetes.io
   - docs.k8s.io

--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -166,6 +166,12 @@ data:
         rewrite ^/(.*)?$    https://github.com/kubernetes/kubernetes/tree/master/$1 redirect;
       }
       server {
+        server_name conduct.kubernetes.io conduct.k8s.io;
+        listen 80;
+
+        rewrite ^/(.*)?$    https://github.com/kubernetes/community/tree/master/committee-code-of-conduct/$1 redirect;
+      }
+      server {
         server_name dl.k8s.io dl.kubernetes.io;
         listen 80;
 

--- a/apps/k8s-io/test.py
+++ b/apps/k8s-io/test.py
@@ -271,6 +271,13 @@ class RedirTest(HTTPTestCase):
                 'https://github.com/kubernetes/kubernetes/tree/master/$path',
                 path=path)
 
+    def test_conduct(self):
+        path = rand_num()
+        for base in ('conduct.kubernetes.io', 'conduct.k8s.io'):
+            self.assert_temp_redirect(base + '/$path',
+                'https://github.com/kubernetes/community/tree/master/committee-code-of-conduct/$path',
+                path=path)
+
     def test_dl(self):
         for base in ('dl.k8s.io', 'dl.kubernetes.io'):
             # Valid release version numbers

--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -110,6 +110,10 @@ ci-test:
 code:
   type: CNAME
   value: redirect.k8s.io.
+# committee-code-of-conduct vanity redirect
+conduct:
+  type: CNAME
+  value: redirect.k8s.io.
 # Code search (@dims)
 # This service runs in a equinix host managed by @dims
 cs:

--- a/dns/zone-configs/kubernetes.io._0_base.yaml
+++ b/dns/zone-configs/kubernetes.io._0_base.yaml
@@ -103,6 +103,9 @@ ci-test:
 code:
   type: CNAME
   value: code.k8s.io.
+conduct:
+  type: CNAME
+  value: conduct.k8s.io.
 cs:
   type: CNAME
   value: cs.k8s.io.


### PR DESCRIPTION
fixes #2923

Adds a vanity redirect for the CoCC committee, redirecting to their k/community page.

This will also enable the conduct.k8s.io/transparency-reports URL