### PR TITLE
releng: Temporary RM access for palnabarun

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -42,6 +42,7 @@ groups:
       - gveronicalg@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
+      - pal.nabarun95@gmail.com
       - saschagrunert@gmail.com
 
   - email-id: k8s-infra-release-viewers@kubernetes.io


### PR DESCRIPTION
Nabarun (palnabarun) is a Release Manager Associate with SIG Release being granted
temporary elevated access to cut the v1.23.0.0 release. Access will be
revoked after the 1.23.0.0 release is cut.

Signed-off-by: Verónica López (verolop) <gveronicalg@gmail.com>