### PR TITLE
Promote Nginx Controller to v1.1.3

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -36,6 +36,7 @@
     "sha256:f766669fdcf3dc26347ed273a55e754b427eb4411ee075a53f30718b4499076a": ["v1.1.0"]
     "sha256:0bc88eb15f9e7f84e8e56c14fa5735aaa488b840983f87bd79b1054190e660de": ["v1.1.1"]
     "sha256:28b11ce69e57843de44e3db6413e98d09de0f6688e33d4bd384002a44f78405c": ["v1.1.2"]
+    "sha256:31f47c1e202b39fadecf822a9b76370bd4baed199a005b3e7d4d1455f4fd3fe2": ["v1.1.3"]
 
 # custom base NGINX image
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/nginx


### PR DESCRIPTION
Promote nginx controller version from gcr.io/k8s-staging-ingress-nginx/controller:v1.1.3@sha256:31f47c1e202b39fadecf822a9b76370bd4baed199a005b3e7d4d1455f4fd3fe2