### PR TITLE
Add DNS entry for Cloudflare page rule

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -198,6 +198,10 @@ issues:
 cloudflare-verify:
   type: TXT
   value: 897924847-535279960
+# DNS entry used for Cloudflare PoC. See https://github.com/kubernetes/k8s.io/issues/3596
+k8s-infra-cdn-cf-sandbox-ame:
+  type: CNAME
+  value: k8s-infra-cdn-cf-sandbox-ame.k8s.io.cdn.cloudflare.net.
 # Hosted on GKE cluster aaa
 k8s-infra-prow:
   - type: A


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/k8s.io/issues/3596

Required to ensure SSL certificate is created by Cloudflare for
k8s-infra-cdn-cf-sandbox-ame.k8s.io. The domain is used to test
Cloudflare caching features.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>