### PR TITLE
Adds k8s-infra-staging-gmsa-webhook@kubernetes.io group

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -178,6 +178,10 @@ restrictions:
       - "^k8s-infra-rbac-gcsweb@kubernetes.io$"
       - "^k8s-infra-rbac-kettle@kubernetes.io$"
       - "^k8s-infra-rbac-prow@kubernetes.io$"
+  - path: "sig-windows/groups.yaml"
+    allowedGroups:
+      - "^sig-windows-leads@kubernetes.io$"
+      - "^k8s-infra-staging-gmsa-webhook@kubernetes.io$"
   - path: "sig-k8s-infra/groups.yaml"
     allowedGroups:
       - "^gke-security-groups@kubernetes.io$"

--- a/groups/sig-windows/OWNERS
+++ b/groups/sig-windows/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- sig-windows-leads
+reviewers:
+- sig-windows-leads
+
+labels:
+- sig/windows

--- a/groups/sig-windows/groups.yaml
+++ b/groups/sig-windows/groups.yaml
@@ -1,0 +1,46 @@
+groups:
+
+  #
+  # Mailing lists
+  #
+  # Each group here represents a mailing list for the SIG or its subprojects,
+  # and is not intended to govern access to infrastructure
+  #
+
+  #
+  # k8s-staging write access for SIG-owned subprojects
+  #
+  # Each group here represents privileged access to a staging project,
+  # allowing the members to directly write to GCS and GCR within the
+  # project, as well as trigger Cloud Build within the project. Ideally
+  # this level access is used solely for troubleshooting purposes.
+  #
+  # Membership should correspond roughly to subproject owners for the set of
+  # subproject artifacts being stored in a given staging project
+  #
+
+  - email-id: k8s-infra-staging-gmsa-webhook@kubernetes.io
+    name: k8s-infra-staging-gmsa-webhook
+    description: |-
+      ACL for staging Windows GMSA Webhook artifacts
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - cbelu@cloudbasesolutions.com
+      - jayunit100.apache@gmail.com
+      - jsturtevant@gmail.com
+      - marosset@microsoft.com
+
+  #
+  # k8s-infra owners for sig-owned subprojects
+  #
+  # Each group here represents highly privileged access to kubernetes project
+  # infrastructure owned or managed by this SIG. A high level of trust is
+  # required for membership in these groups.
+  #
+
+
+  # RBAC groups:
+  # - grant access to the `namespace-user` role for a single namespace on the `aaa` cluster
+  # - must have WhoCanViewMemberShip: "ALL_MEMBERS_CAN_VIEW"
+  # - must be members of gke-security-groups@kubernetes.io

--- a/infra/gcp/bash/namespaces/namespace-user-role.yml
+++ b/infra/gcp/bash/namespaces/namespace-user-role.yml
@@ -22,7 +22,7 @@ rules:
     verbs: ["*"]
   - apiGroups: ["kubernetes-client"]
     resources: ["externalsecrets"]
-    verbs: ["list","watch"]
+    verbs: ["list", "watch"]
   - apiGroups: ["networking.gke.io"]
     resources: ["managedcertificates"]
     verbs: ["*"]

--- a/infra/gcp/infra.yaml
+++ b/infra/gcp/infra.yaml
@@ -327,3 +327,4 @@ infra:
       k8s-staging-sp-operator:
       k8s-staging-storage-migrator:
       k8s-staging-test-infra:
+      k8s-staging-gmsa-webhook:

--- a/k8s.gcr.io/images/k8s-staging-gmsa-webhook/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-gmsa-webhook/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- sig-windows-leads
+reviewers:
+- sig-windows-leads
+
+labels:
+- sig/windows

--- a/k8s.gcr.io/images/k8s-staging-gmsa-webhook/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-gmsa-webhook/images.yaml
@@ -1,0 +1,1 @@
+# No images yet.

--- a/k8s.gcr.io/manifests/k8s-staging-gmsa-webhook/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-gmsa-webhook/promoter-manifest.yaml
@@ -1,0 +1,10 @@
+# google group for gcr.io/k8s-staging-gmsa-webhook is kubernetes-sig-windows-leads@googlegroups.com
+registries:
+- name: gcr.io/k8s-staging-gmsa-webhook
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/gmsa-webhook
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/gmsa-webhook
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/gmsa-webhook
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
Adding the gmsa-admission-webhook group and configuration to support adding the Windows GMSA container image to the official k8s images repository.

* https://github.com/kubernetes-sigs/windows-gmsa/issues/52

Signed-off-by: Jamie Phillips <jamie.phillips@suse.com>