### PR TITLE
Cloudflare: Add DNS entry for domain verification

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -194,6 +194,10 @@ issues:
   type: CNAME
   value: redirect.k8s.io.
 # sig-k8s-infra
+# Domain verification for Cloudflare (managed by @dims and @ameukam)
+cloudflare-verify:
+  type: TXT
+  value: 897924847-535279960
 # Hosted on GKE cluster aaa
 k8s-infra-prow:
   - type: A


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/k8s.io/issues/3596

Access is granted to a Cloudflare account for PoC. This is the initial
step to evaluate Cloudflare as CDN provider.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>