### PR TITLE
Promote pod-security-webhook:v1.23-beta.0

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-sig-auth/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-sig-auth/images.yaml
@@ -1,3 +1,4 @@
 - name: pod-security-webhook
   dmap:
     "sha256:818c11eaaf3863a9f1c9e8de9c310ac85b29cd89ebc54f832aa212bb52b5e7af": ["v1.22-alpha.0"]
+    "sha256:189012639ce8013d2e68705ffada4d446cb93de7649f20087201dad131461402": ["v1.23-beta.0"]


### PR DESCRIPTION
/cc @enj @tallclair 
/sig auth

built from `master` at 0b8ac0c0fc5f521601b205ed500c67a35e908084:
```
make build container push TAG=v1.23-beta.0
Building PodSecurity webhook...
Done!
Building PodSecurity webhook image...
Sending build context to Docker daemon  59.44MB
Step 1/3 : FROM gcr.io/distroless/static:latest
 ---> debcd6a8142b
Step 2/3 : COPY pod-security-webhook /pod-security-webhook
 ---> 689b75c16564
Step 3/3 : ENTRYPOINT [ "/pod-security-webhook" ]
 ---> Running in 020b1193eebd
Removing intermediate container 020b1193eebd
 ---> 1fc28581468b
Successfully built 1fc28581468b
Successfully tagged gcr.io/k8s-staging-sig-auth/pod-security-webhook:v1.23-beta.0
Done!
The push refers to repository [gcr.io/k8s-staging-sig-auth/pod-security-webhook]
bf4e21be58d7: Pushed 
6d75f23be3dd: Layer already exists 
v1.23-beta.0: digest: sha256:189012639ce8013d2e68705ffada4d446cb93de7649f20087201dad131461402 size: 739
```