### PR TITLE
Push 1.3.4 pdcsi image to  k8s prod

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cloud-provider-gcp/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-cloud-provider-gcp/images.yaml
@@ -6,6 +6,7 @@
     "sha256:8e04ffa8060e46b5e07d70990f80ad15446b2f27b286df4a47569e1c818dcce7": ["v1.3.0"]
     "sha256:af42e4cf7bd5af41744d8c3a6c238da1a988cd38ec5dca5efcea343a96a05763": ["v1.3.1"]
     "sha256:e9c355dd1ce57de91a0f9164bd2fe688938723e7f9bd40bb13652d603f41d25a": ["v1.2.2"]
+    "sha256:b316059d0057e2bcb98d680feb99cd16e031260dd4ad0ce6c51ba8a28b48d9b7": ["v1.3.4"]
 - name: gcp-filestore-csi-driver
   dmap:
     "sha256:0ff5800855e8f98467b1976cb442b402f00fed2e2ffab62b8f9a9c9f133e6d98": ["v0.6.1"]


### PR DESCRIPTION
1.3.4 [image](https://pantheon.corp.google.com/gcr/images/k8s-staging-cloud-provider-gcp/global/gcp-compute-persistent-disk-csi-driver@sha256:b316059d0057e2bcb98d680feb99cd16e031260dd4ad0ce6c51ba8a28b48d9b7/details?tab=info)