### PR TITLE
CoCC: offboard Tim and onboard Carlos

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -142,9 +142,9 @@ aliases:
     - phenixblue
   committee-code-of-conduct:
     - celestehorgan
+    - cpanato
     - karenhchu
     - palnabarun
-    - tpepper
     - vllry
   committee-security-response:
     - cjcullen

--- a/groups/committee-code-of-conduct/groups.yaml
+++ b/groups/committee-code-of-conduct/groups.yaml
@@ -9,6 +9,6 @@ groups:
     owners:
       - celeste@cncf.io
       - chu.karen.h@gmail.com
+      - ctadeu@gmail.com
       - pal.nabarun95@gmail.com
-      - tpepper@vmware.com
       - vallery@zeitgeistlabs.io


### PR DESCRIPTION
- offboard Tim because now is part of the Steering Committee
- onboard Carlos to CoCC


related to https://github.com/kubernetes/steering/issues/221

/assign @tpepper @cblecker @parispittman 