### PR TITLE
aaa: Enable GKE workloads metrics

### DIFF
--- a/infra/gcp/terraform/kubernetes-public/10-cluster-configuration.tf
+++ b/infra/gcp/terraform/kubernetes-public/10-cluster-configuration.tf
@@ -132,6 +132,14 @@ resource "google_container_cluster" "cluster" {
   master_authorized_networks_config {
   }
 
+  // Enable GKE workloads monitoring
+  monitoring_config {
+    enable_components = [
+      "SYSTEM_COMPONENTS",
+      "WORKLOADS"
+    ]
+  }
+
   // Enable GKE Usage Metering
   resource_usage_export_config {
     enable_network_egress_metering = true


### PR DESCRIPTION
Related:
  - part of: https://github.com/kubernetes/k8s.io/issues/1394

Enable GKE workloads metrics that give the capability to send metrics
for a GKE cluster to cloud monitoring.
See: https://cloud.google.com/stackdriver/docs/solutions/gke/managing-metrics#enable-workload-metrics

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>