### PR TITLE
groups: move manager groups to members

### DIFF
--- a/groups/sig-k8s-infra/groups.yaml
+++ b/groups/sig-k8s-infra/groups.yaml
@@ -254,7 +254,7 @@ groups:
     settings:
       ReconcileMembers: "true"
       WhoCanPostMessage: "ANYONE_CAN_POST"
-    managers:
+    members:
       - sig-k8s-infra-leads@kubernetes.io
 
   - email-id: k8s-infra-equinix-admins@kubernetes.io
@@ -264,7 +264,7 @@ groups:
     settings:
       ReconcileMembers: "true"
       WhoCanPostMessage: "ANYONE_CAN_POST"
-    managers:
+    members:
       - sig-k8s-infra-leads@kubernetes.io
 
   - email-id: k8s-infra-artifact-admins@kubernetes.io

--- a/groups/sig-testing/groups.yaml
+++ b/groups/sig-testing/groups.yaml
@@ -184,7 +184,7 @@ groups:
       ReconcileMembers: "true"
       WhoCanPostMessage: "ANYONE_CAN_POST"
       WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW"
-    managers:
+    members:
     - ameukam@gmail.com
     - spiffxp@gmail.com
     - spiffxp@google.com
@@ -197,7 +197,7 @@ groups:
     settings:
       ReconcileMembers: "true"
       WhoCanPostMessage: "ANYONE_CAN_POST"
-    managers:
+    members:
     - k8s-infra-prow-oncall@kubernetes.io
     - github@kubernetes.io
 


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/2890

Though I can't find anything in the docs saying that groups aren't
allowed to be added as managers, and I see contributors@kubernetes.io
listed as Owners for leads@kubernetes.io, our groups CI job is
continuously failing attempting to add these groups as managers.

We really should strive to avoid manager permissions for most of these
groups anyway, since they're mostly useful for moderation and spam
deletion. These particular groups are more about ACLs or mailing lists,
the membership of which we should have no issue managing via gitops.
