### PR TITLE
oci-proxy: Add infrastructure for registry.k8s.io

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -244,13 +244,20 @@ monitoring.prow-canary:
 prs:
   type: CNAME
   value: redirect.k8s.io.
-# https://github.com/kubernetes-sigs/release-notes docs (@jeefy)
-# Sandbox OCI redirector service.  (@ameukam,@BenTheElder,@thockin)
+# Sandbox OCI redirector service.  (@ameukam,@BenTheElder,@thockin, @eddiezane)
 registry-sandbox:
   - type: A
     value: 34.110.128.221
   - type: AAAA
     value: "2600:1901:0:a7aa::"
+# Prod OCI redirector service.  (@ameukam,@BenTheElder,@thockin, @eddiezane)
+# Reach to k8s-infra-oci-proxy-admins@kubernetes.io for major issues.
+registry:
+  - type: A
+    value: 34.107.244.51
+  - type: AAAA
+    value: "2600:1901:0:1013::"
+# https://github.com/kubernetes-sigs/release-notes docs (@jeefy)
 relnotes:
   type: CNAME
   value: kubernetes-sigs-release-notes.netlify.app.

--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/network.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/network.tf
@@ -1,0 +1,37 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "google_compute_global_address" "default_ipv4" {
+  project      = google_project.project.project_id
+  name         = "k8s-infra-oci-proxy-prod"
+  address_type = "EXTERNAL"
+  ip_version   = "IPV4"
+
+  depends_on = [
+    google_project_service.project["compute.googleapis.com"],
+  ]
+}
+
+resource "google_compute_global_address" "default_ipv6" {
+  project      = google_project.project.project_id
+  name         = "k8s-infra-oci-proxy-prod-v6"
+  address_type = "EXTERNAL"
+  ip_version   = "IPV6"
+
+  depends_on = [
+    google_project_service.project["compute.googleapis.com"],
+  ]
+}

--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/oci-proxy-prod.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/oci-proxy-prod.tf
@@ -1,0 +1,70 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+locals {
+  project_id = "k8s-infra-oci-proxy-prod"
+  domain     = "registry.k8s.io"
+
+  external_ips = {
+    sandbox = {
+      name = "${local.project_id}-sandbox",
+    },
+    sandbox-v6 = {
+      name = "${local.project_id}-sandbox-v6",
+      ipv6 = true
+    },
+  }
+}
+
+data "google_billing_account" "account" {
+  billing_account = "018801-93540E-22A20E"
+}
+
+data "google_organization" "org" {
+  domain = "kubernetes.io"
+}
+
+resource "google_project" "project" {
+  name            = local.project_id
+  project_id      = local.project_id
+  org_id          = data.google_organization.org.org_id
+  billing_account = data.google_billing_account.account.id
+}
+
+// Enable services needed for the project
+resource "google_project_service" "project" {
+  project = google_project.project.id
+
+  for_each = toset([
+    "compute.googleapis.com",
+    "containerregistry.googleapis.com",
+    "logging.googleapis.com",
+    "oslogin.googleapis.com",
+    "pubsub.googleapis.com",
+    "run.googleapis.com",
+    "storage-api.googleapis.com",
+    "storage-component.googleapis.com"
+  ])
+
+  service = each.key
+}
+
+// Ensure k8s-infra-oci-proxy-admins@kubernetes.io has admin access to this project
+resource "google_project_iam_member" "k8s_infra_oci_proxy_admins" {
+  project = google_project.project.id
+  role    = "roles/owner"
+  member  = "group:k8s-infra-oci-proxy-admins@kubernetes.io"
+}

--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/provider.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/provider.tf
@@ -1,0 +1,39 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This file defines:
+- Required provider versions
+- Storage backend details
+*/
+
+terraform {
+  backend "gcs" {
+    bucket = "k8s-infra-tf-oci-proxy"
+    prefix = "prod"
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.13.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 4.13.0"
+    }
+  }
+}

--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/versions.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/versions.tf
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This file defines:
+- Required Terraform version
+*/
+
+terraform {
+  required_version = "~> 1.1.0"
+}


### PR DESCRIPTION
Related:
  -  https://github.com/kubernetes/k8s.io/issues/3411

Add a new GCP project
Ensure Global public addresses (IPv4/IPv6)
Ensure k8s-infra-oci-proxy@kubernetes.io have admin access
Add DNS entries for `registry.k8s.io`

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>