### PR TITLE
execute bit on for entrypoint.sh - new nginxbaseimage

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -63,6 +63,7 @@
     "sha256:1ef404b5e8741fe49605a1f40c3fdd8ef657aecdb9526ea979d1672eeabd0cd9": ["v20210926-g5662db450"]
     "sha256:ee001455750923c131bff706f20cd95078a78c9538ab0c15f754fd9af7fe9656": ["v20220318-controller-v1.1.2-21-ge51c15160"]
     "sha256:99f079bc9e418b450e0902ea78e86c70315dad3a420871d29e812c55cc0beea1": ["9960efe1e9a9c6e944967b52e1a8a7b7b659874d"]
+    "sha256:ec8a104df307f5c6d68157b7ac8e5e1e2c2f0ea07ddf25bb1c6c43c67e351180": ["5402d35663917ccbbf77ff48a22b8c6f77097f48"]
 # image to run tests
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/test-runner
 - name: e2e-test-runner


### PR DESCRIPTION
Created new nginx base image to set execute bit on entrypoint.sh. This is because entrypoint.sh got added in a recent OpenTelemetry PR without the execute bit on