### PR TITLE
Revoke Release Manager access for jimangel

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -40,7 +40,6 @@ groups:
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
       - gveronicalg@gmail.com
-      - jameswangel@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
       - saschagrunert@gmail.com


### PR DESCRIPTION
James Angel is a Release Manager Associate who was granted temporary elevated access to cut the v1.24.0-alpha.a release.

The release is out, so we are dropping the elevated privileges.

/assign @justaugustus @Verolop @palnabarun
cc: @kubernetes/release-engineering

Closes kubernetes/sig-release#1777