### PR TITLE
groups/sig-cluster-lifecycle: add group for sig-cl leads

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -61,6 +61,7 @@ restrictions:
       - "^k8s-infra-staging-kas-network-proxy@kubernetes.io$"
   - path: "sig-cluster-lifecycle/groups.yaml"
     allowedGroups:
+      - "^sig-cluster-lifecycle-leads@kubernetes.io$"
       - "^sig-cluster-lifecycle-cluster-api-alerts@kubernetes.io$"
       - "^sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io$"
       - "^k8s-infra-kops-maintainers@kubernetes.io$"

--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -48,6 +48,23 @@ groups:
       - fabrizio.pandini@gmail.com
       - neolit123@gmail.com
 
+  - email-id: sig-cluster-lifecycle-leads@kubernetes.io
+    name: sig-cluster-lifecycle-leads
+    description: |-
+      Private group for SIG Cluster Lifecycle leads
+    settings:
+      WhoCanDiscoverGroup: "ALL_MEMBERS_CAN_DISCOVER"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanJoin: "INVITED_CAN_JOIN"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      ReconcileMembers: "false"
+    owners:
+      - fabrizio.pandini@gmail.com
+      - justinsb@google.com
+      - neolit123@gmail.com
+      - prignanov@vmware.com
+
   #
   # k8s-staging write access for SIG-owned subprojects
   #


### PR DESCRIPTION
We usually use Slack for private messages,
so the primary use of this would be to migrate
our Zoom account from:
kubernetes-sig-cluster-lifecycle-leads@googlegroups.com
to:
sig-cluster-lifecycle-leads@kubernetes.io

our Zoom account seems to be blocked right now:
https://kubernetes.slack.com/archives/C1TU9EB9S/p1649180197245759

Zoom tries to send a verification code to the old group:
kubernetes-sig-cluster-lifecycle-leads@googlegroups.com

but i'm not a member of that, not sure if anyone else is.