### PR TITLE
groups: Add emails aliases for Azure and Equinix accounts

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -180,6 +180,8 @@ restrictions:
       - "^gke-security-groups@kubernetes.io$"
       - "^k8s-infra-alerts@kubernetes.io$"
       - "^k8s-infra-aws-admins@kubernetes.io$"
+      - "^k8s-infra-azure-admins@kubernetes.io$"
+      - "^k8s-infra-equinix-admins@kubernetes.io$"
       - "^k8s-infra-artifact-admins@kubernetes.io$"
       - "^k8s-infra-bigquery-admins@kubernetes.io$"
       - "^k8s-infra-cluster-admins@kubernetes.io$"

--- a/groups/sig-k8s-infra/groups.yaml
+++ b/groups/sig-k8s-infra/groups.yaml
@@ -247,6 +247,26 @@ groups:
       - justinsb@google.com
       - thockin@google.com
 
+  - email-id: k8s-infra-azure-admins@kubernetes.io
+    name: k8s-infra-azure-admins
+    description: |-
+      ACL for Azure admins
+    settings:
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+    managers:
+      - sig-k8s-infra-leads@kubernetes.io
+
+  - email-id: k8s-infra-equinix-admins@kubernetes.io
+    name: k8s-infra-equinix-admins
+    description: |-
+      ACL for Equinix admins
+    settings:
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+    managers:
+      - sig-k8s-infra-leads@kubernetes.io
+
   - email-id: k8s-infra-artifact-admins@kubernetes.io
     name: k8s-infra-artifact-admins
     description: |-


### PR DESCRIPTION
Add google groups that will be used for admins access to Azure et
Equinix acccounts funded by the CNCF cloud credits.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>