### PR TITLE
Add ingress nginx v1.1.2 to promotion

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -35,6 +35,7 @@
     "sha256:55a1fcda5b7657c372515fe402c3e39ad93aa59f6e4378e82acd99912fe6028d": ["v1.0.5"]
     "sha256:f766669fdcf3dc26347ed273a55e754b427eb4411ee075a53f30718b4499076a": ["v1.1.0"]
     "sha256:0bc88eb15f9e7f84e8e56c14fa5735aaa488b840983f87bd79b1054190e660de": ["v1.1.1"]
+    "sha256:28b11ce69e57843de44e3db6413e98d09de0f6688e33d4bd384002a44f78405c": ["v1.1.2"]
 
 # custom base NGINX image
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/nginx


### PR DESCRIPTION
build log: https://storage.googleapis.com/kubernetes-jenkins/logs/post-ingress-nginx-push-images/1497945961261961216/artifacts/build.log

xref: https://github.com/kubernetes/ingress-nginx/issues/8274

/cc @rikatz @strongjz 