### PR TITLE
sig-release: update release managers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -216,6 +216,7 @@ aliases:
     - puerco
     - saschagrunert
     - xmudrii
+    - Verolop
   release-engineering-approvers:
     - cpanato # subproject owner / Release Manager / SIG Technical Lead
     - jeremyrickard # subproject owner / SIG Technical Lead
@@ -223,6 +224,7 @@ aliases:
     - palnabarun # Release Manager
     - puerco # subproject owner / Release Manager / SIG Technical Lead
     - saschagrunert # subproject owner / Release Manager / SIG Chair
+    - Verolop # Release Manager
     - xmudrii # Release Manager
   release-engineering-reviewers:
     - cpanato # subproject owner / Release Manager / SIG Technical Lead
@@ -231,6 +233,7 @@ aliases:
     - palnabarun # Release Manager
     - puerco # subproject owner / Release Manager / SIG Technical Lead
     - saschagrunert # subproject owner / Release Manager / SIG Chair
+    - Verolop # Release Manager
     - xmudrii # Release Manager
   # business hours oncall for prow etc (https://go.k8s.io/oncall)
   test-infra-oncall:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -212,6 +212,7 @@ aliases:
     - cpanato
     - jeremyrickard
     - justaugustus
+    - palnabarun
     - puerco
     - saschagrunert
     - xmudrii
@@ -219,6 +220,7 @@ aliases:
     - cpanato # subproject owner / Release Manager / SIG Technical Lead
     - jeremyrickard # subproject owner / SIG Technical Lead
     - justaugustus # subproject owner / Release Manager / SIG Chair
+    - palnabarun # Release Manager
     - puerco # subproject owner / Release Manager / SIG Technical Lead
     - saschagrunert # subproject owner / Release Manager / SIG Chair
     - xmudrii # Release Manager
@@ -226,6 +228,7 @@ aliases:
     - cpanato # subproject owner / Release Manager / SIG Technical Lead
     - jeremyrickard # subproject owner / SIG Technical Lead
     - justaugustus # subproject owner / Release Manager / SIG Chair
+    - palnabarun # Release Manager
     - puerco # subproject owner / Release Manager / SIG Technical Lead
     - saschagrunert # subproject owner / Release Manager / SIG Chair
     - xmudrii # Release Manager

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -42,6 +42,7 @@ groups:
       - gveronicalg@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
+      - pal.nabarun95@gmail.com
       - saschagrunert@gmail.com
 
   - email-id: k8s-infra-release-viewers@kubernetes.io
@@ -225,6 +226,7 @@ groups:
       - augustus@cisco.com
       - gveronicalg@gmail.com
       - mudrinic.mare@gmail.com
+      - pal.nabarun95@gmail.com
 
   - email-id: release-managers@kubernetes.io
     name: release-managers
@@ -343,7 +345,7 @@ groups:
       - m.r.boxell@gmail.com # 1.23 Release Comms Shadow
       - nng.grace@gmail.com # 1.23 Enhancements Shadow
       - nwaddington@cncf.io # 1.23 Docs Shadow
-      - pal.nabarun95@gmail.com # 1.23 Release Branch Manager Shadow
+      - pal.nabarun95@gmail.com # Release Manager // 1.24 Release Branch Manager
       - panjwaniritu45@gmail.com # 1.23 Bug Triage Shadow
       - parulsahoo5jan@gmail.com # 1.23 Release Notes Shadow
       - priyankasaggu11929@gmail.com # 1.23 Enhancements Shadow


### PR DESCRIPTION
In OWNERS_ALIASES:
- add palnabarun as a Release Manager (https://github.com/kubernetes/sig-release/issues/1789)
- add Verolop as a Release Manager (https://github.com/kubernetes/sig-release/issues/1713)

In groups/sig-release/groups.yaml:
- add Nabarun Pal as a Release Manager (https://github.com/kubernetes/sig-release/issues/1789)

/sig release