### PR TITLE
create GCP project for krm functions registry subproject

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -49,6 +49,7 @@ restrictions:
     allowedGroups:
       - "^sig-cli-leads@kubernetes.io$"
       - "^k8s-infra-staging-kustomize@kubernetes.io$"
+      - "^k8s-infra-staging-krm-functions@kubernetes.io$"
       - "^k8s-infra-rbac-triageparty-cli@kubernetes.io$"
   - path: "sig-cloud-provider/groups.yaml"
     allowedGroups:

--- a/groups/sig-cli/groups.yaml
+++ b/groups/sig-cli/groups.yaml
@@ -45,6 +45,18 @@ groups:
       - extaeger@google.com
       - samwronski@google.com
       - katrina.verey@shopify.com
+
+  - email-id: k8s-infra-staging-krm-functions@kubernetes.io
+    name: k8s-infra-staging-krm-functions
+    description: |-
+      ACL for k8s-infra-staging-krm-functions
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - jeremy.r.rickard@gmail.com
+      - katrina.verey@shopify.com
+      - mengqiy@google.com
+      - natashasarkar@google.com
   #
   # k8s-infra gcs write access
   #

--- a/infra/gcp/infra.yaml
+++ b/infra/gcp/infra.yaml
@@ -300,6 +300,7 @@ infra:
       k8s-staging-kas-network-proxy:
       k8s-staging-kind:
       k8s-staging-kops:
+      k8s-staging-krm-functions:
       k8s-staging-kube-state-metrics:
       k8s-staging-kubeadm:
       k8s-staging-kubernetes:

--- a/k8s.gcr.io/images/k8s-staging-krm-functions/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-krm-functions/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- jeremyrickard
+- knverey
+- mengqiy
+- natasha41575
+
+approvers:
+- jeremyrickard
+- knverey
+- mengqiy
+- natasha41575

--- a/k8s.gcr.io/images/k8s-staging-krm-functions/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-krm-functions/images.yaml
@@ -1,0 +1,1 @@
+# No images yet

--- a/k8s.gcr.io/manifests/k8s-staging-krm-functions/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-krm-functions/promoter-manifest.yaml
@@ -1,0 +1,10 @@
+# google group for gcr.io/k8s-staging-krm-functions k8s-infra-staging-krm-functions@kubernetes.io
+registries:
+  - name: gcr.io/k8s-staging-krm-functions
+    src: true
+  - name: us.gcr.io/k8s-artifacts-prod/krm-functions
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: eu.gcr.io/k8s-artifacts-prod/krm-functions
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia.gcr.io/k8s-artifacts-prod/krm-functions
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
We have a new SIG-CLI subproject, the [KRM Functions Registry](https://github.com/kubernetes-sigs/krm-functions-registry). We would like to create a GCP project to stage our docker images before publishing them as official images. This PR is intended to set that up, please let me know if there are any additional steps required to set up such a GCP project. 