### PR TITLE
kubernetes-public: Fix workload identity binding

### DIFF
--- a/infra/gcp/bash/ensure-main-project.sh
+++ b/infra/gcp/bash/ensure-main-project.sh
@@ -498,7 +498,7 @@ function ensure_main_project() {
 
         color 6 "Ensure Monitoring Admin service account for Terraform"
         svcacct_args=("${project}" "tf-monitoring-deployer" "roles/monitoring.admin")
-        cluster_args=("${project}" "${PROWJOB_POD_NAMESPACE}")
+        cluster_args=("k8s-infra-prow-build-trusted" "${PROWJOB_POD_NAMESPACE}")
         ensure_workload_identity_serviceaccount "${svcacct_args[@]}" "${cluster_args[@]}" 2>&1 | indent
     ) 2>&1 | indent
 


### PR DESCRIPTION
Related:
  - Part of: https://github.com/kubernetes/k8s.io/issues/2588
  - Fixes: https://github.com/kubernetes/k8s.io/issues/2942
  - followup of: https://github.com/kubernetes/k8s.io/pull/2898

Ensure service account tf-monitoring-deployer can be used in build cluster prow-build-trusted

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>