### PR TITLE
Add staging gcp project for bom

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -135,6 +135,7 @@ restrictions:
       - "^k8s-infra-staging-releng@kubernetes.io$"
       - "^k8s-infra-staging-releng-test@kubernetes.io$"
       - "^k8s-infra-staging-publishing-bot@kubernetes.io$"
+      - "^k8s-infra-staging-bom@kubernetes.io$"
       - "^release-comms@kubernetes.io$"
       - "^release-managers-private@kubernetes.io$"
       - "^release-managers@kubernetes.io$"

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -443,3 +443,14 @@ groups:
       - hebaelayoty@gmail.com # 1.24 Bug Triage Shadow
       - igor.segodnya@gmail.com # 1.24 Bug Triage Shadow
       - panjwaniritu45@gmail.com # 1.24 Bug Triage Shadow
+
+  - email-id: k8s-infra-staging-bom@kubernetes.io
+    name: k8s-infra-staging-bom
+    description: |-
+      ACL for staging BOM project
+
+      This project is used to test and stage BOM project.
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - k8s-infra-release-editors@kubernetes.io

--- a/infra/gcp/infra.yaml
+++ b/infra/gcp/infra.yaml
@@ -260,6 +260,7 @@ infra:
       k8s-staging-artifact-promoter:
       k8s-staging-autoscaling:
       k8s-staging-boskos:
+      k8s-staging-bom:
       k8s-staging-build-image:
       k8s-staging-capi-docker:
       k8s-staging-capi-ibmcloud:

--- a/k8s.gcr.io/images/k8s-staging-bom/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-bom/OWNERS
@@ -1,0 +1,14 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+options:
+  no_parent_owners: true
+approvers:
+  - release-engineering-approvers
+  - sig-testing-leads
+  - sig-k8s-infra-leads
+reviewers:
+  - release-engineering-reviewers
+
+labels:
+  - sig/release
+  - area/release-eng

--- a/k8s.gcr.io/images/k8s-staging-bom/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-bom/images.yaml
@@ -1,0 +1,1 @@
+# No images yet

--- a/k8s.gcr.io/manifests/k8s-staging-bom/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-bom/promoter-manifest.yaml
@@ -1,0 +1,10 @@
+# google group for gcr.io/k8s-staging-bom is k8s-infra-staging-bom@kubernetes.io
+registries:
+  - name: gcr.io/k8s-staging-bom
+    src: true
+  - name: us.gcr.io/k8s-artifacts-prod/bom
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: eu.gcr.io/k8s-artifacts-prod/bom
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia.gcr.io/k8s-artifacts-prod/bom
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
we need to start releasing and promoting the artifacts we generate in the bom project (https://github.com/kubernetes-sigs/bom)

so we need to create a staging gcp project with bucket for that :)

Related to https://github.com/kubernetes-sigs/bom/issues/35

/assign @ameukam @spiffxp @puerco
cc @justaugustus @saschagrunert  @kubernetes/release-engineering 