### PR TITLE
Fix some scripts to satisfy latest shellcheck

### DIFF
--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -46,7 +46,7 @@ passed_files=()
 # - allows --source-path to work for adjacent files
 # - allows listing which specific files failed at end
 for file in "${files[@]}"; do
-    echo "# checking ${file#${REPO_ROOT}\/}"
+    echo "# checking ${file#"${REPO_ROOT}"\/}"
     if ! "${shellcheck_cmd[@]}" "${file}" >>"${SHELLCHECK_OUTPUT}" 2>&1; then
         failed_files+=("${file}")
     else

--- a/images/public-log-asn-matcher/pg-init.d/lib-04-load-into-a-bigquery-dataset.sh
+++ b/images/public-log-asn-matcher/pg-init.d/lib-04-load-into-a-bigquery-dataset.sh
@@ -40,7 +40,7 @@ VENDORS=(
     tencentcloud
 )
 ## This should be the end of pyasn section, we have results table that covers start_ip/end_ip from fs our requirements
-for VENDOR in ${VENDORS[*]}; do
+for VENDOR in "${VENDORS[@]}"; do
   # shellcheck disable=SC2016
   curl -s "https://raw.githubusercontent.com/kubernetes/k8s.io/main/registry.k8s.io/infra/meta/asns/${VENDOR}.yaml" \
       | yq -r '.name as $name | .redirectsTo.registry as $redirectsToRegistry | .redirectsTo.artifacts as $redirectsToArtifacts | .asns[] | [. ,$name, $redirectsToRegistry, $redirectsToArtifacts] | @csv' \
@@ -67,7 +67,7 @@ curl "${MS_SERVICETAG_PUBLIC_REF}" \
       > /tmp/vendor/microsoft_raw_subnet_region.csv
 
 ## Load all the csv
-for VENDOR in ${ASN_VENDORS[*]}; do
+for VENDOR in "${ASN_VENDORS[@]}"; do
   bq load --autodetect "${GCP_BIGQUERY_DATASET}_${PIPELINE_DATE}.vendor_json" "/tmp/vendor/${VENDOR}_raw_subnet_region.csv" ipprefix:string,service:string,region:string >> "${BQ_OUTPUT:-/dev/null}" 2>&1
 done
 
@@ -76,7 +76,7 @@ PEERINGDB_TABLES=(
     net
     poc
 )
-for PEERINGDB_TABLE in ${PEERINGDB_TABLES[*]}; do
+for PEERINGDB_TABLE in "${PEERINGDB_TABLES[@]}"; do
     curl -sG "https://www.peeringdb.com/api/${PEERINGDB_TABLE}" | jq -c '.data[]' | sed 's,",\",g' > "/tmp/peeringdb-tables/${PEERINGDB_TABLE}.json"
 done
 

--- a/images/public-log-asn-matcher/pg-init.d/lib-07-bq-load-logs.sh
+++ b/images/public-log-asn-matcher/pg-init.d/lib-07-bq-load-logs.sh
@@ -18,7 +18,7 @@
 if [ -z "${GCP_BIGQUERY_DATASET_LOGS:-}" ]; then
     echo "Using dataset logs, since \$GCP_BIGQUERY_DATASET_LOGS was provided and set to '${GCP_BIGQUERY_DATASET_LOGS:-}'"
     BUCKETS=$(cat /app/buckets.txt)
-    for BUCKET in ${BUCKETS[*]}; do
+    for BUCKET in "${BUCKETS[@]}"; do
             bq load \
                 --autodetect \
                 --max_bad_records=2000 \


### PR DESCRIPTION
Shellcheck was updated and some existing scripts started making tests SC2295 and SC2048 fail (see [here](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/k8s.io/3456/pull-k8sio-verify/1501707804971372544/build-log.txt) or [here](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/k8s.io/3455/pull-k8sio-verify/1501623486894837760/build-log.txt) )

This PR fixes the cycling of arrays and quoting to satisfy them.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>
