### PR TITLE
Add cloudbuild to public-log-asn-matcher

### DIFF
--- a/images/public-log-asn-matcher/cloudbuild.yaml
+++ b/images/public-log-asn-matcher/cloudbuild.yaml
@@ -1,0 +1,18 @@
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+        "build",
+        "-t",
+        "gcr.io/$PROJECT_ID/public-log-asn-matcher:$_GIT_TAG",
+        "--build-arg",
+        "IMAGE_ARG=gcr.io/$PROJECT_ID/public-log-asn-matcher:$_GIT_TAG",
+        ".",
+      ]
+substitutions:
+  _GIT_TAG: "12345"
+  _PULL_BASE_REF: "main"
+images:
+  - "gcr.io/$PROJECT_ID/public-log-asn-matcher:$_GIT_TAG"
+options:
+  substitution_option: "ALLOW_LOOSE"


### PR DESCRIPTION
Addresses requirement of `cloudbuild.yaml` for container image build, as seen in logs of job.

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-k8sio-push-image-public-log-asn-matcher/1450439763910725632