### PR TITLE
groups: update k8s-infra-cherrypick-robot owners

### DIFF
--- a/groups/sig-testing/groups.yaml
+++ b/groups/sig-testing/groups.yaml
@@ -191,14 +191,14 @@ groups:
   - email-id: k8s-infra-cherrypick-robot@kubernetes.io
     name: k8s-infra-cherrypick-robot
     description: |-
-      Github admins for github account k8s-cherry-pick-bot (to be renamed to match group name)
+      Github admins for github account k8s-infra-cherry-pick-bot.
+      2fa in kubernetes.1password.com SIG Testing vault
     settings:
       ReconcileMembers: "true"
       WhoCanPostMessage: "ANYONE_CAN_POST"
     managers:
-    - ameukam@gmail.com
-    - spiffxp@gmail.com
-    - spiffxp@google.com
+    - k8s-infra-prow-oncall@kubernetes.io
+    - github@kubernetes.io
 
   - email-id: k8s-infra-prow-oncall@kubernetes.io
     name: k8s-infra-prow-oncall


### PR DESCRIPTION
Related to:
- Allows more people to address https://github.com/kubernetes/test-infra/issues/24108

Replace individuals with github admin team and k8s-infra-prow-oncall