### PR TITLE
Add kueue to k8s.gcr.io

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -155,6 +155,7 @@ restrictions:
       - "^k8s-infra-staging-descheduler@kubernetes.io$"
       - "^k8s-infra-staging-scheduler-plugins@kubernetes.io$"
       - "^k8s-infra-staging-sched-simulator@kubernetes.io$"
+      - "^k8s-infra-staging-kueue@kubernetes.io$"
   - path: "sig-security/groups.yaml"
     allowedGroups:
       - "^security-tooling-private@kubernetes.io$"

--- a/groups/sig-scheduling/groups.yaml
+++ b/groups/sig-scheduling/groups.yaml
@@ -18,6 +18,17 @@ groups:
   # Membership should correspond roughly to subproject owners for the set of
   # subproject artifacts being stored in a given staging project
   #
+  - email-id: k8s-infra-staging-kueue@kubernetes.io
+    name: k8s-infra-staging-kueue
+    description: |-
+      ACL for staging kueue
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - acondor@google.com
+      - ahg@google.com
+      - carangog@redhat.com
+      - wangqingcan1990@gmail.com
 
   - email-id: k8s-infra-staging-descheduler@kubernetes.io
     name: k8s-infra-staging-descheduler

--- a/infra/gcp/infra.yaml
+++ b/infra/gcp/infra.yaml
@@ -303,6 +303,7 @@ infra:
       k8s-staging-krm-functions:
       k8s-staging-kube-state-metrics:
       k8s-staging-kubeadm:
+      k8s-staging-kueue:
       k8s-staging-kubernetes:
       k8s-staging-kubetest2:
       k8s-staging-kustomize:

--- a/k8s.gcr.io/images/k8s-staging-kueue/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-kueue/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS file documentation:
+#  https://github.com/kubernetes/community/blob/master/contributors/devel/owners.md
+
+approvers:
+- ahg-g
+- alculquicondor
+reviewers:
+- ArangoGutierrez
+- denkensk
+labels:
+- sig/scheduling

--- a/k8s.gcr.io/images/k8s-staging-kueue/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-kueue/images.yaml
@@ -1,0 +1,1 @@
+# TODO: add images

--- a/k8s.gcr.io/manifests/k8s-staging-kueue/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-kueue/promoter-manifest.yaml
@@ -1,0 +1,11 @@
+# google group for gcr.io/k8s-staging-kueue is k8s-infra-staging-kueue@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-kueue
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/kueue
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/kueue
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/kueue
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+imagesPath: "../../images/k8s-staging-kueue/images.yaml"


### PR DESCRIPTION
We would like to host images for [kueue](https://github.com/kubernetes-sigs/kueue) in k8s.gcr.io, see [kubernetes-sigs/kueue#52](https://github.com/kubernetes-sigs/kueue/issues/52)

/sig scheduling

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>