### PR TITLE
releng: Drop jimangel temporary access

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -40,7 +40,6 @@ groups:
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
       - gveronicalg@gmail.com
-      - jameswangel@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
       - saschagrunert@gmail.com


### PR DESCRIPTION
James Angel is a Release Manager Associate who was granted temporary elevated access to cut the v1.23.0-alpha.4 release.

The release is out, so we are dropping the elevated privileges.

/assign @justaugustus @verolop @palnabarun
cc: @kubernetes/release-engineering

SIG Release issue: kubernetes/sig-release#1733

Closes kubernetes/sig-release#1733

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>