### PR TITLE
ensure-staging-storage.sh: Reflect all RelEng-owned staging projects

### DIFF
--- a/infra/gcp/bash/ensure-staging-storage.sh
+++ b/infra/gcp/bash/ensure-staging-storage.sh
@@ -44,9 +44,15 @@ mapfile -t STAGING_PROJECTS < <(k8s_infra_projects "staging")
 readonly STAGING_PROJECTS
 
 readonly RELEASE_STAGING_PROJECTS=(
+    "$(k8s_infra_project staging k8s-staging-artifact-promoter)"
+    "$(k8s_infra_project staging k8s-staging-build-image)"
+    "$(k8s_infra_project staging k8s-staging-ci-images)"
+    "$(k8s_infra_project staging k8s-staging-cip-test)"
     "$(k8s_infra_project staging k8s-staging-experimental)"
     "$(k8s_infra_project staging k8s-staging-kubernetes)"
     "$(k8s_infra_project staging k8s-staging-releng)"
+    "$(k8s_infra_project staging k8s-staging-releng-test)"
+    "$(k8s_infra_project staging k8s-staging-publishing-bot)"
 )
 
 readonly STAGING_PROJECT_SERVICES=(


### PR DESCRIPTION
Noticed when [enabling Google Artifact Registry](https://github.com/kubernetes/k8s.io/pull/3183) that not all of our
projects are having the Release Manager special cases applied.

This updates `RELEASE_STAGING_PROJECTS` to reflect the current list.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @dims @ameukam 
cc: @kubernetes/release-engineering 