### PR TITLE
tf/k8s-infra-prow-build: mv boskos crds to v1

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/test-pods/boskos.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/test-pods/boskos.yaml
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: dynamicresourcelifecycles.boskos.k8s.io
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/boskos/pull/105
 spec:
   group: boskos.k8s.io
   names:
@@ -24,29 +26,74 @@ spec:
     plural: dynamicresourcelifecycles
     singular: dynamicresourcelifecycle
   scope: Namespaced
-  version: v1
   versions:
-  - name: v1
-    served: true
-    storage: true
-  additionalPrinterColumns:
-  - name: Type
-    type: string
-    description: The dynamic resource type.
-    JSONPath: .spec.config.type
-  - name: Min-Count
-    type: integer
-    description: The minimum count requested.
-    JSONPath: .spec.min-count
-  - name: Max-Count
-    type: integer
-    description: The maximum count requested.
-    JSONPath: .spec.max-count
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Type
+          type: string
+          description: The dynamic resource type.
+          jsonPath: .spec.config.type
+        - name: Min-Count
+          type: integer
+          description: The minimum count requested.
+          jsonPath: .spec.min-count
+        - name: Max-Count
+          type: integer
+          description: The maximum count requested.
+          jsonPath: .spec.max-count
+      schema:
+        openAPIV3Schema:
+          description: Defines the lifecycle of a dynamic resource. All
+            Resource of a given type will be constructed using the same
+            configuration
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                state:
+                  type: string
+                max-count:
+                  description: Maxiumum number of resources expected. This
+                    maximum may be temporarily exceeded while resources are in
+                    the process of being deleted, though this is only expected
+                    when MaxCount is lowered.
+                  type: integer
+                  format: int32
+                min-count:
+                  description: Minimum number of resources to be used as a
+                    buffer. Resources in the process of being deleted and
+                    cleaned up are included in this count.
+                  type: integer
+                  format: int32
+                lifespan:
+                  description: Lifespan of a resource, time after which the
+                    resource should be reset
+                  type: integer
+                  format: int64
+                config:
+                  description: Config information about how to create the
+                    object
+                  type: object
+                  properties:
+                    type:
+                      description: The dynamic resource type
+                      type: string
+                    content:
+                      type: string
+                needs:
+                  description: Define the resource needs to create the object
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: resources.boskos.k8s.io
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes-sigs/boskos/pull/105
 spec:
   group: boskos.k8s.io
   names:
@@ -55,27 +102,54 @@ spec:
     plural: resources
     singular: resource
   scope: Namespaced
-  version: v1
   versions:
-  - name: v1
-    served: true
-    storage: true
-  additionalPrinterColumns:
-  - name: Type
-    type: string
-    description: The resource type.
-    JSONPath: .spec.type
-  - name: State
-    type: string
-    description: The current state of the resource.
-    JSONPath: .status.state
-  - name: Owner
-    type: string
-    description: The current owner of the resource.
-    JSONPath: .status.owner
-  - name: Last-Updated
-    type: date
-    JSONPath: .status.lastUpdate
+    - name: v1
+      served: true
+      storage: true
+      additionalPrinterColumns:
+        - name: Type
+          type: string
+          description: The resource type.
+          jsonPath: .spec.type
+        - name: State
+          type: string
+          description: The current state of the resource.
+          jsonPath: .status.state
+        - name: Owner
+          type: string
+          description: The current owner of the resource.
+          jsonPath: .status.owner
+        - name: Last-Updated
+          type: date
+          jsonPath: .status.lastUpdate
+      schema:
+        openAPIV3Schema:
+          description: Abstracts any resource type that can be tracked by boskos
+          type: object
+          properties:
+            spec:
+              description: Holds information that are not likely to change
+              type: object
+              properties:
+                type:
+                  type: string
+            status:
+              description: Holds information that are likely to change
+              type: object
+              properties:
+                state:
+                  type: string
+                owner:
+                  type: string
+                lastUpdate:
+                  type: string
+                  format: date-time
+                userData:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                expirationDate:
+                  type: string
+                  format: date-time
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes-sigs/boskos/issues/94
- Uses CRD definition from: https://github.com/kubernetes-sigs/boskos/pull/105

This updates the CRDs used by boskos from apiextensions.k8s.io/v1beta1 to apiextensions.k8s.io/v1

The actual resources themselves and boskos should require no update