### PR TITLE
[DO NOT MERGE][WIP] Testing Google Artifact Registry promotion

### DIFF
--- a/infra/gcp/bash/ensure-releng-gar.sh
+++ b/infra/gcp/bash/ensure-releng-gar.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used to create a new "staging" repo in Artifact Repository.
+#
+# Each sub-project that needs to publish artifacts should have their
+# own staging Artifact Repository repo.
+#
+# Each staging repo exists in its own GCP project, and is writable by a
+# dedicated googlegroup.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+. "${SCRIPT_DIR}/lib.sh"
+. "${SCRIPT_DIR}/ensure-staging-storage.sh"
+
+function usage() {
+    echo "usage: $0 [repo...]" > /dev/stderr
+    echo "example:" > /dev/stderr
+    echo "  $0 # do all staging repos" > /dev/stderr
+    echo "  $0 coredns # just do one" > /dev/stderr
+    echo > /dev/stderr
+}
+
+#
+# Staging functions
+#
+
+# Provision and configure a "staging" GCP project, intended to hold 
+# temporary release artifacts in a pre-provisioned GCS bucket or 
+# GAR. The intent is to then promote some of these artifacts to
+# production, which is long-lived and immutable.
+#
+# Artifacts are ideally written here via automation, either via GCB
+# builds run within the project, or by prowjobs running in a trusted
+# cluster (currently: k8s-infra-prow-build-trusted)
+#
+# As a fallback, a per-project group of humans is given access to
+# manually write artifacts andtrigger GCB builds in the project
+#
+# $1: GCP project name (e.g. "k8s-staging-foo")
+# $2: Group for manual access (e.g. "k8s-infra-staging-foo@kubernetes.io")
+function ensure_releng_gar_project() {
+    if [ $# != 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
+        echo "${FUNCNAME[0]}(gcp_project, writers_group) requires 2 arguments" >&2
+        return 1
+    fi
+    local project="${1}"
+    local writers="${2}"
+
+    # Ensure staging project GAR
+
+    color 3 "Ensuring staging GAR repo: gcr.io/${project}"
+    ensure_staging_gar_repo "${project}" "${writers}" 2>&1 | indent
+}
+
+function ensure_releng_gar_projects() {
+    color 6 "Ensuring staging projects..."
+
+    # default to all staging projects
+    if [ $# = 0 ]; then
+        set -- "${RELEASE_STAGING_PROJECTS[@]}"
+    fi
+
+    for arg in "${@}"; do
+        local repo="${arg#k8s-staging-}"
+        local project="k8s-staging-${repo}"
+        if ! k8s_infra_project "staging" "${project}" >/dev/null; then
+            color 1 "Skipping unrecognized staging project name: ${project}"
+            continue
+        fi
+
+        color 3 "Configuring staging project: ${project}"
+        ensure_releng_gar_project \
+            "${project}" \
+            "k8s-infra-staging-${repo}@kubernetes.io" \
+            2>&1 | indent
+
+    done
+
+    color 6 "Done"
+}
+
+ensure_releng_gar_projects "${@}"

--- a/infra/gcp/bash/ensure-staging-storage.sh
+++ b/infra/gcp/bash/ensure-staging-storage.sh
@@ -220,6 +220,36 @@ function ensure_staging_gcs_bucket() {
     fi
 }
 
+# Ensure a GAR repo is provisioned in the given staging project, with
+# appropriate permissions for the given group and GAR admins
+# with auto-deletion enabled and appropriate permissions for the
+# given group and GCS admins
+#
+# $1: The GCP project (e.g. k8s-staging-foo)
+# $2: The group to grant write access (e.g. k8s-infra-staging-foo@kubernetes.io)
+function ensure_staging_gar_repo() {
+    if [ $# != 2 ] || [ -z "$1" ] || [ -z "$2" ]; then
+        echo "${FUNCNAME[0]}(project, writers) requires 2 arguments" >&2
+        return 1
+    fi
+    local project="${1}"
+    local writers="${2}"
+    #local gar_bucket="gs://artifacts.${1}.appspot.com"
+
+    color 6 "Ensuring a GAR repo exists for project: ${project}"
+    ensure_gar_repo "${project}"
+
+    color 6 "Ensuring ${writers} can write to GAR for project: ${project}"
+    empower_group_to_write_gar "${writers}" "${project}"
+
+    color 6 "Ensuring GAR admins can admin GAR for project: ${project}"
+    empower_gar_admins "${project}"
+
+    # TODO(gar): Is this required?
+    #color 6 "Ensuring GCS access logs enabled for GAR bucket in project: ${project}"
+    #ensure_gcs_bucket_logging "${gcr_bucket}"
+}
+
 # Ensure a GCR repo is provisioned in the given staging project, with
 # appropriate permissions for the given group and GCR admins
 # with auto-deletion enabled and appropriate permissions for the

--- a/k8s.gcr.io/images/k8s-staging-releng/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-releng/images.yaml
@@ -4,6 +4,9 @@
 - name: kubepkg-rpm
   dmap:
     "sha256:f5fc791f5ef03c5fe3329fff3a40b80a44029a6e236981a2e5133ebf9597f9dd": ["v0.1.0", "v20201103-v0.5.0-63-ga247d79"]
+- name: pause
+  dmap:
+    "sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db": ["3.6"]
 - name: releng-ci
   dmap:
     "sha256:00066c142addfb35a66cb391e8c00de42f015410723b8e1dfbe11a242c19c262": ["1.17.3-bullseye-0"]

--- a/k8s.gcr.io/manifests/k8s-staging-releng/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-releng/promoter-manifest.yaml
@@ -1,6 +1,6 @@
 # google group for gcr.io/k8s-staging-releng is k8s-infra-staging-releng@kubernetes.io
 registries:
-- name: gcr.io/k8s-staging-releng
+- name: us-docker.pkg.dev/k8s-staging-releng
   src: true
 - name: us.gcr.io/k8s-artifacts-prod/releng
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/k8s.gcr.io/manifests/k8s-staging-releng/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-releng/promoter-manifest.yaml
@@ -1,6 +1,6 @@
 # google group for gcr.io/k8s-staging-releng is k8s-infra-staging-releng@kubernetes.io
 registries:
-- name: us-docker.pkg.dev/k8s-staging-releng/k8s-staging-releng
+- name: us-docker.pkg.dev/k8s-staging-releng/i
   src: true
 - name: us.gcr.io/k8s-artifacts-prod/releng
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/k8s.gcr.io/manifests/k8s-staging-releng/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-releng/promoter-manifest.yaml
@@ -1,6 +1,6 @@
 # google group for gcr.io/k8s-staging-releng is k8s-infra-staging-releng@kubernetes.io
 registries:
-- name: us-docker.pkg.dev/k8s-staging-releng
+- name: us-docker.pkg.dev/k8s-staging-releng/k8s-staging-releng
   src: true
 - name: us.gcr.io/k8s-artifacts-prod/releng
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
Part of https://github.com/kubernetes/k8s.io/issues/1343.

DO NOT MERGE

Opening this PR to see what happens when the image promoter attempts to look at Google Artifact Registry (instead of GCR) as a staging repository.

- k8s-staging-releng: Update staging repo to us-docker.pkg.dev/k8s-staging-releng

Signed-off-by: Stephen Augustus <foo@auggie.dev>

cc: @kubernetes/release-engineering 