### PR TITLE
Add Google group for Cloudflare account

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -187,6 +187,7 @@ restrictions:
       - "^k8s-infra-equinix-admins@kubernetes.io$"
       - "^k8s-infra-artifact-admins@kubernetes.io$"
       - "^k8s-infra-bigquery-admins@kubernetes.io$"
+      - "^k8s-infra-cloudflare-admins@kubernetes.io$"
       - "^k8s-infra-cluster-admins@kubernetes.io$"
       - "^k8s-infra-dns-admins@kubernetes.io$"
       - "^k8s-infra-gcp-accounting@kubernetes.io$"

--- a/groups/sig-k8s-infra/groups.yaml
+++ b/groups/sig-k8s-infra/groups.yaml
@@ -293,6 +293,16 @@ groups:
       - spiffxp@google.com
       - thockin@google.com
 
+  - email-id: k8s-infra-cloudflare-admins@kubernetes.io
+    name: k8s-infra-cloudflare-admins
+    description: |-
+      ACL for Cloudflare admins
+    settings:
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+    members:
+      - sig-k8s-infra-leads@kubernetes.io
+
   - email-id: k8s-infra-cluster-admins@kubernetes.io
     name: k8s-infra-cluster-admins
     description: |-


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/k8s.io/issues/3556

Add a Google that will be used for Cloudflare signup account.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>