### PR TITLE
apps/kettle: Add PubSub Topic and Subscripton for kubernetes-jenkins

### DIFF
--- a/infra/gcp/terraform/kubernetes-public/k8s-kettle.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-kettle.tf
@@ -94,8 +94,4 @@ resource "google_bigquery_data_transfer_config" "bq_data_transfer_kettle" {
     source_dataset_id           = "build"
     source_project_id           = "k8s-gubernator"
   }
-
-  email_preferences {
-    enable_failure_email = false
-  }
 }

--- a/infra/gcp/terraform/kubernetes-public/k8s-kettle.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-kettle.tf
@@ -95,3 +95,27 @@ resource "google_bigquery_data_transfer_config" "bq_data_transfer_kettle" {
     source_project_id           = "k8s-gubernator"
   }
 }
+
+# Used to monitor kubernetes jenkings changes
+resource "google_pubsub_topic" "notification_topic" {
+  project = data.google_project.project.project_id
+  name    = "k8s-infra-kubernetes-jenkins-changes"
+}
+
+# Use by kettle to collect job information
+resource "google_pubsub_subscription" "kettle_subscription" {
+  name    = "k8s-infra-kettle-staging"
+  topic   = google_pubsub_topic.notification_topic.name
+  project = data.google_project.project.project_id
+
+  filter = "attributes.eventType = \"OBJECT_FINALIZE\""
+}
+
+resource "google_pubsub_subscription_iam_binding" "subscription_binding" {
+  project      = data.google_project.project.project_id
+  subscription = google_pubsub_subscription.kettle_subscription.name
+  role         = "roles/pubsub.editor"
+  members = [
+    "serviceAccount:${module.aaa_kettle_sa.email}"
+  ]
+}


### PR DESCRIPTION
Related:
 - Part of:https://github.com/kubernetes/k8s.io/issues/787
 - Followup of: https://github.com/kubernetes/k8s.io/pull/2737

Following instructions in
https://github.com/kubernetes/test-infra/tree/master/kettle#pubsub to
setup a PubSub Topic that  will monitor kubernetes-jenkins change

Also remove email notification for BigQuery Data Transfer.  The change is not applied.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>