### PR TITLE
Update gcp-compute-persistent-disk-csi-driver 1.4.0 image

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cloud-provider-gcp/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-cloud-provider-gcp/images.yaml
@@ -8,6 +8,7 @@
     "sha256:af42e4cf7bd5af41744d8c3a6c238da1a988cd38ec5dca5efcea343a96a05763": ["v1.3.1"]
     "sha256:b316059d0057e2bcb98d680feb99cd16e031260dd4ad0ce6c51ba8a28b48d9b7": ["v1.3.4"]
     "sha256:e9c355dd1ce57de91a0f9164bd2fe688938723e7f9bd40bb13652d603f41d25a": ["v1.2.2"]
+    "sha256:dc0301d9a43e23e389abb7690cd631f98af76ea3429259c7f5f643fd31fc0a3e": ["v1.4.0"]
 - name: gcp-filestore-csi-driver
   dmap:
     "sha256:0ff5800855e8f98467b1976cb442b402f00fed2e2ffab62b8f9a9c9f133e6d98": ["v0.6.1"]


### PR DESCRIPTION
The 1.4.0 release has [been pushed](https://pantheon.corp.google.com/gcr/images/k8s-staging-cloud-provider-gcp/global/gcp-compute-persistent-disk-csi-driver@sha256:dc0301d9a43e23e389abb7690cd631f98af76ea3429259c7f5f643fd31fc0a3e/details?project=k8s-staging-cloud-provider-gcp&supportedpurview=project).

/assign @saikat-royc 