### PR TITLE
Adds Puja for handling KCSEU22 messages

### DIFF
--- a/groups/sig-contributor-experience/groups.yaml
+++ b/groups/sig-contributor-experience/groups.yaml
@@ -30,6 +30,7 @@ groups:
       - jberkus@redhat.com
       - chris@chrisshort.net
       - samudralavamshi@gmail.com
+      - puja@giantswarm.io
 
   - email-id: dev@kubernetes.io
     name: dev


### PR DESCRIPTION
As discussed in KCSEU22 Planning (https://docs.google.com/document/d/1YGPnM3UF4i9Jx4VTdIg-zfjn-_2kyps24XhPoMB67gA/edit#) I need to be added to the list, so I get the messages we expect contributors to send to community@