### PR TITLE
Release v4.1.0 version of image for ibm-vpc-block-csi-driver

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cloud-provider-ibm/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-cloud-provider-ibm/images.yaml
@@ -1,3 +1,4 @@
 - name: ibm-vpc-block-csi-driver
   dmap:
     "sha256:7fbf041a9952c3ea54c626ba54e2fa1cbb243d3b04806cfc554f9ab37676a55f": ["v0.0.0"]
+    "sha256:39e9d71ded90227e25c3135ebeb2b73092fddbfeb4cd2d67ec80f568cbe666bc": ["v4.1.0"]


### PR DESCRIPTION
```
docker pull gcr.io/k8s-staging-cloud-provider-ibm/ibm-vpc-block-csi-driver:v4.1.0
v4.1.0: Pulling from k8s-staging-cloud-provider-ibm/ibm-vpc-block-csi-driver
58690f9b18fc: Already exists 
b51569e7c507: Already exists 
da8ef40b9eca: Already exists 
fb15d46c38dc: Already exists 
c9b217a32777: Pull complete 
d1143cdca97a: Pull complete 
f94668bac91e: Pull complete 
Digest: sha256:39e9d71ded90227e25c3135ebeb2b73092fddbfeb4cd2d67ec80f568cbe666bc
Status: Downloaded newer image for gcr.io/k8s-staging-cloud-provider-ibm/ibm-vpc-block-csi-driver:v4.1.0
gcr.io/k8s-staging-cloud-provider-ibm/ibm-vpc-block-csi-driver:v4.1.0
```