### PR TITLE
Update release-team-shadows in sig-release groups

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -340,9 +340,9 @@ groups:
       - mehabhalodiya@gmail.com # 1.23 Docs Shadow
       - mickey.boxell@oracle.com # 1.23 Release Comms Shadow
       - m.r.boxell@gmail.com # 1.23 Release Comms Shadow
-      - pal.nabarun95@gmail.com # 1.23 Release Branch Manager Shadow
       - nng.grace@gmail.com # 1.23 Enhancements Shadow
       - nwaddington@cncf.io # 1.23 Docs Shadow
+      - pal.nabarun95@gmail.com # 1.23 Release Branch Manager Shadow
       - panjwaniritu45@gmail.com # 1.23 Bug Triage Shadow
       - parulsahoo5jan@gmail.com # 1.23 Release Notes Shadow
       - priyankasaggu11929@gmail.com # 1.23 Enhancements Shadow
@@ -380,6 +380,8 @@ groups:
       - calvinho.ca@gmail.com # 1.23 CI Signal Shadow
       - cccswann@gmail.com # 1.23 Release Comms Shadow
       - DamanArora@cmail.carleton.ca # 1.23 Release Notes Shadow
+      - james.laverack@jetstack.io # 1.23 RT Lead Shadow
+      - joseph.r.sandoval@gmail.com # 1.23 RT Lead Shadow
       - jyotima@amazon.com # 1.23 Bug Triage Shadow
       - kaslin.fields@gmail.com # 1.23 Release Comms Shadow
       - kat.cosgrove@gmail.com # 1.23 Release Comms Shadow
@@ -388,8 +390,10 @@ groups:
       - leonard.pahlke@googlemail.com # 1.23 CI Signal Shadow
       - lucasdwyer@pm.me # 1.23 Release Notes Shadow
       - mail@samcogan.com # 1.23 Release Notes Shadow
+      - max@koerbaecher.io # 1.23 RT Lead Shadow
       - mehabhalodiya@gmail.com # 1.23 Docs Shadow
       - mickey.boxell@oracle.com # 1.23 Release Comms Shadow
+      - monmonmsc@gmail.com # 1.23 RT Lead Shadow
       - nng.grace@gmail.com # 1.23 Enhancements Shadow
       - nwaddington@cncf.io # 1.23 Docs Shadow
       - panjwaniritu45@gmail.com # 1.23 Bug Triage Shadow


### PR DESCRIPTION
This PR:
  - adds 1.23 lead shadows to the release-team-shadows@kubernetes.io sig-release group
  - fixes alpha sorting for Nabarun's email in the release-team@kubernetes.io sig-release group

/assign @jeremyrickard 