### PR TITLE
Add mkumatag into k8s-infra-staging-e2e-test-images

### DIFF
--- a/groups/sig-testing/groups.yaml
+++ b/groups/sig-testing/groups.yaml
@@ -57,6 +57,7 @@ groups:
     - cblecker@gmail.com
     - davanum@gmail.com
     - justinsb@google.com
+    - manjunath.cse@gmail.com
     - thockin@google.com
     - spiffxp@gmail.com
 


### PR DESCRIPTION
Being a [maintainer](https://github.com/kubernetes/kubernetes/blob/ae9ca48f01ddb03731e7903cfe91ef3db9ce8990/test/images/OWNERS#L8) for `k/test/images`, this is required at times to rerun the cloudbuild if failed post merge.