### PR TITLE
adding CAA record for k8s.io

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -16,6 +16,17 @@
       preference: 10
     - exchange: alt4.aspmx.l.google.com.
       preference: 10
+  - type: CAA # The CAA record set for a domain also applies to all sub-domains. If a sub-domain has its own CAA record set, it takes precedence.
+    values:
+    - flags: 0
+      tag: issue
+      value: pki.goog
+    - flags: 0
+      tag: issue
+      value: letsencrypt.org
+    - flags: 0
+      tag: issue
+      value: amazon.com
   - type: TXT
     values:
     - google-site-verification=RJbZ_ganmSWvslSKOBG-QHv62XTjJZcigpWIFttStFs


### PR DESCRIPTION
This is the tail-end of the CAA efforts I started in https://github.com/kubernetes/k8s.io/pull/1849. First we did kubernetes.io, now this PR is for k8s.io.

An interesting thing to note, I found `amazon.com` listed when I [searched the transparency logs](https://github.com/kubernetes/k8s.io/pull/1849#discussion_r605064538)  but checking again today (9 months later) I did not see it.

We did identity in a test-infra call that the source was for kops e2e testing ([link](https://github.com/kubernetes/k8s.io/pull/1849#issuecomment-930578316)).

In any event, I don't think it hurts to keep it in but I think we can remove it if new certs haven't been issued in awhile.

/cc @celestehorgan
/milestone v1.24