### PR TITLE
releng: Temporary RM access for Jim Angel (jimangel)

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -40,6 +40,7 @@ groups:
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
       - gveronicalg@gmail.com
+      - jameswangel@gmail.com 
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
       - saschagrunert@gmail.com


### PR DESCRIPTION
 - temporary: Jim (@jimangel  ) is a Release Manager Associate being granted temporary elevated access to cut the v1.24.0-alpha.1 release.

- Access should be revoked after the v1.24.0-alpha.1 release is cut.

sig-release issue: kubernetes/sig-release#1777

/assign @puerco @cpanato 
cc: @kubernetes/release-engineering

/priority important-soon

Signed-off-by: Verónica López (verolop) gveronicalg@gmail.com