### PR TITLE
releng: Drop temporary Release Manager access for Jim Angel

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -40,7 +40,6 @@ groups:
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
       - gveronicalg@gmail.com
-      - jameswangel@gmail.com # temporary access grant ref: https://github.com/kubernetes/sig-release/issues/1826
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
       - pal.nabarun95@gmail.com


### PR DESCRIPTION
Jim is a Release Manager Associate who was granted temporary elevated access to cut January 2022 patch releases.

Fixes https://github.com/kubernetes/sig-release/issues/1826

/assign @puerco @adolfo @saschagrunert 

/sig release
/priority critical-urgent

/hold until patch releases are out