### PR TITLE
kubernetes-public: Allow access to Cloud SQL

### DIFF
--- a/infra/gcp/terraform/kubernetes-public/k8s-elections-database.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-elections-database.tf
@@ -95,6 +95,14 @@ resource "google_sql_user" "db_user" {
   password = random_password.db_password.result
 }
 
+resource "google_project_iam_binding" "cloud_sql_access" {
+  project = data.google_project.project.project_id
+  role    = "roles/cloudsql.editor"
+  members = [
+    "group:k8s-infra-rbac-elekto@kubernetes.io"
+  ]
+}
+
 resource "google_compute_global_address" "db_private_ip_address" {
   name          = "k8s-infra-db-election-private-ip"
   project       = data.google_project.project.project_id


### PR DESCRIPTION
Grant to members of the Steering Election committee control of Cloud SQL
instances in kubernetes-public.
It's currently not possible to scope it at the instance level.

EDIT: Part of: https://github.com/kubernetes/k8s.io/issues/2575

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>