### PR TITLE
Retain in public-log-asn-matcher/generate-buckets.sh

### DIFF
--- a/images/public-log-asn-matcher/buckets.txt
+++ b/images/public-log-asn-matcher/buckets.txt
@@ -63,6 +63,7 @@ k8s-staging-multitenancy
 k8s-staging-networking
 k8s-staging-nfd
 k8s-staging-npd
+k8s-staging-perf-tests
 k8s-staging-prometheus-adapter
 k8s-staging-provider-aws
 k8s-staging-provider-azure
@@ -73,6 +74,7 @@ k8s-staging-releng-test
 k8s-staging-sched-simulator
 k8s-staging-scheduler-plugins
 k8s-staging-scl-image-builder
+k8s-staging-sig-auth
 k8s-staging-sig-docs
 k8s-staging-sig-storage
 k8s-staging-slack-infra

--- a/images/public-log-asn-matcher/generate-buckets.sh
+++ b/images/public-log-asn-matcher/generate-buckets.sh
@@ -24,7 +24,7 @@ GIT_ROOT="$(git rev-parse --show-toplevel)"
 # ls -1 "${GIT_ROOT}"/audit/projects/*/buckets/ \
 #     | grep -E '^k8s-artifacts|^k8s-staging|.*\.artifacts.k8s-artifacts-prod.appspot.com' \
 
-(
+cat "${SCRIPT_DIR}/buckets.txt" <(
     for B in "${GIT_ROOT}"/audit/projects/*/buckets/*; do
         BUCKET_NAME="$(basename "${B}")"
         if echo "${BUCKET_NAME}" \
@@ -36,4 +36,6 @@ GIT_ROOT="$(git rev-parse --show-toplevel)"
 ) \
     | sort \
     | uniq \
-    | cat > "${SCRIPT_DIR}/buckets.txt"
+    | cat > "${SCRIPT_DIR}/buckets.txt.tmp"
+
+mv "${SCRIPT_DIR}/buckets.txt.tmp" "${SCRIPT_DIR}/buckets.txt"


### PR DESCRIPTION
Update to ensure that historical buckets remain in listing, so that data can be pulled for historical accuracy.
There might be a need to find all bucket names across projects over time for more history.

Also updates the buckets in the list.