### PR TITLE
Promote CAPA v1.2.0 image

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cluster-api-aws/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api-aws/images.yaml
@@ -56,6 +56,7 @@
     "sha256:26a52ddd209fba246fe128049b550e4c92abec9a2d208236547f651853d8ebc8": ["v0.6.9"]
     "sha256:17d341ccc816916339198050b156fbca64dfce1ee0ddab55c1047c94c1655a1d": ["v0.7.2"]
     "sha256:ddd25180f1893ed914b0651cdd53b281ad1f1edf242c4b72f28b8cad1084d89b": ["v1.1.0"]
+    "sha256:073bec3b747b5bccdc531c608d1871b95ba0f0c9453a940ce0fa76660c797ee3": ["v1.2.0"]
 - name: eks-bootstrap-controller
   dmap:
     "sha256:0dda3f1be2c56b0ffee4668c67a9da2a5af33a5aa66c7db91c98534140265408": ["v0.6.0"]


### PR DESCRIPTION
Promotes the image for the CAPA v1.2.0 release.

