### PR TITLE
Add new CAPA alerts group

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -71,6 +71,7 @@ restrictions:
       - "^k8s-infra-staging-capi-vsphere@kubernetes.io$"
       - "^k8s-infra-staging-cluster-api@kubernetes.io$"
       - "^k8s-infra-staging-cluster-api-aws@kubernetes.io$"
+      - "^sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io$"
       - "^k8s-infra-staging-cluster-api-do@kubernetes.io$"
       - "^k8s-infra-staging-cluster-api-azure@kubernetes.io$"
       - "^k8s-infra-staging-cluster-api-gcp@kubernetes.io$"

--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -167,6 +167,21 @@ groups:
       - richmcase@gmail.com
       - sedefsavas@gmail.com
 
+  - email-id: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
+    name: sig-cluster-lifecycle-cluster-api-aws-alerts
+    description: |-
+
+    settings:
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      MessageModerationLevel: "MODERATE_ALL_MESSAGES"
+      ReconcileMembers: "false"
+    owners:
+      - richmcase@gmail.com
+      - sedefsavas@gmail.com
+
   - email-id: k8s-infra-staging-cluster-api-do@kubernetes.io
     name: k8s-infra-staging-cluster-api-do
     description: |-


### PR DESCRIPTION
This adds a new group that will be used for Cluster API Provider AWS
alerts.

Signed-off-by: Richard Case <richard@weave.works>