### PR TITLE
elekto: redirect http to https

### DIFF
--- a/apps/elekto/frontendconfig.yaml
+++ b/apps/elekto/frontendconfig.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.gke.io/v1beta1
+kind: FrontendConfig
+metadata:
+  name: elekto-ingress-security
+  namespace: elekto
+spec:
+  redirectToHttps:
+    enabled: true
+    responseCodeName: MOVED_PERMANENTLY_DEFAULT

--- a/apps/elekto/ingress.yaml
+++ b/apps/elekto/ingress.yaml
@@ -10,6 +10,7 @@ metadata:
     kubernetes.io/ingress.class: gce
     kubernetes.io/ingress.global-static-ip-name: k8s-io-elections
     networking.gke.io/managed-certificates: elections-k8s-io
+    networking.gke.io/v1beta1.FrontendConfig: elekto-ingress-security
 spec:
   defaultBackend:
     service:


### PR DESCRIPTION
Ref: https://github.com/kubernetes/k8s.io/issues/3005

Add a `FrontConfig` CRD that helps redirect from
`http://elections.k8s.io` to `https://elections.k8s.io`.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>