### PR TITLE
Promote pod-security-webhook:v1.22-alpha.0

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-sig-auth/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-sig-auth/images.yaml
@@ -1,1 +1,3 @@
-# No images yet
+- name: pod-security-webhook
+  dmap:
+    "sha256:818c11eaaf3863a9f1c9e8de9c310ac85b29cd89ebc54f832aa212bb52b5e7af": ["v1.22-alpha.0"]


### PR DESCRIPTION
This is a local build off the v1.22 branch using the docker image from https://github.com/kubernetes/kubernetes/pull/105362/commits/525f2d37162a3e554babd5a15e84d404299125d3

The intention is to get an early iteration out that users can start playing with. The `-alpha.0` tag is intended to indicate that this is not production-ready.

We will work on setting up cloud build & multi-arch builds in a future iteration.

/sig auth
/assign @liggitt @sejr 