### PR TITLE
groups: Add Google group for AWS account

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -188,6 +188,7 @@ restrictions:
       - "^gke-security-groups@kubernetes.io$"
       - "^k8s-infra-alerts@kubernetes.io$"
       - "^k8s-infra-aws-admins@kubernetes.io$"
+      - "^k8s-infra-aws-root-account@kubernetes.io$"
       - "^k8s-infra-azure-admins@kubernetes.io$"
       - "^k8s-infra-equinix-admins@kubernetes.io$"
       - "^k8s-infra-artifact-admins@kubernetes.io$"

--- a/groups/sig-k8s-infra/groups.yaml
+++ b/groups/sig-k8s-infra/groups.yaml
@@ -247,6 +247,16 @@ groups:
       - justinsb@google.com
       - thockin@google.com
 
+  - email-id: k8s-infra-aws-root-account@kubernetes.io
+    name: k8s-infra-aws-root-account
+    description: |-
+      ACL for AWS root account
+    settings:
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      ReconcileMembers: "true"
+    members:
+      - sig-k8s-infra-leads@kubernetes.io
+
   - email-id: k8s-infra-azure-admins@kubernetes.io
     name: k8s-infra-azure-admins
     description: |-


### PR DESCRIPTION
Related:
  - https://github.com/kubernetes/funding/issues/28

Create a Google group that will be used AWS account creation.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>