### PR TITLE
releng: Enable Release Managers to do publishing-bot reviews

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -204,6 +204,17 @@ aliases:
   provider-vmware:
     - cantbewong
     - frapposelli
+  publishing-bot-approvers:
+    - dims
+    - nikhita
+    - sttts
+  publishing-bot-reviewers:
+    - cpanato
+    - jeremyrickard
+    - justaugustus
+    - puerco
+    - saschagrunert
+    - xmudrii
   release-engineering-approvers:
     - cpanato # subproject owner / Release Manager / SIG Technical Lead
     - jeremyrickard # subproject owner / SIG Technical Lead

--- a/apps/publishing-bot/OWNERS
+++ b/apps/publishing-bot/OWNERS
@@ -6,7 +6,6 @@ approvers:
 - sttts
 
 reviewers:
-- mfojtik
 - nikhita
 
 labels:

--- a/apps/publishing-bot/OWNERS
+++ b/apps/publishing-bot/OWNERS
@@ -1,13 +1,15 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- dims
-- nikhita
-- sttts
-
+  - publishing-bot-approvers
+  # TODO(releng): Enable once Release Managers are onboarded
+  #               ref: https://github.com/kubernetes/sig-release/issues/1772
+  #- release-engineering-approvers
 reviewers:
-- nikhita
+  - publishing-bot-reviewers
+  - release-engineering-reviewers
 
 labels:
 - sig/release
 - area/apps/publishing-bot
+- area/release-eng

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -172,6 +172,7 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
+      - k8s-infra-release-editors@kubernetes.io
       - davanum@gmail.com
       - nikitaraghunath@gmail.com
       - stefan.schimanski@gmail.com

--- a/k8s.gcr.io/images/k8s-staging-publishing-bot/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-publishing-bot/OWNERS
@@ -3,11 +3,10 @@
 options:
   no_parent_owners: true
 approvers:
+  - publishing-bot-approvers
   - release-engineering-approvers
-  - dims
-  - nikhita
-  - sttts
 reviewers:
+  - publishing-bot-reviewers
   - release-engineering-reviewers
 
 labels:

--- a/k8s.gcr.io/images/k8s-staging-publishing-bot/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-publishing-bot/OWNERS
@@ -1,0 +1,15 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+options:
+  no_parent_owners: true
+approvers:
+  - release-engineering-approvers
+  - dims
+  - nikhita
+  - sttts
+reviewers:
+  - release-engineering-reviewers
+
+labels:
+  - sig/release
+  - area/release-eng


### PR DESCRIPTION
Part of https://github.com/kubernetes/sig-release/issues/1772.

- releng: Enable publishing-bot image promotion review/approval
- OWNERS_ALIASES: Add publishing-bot reviewers/approvers
- apps/publishing-bot: Remove @mfojtik as reviewer (inactive) (ref: https://github.com/kubernetes/publishing-bot/pull/271)
- releng(publishing-bot): Simplify existing OWNERS with aliases

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @nikhita @dims @cpanato @puerco 
cc: @kubernetes/publishing-bot-reviewers @kubernetes/release-engineering 