### PR TITLE
Add dependabot configuration for Terraform

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "terraform"
+    directory: "infra/gcp/terraform"
+    schedule:
+      day: "tuesday"
+      time: "16:00" #in UTC
+      interval: "weekly"
+    rebase-strategy: "disabled"
+    assignees:
+      - "ameukam"


### PR DESCRIPTION
Enable and configure `dependabot` to scan Terraform code and bump the
Terraform provider to the latest version if needed.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>