### PR TITLE
remove image hash of iscsiplugin

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-sig-storage/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-sig-storage/images.yaml
@@ -100,7 +100,6 @@
     "sha256:6029c252dae6178c99b580de72d7776158edbc81be0de15cedc4152a3acfed18": [ "v1.7.3" ]
 - name: iscsiplugin
   dmap:
-    "sha256:31117074c183242b223340f2fc0f886243e97c6cb1a83d98cfb00a69d1746697": [ "v0.1.0" ]
 - name: livenessprobe
   dmap:
     "sha256:f8cec70adc74897ddde5da4f1da0209a497370eaf657566e2b36bc5f0f3ccbd7": [ "v1.1.0" ]


### PR DESCRIPTION
The canary image hash (v0.1.0-canary)  was mentioned as release tag,  considering canary get updated over time, we shouldnt be overwriting it.  This remove the same.
 
Note For reviewer :

A quick followup PR will place the release tag in place. Also both hashes are pointing to the same code/binary.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>