### PR TITLE
publishing-bot: Fix secret name for GitHub token

### DIFF
--- a/apps/publishing-bot/externalsecrets.yaml
+++ b/apps/publishing-bot/externalsecrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
-  name: triage-party-github-token # Name of the secret
+  name: publishing-bot-github-token # Name of the secret
   namespace: publishing-bot
   labels:
     app: publishing-bot


### PR DESCRIPTION
Name of the secret created by KSE is incorrect.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>