### PR TITLE
update sippy to match new docker image location

### DIFF
--- a/apps/sippy/deployment.yaml
+++ b/apps/sippy/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
           command:
-            - /go/src/sippy/sippy
+            - /bin/sippy
           args:
             - --server
             - --end-day
@@ -54,7 +54,7 @@ spec:
           # This runs in a loop to collect data every hour or so.  We run it in the same pod so that both containers can mount
           # and we don't need r/w many.
           command:
-            - /go/src/sippy/scripts/fetchdata-kube.sh
+            - /bin/fetchdata-kube.sh
           volumeMounts:
             - mountPath: /data
               name: data


### PR DESCRIPTION
fixes https://github.com/kubernetes/k8s.io/issues/3431

at some point these got moved in the sippy Dockerfile: https://github.com/openshift/sippy/blob/master/Dockerfile#L10-L13

/assign @wojtek-t 