### PR TITLE
Enabe IAM API in promoter projects and test signing svc acct

### DIFF
--- a/infra/gcp/bash/ensure-prod-storage.sh
+++ b/infra/gcp/bash/ensure-prod-storage.sh
@@ -391,6 +391,14 @@ function ensure_all_prod_special_cases() {
     ensure_gcs_role_binding "gs://k8s-artifacts-gcslogs" \
         "group:k8s-infra-gcs-access-logs@kubernetes.io" \
         "objectViewer"
+
+    # Special case: In order to run the container image signing tests, k8s-cip-test-prod
+    # requires to have the IAM Service Account Credentials API enabled to generate OIDC
+    # identity tokens. The production project needs the API too to sign all promoted images.
+
+    color 6 "Ensuring IAM Service Account Credentials API for image signing"
+    ensure_services "${IMAGE_PROMOTER_TEST_PROD_PROJECT}" "iamcredentials.googleapis.com"
+    ensure_services "${PROD_PROJECT}" "iamcredentials.googleapis.com"
 }
 
 function main() {

--- a/infra/gcp/bash/ensure-prod-storage.sh
+++ b/infra/gcp/bash/ensure-prod-storage.sh
@@ -399,6 +399,20 @@ function ensure_all_prod_special_cases() {
     color 6 "Ensuring IAM Service Account Credentials API for image signing"
     ensure_services "${IMAGE_PROMOTER_TEST_PROD_PROJECT}" "iamcredentials.googleapis.com"
     ensure_services "${PROD_PROJECT}" "iamcredentials.googleapis.com"
+
+    # The promoter project also requires a service account to issue the test signatures
+    # during the e2e tests
+    color 6 "Ensuring image signing test account exists and e2es have access to it"
+    ensure_service_account \
+        "${IMAGE_PROMOTER_TEST_PROD_PROJECT}" \
+        "${IMAGE_PROMOTER_TEST_SIGNER_SVCACCT}" \
+        "image promoter e2e test signing account"
+
+    test_sign_account="$(svc_acct_email "${IMAGE_PROMOTER_TEST_PROD_PROJECT}" "${IMAGE_PROMOTER_TEST_SIGNER_SVCACCT}")"
+    ensure_serviceaccount_role_binding \
+        "${test_sign_account}" \
+        "serviceAccount:k8s-infra-gcr-promoter@k8s-cip-test-prod.iam.gserviceaccount.com" \
+        "roles/iam.serviceAccountTokenCreator"
 }
 
 function main() {

--- a/infra/gcp/bash/lib.sh
+++ b/infra/gcp/bash/lib.sh
@@ -85,6 +85,10 @@ readonly FILE_PROMOTER_SVCACCT="k8s-infra-promoter"
 # The service account name for the image promoter.
 readonly IMAGE_PROMOTER_SVCACCT="k8s-infra-gcr-promoter"
 
+# The service account to generate image and artifact signatures during
+# e2e tests of the image promoter
+export IMAGE_PROMOTER_TEST_SIGNER_SVCACCT="k8s-infra-promoter-test-signer"
+
 # The service account name for the image promoter's vulnerability check.
 # used in: ensure-prod-storage.sh ensure-staging-storage.sh
 export IMAGE_PROMOTER_VULN_SCANNING_SVCACCT="k8s-infra-gcr-vuln-scanning"


### PR DESCRIPTION
This PR adds two things to the infra bash scripts:

1. It adds to the `ensure-prod-storage.sh` script calls to enable the
IAM Service Account Credentials API (iamcredentials.googleapis.com)
in the promoter projects (k8s-cip-test-prod and k8s-artifacts-prod). This is required to generate OIDC identity tokens that will be used to sign images and artifacts.

2. It adds a new service account to the test project (`k8s-infra-promoter-test-signer`) to sign images during e2es and ensures the account that runs the tests has access to them.

Fixes https://github.com/kubernetes/k8s.io/issues/3445

/sig k8s-infra
/sig release

/assign @ameukam 
/cc @kubernetes/release-engineering 

Signed-off-by: Adolfo García Veytia <adolfo.garcia@uservers.net>