### PR TITLE
promoting nginx base image for ssl/xml patch

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -62,7 +62,7 @@
     "sha256:8c1e48123e64e3f2b90ed32a53babd9b5f5431dad26beecdcb8fc185ded3b6dd": ["v20210915-g498892514"]
     "sha256:1ef404b5e8741fe49605a1f40c3fdd8ef657aecdb9526ea979d1672eeabd0cd9": ["v20210926-g5662db450"]
     "sha256:ee001455750923c131bff706f20cd95078a78c9538ab0c15f754fd9af7fe9656": ["v20220318-controller-v1.1.2-21-ge51c15160"]
-
+    "sha256:99f079bc9e418b450e0902ea78e86c70315dad3a420871d29e812c55cc0beea1": ["9960efe1e9a9c6e944967b52e1a8a7b7b659874d"]
 # image to run tests
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/test-runner
 - name: e2e-test-runner


### PR DESCRIPTION
Promoting new nginx base image created to patch for ssl & xml CVEs

More info at :-
https://github.com/kubernetes/ingress-nginx/issues/8339
https://github.com/kubernetes/ingress-nginx/issues/8321
https://github.com/kubernetes/ingress-nginx/pull/8394
https://github.com/kubernetes/ingress-nginx/pull/8386

@strongjz @rikatz @tao12345666333 