### PR TITLE
promote gcp-compute-persistent-disk-csi-driver release v1.2.4

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cloud-provider-gcp/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-cloud-provider-gcp/images.yaml
@@ -1,12 +1,13 @@
 - name: gcp-compute-persistent-disk-csi-driver
   dmap:
     "sha256:23d2fe20c5307c3ef2580ed035084d9a57866717bd8b80bdc2dabd2097591227": ["v1.2.1"]
+    "sha256:2d920e96444596fbeb3c8ebee2197bdebbaf6a1aacb02516f95bf6794f3fea58": ["v1.2.4"]
     "sha256:60c31b6b1f5e18e14e8f9be312afbad67ff5c46785e01e99d2ee3fb815a3c29c": ["v1.3.3"]
     "sha256:7d20ed9af18c24b68b6afe715aeb539fd9c352af875d8329df4652bd0bc38ea8": ["v1.2.3"]
     "sha256:8e04ffa8060e46b5e07d70990f80ad15446b2f27b286df4a47569e1c818dcce7": ["v1.3.0"]
     "sha256:af42e4cf7bd5af41744d8c3a6c238da1a988cd38ec5dca5efcea343a96a05763": ["v1.3.1"]
-    "sha256:e9c355dd1ce57de91a0f9164bd2fe688938723e7f9bd40bb13652d603f41d25a": ["v1.2.2"]
     "sha256:b316059d0057e2bcb98d680feb99cd16e031260dd4ad0ce6c51ba8a28b48d9b7": ["v1.3.4"]
+    "sha256:e9c355dd1ce57de91a0f9164bd2fe688938723e7f9bd40bb13652d603f41d25a": ["v1.2.2"]
 - name: gcp-filestore-csi-driver
   dmap:
     "sha256:0ff5800855e8f98467b1976cb442b402f00fed2e2ffab62b8f9a9c9f133e6d98": ["v0.6.1"]


### PR DESCRIPTION
release v1.2.4 https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/releases/tag/v1.2.4


/assign @mattcary @saikat-royc @msau42 