### PR TITLE
Promote ip-masq-agent v2.6.1 images for CVE fixes.

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-networking/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-networking/images.yaml
@@ -1,17 +1,22 @@
 - name: ip-masq-agent
   dmap:
+    "sha256:f2a89c4add9ff48a011ad8b59cb7c6ae2e3eaa8aa66cb521a798a07f9d816368": ["v2.6.1"]
     "sha256:0d27fb2864a100a56da9582b3112f98fb06fa1f930c8c47773aa18bb0988d14d": ["v2.6.0"]
 - name: ip-masq-agent-amd64
   dmap:
+    "sha256:257da798d58bcb463b26df4109f3f6bd947ea50c8165492f0a8ba101d31e2a6b": ["v2.6.1"]
     "sha256:5469b2315904f5f720034495c3938a4d6f058ec468ce4eca0b1a9291c616c494": ["v2.6.0"]
 - name: ip-masq-agent-arm
   dmap:
+    "sha256:0510d109531604f47707d41007d3f1a35a410da58582df18ab2c0a5bbfa85b5b": ["v2.6.1"]
     "sha256:55119a67d3c92b27a67b30875642911a7bf1650e632ec17abb9916cc2b5a3a45": ["v2.6.0"]
 - name: ip-masq-agent-arm64
   dmap:
+    "sha256:c8c0a59aec46b781e8a37310ce66a93e935b1e8968e5bfbea536dd6990907152": ["v2.6.1"]
     "sha256:1f9e9889109ded149475aa3987d61d21e2f08097ab36338466c16bda63631382": ["v2.6.0"]
 - name: ip-masq-agent-ppc64le
   dmap:
+    "sha256:8de7f222165cbe458d39c5245dc6c3022027b3ea675cc4e7d23f8473bfeaeac1": ["v2.6.1"]
     "sha256:fd7449efcd712a85dbcdf6c1648f5f9bb674c208862f469c457ccd154d7d12bf": ["v2.6.0"]
 - name: ingress-gce-404-server-with-metrics-amd64
   dmap:


### PR DESCRIPTION
These are essentially a re-build of the v2.6.0 images with a newer base image.

/assign @varunmar 