### PR TITLE
oci-proxy: deploy sandbox infrastructure.

### DIFF
--- a/infra/gcp/terraform/k8s-infra-oci-proxy/network.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy/network.tf
@@ -1,0 +1,94 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "google_compute_global_address" "default_ipv4" {
+  project      = google_project.project.project_id
+  name         = "k8s-infra-oci-proxy-sandbox"
+  address_type = "EXTERNAL"
+  ip_version   = "IPV4"
+}
+
+resource "google_compute_global_address" "default_ipv6" {
+  project      = google_project.project.project_id
+  name         = "k8s-infra-oci-proxy-sandbox-v6"
+  address_type = "EXTERNAL"
+  ip_version   = "IPV6"
+}
+
+
+resource "google_compute_region_network_endpoint_group" "default" {
+  for_each = google_cloud_run_service.regions
+
+  provider              = google-beta
+  project               = google_project.project.project_id
+  name                  = "${local.project_id}--${each.key}--neg"
+  network_endpoint_type = "SERVERLESS"
+  region                = google_cloud_run_service.regions[each.key].location
+  cloud_run {
+    service = google_cloud_run_service.regions[each.key].name
+  }
+}
+
+module "lb-http" {
+  source  = "GoogleCloudPlatform/lb-http/google//modules/serverless_negs"
+  version = "~> 6.2.0"
+
+  project = google_project.project.project_id
+  name    = local.project_id
+
+  # ...
+  backends = {
+    default = {
+      description = null
+      groups = [
+        for neg in google_compute_region_network_endpoint_group.default :
+        {
+          group = neg.id
+        }
+      ]
+      enable_cdn              = true
+      security_policy         = null
+      custom_request_headers  = null
+      custom_response_headers = null
+
+      iap_config = {
+        enable               = false
+        oauth2_client_id     = ""
+        oauth2_client_secret = ""
+      }
+
+      log_config = {
+        enable      = true
+        sample_rate = "1.0"
+      }
+    }
+  }
+  create_address      = false
+  create_ipv6_address = false
+  enable_ipv6         = true
+  https_redirect      = true
+  #TODO(ameukam): current the TF resource google_compute_global_address don't have
+  #the value of IP in his attribute. But it's accessible with the data source:
+  #https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_global_address
+  address      = "34.110.128.221"
+  ipv6_address = "2600:1901:0:a7aa::"
+  managed_ssl_certificate_domains = [
+    local.domain
+  ]
+  random_certificate_suffix = true
+  ssl                       = true
+  use_ssl_certificates      = false
+}

--- a/infra/gcp/terraform/k8s-infra-oci-proxy/outputs.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy/outputs.tf
@@ -14,26 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
-This file defines:
-- Required provider versions
-- Storage backend details
-*/
-
-terraform {
-  backend "gcs" {
-    bucket = "k8s-infra-tf-oci-proxy"
-    prefix = "sanbox"
-  }
-
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = "~> 4.9.0"
-    }
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = "~> 4.9.0"
-    }
+// Print each service URL.
+output "services" {
+  value = {
+    for svc in google_cloud_run_service.regions :
+    svc.name => svc.status[0].url
   }
 }

--- a/infra/gcp/terraform/k8s-infra-oci-proxy/sandbox.auto.tfvars
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy/sandbox.auto.tfvars
@@ -14,4 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-tag = "v20220128-a6b8a96"
+tag = "v20220204-786ae98"

--- a/infra/gcp/terraform/k8s-infra-oci-proxy/sandbox.auto.tfvars
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy/sandbox.auto.tfvars
@@ -14,26 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
-This file defines:
-- Required provider versions
-- Storage backend details
-*/
-
-terraform {
-  backend "gcs" {
-    bucket = "k8s-infra-tf-oci-proxy"
-    prefix = "sanbox"
-  }
-
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = "~> 4.9.0"
-    }
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = "~> 4.9.0"
-    }
-  }
-}
+tag = "v20220128-a6b8a96"

--- a/infra/gcp/terraform/k8s-infra-oci-proxy/variables.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy/variables.tf
@@ -14,7 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "name" {
+variable "tag" {
   type    = string
-  default = "oci-proxy"
+  default = "latest"
+}
+
+variable "cloud_run_regions" {
+  type = list(string)
+  default = [
+    "us-central1",
+    "us-west1"
+  ]
 }


### PR DESCRIPTION
Add terraform code to handle deployment of a Cloud Run service for
`archeio`

- Add a global loadbalancer support IPv4 and IPv6
- ensure the Cloud Run run inside more than 1 GCP region
- ensure SSL certificates for `registry-sandbox.k8s.io`
- ensure traffic is redirect from HTTP to HTTPS

Still WIP because:
automated process of deployment is missing
discussion around naming

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>