### PR TITLE
Temporary Release Manager access for jimangel

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -40,6 +40,7 @@ groups:
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
       - gveronicalg@gmail.com
+      - jameswangel@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
       - saschagrunert@gmail.com


### PR DESCRIPTION
Jim Angel (@jimangel ) is a Release Manager Associate being granted temporary elevated access to cut the v1.24.0-alpha.1 release. Access should be revoked after the releases are cut.

SIG Release Issue: https://github.com/kubernetes/sig-release/issues/1777

/assign @saschagrunert @cpanato @ameukam
/priority critical-urgent