### PR TITLE
Add SIG Docs co-chairs to leads

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -95,12 +95,14 @@ groups:
       - mikedanese@google.com
       - msau@google.com
       - mwielgus@google.com
+      - natalivlatko@gmail.com
       - neolit123@gmail.com
       - nospam.wong@gmail.com
       - pal.nabarun95@gmail.com #CoCC
       - patrick.ohly@intel.com
       - prydonius@gmail.com
       - quinton@hoole.biz
+      - rlejano@gmail.com
       - saadali@google.com
       - saschagrunert@gmail.com # SIG Release
       - saveetha13@gmail.com


### PR DESCRIPTION
Add SIG Docs co-chairs, Rey Lejano and Natali Vlatko, to leads@kubernetes.io group
https://github.com/kubernetes/community/tree/master/sig-docs#leadership

cc: @natalisucks 