### PR TITLE
terraform: replace deprecated node_metadata field

### DIFF
--- a/infra/gcp/terraform/kubernetes-public/11-pool1-configuration.tf
+++ b/infra/gcp/terraform/kubernetes-public/11-pool1-configuration.tf
@@ -59,7 +59,7 @@ resource "google_container_node_pool" "pool1" {
 
     // Needed for workload identity
     workload_metadata_config {
-      node_metadata = "GKE_METADATA_SERVER"
+      mode = "GKE_METADATA"
     }
     metadata = {
       disable-legacy-endpoints = "true"

--- a/infra/gcp/terraform/kubernetes-public/11-pool2-configuration.tf
+++ b/infra/gcp/terraform/kubernetes-public/11-pool2-configuration.tf
@@ -59,7 +59,7 @@ resource "google_container_node_pool" "pool2" {
 
     // Needed for workload identity
     workload_metadata_config {
-      node_metadata = "GKE_METADATA_SERVER"
+      mode = "GKE_METADATA"
     }
     metadata = {
       disable-legacy-endpoints = "true"

--- a/infra/gcp/terraform/modules/gke-nodepool/main.tf
+++ b/infra/gcp/terraform/modules/gke-nodepool/main.tf
@@ -59,7 +59,7 @@ resource "google_container_node_pool" "node_pool" {
 
     // Needed for workload identity
     workload_metadata_config {
-      node_metadata = "GKE_METADATA_SERVER"
+      mode = "GKE_METADATA"
     }
     metadata = {
       disable-legacy-endpoints = "true"


### PR DESCRIPTION
Related:
- Followup to: https://github.com/kubernetes/k8s.io/pull/2996

When running terraform plan this came across as a deprecation warning but also as a disagreement with live statement requiring an update-in-place.  Looks like this is a bug that was fixed in the most recent terraform provider: https://github.com/hashicorp/terraform-provider-google/blob/master/CHANGELOG.md#3900-october-26-2021
```
container: fixed a permadiff on google_container_node_pool.workload_metadata_config.mode (#10313)
```

I suspect https://github.com/kubernetes/k8s.io/pull/2996 to be the culprit here.  I tested rolling the provider version forward locally, which doesn't completely fix this.  It's a little less surgical than this, so we'll start with using the non-deprecated field/value, and save the provider bump for a followup PR (or dependabot)

Config that was changed is documented here: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_workload_metadata_config