### PR TITLE
minor typo fix in cloudsearch ingress.yaml

### DIFF
--- a/apps/codesearch/ingress.yaml
+++ b/apps/codesearch/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: codesearch
   annotations:
-    kubernetes.io/ingress.allow-http: false
+    kubernetes.io/ingress.allow-http: "false"
     kubernetes.io/ingress.global-static-ip-name: cs-k8s-io-ingress
     kubernetes.io/ingress.class: gce
     networking.gke.io/managed-certificates: codesearch


### PR DESCRIPTION
The PR is part of the fix for failing postsubmit `post-k8sio-deploy-app-codesearch` job.

- Ref: https://cloud.google.com/kubernetes-engine/docs/concepts/ingress-xlb#disabling_http
- Failing job: https://storage.googleapis.com/kubernetes-jenkins/logs/post-k8sio-deploy-app-codesearch/1502042402167197696/build-log.txt

![Screenshot 2022-03-11 at 10 39 00 AM](https://user-images.githubusercontent.com/30499743/157806048-b4306b19-981d-4398-83de-c05f00792fb0.png)
