### PR TITLE
promote cluster-api-ibmcloud-controller:v0.1.0 image

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-capi-ibmcloud/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-capi-ibmcloud/images.yaml
@@ -1,1 +1,3 @@
-# No images yet
+- name: cluster-api-ibmcloud-controller
+  dmap:
+    "sha256:6c92a6a337ca5152eda855ac27c9e4ca1f30bba0aa4de5c3a0b937270ead4363": ["v0.1.0"]


### PR DESCRIPTION
```shell
$ manifest-tool inspect gcr.io/k8s-staging-capi-ibmcloud/cluster-api-ibmcloud-controller:v0.1.0
Name:   gcr.io/k8s-staging-capi-ibmcloud/cluster-api-ibmcloud-controller:v0.1.0 (Type: application/vnd.docker.distribution.manifest.list.v2+json)
Digest: sha256:6c92a6a337ca5152eda855ac27c9e4ca1f30bba0aa4de5c3a0b937270ead4363
 * Contains 2 manifest references:
1    Mfst Type: application/vnd.docker.distribution.manifest.v2+json
1       Digest: sha256:50ac6910f5289ce38168fada4bd1b44928f02e404641eb9c659b829f26463094
1  Mfst Length: 739
1     Platform:
1           -      OS: linux
1           - OS Vers:
1           - OS Feat: []
1           -    Arch: amd64
1           - Variant:
1           - Feature:
1     # Layers: 2
         layer 1: digest = sha256:e8614d09b7bebabd9d8a450f44e88a8807c98a438a2ddd63146865286b132d1b
         layer 2: digest = sha256:4cd6811653df4d1196f196b57c04c6543b7b974b73239411d13ba64139e7d06f

2    Mfst Type: application/vnd.docker.distribution.manifest.v2+json
2       Digest: sha256:58892d9107d39e3c1b95744a49420832e9899e5db21e68bb687cc0c8cf292108
2  Mfst Length: 739
2     Platform:
2           -      OS: linux
2           - OS Vers:
2           - OS Feat: []
2           -    Arch: ppc64le
2           - Variant:
2           - Feature:
2     # Layers: 2
         layer 1: digest = sha256:e8614d09b7bebabd9d8a450f44e88a8807c98a438a2ddd63146865286b132d1b
         layer 2: digest = sha256:555cc7723b215481603de680828682061ff25236e7d8d15c4bbe9608637cd03d
```