### PR TITLE
prow-build-trusted: Allow KES Service Account access to GSM secret

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/secrets.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/secrets.tf
@@ -73,3 +73,22 @@ resource "google_secret_manager_secret_iam_binding" "build_cluster_secret_admins
     "group:${each.value.owners}"
   ]
 }
+
+data "google_secret_manager_secret" "capdo_quayio_registry_secret" {
+  project   = module.project.project_id
+  secret_id = "capdo-quayio-registry-secret"
+}
+
+resource "google_secret_manager_secret_iam_member" "k8s_prow_kes_sa_role_viewer" {
+  project   = module.project.project_id
+  secret_id = data.google_secret_manager_secret.capdo_quayio_registry_secret.id
+  role      = "roles/secretmanager.viewer"
+  member    = "serviceAccount:kubernetes-external-secrets-sa@k8s-prow.iam.gserviceaccount.com"
+}
+
+resource "google_secret_manager_secret_iam_member" "k8s_prow_kes_sa_role_accessor" {
+  project   = module.project.project_id
+  secret_id = data.google_secret_manager_secret.capdo_quayio_registry_secret.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:kubernetes-external-secrets-sa@k8s-prow.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
Followup of:
  - https://github.com/kubernetes/test-infra/pull/24697

Add non-authoritative Google Secret Manager IAM bindings for
`kubernetes-external-secrets-sa@k8s-prow.iam.gserviceaccount.com`
service account.
This required to ensure Kubernetes-Externel-Secrets deployed in the
`k8s-prow` Google project can access the secret needed for usage by
prow.k8s.io.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>