### PR TITLE
Update tagging and docs for public-log-asn-matcher

### DIFF
--- a/images/public-log-asn-matcher/README.md
+++ b/images/public-log-asn-matcher/README.md
@@ -70,3 +70,19 @@ A list of buckets is used for their `.*_usage` bucket which stores the public ac
 ```bash
 ./generate-buckets.sh
 ```
+
+## Run a test build
+
+```bash
+TAG="$(date -u '+%Y%m%d')-$(git describe --tags --always --dirty)"
+PROJECT="k8s-infra-ii-sandbox"
+BUCKET="ii_bq_scratch_dump"
+
+gcloud builds submit \
+    --verbosity info \
+    --config cloudbuild.yaml \
+    --substitutions _TAG="${TAG}",_GIT_TAG="${TAG}" \
+    --project ${PROJECT} \
+    --gcs-source-staging-dir "gs://${BUCKET}/source" \
+    .
+```

--- a/images/public-log-asn-matcher/cloudbuild.yaml
+++ b/images/public-log-asn-matcher/cloudbuild.yaml
@@ -5,8 +5,8 @@ steps:
         "build",
         "-t",
         "gcr.io/$PROJECT_ID/public-log-asn-matcher:$_GIT_TAG",
-        "--build-arg",
-        "IMAGE_ARG=gcr.io/$PROJECT_ID/public-log-asn-matcher:$_GIT_TAG",
+        "-t",
+        "gcr.io/$PROJECT_ID/public-log-asn-matcher:latest",
         ".",
       ]
 substitutions:
@@ -14,5 +14,6 @@ substitutions:
   _PULL_BASE_REF: "main"
 images:
   - "gcr.io/$PROJECT_ID/public-log-asn-matcher:$_GIT_TAG"
+  - "gcr.io/$PROJECT_ID/public-log-asn-matcher:latest"
 options:
   substitution_option: "ALLOW_LOOSE"

--- a/images/public-log-asn-matcher/cloudbuild.yaml
+++ b/images/public-log-asn-matcher/cloudbuild.yaml
@@ -1,17 +1,15 @@
 steps:
   - name: gcr.io/cloud-builders/docker
     args:
-      [
-        "build",
-        "-t",
-        "gcr.io/$PROJECT_ID/public-log-asn-matcher:$_GIT_TAG",
-        "-t",
-        "gcr.io/$PROJECT_ID/public-log-asn-matcher:latest",
-        ".",
-      ]
+      - build
+      - -t
+      - gcr.io/$PROJECT_ID/public-log-asn-matcher:$_GIT_TAG
+      - -t
+      - gcr.io/$PROJECT_ID/public-log-asn-matcher:latest
+      - .
 substitutions:
   _GIT_TAG: "12345"
-  _PULL_BASE_REF: "main"
+  _PULL_BASE_REF: ""
 images:
   - "gcr.io/$PROJECT_ID/public-log-asn-matcher:$_GIT_TAG"
   - "gcr.io/$PROJECT_ID/public-log-asn-matcher:latest"


### PR DESCRIPTION
Adds some docs for running `cloudbuild` manually and adds a `latest` tag