### PR TITLE
k8s-infra-monitoring: Add a monitoring dashboard for k8s-artifacts-prod

### DIFF
--- a/infra/gcp/terraform/k8s-infra-monitoring/dashboards/cloud-storage-monitoring.json
+++ b/infra/gcp/terraform/k8s-infra-monitoring/dashboards/cloud-storage-monitoring.json
@@ -1,0 +1,198 @@
+{
+  "displayName": "GCS Bucket Monitoring - k8s-artifacts-prod",
+  "gridLayout": {
+    "columns": "2",
+    "widgets": [
+      {
+        "title": "Total object count",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "perSeriesAligner": "ALIGN_MEAN"
+                  },
+                  "filter": "metric.type=\"storage.googleapis.com/storage/object_count\" resource.type=\"gcs_bucket\" resource.label.\"bucket_name\"=monitoring.regex.full_match(\".*k8s-artifacts-prod.*\")",
+                  "secondaryAggregation": {}
+                },
+                "unitOverride": "1"
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "Total bytes",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "crossSeriesReducer": "REDUCE_SUM",
+                    "perSeriesAligner": "ALIGN_MEAN"
+                  },
+                  "filter": "metric.type=\"storage.googleapis.com/storage/total_bytes\" resource.type=\"gcs_bucket\" resource.label.\"bucket_name\"=monitoring.regex.full_match(\".*k8s-artifacts-prod.*\")",
+                  "secondaryAggregation": {}
+                },
+                "unitOverride": "By"
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "Bucket object count",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "perSeriesAligner": "ALIGN_MEAN"
+                  },
+                  "filter": "metric.type=\"storage.googleapis.com/storage/object_count\" resource.type=\"gcs_bucket\" resource.label.\"bucket_name\"=monitoring.regex.full_match(\".*k8s-artifacts-prod.*\")",
+                  "secondaryAggregation": {}
+                },
+                "unitOverride": "1"
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "Bucket total bytes",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "perSeriesAligner": "ALIGN_MEAN"
+                  },
+                  "filter": "metric.type=\"storage.googleapis.com/storage/total_bytes\" resource.type=\"gcs_bucket\" resource.label.\"bucket_name\"=monitoring.regex.full_match(\".*k8s-artifacts-prod.*\")",
+                  "secondaryAggregation": {}
+                },
+                "unitOverride": "By"
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "Bucket - Received bytes, Sent bytes",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "perSeriesAligner": "ALIGN_RATE"
+                  },
+                  "filter": "metric.type=\"storage.googleapis.com/network/received_bytes_count\" resource.type=\"gcs_bucket\" resource.label.\"bucket_name\"=monitoring.regex.full_match(\".*k8s-artifacts-prod.*\")",
+                  "secondaryAggregation": {}
+                },
+                "unitOverride": "By"
+              }
+            },
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "perSeriesAligner": "ALIGN_RATE"
+                  },
+                  "filter": "metric.type=\"storage.googleapis.com/network/sent_bytes_count\" resource.type=\"gcs_bucket\" resource.label.\"bucket_name\"=monitoring.regex.full_match(\".*k8s-artifacts-prod.*\")",
+                  "secondaryAggregation": {}
+                },
+                "unitOverride": "By"
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          }
+        }
+      },
+      {
+        "title": "Bucket - Request count",
+        "xyChart": {
+          "chartOptions": {
+            "mode": "COLOR"
+          },
+          "dataSets": [
+            {
+              "minAlignmentPeriod": "60s",
+              "plotType": "LINE",
+              "timeSeriesQuery": {
+                "timeSeriesFilter": {
+                  "aggregation": {
+                    "perSeriesAligner": "ALIGN_RATE"
+                  },
+                  "filter": "metric.type=\"storage.googleapis.com/api/request_count\" resource.type=\"gcs_bucket\" resource.label.\"bucket_name\"=monitoring.regex.full_match(\".*k8s-artifacts-prod.*\")",
+                  "secondaryAggregation": {}
+                },
+                "unitOverride": "1"
+              }
+            }
+          ],
+          "timeshiftDuration": "0s",
+          "yAxis": {
+            "label": "y1Axis",
+            "scale": "LINEAR"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/infra/gcp/terraform/k8s-infra-monitoring/main.tf
+++ b/infra/gcp/terraform/k8s-infra-monitoring/main.tf
@@ -30,9 +30,14 @@ resource "google_monitoring_notification_channel" "email" {
     "sig-k8s-infra-leads@kubernetes.io",
   ])
   display_name = each.value
-  project = data.google_project.project.project_id
-  type = "email"
+  project      = data.google_project.project.project_id
+  type         = "email"
   labels = {
     email_address = each.value
   }
+}
+
+resource "google_monitoring_dashboard" "gcs_dashboard" {
+  project        = data.google_project.project.project_id
+  dashboard_json = file("./dashboards/cloud-storage-monitoring.json")
 }


### PR DESCRIPTION
Add a Cloud Monitoring dashboard for all the GCS buckets :  `.*k8s-artifacts-prod.`.
The dashboard help visualize:

- The total objects count
- The total size of the buckets
- The egress network traffic
- The ingress network traffic

source:
https://github.com/GoogleCloudPlatform/monitoring-dashboard-samples/blob/master/dashboards/storage/cloud-storage-monitoring.json.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>