### PR TITLE
k8s-releng-prod: Signer accounts, access and IAM API

### DIFF
--- a/infra/gcp/bash/ensure-releng.sh
+++ b/infra/gcp/bash/ensure-releng.sh
@@ -62,8 +62,8 @@ for PROJECT; do
     empower_group_as_viewer "${PROJECT}" "${RELEASE_ADMINS}"
 
     # Enable KMS APIs
-    color 6 "Enabling the KMS API"
-    ensure_only_services "${PROJECT}" cloudkms.googleapis.com
+    color 6 "Enabling the KMS and IAM Credentials APIs"
+    ensure_only_services "${PROJECT}" cloudkms.googleapis.com iamcredentials.googleapis.com
 
     # Let project admins use KMS.
     color 6 "Empowering ${RELEASE_ADMINS} as KMS admins"

--- a/infra/gcp/bash/ensure-releng.sh
+++ b/infra/gcp/bash/ensure-releng.sh
@@ -44,6 +44,61 @@ if [ $# = 0 ]; then
     set -- "${PROJECTS[@]}"
 fi
 
+RELEASE_PROCESS_CLOUDBUILD_SVCACCT="648026197307@cloudbuild.gserviceaccount.com"
+STAGING_SIGNER_SVCACCT="krel-staging"
+K8s_ORG_SIGNER_SVCACCT="trust"
+PROMOTER_PROJECT="k8s-artifacts-prod"
+
+# Ensure the signer service accounts exist and the
+# required accounts have access to them as token creators
+function ensure_signer_service_accounts() {
+    if [ $# != 1 ] || [ -z "$1" ]; then
+        echo "ensure_signer_service_accounts requires a project name" >&2
+        return 1
+    fi
+    
+    local project="${1}"
+
+    # Service account for signing artifacts during staging
+    color 6 "Ensuring staging signing account"
+    ensure_service_account \
+        "${project}" \
+        "${STAGING_SIGNER_SVCACCT}" \
+        "krel staging signing account"
+
+    # Service account for signing artifacts during staging
+    color 6 "Ensuring main Kubernetes org signing account"
+    ensure_service_account \
+        "${project}" \
+        "${K8s_ORG_SIGNER_SVCACCT}" \
+        "Kubernetes signer account"
+        
+    # The cloud build account needs to be able to produce OIDC identity
+    # tokens with the staging signer identity
+    staging_sign_account="$(svc_acct_email "${project}" "${STAGING_SIGNER_SVCACCT}")"
+    ensure_serviceaccount_role_binding \
+        "${staging_sign_account}" \
+        "serviceAccount:${RELEASE_PROCESS_CLOUDBUILD_SVCACCT}" \
+        "roles/iam.serviceAccountTokenCreator"
+
+    # The image promoter accounts that handle image and file promotion need
+    # access to the main Kubernetes signing account to produce OIDC tokens
+    # with its identity. 
+    prod_sign_account="$(svc_acct_email "${project}" "${K8s_ORG_SIGNER_SVCACCT}")"
+    promoter_file_account="$(svc_acct_email "${PROMOTER_PROJECT}" "${FILE_PROMOTER_SVCACCT}")"
+    promoter_image_account="$(svc_acct_email "${PROMOTER_PROJECT}" "${IMAGE_PROMOTER_SVCACCT}")"
+    
+    ensure_serviceaccount_role_binding \
+        "${prod_sign_account}" \
+        "serviceAccount:${promoter_file_account}" \
+        "roles/iam.serviceAccountTokenCreator"
+    
+    ensure_serviceaccount_role_binding \
+        "${prod_sign_account}" \
+        "serviceAccount:${promoter_image_account}" \
+        "roles/iam.serviceAccountTokenCreator"
+}
+
 for PROJECT; do
 
     if ! k8s_infra_project "releng" "${PROJECT}" >/dev/null; then
@@ -61,13 +116,16 @@ for PROJECT; do
     color 6 "Empowering ${RELEASE_ADMINS} as project viewers"
     empower_group_as_viewer "${PROJECT}" "${RELEASE_ADMINS}"
 
-    # Enable KMS APIs
+    # Enable KMS and IAM APIs
     color 6 "Enabling the KMS and IAM Credentials APIs"
     ensure_only_services "${PROJECT}" cloudkms.googleapis.com iamcredentials.googleapis.com
 
     # Let project admins use KMS.
     color 6 "Empowering ${RELEASE_ADMINS} as KMS admins"
     empower_group_for_kms "${PROJECT}" "${RELEASE_ADMINS}"
+
+    # Ensure service accounts and role bindings.
+    ensure_signer_service_accounts "${PROJECT}"
 
     color 6 "Done"
 done


### PR DESCRIPTION
Following our discussions on the RelEng meetings and in https://github.com/kubernetes/k8s.io/issues/3461#issuecomment-1056017938 this PR sets up some cloud resources for the signing MVP on `k8s-releng-prod`. 

Namely does the following:

1. Creates the staging and production signer accounts
2. Ensures the IAM Service Account Credentials API is enabled
4. Grants access to the signer accounts to the following:
  - Grants the release process service account access to the stage signer acct
  - Grants the image promoter service accounts (file+image) access to the production signer 
5. Ensures the cross-project impersonation constraint is not enforced in the project

Part of https://github.com/kubernetes/release/issues/2445

/assign @ameukam 
/cc @kubernetes/sig-release-leads @kubernetes/release-engineering 
/sig k8s-infra
/sig release
/priority important-soon
/area bash
/area infra


Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>