### PR TITLE
promote cluster-api-ibmcloud-controller:v0.1.1 image

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-capi-ibmcloud/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-capi-ibmcloud/images.yaml
@@ -1,3 +1,4 @@
 - name: cluster-api-ibmcloud-controller
   dmap:
     "sha256:6c92a6a337ca5152eda855ac27c9e4ca1f30bba0aa4de5c3a0b937270ead4363": ["v0.1.0"]
+    "sha256:930d22f704175eff2f51a131a56e2fb4c335dda887d229e430b6dec19c00698c": ["v0.1.1"]


### PR DESCRIPTION
Promote `v0.1.1` release

```
% manifest-tool inspect --raw gcr.io/k8s-staging-capi-ibmcloud/cluster-api-ibmcloud-controller:v0.1.1 | jq '.[0].Digest'
"sha256:930d22f704175eff2f51a131a56e2fb4c335dda887d229e430b6dec19c00698c"
```