### PR TITLE
dns: Domain validation for kubernetes.io

### DIFF
--- a/dns/zone-configs/kubernetes.io._0_base.yaml
+++ b/dns/zone-configs/kubernetes.io._0_base.yaml
@@ -29,7 +29,11 @@
   - type: TXT
     values:
     - google-site-verification=oPORCoq9XU6CmaR7G_bV00CLmEz-wLGOL7SXpeEuTt8
+    # Domain validation for kubernetes.io on https://search.google.com/search-console/welcome
+    # Only Org admins have access to the console. (contact @ameukam)
+    - google-site-verification=qmfDqvHjWJBL78F9saApyW0VFRyymuSMpqMn8gtGmd0
     - v=spf1 include:_spf.google.com ~all
+
 www:
   type: CNAME
   value: kubernetes.io.


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/613
- Followup of: https://github.com/kubernetes/k8s.io/pull/2489

Domain validation for kubernetes.io to ensure full access in Google
Search Console.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>