### PR TITLE
releng: Drop onlydole temporary RM access

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -43,7 +43,6 @@ groups:
       - jameswangel@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
-      - onlydole@gmail.com
       - saschagrunert@gmail.com
 
   - email-id: k8s-infra-release-viewers@kubernetes.io


### PR DESCRIPTION
Taylor (@onlydole) is a Release Manager Associate with SIG Release who was granted temporary access to cut the v1.23.0-beta.0 release.

The release is out so we drop the temporary access.

k/sig-release issue: kubernetes/sig-release#1744

/assign @cpanato @puerco 
cc: @kubernetes/release-engineering

Signed-off-by: Verónica López (Verolop) gveronicalg@gmail.com