### PR TITLE
kOps Artifacts - Sync Owners File to Current

### DIFF
--- a/artifacts/manifests/k8s-staging-kops/OWNERS
+++ b/artifacts/manifests/k8s-staging-kops/OWNERS
@@ -1,4 +1,5 @@
 # See the OWNERS docs at https://go.k8s.io/owners
+# Synced to the root OWNERS file in k8s.io/kops as of 11/01/21
 
 # These OWNERS files should stay in sync:
 # https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/kops/OWNERS
@@ -16,11 +17,11 @@ approvers:
 - justinsb
 - kashifsaadat
 - mikesplain
+- olemarkus
 - rdrgmnzs
 - rifelpet
 - zetaab
 reviewers:
-- gjtempleton
 - hakman
 - johngmyers
 - joshbranham

--- a/k8s.gcr.io/images/k8s-staging-kops/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-kops/OWNERS
@@ -1,4 +1,5 @@
 # See the OWNERS docs at https://go.k8s.io/owners
+# Synced to the root OWNERS file in k8s.io/kops as of 11/01/21
 
 # These OWNERS files should stay in sync:
 # https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/kops/OWNERS
@@ -16,11 +17,11 @@ approvers:
 - justinsb
 - kashifsaadat
 - mikesplain
+- olemarkus
 - rdrgmnzs
 - rifelpet
 - zetaab
 reviewers:
-- gjtempleton
 - hakman
 - johngmyers
 - joshbranham


### PR DESCRIPTION
Synced both kOps artifacts owners files to upstream status at [kubernetes/kops](https://github.com/kubernetes/kops/blob/master/OWNERS). Also added the same comment line denoting the last sync time as the other files linked to.