### PR TITLE
groups/steering: Add Stephen's work email to Steering lists

### DIFF
--- a/groups/committee-steering/groups.yaml
+++ b/groups/committee-steering/groups.yaml
@@ -6,6 +6,7 @@ groups:
     settings:
       ReconcileMembers: "true"
     owners:
+      - augustus@cisco.com
       - bburns@microsoft.com
       - briangrant@google.com
       - cblecker@gmail.com
@@ -37,6 +38,7 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
+      - augustus@cisco.com
       - cblecker@gmail.com
       - davanum@gmail.com
       - k8s@auggie.dev
@@ -61,6 +63,7 @@ groups:
       MessageModerationLevel: "MODERATE_NON_MEMBERS"
       ReconcileMembers: "false"
     owners:
+      - augustus@cisco.com
       - cblecker@gmail.com
       - davanum@gmail.com
       - k8s@auggie.dev


### PR DESCRIPTION
Revisiting https://github.com/kubernetes/k8s.io/pull/3051#pullrequestreview-800477638:

> @cblecker --
> 
>     ...
> 
>     2. Can you also include my work address ([augustus@cisco.com](mailto:augustus@cisco.com)) in the lists for calendar events (the auggie.dev one is a Google Workspace one for IAM)?

Not having up-to-date calendar invites on my work calendar is annoying.

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @cblecker @dims @parispittman 
cc: @kubernetes/steering-committee 