### PR TITLE
groups: rm emeritus sig-docs lead from leads

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -117,6 +117,5 @@ groups:
       - wojtekt@google.com
       - xingyang105@gmail.com
       - ynli@google.com
-      - zcorleissen@linuxfoundation.org
       - jim@nirmata.com
       - rficcaglia@gmail.com


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/2890

I was about to do a manual add/remove dance when I remembered this user is no longer a lead of SIG Docs, so they shouldn't be a member of leads@kubernetes.io

This should clear up the last failure in our automated groups reconciling jobs
