### PR TITLE
tf/k8s-infra-monitoring: add missing project field

### DIFF
--- a/infra/gcp/terraform/k8s-infra-monitoring/main.tf
+++ b/infra/gcp/terraform/k8s-infra-monitoring/main.tf
@@ -30,6 +30,7 @@ resource "google_monitoring_notification_channel" "email" {
     "sig-k8s-infra-leads@kubernetes.io",
   ])
   display_name = each.value
+  project = data.google_project.project.project_id
   type = "email"
   labels = {
     email_address = each.value


### PR DESCRIPTION
Related:
- Followup to: https://github.com/kubernetes/k8s.io/pull/2944

Missed a project field for the monitoring channel resources

Have already run `terraform apply` for these resources