### PR TITLE
add dummy A record for an invalid registry

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -51,6 +51,10 @@ docs:
 _acme-challenge.docs:
   type: A
   value: 0.0.0.0
+# Dummy A record used for e2e tests to reach an invalid registry:
+invalid.registry:
+  type: A
+  value: 0.0.0.0
 
 # Prove that we own these github orgs. sig-contributor-experience
 _github-challenge-kubernetes:


### PR DESCRIPTION
Some e2e test use an invalid registry, currently it is being hardcoded to an external domain `invalid.com` that is handled by an external company.

In order to avoid that e2e users create traffic to an external domain, we can create a dummy record and use it for the e2e tests, so the e2e traffic remains controlled by the project.

Ref: https://github.com/kubernetes/kubernetes/pull/104522#discussion_r781008308