### PR TITLE
releng: Drop temporary RM access for palnabarun

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -42,7 +42,6 @@ groups:
       - gveronicalg@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
-      - pal.nabarun95@gmail.com
       - saschagrunert@gmail.com
 
   - email-id: k8s-infra-release-viewers@kubernetes.io


### PR DESCRIPTION
Dropping temporary access granted to Nabarun Pal to cut the v1.23.0 release

SIG Release issue: kubernetes/sig-release#1758

cc: @kubernetes/release-engineering

/priority important-soon
/sig release

Signed-off-by: Verónica López (verolop) gveronicalg@gmail.com