### PR TITLE
Update k8s-infra-*-capi-openstack with current maintainers

### DIFF
--- a/groups/sig-architecture/groups.yaml
+++ b/groups/sig-architecture/groups.yaml
@@ -142,8 +142,11 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
+      - christi.schlotter@gmail.com
       - jichenjc@cn.ibm.com
-      - sbueringer@gmail.com
+      - mbooth@redhat.com
+      - seansnowwhite@gmail.com
+      - tobiasgiese@gmail.com
 
   - email-id: k8s-infra-conform-cri-o@kubernetes.io
     name: k8s-infra-conform-cri-o

--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -116,8 +116,11 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
+      - christi.schlotter@gmail.com
       - jichenjc@cn.ibm.com
-      - sbueringer@gmail.com
+      - mbooth@redhat.com
+      - seansnowwhite@gmail.com
+      - tobiasgiese@gmail.com
 
   - email-id: k8s-infra-staging-capi-vsphere@kubernetes.io
     name: k8s-infra-staging-capi-vsphere


### PR DESCRIPTION
@sbueringer is removed as he is no longer a CAPO maintainer.

@chrischdi @mdbooth @seanschneeweiss and @tobiasgiese are added from https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/main/OWNERS_ALIASES

@hidekazuna is still missing as I don't have a google id for him yet.