### PR TITLE
k8s.io: Redirect common Go package URLs to pkg.go.dev

### DIFF
--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -55,8 +55,8 @@ data:
           }
 
           # Redirect go import paths to Go package documentation.
-          if ($repo ~ "api|apimachinery|client-go|kubernetes") {
-            return 301 https://pkg.go.dev/k8s.io/$repo/$subpath;
+          if ($repo ~ "api|apimachinery|client-go") {
+            return 302 https://pkg.go.dev/k8s.io/$repo/$subpath;
           }
 
           # Default to redirecting to the "real" site.

--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -54,6 +54,11 @@ data:
             ';
           }
 
+          # Redirect go import paths to Go package documentation.
+          if ($repo ~ "api|apimachinery|client-go|kubernetes") {
+            return 301 https://pkg.go.dev/k8s.io/$repo/$subpath;
+          }
+
           # Default to redirecting to the "real" site.
           return 301 https://kubernetes.io$request_uri;
         }

--- a/apps/k8s-io/test.py
+++ b/apps/k8s-io/test.py
@@ -153,7 +153,7 @@ class RedirTest(HTTPTestCase):
         self.assert_scheme_redirect(
                 'http://k8s.io/kubernetes',
                 'https://k8s.io/kubernetes', 301)
-        for repo in ('api', 'apimachinery', 'client-go', 'kubernetes'):
+        for repo in ('api', 'apimachinery', 'client-go'):
           self.assert_scheme_redirect(
                   'https://k8s.io/%s' % repo,
                   'https://pkg.go.dev/k8s.io/%s' % repo, 301)

--- a/apps/k8s-io/test.py
+++ b/apps/k8s-io/test.py
@@ -149,6 +149,19 @@ class RedirTest(HTTPTestCase):
                     'http://' + url + path,
                     'https://' + url + path, 301)
 
+    def test_godoc_redirect(self):
+        self.assert_scheme_redirect(
+                'http://k8s.io/kubernetes',
+                'https://k8s.io/kubernetes', 301)
+        for repo in ('api', 'apimachinery', 'client-go', 'kubernetes'):
+          self.assert_scheme_redirect(
+                  'https://k8s.io/%s' % repo,
+                  'https://pkg.go.dev/k8s.io/%s' % repo, 301)
+        # Sub-paths also work.
+        self.assert_scheme_redirect(
+                'https://k8s.io/api/core/v1',
+                'https://pkg.go.dev/k8s.io/api/core/v1', 301)
+
     def test_go_get(self):
         self.assert_scheme_redirect(
                 'http://k8s.io/kubernetes?go-get=1',


### PR DESCRIPTION
Today, a valid Go import path like `k8s.io/api/core/v1` redirects to https://kubernetes.io/api/core/v1 when viewed in a browser, which is an unhelpful 404. 😢 

With this change, I'd like to propose that that import path should redirect to the much more helpful Go package documentation at https://pkg.go.dev/k8s.io/api/core/v1

This change currently only applies to:
- `k8s.io/api/...`
- `k8s.io/apimachinery/...`
- `k8s.io/client-go/...`
- `k8s.io/kubernetes/...`

If this is helpful we can look into applying this across more repos. The Go import redirects triggered by the presence of `?go-get=1` should be unaffected.