### PR TITLE
releng: Temporary Release Manager access for Jim Angel

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -40,6 +40,7 @@ groups:
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
       - gveronicalg@gmail.com
+      - jameswangel@gmail.com # temporary access grant ref: https://github.com/kubernetes/sig-release/issues/1826
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
       - pal.nabarun95@gmail.com


### PR DESCRIPTION
Jim is a Release Manager Associate being granted temporary elevated access to cut releases. Access should be revoked after the January 2022 patch releases are cut.

Part of https://github.com/kubernetes/sig-release/issues/1826

/assign @puerco @adolfo @saschagrunert 

/sig release
/priority critical-urgent