### PR TITLE
elekto: Fix http to https redirect.

### DIFF
--- a/apps/elekto/ingress.yaml
+++ b/apps/elekto/ingress.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: elekto
   annotations:
-    kubernetes.io/ingress.allow-http: "false"
     kubernetes.io/ingress.class: gce
     kubernetes.io/ingress.global-static-ip-name: k8s-io-elections
     networking.gke.io/managed-certificates: elections-k8s-io


### PR DESCRIPTION
Related to:
Fixes https://github.com/kubernetes/k8s.io/issues/3005.
Followup of: https://github.com/kubernetes/k8s.io/pull/3006

Turnout we cannot have a `FrontendConfig` with http redirection and the annotation disabling
http at the same time.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>