### PR TITLE
second trigger for cs-fetch-repos image initial build & push

### DIFF
--- a/images/codesearch/cs-fetch-repos/README.md
+++ b/images/codesearch/cs-fetch-repos/README.md
@@ -16,7 +16,6 @@ File config saved to: /tmp/config.json
 ```
 
 To add a new repo, update `REPOS` in the `fetch-repos.py` script.
-
 ```
 REPOS = [
     'kubernetes',


### PR DESCRIPTION
The PR is for re-triggering the currently failing `cs-fetch-repos` image build/push post-submit job ~ https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-k8sio-push-image-cs-fetch-repos-canary/1504388922468208640


cc: @ameukam