### PR TITLE
promote csi-secrets-store driver: v1.1.2

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-csi-secrets-store/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-csi-secrets-store/images.yaml
@@ -22,6 +22,7 @@
     "sha256:c85ae070057c33108cf0758041434ff93e04ff84498a8d253ca6acb6477599c3": [ "v1.1.0" ]
     "sha256:a98610ffd33fb2d16a18973618c41caffa49cd6e0c2d020903dace8d2f260838": [ "v1.1.0-rc.0" ]
     "sha256:33faa887d8ad681c73c0de3ca9e68ba3ce6864e4af49bc9e7e2e22c897a340e4": [ "v1.1.1" ]
+    "sha256:4df23dc3720360ec88136abddb3ab62eb2a7ed758722bc045485ab6d0bd43748": [ "v1.1.2" ]
 - name: driver-crds
   dmap:
     "sha256:508f58321f8085877a8b8e7268e5a5efbca707ebe10e8c705124a5c9e1b5ceab": [ "v0.1.0" ]
@@ -34,3 +35,4 @@
     "sha256:f0ac76debb4eacb1bcb21c9435aa0db03e7e7b016ae9f320dcea1b191b0c8a0a": [ "v1.1.0" ]
     "sha256:2af839dfb280c43c05cfad58c1f1276055676cf9cd3fdad0f1b842fe317fa71f": [ "v1.1.0-rc.0" ]
     "sha256:211e7806db52cc417129363f20316b14ceb115202dd59c1710ee49e768f79d0f": [ "v1.1.1" ]
+    "sha256:9aa31710e6df5bacc238c6fd441abc66f1d5734ef5ca43dedfe784f4bfdb7fab": [ "v1.1.2" ]


### PR DESCRIPTION
```
++ docker manifest push --purge gcr.io/k8s-staging-csi-secrets-store/driver:v1.1.2
sha256:4df23dc3720360ec88136abddb3ab62eb2a7ed758722bc045485ab6d0bd43748
```

```
++ docker manifest push --purge gcr.io/k8s-staging-csi-secrets-store/driver-crds:v1.1.2
sha256:9aa31710e6df5bacc238c6fd441abc66f1d5734ef5ca43dedfe784f4bfdb7fab
```

from https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/secrets-store-csi-driver-push-image/1509288853238714368

Generated by running -

➜ k8s.gcr.io/images/k8s-staging-csi-secrets-store/generate.sh > k8s.gcr.io/images/k8s-staging-csi-secrets-store/images.yaml

Test run with the staging image: https://github.com/kubernetes-sigs/secrets-store-csi-driver/runs/5773069877?check_suite_focus=true

/assign @aramase 