### PR TITLE
Temporary Release Manager access for jimangel

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -40,6 +40,7 @@ groups:
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
       - gveronicalg@gmail.com
+      - jameswangel@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
       - saschagrunert@gmail.com


### PR DESCRIPTION
Jim Angel (@jimangel) is a Release Manager Associate with SIG Release being granted
temporary elevated access to cut the v1.23.0-alpha.4 release. Access will be
revoked after the release is cut.

SIG Release Issue: kubernetes/sig-release#1733

/assign @saschagrunert @cpanato @ameukam 
/priority critical-urgent

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>