### PR TITLE
Updating sig-docs blog email list with new owners and members

### DIFF
--- a/groups/sig-docs/groups.yaml
+++ b/groups/sig-docs/groups.yaml
@@ -17,14 +17,11 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
-      - jorgec@vmware.com
-      - kaitlynbarnard10@gmail.com
-      - paris.pittman@gmail.com
       - killen.bob@gmail.com
-      - zcorleissen@linuxfoundation.org
+      - onlydole@gmail.com
+      - tim+kubernetes@scalefactory.com
     members:
-      - codyclark@google.com
-      - vonguard@gmail.com
+      - natew@cncf.io
 
   #
   # k8s-staging write access for SIG-owned subprojects


### PR DESCRIPTION
As per issue https://github.com/kubernetes/website/issues/29065, the blog list is out of date.

Closes https://github.com/kubernetes/website/issues/29065

CCing folks affected (happy to make adjustments):
/cc @onlydole, @mrbobbytables, @kbarnard10, @parispittman, @zacharysarah, @vonguard, @cody-clark 