### PR TITLE
Add registry.k8s.io explorations

### DIFF
--- a/registry.k8s.io/explorations/2021-10-implementations/README.org
+++ b/registry.k8s.io/explorations/2021-10-implementations/README.org
@@ -1,0 +1,37 @@
+#+TITLE: registry.k8s.io
+
+#+begin_quote
+Implementation proposals for registry.k8s.io
+#+end_quote
+
+* Background + Purpose
+Kubernetes release artifacts are currently stored in [[https://k8s.gcr.io][k8s.gcr.io]] and [[https://storage.googleapis.com/kubernetes-release][gs://kubernetes-release]].
+Distributions in the ecosystem tend to pull from these artifacts and images.
+
+ii set up [[https://github.com/kubernetes/k8s.io/tree/main/images/public-log-asn-matcher][a pipeline]] for processing the [PII] logs from the Kubernetes public /GCS/ buckets, which shows the traffic overtime.
+Pulling in this data and ASN data from multiple providers, the fields of source IP can be matched all the way to company name.
+With this limited data access, members of [[https://github.com/kubernetes/community/tree/master/sig-k8s-infra][sig-k8s-infra]] are then able to engage in informed conversation with various credit providers.
+
+To ensure funding is well-spent and high spenders share the load of traffic, distributing traffic to other credit providers is required.
+One solution would be to redirect to different container registries based on source IP.
+This repo contains several, rough implementations of this solution.
+
+Once a solution is chosen, it will be fully-fedged out to support redirection based on a mapping of source IP => IP block => ASN => credit provider.
+If a request is made from /registry.k8s.io/ inside a credit provider's infrastructure and the credit provider is included in a redirection policy,
+the request will be redirected with a status code of 302 to the given credit provider.
+
+The process described will save on artifact distribution costs and help the Kubernetes project spend better.
+
+* Proposals
+- [[./artifactserver/README.org][ArtifactServer]] :: existing k8s infra project, adapted for configuring and 302 redirecting; supports unified artifacts and registry redirection
+- [[./envoy-lua-go/README.org][Envoy-Lua-Go]] :: earlier implementation using Envoy's HTTP Lua filter and an /external/ backend;
+- [[./envoy-wasm/README.org][Envoy-WASM]] :: implementation using Envoy's HTTP WASM filter + WASM filter written in Go
+- [[./nginx-njs/README.org][NGINX-njs]] :: implementation using NGINX's njs (JavaScript embedded functions)
+
+* Notes
+The solutions docs detailed above are set out to deploy easily on a [[https://pair.sharing.io][Pair instance]].
+To deploy elsewhere, the images will need to be pushed to a registry and the manifests modified to point to another host.
+
+* Links
+- Umbrella issue :: https://github.com/kubernetes/k8s.io/issues/1834#issuecomment-943836836
+- Original repo :: https://github.com/ii/registry.k8s.io

--- a/registry.k8s.io/explorations/2021-10-implementations/artifactserver/README.org
+++ b/registry.k8s.io/explorations/2021-10-implementations/artifactserver/README.org
@@ -1,0 +1,226 @@
+#+TITLE: Artifactserver
+
+#+begin_quote
+An implementation using an existing Go project from k8s infra
+#+end_quote
+
+* Bringing the implementation up
+#+begin_src tmate :window registry-a-prepare
+git-clone-structured https://github.com/kubernetes/k8s.io
+cd ~/kubernetes/k8s.io
+git remote add ii https://github.com/ii/k8s.io
+git fetch ii
+git checkout update-artifactserver-with-conditions-and-config-file
+#+end_src
+
+Prepare a container image
+#+begin_src dockerfile :tangle ~/kubernetes/k8s.io/artifactserver/Dockerfile
+FROM golang:1.17.0-alpine3.14 AS build
+WORKDIR /app
+COPY cmd /app/cmd
+COPY go.* *.go /app/
+ARG GOARCH=""
+RUN CGO_ENABLED=0 GOOS=linux GOARCH="$GOARCH" go build \
+  -a \
+  -installsuffix cgo \
+  -ldflags "-extldflags '-static' -s -w" \
+  -o bin/artifactserver \
+  cmd/artifactserver/main.go
+
+FROM alpine:3.14 AS extras
+RUN apk add --no-cache tzdata ca-certificates
+RUN adduser -D user
+
+FROM scratch AS final
+WORKDIR /app
+ENV PATH=/app \
+  APP_DIST_FOLDER=./dist
+COPY --from=build /app/bin/artifactserver /app/bin/artifactserver
+COPY --from=extras /etc/passwd /etc/passwd
+COPY --from=extras /etc/group /etc/group
+COPY --from=extras /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=extras /etc/ssl /etc/ssl
+EXPOSE 8080
+USER user
+ENTRYPOINT ["/app/bin/artifactserver"]
+#+end_src
+
+Build the container image
+#+begin_src tmate :window registry-a :dir ~/kubernetes/k8s.io/artifactserver/
+docker build -t artifactserver .
+#+end_src
+
+Push the image out to the other nodes
+#+begin_src tmate :window registry-a
+for NODE_IP in $(kubectl get nodes -l node-role.kubernetes.io/control-plane!='' -o=jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}'); do
+    printf "${NODE_IP} :: "
+    docker save artifactserver:latest | ssh "root@${NODE_IP}" docker load
+done
+#+end_src
+
+Configure ArtifactServer
+#+begin_src yaml :tangle artifactserver-config.yaml
+backends:
+  kops:
+    host: kubeupv2.s3.amazonaws.com
+    conditions:
+      paths:
+        - /kops/
+  local-distribution:
+    host: registry-1.docker.io
+    conditions:
+      headers:
+        X-Real-Ip:
+          - ${HUMACS_POD_IP}
+  k8s.gcr.io:
+    host: k8s.gcr.io
+#+end_src
+
+Configure the Kubernetes deployment
+#+begin_src yaml :tangle ./artifactserver.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: k8s-reg-artifactserver
+  labels:
+    cert-manager-tls: sync
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: k8s-reg-artifactserver
+  name: k8s-reg-artifactserver
+  labels:
+    app: k8s-reg-artifactserver
+spec:
+  replicas: 10
+  selector:
+    matchLabels:
+      app: k8s-reg-artifactserver
+  template:
+    metadata:
+      labels:
+        app: k8s-reg-artifactserver
+      annotations:
+        lastcfg: |
+          ${ARTIFACTSERVER_LAST_CFG}
+    spec:
+      terminationGracePeriodSeconds: 30
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - artifactserver
+                topologyKey: "kubernetes.io/hostname"
+      containers:
+        - name: k8s-reg-artifactserver
+          image: artifactserver:latest
+          imagePullPolicy: Never
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+          args:
+            - --config=/etc/artifactserver/config.yaml
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/artifactserver
+          resources:
+            requests:
+              cpu: 0.1
+              memory: 256Mi
+            limits:
+              memory: 256Mi
+      volumes:
+        - name: config
+          configMap:
+            name: k8s-reg-artifactserver
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: k8s-reg-artifactserver
+  name: k8s-reg-artifactserver
+  labels:
+    app: k8s-reg-artifactserver
+spec:
+  selector:
+    app: k8s-reg-artifactserver
+  type: NodePort
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: k8s-reg-artifactserver
+  namespace: k8s-reg-artifactserver
+spec:
+  rules:
+  - host: k8s-reg-artifactserver.${SHARINGIO_PAIR_BASE_DNS_NAME}
+    http:
+      paths:
+      - backend:
+          service:
+            name: k8s-reg-artifactserver
+            port:
+              number: 8080
+        path: /
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    - k8s-reg-artifactserver.${SHARINGIO_PAIR_BASE_DNS_NAME}
+    secretName: letsencrypt-prod
+#+end_src
+
+Apply the manifests
+#+begin_src shell
+export ARTIFACTSERVER_LAST_CFG=$(cat artifactserver-config.yaml | sha256sum)
+envsubst < ./artifactserver.yaml | kubectl apply -f -
+export HUMACS_POD_IP=$(kubectl get pods $(hostname) -o=jsonpath='{.status.podIP}')
+kubectl -n k8s-reg-artifactserver create configmap k8s-reg-artifactserver \
+    --from-file=config\.yaml=<(envsubst < artifactserver-config.yaml) \
+    -o yaml --dry-run=client \
+      | kubectl apply -f -
+#+end_src
+
+#+RESULTS:
+#+begin_example
+namespace/k8s-reg-artifactserver created
+deployment.apps/k8s-reg-artifactserver created
+service/k8s-reg-artifactserver created
+ingress.networking.k8s.io/k8s-reg-artifactserver created
+configmap/k8s-reg-artifactserver created
+#+end_example
+
+* Making a request
+Test it from the Service
+#+begin_src shell
+curl -v http://k8s-reg-artifactserver.artifactserver:8080 2>&1
+#+end_src
+
+* Notes
+The code in my branch appears to have some bug, where the location host is not consistent: almost every request is responded with a different location. (1)
+For now, the benchmark should be on it's request time and it's liveness.
+
+* Pros
+- using existing codebase
+- codebase isn't too big
+- config file
+- unified artifacts and registries
+
+* Cons
+- current bug (1 in notes)
+- force supporting of current usage of ArtifactServer as well as registry.k8s.io

--- a/registry.k8s.io/explorations/2021-10-implementations/artifactserver/artifactserver-config.yaml
+++ b/registry.k8s.io/explorations/2021-10-implementations/artifactserver/artifactserver-config.yaml
@@ -1,0 +1,18 @@
+
+
+# Configure ArtifactServer
+
+backends:
+  kops:
+    host: kubeupv2.s3.amazonaws.com
+    conditions:
+      paths:
+        - /kops/
+  local-distribution:
+    host: registry-1.docker.io
+    conditions:
+      headers:
+        X-Real-Ip:
+          - ${HUMACS_POD_IP}
+  k8s.gcr.io:
+    host: k8s.gcr.io

--- a/registry.k8s.io/explorations/2021-10-implementations/artifactserver/artifactserver.yaml
+++ b/registry.k8s.io/explorations/2021-10-implementations/artifactserver/artifactserver.yaml
@@ -1,0 +1,109 @@
+
+
+# Configure the Kubernetes deployment
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: k8s-reg-artifactserver
+  labels:
+    cert-manager-tls: sync
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: k8s-reg-artifactserver
+  name: k8s-reg-artifactserver
+  labels:
+    app: k8s-reg-artifactserver
+spec:
+  replicas: 10
+  selector:
+    matchLabels:
+      app: k8s-reg-artifactserver
+  template:
+    metadata:
+      labels:
+        app: k8s-reg-artifactserver
+      annotations:
+        lastcfg: |
+          ${ARTIFACTSERVER_LAST_CFG}
+    spec:
+      terminationGracePeriodSeconds: 30
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: app
+                      operator: In
+                      values:
+                        - artifactserver
+                topologyKey: "kubernetes.io/hostname"
+      containers:
+        - name: k8s-reg-artifactserver
+          image: artifactserver:latest
+          imagePullPolicy: Never
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+          args:
+            - --config=/etc/artifactserver/config.yaml
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: config
+              mountPath: /etc/artifactserver
+          resources:
+            requests:
+              cpu: 0.1
+              memory: 256Mi
+            limits:
+              memory: 256Mi
+      volumes:
+        - name: config
+          configMap:
+            name: k8s-reg-artifactserver
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: k8s-reg-artifactserver
+  name: k8s-reg-artifactserver
+  labels:
+    app: k8s-reg-artifactserver
+spec:
+  selector:
+    app: k8s-reg-artifactserver
+  type: NodePort
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: k8s-reg-artifactserver
+  namespace: k8s-reg-artifactserver
+spec:
+  rules:
+  - host: k8s-reg-artifactserver.${SHARINGIO_PAIR_BASE_DNS_NAME}
+    http:
+      paths:
+      - backend:
+          service:
+            name: k8s-reg-artifactserver
+            port:
+              number: 8080
+        path: /
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    - k8s-reg-artifactserver.${SHARINGIO_PAIR_BASE_DNS_NAME}
+    secretName: letsencrypt-prod

--- a/registry.k8s.io/explorations/2021-10-implementations/envoy-lua-go/README.org
+++ b/registry.k8s.io/explorations/2021-10-implementations/envoy-lua-go/README.org
@@ -1,0 +1,377 @@
+#+TITLE: envoy-lua-go
+
+#+begin_quote
+An implementation using Envoy's HTTP Lua filter and an /external/ backend
+#+end_quote
+
+* Bringing the implementation up
+Prepare a container image for the reg-host-authority
+#+begin_src dockerfile :tangle ~/ii/org/research/k8s-infra-registry-artifacts-migration/envoy-dynamic-host-rewriting/reg-host-authority/Dockerfile
+FROM golang:1.17.0-alpine3.14 AS build
+WORKDIR /app
+COPY main.go /app/
+COPY go.* *.go /app/
+ARG GOARCH=""
+RUN CGO_ENABLED=0 GOOS=linux GOARCH="$GOARCH" go build \
+  -a \
+  -installsuffix cgo \
+  -ldflags "-extldflags '-static' -s -w" \
+  -o bin/reg-host-authority \
+  main.go
+
+FROM alpine:3.14 AS extras
+RUN apk add --no-cache tzdata ca-certificates
+RUN adduser -D user
+
+FROM scratch AS final
+WORKDIR /app
+ENV PATH=/app \
+  APP_DIST_FOLDER=./dist
+COPY --from=build /app/bin/reg-host-authority /app/bin/reg-host-authority
+COPY --from=extras /etc/passwd /etc/passwd
+COPY --from=extras /etc/group /etc/group
+COPY --from=extras /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=extras /etc/ssl /etc/ssl
+EXPOSE 8080
+USER user
+ENTRYPOINT ["/app/bin/reg-host-authority"]
+#+end_src
+
+Build the container image
+#+begin_src tmate :window registry-e :dir ~/ii/org/research/k8s-infra-registry-artifacts-migration/envoy-dynamic-host-rewriting/reg-host-authority
+docker build -t reg-host-authority .
+#+end_src
+
+Push the image out to the other nodes
+#+begin_src shell
+for NODE_IP in $(kubectl get nodes -l node-role.kubernetes.io/control-plane!='' -o=jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}'); do
+    printf "${NODE_IP} :: "
+    docker save reg-host-authority:latest | ssh "root@${NODE_IP}" docker load
+done
+#+end_src
+
+#+RESULTS:
+#+begin_example
+145.40.67.1 :: Loaded image: reg-host-authority:latest
+#+end_example
+Prepare the envoy configuration
+#+begin_src yaml :tangle ./envoy-config.yaml
+static_resources:
+  listeners:
+  - name: main
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 10000
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          codec_type: auto
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: web_service
+          http_filters:
+          - name: envoy.filters.http.lua
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+              inline_code: |
+                function envoy_on_request(request_handle)
+                  remoteAddr = request_handle:headers():get("x-real-ip")
+                  local headers, body = request_handle:httpCall(
+                  "reg-host-authority",
+                  {
+                    [":method"] = "GET",
+                    [":path"] = "/",
+                    [":authority"] = "humacs",
+                    ["X-Real-Ip"] = remoteAddr
+                  },
+                  remoteAddr,
+                  5000
+                  )
+                  reg = body
+                  if request_handle:headers():get(":method") == "GET" then
+                    request_handle:respond(
+                      {
+                        [":status"] = "302",
+                        ["location"] = "https://"..reg..request_handle:headers():get(":path"),
+                        ["Content-Type"] = "text/html; charset=utf-8",
+                        [":authority"] = "web_service"
+                      },
+                      '<a href="'.."https://"..reg..request_handle:headers():get(":path")..'">'.."302".."</a>.\n")
+                  end
+                end
+          - name: envoy.filters.http.router
+            typed_config: {}
+
+  clusters:
+  - name: web_service
+    connect_timeout: 0.25s
+    type: LOGICAL_DNS
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: web_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: k8s.io
+                port_value: 443
+  - name: reg-host-authority
+    connect_timeout: 0.25s
+    type: LOGICAL_DNS
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: humacs
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: reg-host-authority
+                port_value: 8080
+#+end_src
+
+Configure the Kubernetes deployment
+#+begin_src yaml :tangle ./envoy-reg-host-authority.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: reg-host-authority
+  name: reg-host-authority
+  namespace: k8s-reg-envoy-lua-go
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: reg-host-authority
+  template:
+    metadata:
+      labels:
+        app: reg-host-authority
+    spec:
+      containers:
+      - name: envoy
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+        image: reg-host-authority:latest
+        imagePullPolicy: Never
+        ports:
+          - name: http
+            containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: reg-host-authority
+  name: reg-host-authority
+  namespace: k8s-reg-envoy-lua-go
+spec:
+  type: ClusterIP
+  ports:
+  - name: registry-k8s-io
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: reg-host-authority
+#+end_src
+#+begin_src yaml :tangle ./envoy.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: k8s-reg-envoy-lua-go
+  labels:
+    cert-manager-tls: sync
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    lastcfg: |
+      ${ENVOY_LAST_CFG}
+  labels:
+    app: k8s-reg-envoy-lua-go
+  name: k8s-reg-envoy-lua-go
+  namespace: k8s-reg-envoy-lua-go
+spec:
+  replicas: 10
+  selector:
+    matchLabels:
+      app: k8s-reg-envoy-lua-go
+  template:
+    metadata:
+      annotations:
+        lastcfg: |
+          ${ENVOY_LAST_CFG}
+      labels:
+        app: k8s-reg-envoy-lua-go
+    spec:
+      containers:
+      - name: envoy
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+        args:
+        - -c
+        - /etc/envoy/envoy.yaml
+        image: envoyproxy/envoy-distroless:v1.20.0
+        volumeMounts:
+          - name: config
+            mountPath: /etc/envoy/envoy.yaml
+            subPath: envoy.yaml
+        ports:
+          - name: http
+            containerPort: 10000
+      volumes:
+      - name: config
+        configMap:
+          name: envoy-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: k8s-reg-envoy-lua-go
+  name: k8s-reg-envoy-lua-go
+  namespace: k8s-reg-envoy-lua-go
+spec:
+  ports:
+  - name: registry-k8s-io
+    port: 10000
+    protocol: TCP
+    targetPort: 10000
+  selector:
+    app: k8s-reg-envoy-lua-go
+  type: NodePort
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: k8s-reg-envoy-lua-go
+  namespace: k8s-reg-envoy-lua-go
+spec:
+  rules:
+  - host: k8s-reg-envoy-lua-go.${SHARINGIO_PAIR_BASE_DNS_NAME}
+    http:
+      paths:
+      - backend:
+          service:
+            name: k8s-reg-envoy-lua-go
+            port:
+              number: 10000
+        path: /
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    - k8s-reg-envoy-lua-go.${SHARINGIO_PAIR_BASE_DNS_NAME}
+    secretName: letsencrypt-prod
+#+end_src
+
+Apply the Envoy manifests
+#+BEGIN_SRC shell
+export ENVOY_LAST_CFG=$(cat envoy-config.yaml | sha256sum)
+envsubst < envoy.yaml | kubectl apply -f -
+kubectl -n k8s-reg-envoy-lua-go apply -f envoy-reg-host-authority.yaml
+kubectl -n k8s-reg-envoy-lua-go create configmap envoy-config --from-file=envoy\.yaml=envoy-config.yaml --dry-run=client -o yaml | kubectl apply -f -
+#+END_SRC
+
+#+RESULTS:
+#+begin_example
+namespace/k8s-reg-envoy-lua-go unchanged
+deployment.apps/k8s-reg-envoy-lua-go unchanged
+service/k8s-reg-envoy-lua-go unchanged
+ingress.networking.k8s.io/k8s-reg-envoy-lua-go unchanged
+deployment.apps/reg-host-authority created
+service/reg-host-authority created
+configmap/envoy-config created
+#+end_example
+
+* Making requests
+Test it from the Service
+#+begin_src shell
+curl -v http://reg-host-authority.k8s-reg-envoy-lua-go:8080 2>&1
+#+end_src
+
+#+RESULTS:
+#+begin_example
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 10.106.186.118:8080...
+,* TCP_NODELAY set
+,* Connected to reg-host-authority.k8s-reg-envoy-lua-go (10.106.186.118) port 8080 (#0)
+> GET / HTTP/1.1
+> Host: reg-host-authority.k8s-reg-envoy-lua-go:8080
+> User-Agent: curl/7.68.0
+> Accept: */*
+> 
+,* Mark bundle as not supporting multiuse
+< HTTP/1.1 200 OK
+< Date: Thu, 21 Oct 2021 19:58:13 GMT
+< Content-Length: 20
+< Content-Type: text/plain; charset=utf-8
+< 
+{ [20 bytes data]
+100    20  100    20    0     0   6666      0 --:--:-- --:--:-- --:--:--  6666
+,* Connection #0 to host reg-host-authority.k8s-reg-envoy-lua-go left intact
+registry-1.docker.io
+#+end_example
+
+#+begin_src shell
+curl -v http://k8s-reg-envoy-lua-go.k8s-reg-envoy-lua-go:10000 2>&1
+#+end_src
+
+#+RESULTS:
+#+begin_example
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 10.105.25.30:10000...
+,* TCP_NODELAY set
+,* Connected to k8s-reg-envoy-lua-go.k8s-reg-envoy-lua-go (10.105.25.30) port 10000 (#0)
+> GET / HTTP/1.1
+> Host: k8s-reg-envoy-lua-go.k8s-reg-envoy-lua-go:10000
+> User-Agent: curl/7.68.0
+> Accept: */*
+> 
+,* Mark bundle as not supporting multiuse
+< HTTP/1.1 302 Found
+< host: web_service
+< content-type: text/html; charset=utf-8
+< location: https://registry-1.docker.io/
+< content-length: 49
+< date: Thu, 21 Oct 2021 19:58:39 GMT
+< server: envoy
+< 
+{ [49 bytes data]
+100    49  100    49    0     0   8166      0 --:--:-- --:--:-- --:--:--  8166
+,* Connection #0 to host k8s-reg-envoy-lua-go.k8s-reg-envoy-lua-go left intact
+<a href="https://registry-1.docker.io/">302</a>.
+#+end_example
+
+* Notes
+This was an earlier implementation, which is valid but is intended to be the precursor to a WASM filter (written in Go)
+
+* Pros
+- host declared from an external source
+
+* Cons
+- Lua code embedded in config
+- apparent failure on service discovery if backend has downtime (might be my configuration, in CDS?)

--- a/registry.k8s.io/explorations/2021-10-implementations/envoy-lua-go/envoy-config.yaml
+++ b/registry.k8s.io/explorations/2021-10-implementations/envoy-lua-go/envoy-config.yaml
@@ -1,0 +1,93 @@
+
+
+# #+RESULTS:
+# #+begin_example
+# 145.40.67.1 :: Loaded image: reg-host-authority:latest
+# #+end_example
+# Prepare the envoy configuration
+
+static_resources:
+  listeners:
+  - name: main
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 10000
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          codec_type: auto
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: web_service
+          http_filters:
+          - name: envoy.filters.http.lua
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+              inline_code: |
+                function envoy_on_request(request_handle)
+                  remoteAddr = request_handle:headers():get("x-real-ip")
+                  local headers, body = request_handle:httpCall(
+                  "reg-host-authority",
+                  {
+                    [":method"] = "GET",
+                    [":path"] = "/",
+                    [":authority"] = "humacs",
+                    ["X-Real-Ip"] = remoteAddr
+                  },
+                  remoteAddr,
+                  5000
+                  )
+                  reg = body
+                  if request_handle:headers():get(":method") == "GET" then
+                    request_handle:respond(
+                      {
+                        [":status"] = "302",
+                        ["location"] = "https://"..reg..request_handle:headers():get(":path"),
+                        ["Content-Type"] = "text/html; charset=utf-8",
+                        [":authority"] = "web_service"
+                      },
+                      '<a href="'.."https://"..reg..request_handle:headers():get(":path")..'">'.."302".."</a>.\n")
+                  end
+                end
+          - name: envoy.filters.http.router
+            typed_config: {}
+
+  clusters:
+  - name: web_service
+    connect_timeout: 0.25s
+    type: LOGICAL_DNS
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: web_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: k8s.io
+                port_value: 443
+  - name: reg-host-authority
+    connect_timeout: 0.25s
+    type: LOGICAL_DNS
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: humacs
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: reg-host-authority
+                port_value: 8080

--- a/registry.k8s.io/explorations/2021-10-implementations/envoy-lua-go/envoy-reg-host-authority.yaml
+++ b/registry.k8s.io/explorations/2021-10-implementations/envoy-lua-go/envoy-reg-host-authority.yaml
@@ -1,0 +1,50 @@
+
+
+# Configure the Kubernetes deployment
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: reg-host-authority
+  name: reg-host-authority
+  namespace: k8s-reg-envoy-lua-go
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: reg-host-authority
+  template:
+    metadata:
+      labels:
+        app: reg-host-authority
+    spec:
+      containers:
+      - name: envoy
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+        image: reg-host-authority:latest
+        imagePullPolicy: Never
+        ports:
+          - name: http
+            containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: reg-host-authority
+  name: reg-host-authority
+  namespace: k8s-reg-envoy-lua-go
+spec:
+  type: ClusterIP
+  ports:
+  - name: registry-k8s-io
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: reg-host-authority

--- a/registry.k8s.io/explorations/2021-10-implementations/envoy-lua-go/envoy.yaml
+++ b/registry.k8s.io/explorations/2021-10-implementations/envoy-lua-go/envoy.yaml
@@ -1,0 +1,91 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: k8s-reg-envoy-lua-go
+  labels:
+    cert-manager-tls: sync
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    lastcfg: |
+      ${ENVOY_LAST_CFG}
+  labels:
+    app: k8s-reg-envoy-lua-go
+  name: k8s-reg-envoy-lua-go
+  namespace: k8s-reg-envoy-lua-go
+spec:
+  replicas: 10
+  selector:
+    matchLabels:
+      app: k8s-reg-envoy-lua-go
+  template:
+    metadata:
+      annotations:
+        lastcfg: |
+          ${ENVOY_LAST_CFG}
+      labels:
+        app: k8s-reg-envoy-lua-go
+    spec:
+      containers:
+      - name: envoy
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+        args:
+        - -c
+        - /etc/envoy/envoy.yaml
+        image: envoyproxy/envoy-distroless:v1.20.0
+        volumeMounts:
+          - name: config
+            mountPath: /etc/envoy/envoy.yaml
+            subPath: envoy.yaml
+        ports:
+          - name: http
+            containerPort: 10000
+      volumes:
+      - name: config
+        configMap:
+          name: envoy-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: k8s-reg-envoy-lua-go
+  name: k8s-reg-envoy-lua-go
+  namespace: k8s-reg-envoy-lua-go
+spec:
+  ports:
+  - name: registry-k8s-io
+    port: 10000
+    protocol: TCP
+    targetPort: 10000
+  selector:
+    app: k8s-reg-envoy-lua-go
+  type: NodePort
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: k8s-reg-envoy-lua-go
+  namespace: k8s-reg-envoy-lua-go
+spec:
+  rules:
+  - host: k8s-reg-envoy-lua-go.${SHARINGIO_PAIR_BASE_DNS_NAME}
+    http:
+      paths:
+      - backend:
+          service:
+            name: k8s-reg-envoy-lua-go
+            port:
+              number: 10000
+        path: /
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    - k8s-reg-envoy-lua-go.${SHARINGIO_PAIR_BASE_DNS_NAME}
+    secretName: letsencrypt-prod

--- a/registry.k8s.io/explorations/2021-10-implementations/envoy-wasm/Dockerfile
+++ b/registry.k8s.io/explorations/2021-10-implementations/envoy-wasm/Dockerfile
@@ -1,5 +1,16 @@
-# Deploying in Kubernetes
-# Create container image
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 FROM tinygo/tinygo:0.20.0 AS build
 WORKDIR /app

--- a/registry.k8s.io/explorations/2021-10-implementations/envoy-wasm/Dockerfile
+++ b/registry.k8s.io/explorations/2021-10-implementations/envoy-wasm/Dockerfile
@@ -1,0 +1,10 @@
+# Deploying in Kubernetes
+# Create container image
+
+FROM tinygo/tinygo:0.20.0 AS build
+WORKDIR /app
+COPY go.* *.go /app/
+RUN tinygo build -o wasm.wasm -scheduler=none -target=wasi /app/main.go
+
+FROM envoyproxy/envoy-distroless:v1.20.0 AS final
+COPY --from=build /app/wasm.wasm /etc/envoy/wasm.wasm

--- a/registry.k8s.io/explorations/2021-10-implementations/envoy-wasm/README.org
+++ b/registry.k8s.io/explorations/2021-10-implementations/envoy-wasm/README.org
@@ -6,7 +6,23 @@ Rewrite the location header with Envoy, written in Golang and compiled as WASM
 
 * Bringing the implementation up
 ** the code
-#+begin_src go :tangle ./main.go
+#+begin_src go :tangle ./main.go :comments none
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (
@@ -191,7 +207,21 @@ docker \
 
 ** Deploying in Kubernetes
 Create container image
-#+begin_src dockerfile :tangle Dockerfile
+#+begin_src dockerfile :tangle Dockerfile :comments none
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 FROM tinygo/tinygo:0.20.0 AS build
 WORKDIR /app
 COPY go.* *.go /app/

--- a/registry.k8s.io/explorations/2021-10-implementations/envoy-wasm/README.org
+++ b/registry.k8s.io/explorations/2021-10-implementations/envoy-wasm/README.org
@@ -1,0 +1,345 @@
+#+TITLE: Envoy WASM dynamic host rewriting
+
+#+begin_quote
+Rewrite the location header with Envoy, written in Golang and compiled as WASM
+#+end_quote
+
+* Bringing the implementation up
+** the code
+#+begin_src go :tangle ./main.go
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+const (
+	realIPKey       = "x-real-ip"
+	matchIPEnvKey   = "MATCH_IP"
+	authorityEnvKey = "AUTHORITY"
+	locationKey     = "location"
+	authorityKey    = ":authority"
+	statusKey       = ":status"
+	pathKey         = ":path"
+	statusCode      = 302
+	defaultHost     = "k8s.gcr.io"
+	rewriteHost     = "registry-1.docker.io"
+)
+
+var (
+	authority = os.Getenv(authorityEnvKey)
+	matchIP   = os.Getenv(matchIPEnvKey)
+)
+
+func main() {
+	proxywasm.SetVMContext(&vmContext{})
+}
+
+type vmContext struct {
+	// Embed the default VM context here,
+	// so that we don't need to reimplement all the methods.
+	types.DefaultVMContext
+}
+
+// Override types.DefaultVMContext.
+func (*vmContext) NewPluginContext(contextID uint32) types.PluginContext {
+	return &pluginContext{}
+}
+
+type pluginContext struct {
+	// Embed the default plugin context here,
+	// so that we don't need to reimplement all the methods.
+	types.DefaultPluginContext
+}
+
+// Override types.DefaultPluginContext.
+func (*pluginContext) NewHttpContext(contextID uint32) types.HttpContext {
+	return &httpRouting{}
+}
+
+type httpRouting struct {
+	// Embed the default http context here,
+	// so that we don't need to reimplement all the methods.
+	types.DefaultHttpContext
+	bodySize    int
+	endOfStream bool
+}
+
+func (ctx *pluginContext) OnPluginStart(pluginConfigurationSize int) types.OnPluginStartStatus {
+	return types.OnPluginStartStatusOK
+}
+
+// Override types.DefaultHttpContext.
+func (ctx *httpRouting) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
+	host := defaultHost
+	remoteAddr, err := proxywasm.GetHttpRequestHeader(realIPKey)
+	if err != nil {
+		proxywasm.LogCritical(fmt.Sprintf("Error: getting request header: '%v'", realIPKey))
+	}
+	if matchIP == remoteAddr {
+		host = rewriteHost
+	}
+
+	path, _ := proxywasm.GetHttpRequestHeader(pathKey)
+	body := fmt.Sprintf(`<a href="https://%v%v">%v</a>.`, host, path, statusCode)
+	if err := proxywasm.SendHttpResponse(statusCode, [][2]string{
+		{authorityKey, authority},
+		{locationKey, fmt.Sprintf("https://%v%v", host, path)},
+		{statusKey, fmt.Sprintf("%s", statusCode)},
+		{pathKey, path},
+	}, []byte(body)); err != nil {
+		proxywasm.LogErrorf("Error: sending http response: %v", err)
+		proxywasm.ResumeHttpRequest()
+	}
+	return types.ActionPause
+}
+
+func (ctx *pluginContext) OnTick() {}
+
+#+end_src
+
+Compile with tinygo
+#+begin_src tmate :window build-wasm :prologue "docker run --rm --user $(id -u):$(id -g) --tmpfs /.cache --tmpfs /go -v $(pwd):$(pwd) --workdir=$(pwd) tinygo/tinygo:0.20.0 \\"
+tinygo build -o wasm.wasm -scheduler=none -target=wasi .
+#+end_src
+
+** Configure
+#+begin_src yaml :tangle ./envoy-config.yaml
+static_resources:
+  listeners:
+  - name: main
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 10000
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          codec_type: auto
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: web_service
+          http_filters:
+          - name: envoy.filters.http.wasm
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+              config:
+                name: "wasm"
+                root_id: "wasm_root"
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {
+                    }
+                vm_config:
+                  runtime: "envoy.wasm.runtime.v8"
+                  vm_id: "wasm_vm"
+                  code:
+                    local:
+                      filename: "/etc/envoy/wasm.wasm"
+                  environment_variables:
+                    host_env_keys:
+                      - MATCH_IP
+                    key_values:
+                      AUTHORITY: web_service
+          - name: envoy.filters.http.router
+            typed_config: {}
+  clusters:
+  - name: web_service
+    connect_timeout: 0.25s
+    type: LOGICAL_DNS
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: web_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: k8s.io
+                port_value: 443
+#+end_src
+
+** Testing in Docker
+#+begin_src tmate :window envoy
+docker \
+    run \
+    -it \
+    --rm \
+    -p 10000:10000 \
+    -v $PWD/envoy-config.yaml:/etc/envoy/envoy.yaml \
+    -v $PWD/wasm.wasm:/etc/envoy/wasm.wasm \
+    -e MATCH_IP="$(kubectl -n "${SHARINGIO_PAIR_NAME}" get pod "${SHARINGIO_PAIR_NAME}-humacs-0" -o=jsonpath='{.status.podIP}')" \
+    envoyproxy/envoy-distroless:v1.20.0 \
+    -c /etc/envoy/envoy.yaml
+#+end_src
+
+** Deploying in Kubernetes
+Create container image
+#+begin_src dockerfile :tangle Dockerfile
+FROM tinygo/tinygo:0.20.0 AS build
+WORKDIR /app
+COPY go.* *.go /app/
+RUN tinygo build -o wasm.wasm -scheduler=none -target=wasi /app/main.go
+
+FROM envoyproxy/envoy-distroless:v1.20.0 AS final
+COPY --from=build /app/wasm.wasm /etc/envoy/wasm.wasm
+#+end_src
+
+Build the container image
+#+begin_src tmate :window build-wasm
+docker build -t envoy-with-registry-k8s-io-wasm .
+#+end_src
+
+Push the image out to the other nodes
+#+begin_src shell
+for NODE_IP in $(kubectl get nodes -l node-role.kubernetes.io/control-plane!='' -o=jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}'); do
+    printf "${NODE_IP} :: "
+    docker save envoy-with-registry-k8s-io-wasm:latest | ssh "root@${NODE_IP}" docker load
+done
+#+end_src
+
+Create a namespace
+#+begin_src shell
+kubectl create namespace k8s-reg-envoy-wasm -o yaml --dry-run=client | \
+    kubectl apply -f -
+kubectl label namespace k8s-reg-envoy-wasm cert-manager-tls=sync --overwrite
+#+end_src
+
+#+RESULTS:
+#+begin_example
+namespace/k8s-reg-envoy-wasm created
+namespace/k8s-reg-envoy-wasm labeled
+#+end_example
+
+Create a ConfigMap for the config
+#+BEGIN_SRC shell :results silent
+kubectl -n k8s-reg-envoy-wasm create configmap config --from-file=envoy\.yaml=./envoy-config.yaml --dry-run=client -o yaml | kubectl apply -f -
+#+END_SRC
+
+Configuring Envoy
+#+BEGIN_SRC yaml :tangle ./envoy.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    lastcfg: |
+      ${ENVOY_LAST_CFG}
+  labels:
+    app: k8s-reg-envoy-wasm
+  name: k8s-reg-envoy-wasm
+spec:
+  replicas: 10
+  selector:
+    matchLabels:
+      app: k8s-reg-envoy-wasm
+  template:
+    metadata:
+      annotations:
+        lastcfg: |
+          ${ENVOY_LAST_CFG}
+      labels:
+        app: k8s-reg-envoy-wasm
+    spec:
+      containers:
+      - name: envoy
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+        env:
+          - name: MATCH_IP
+            value: ${MATCH_IP}
+        args:
+        - -c
+        - /etc/envoy/envoy.yaml
+        image: envoy-with-registry-k8s-io-wasm:latest
+        imagePullPolicy: Never
+        volumeMounts:
+          - name: config
+            mountPath: /etc/envoy/envoy.yaml
+            subPath: envoy.yaml
+        ports:
+          - name: http
+            containerPort: 10000
+      volumes:
+      - name: config
+        configMap:
+          name: config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: k8s-reg-envoy-wasm
+  name: k8s-reg-envoy-wasm
+spec:
+  ports:
+  - name: wasm
+    port: 10000
+    protocol: TCP
+    targetPort: 10000
+  selector:
+    app: k8s-reg-envoy-wasm
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: k8s-reg-envoy-wasm
+spec:
+  rules:
+  - host: k8s-reg-envoy-wasm.${SHARINGIO_PAIR_BASE_DNS_NAME}
+    http:
+      paths:
+      - backend:
+          service:
+            name: k8s-reg-envoy-wasm
+            port:
+              number: 10000
+        path: /
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    - k8s-reg-envoy-wasm.${SHARINGIO_PAIR_BASE_DNS_NAME}
+    secretName: letsencrypt-prod
+#+END_SRC
+
+#+BEGIN_SRC shell :results silent
+export \
+    ENVOY_LAST_CFG=$(cat Dockerfile main.go envoy-config.yaml wasm.wasm | sha256sum) \
+    MATCH_IP="$(kubectl -n "${SHARINGIO_PAIR_NAME}" get pod "${SHARINGIO_PAIR_NAME}-humacs-0" -o=jsonpath='{.status.podIP}')"
+envsubst < envoy.yaml | kubectl -n k8s-reg-envoy-wasm apply -f -
+#+END_SRC
+
+* References
+- https://tufin.medium.com/extending-envoy-proxy-with-golang-webassembly-e51202809ba6
+- https://github.com/mstrYoda/envoy-proxy-wasm-filter-golang/blob/master/main.go
+- https://github.com/tetratelabs/proxy-wasm-go-sdk/blob/main/examples/http_routing/main.go
+
+* Notes
+This implementation is well extendable and rather clean, naturally supporting any useful Go module.
+
+* Pros
+- fast! this implementation appear to be rather fast
+- secure using compiled binaries and distroless images
+
+* Cons
+- moderate understanding of Envoy
+- low to moderate understanding of WASM (especially Go)

--- a/registry.k8s.io/explorations/2021-10-implementations/envoy-wasm/envoy-config.yaml
+++ b/registry.k8s.io/explorations/2021-10-implementations/envoy-wasm/envoy-config.yaml
@@ -1,0 +1,66 @@
+# Configure
+
+static_resources:
+  listeners:
+  - name: main
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 10000
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: ingress_http
+          codec_type: auto
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: local_service
+              domains:
+              - "*"
+              routes:
+              - match:
+                  prefix: "/"
+                route:
+                  cluster: web_service
+          http_filters:
+          - name: envoy.filters.http.wasm
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+              config:
+                name: "wasm"
+                root_id: "wasm_root"
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {
+                    }
+                vm_config:
+                  runtime: "envoy.wasm.runtime.v8"
+                  vm_id: "wasm_vm"
+                  code:
+                    local:
+                      filename: "/etc/envoy/wasm.wasm"
+                  environment_variables:
+                    host_env_keys:
+                      - MATCH_IP
+                    key_values:
+                      AUTHORITY: web_service
+          - name: envoy.filters.http.router
+            typed_config: {}
+  clusters:
+  - name: web_service
+    connect_timeout: 0.25s
+    type: LOGICAL_DNS
+    lb_policy: round_robin
+    load_assignment:
+      cluster_name: web_service
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: k8s.io
+                port_value: 443

--- a/registry.k8s.io/explorations/2021-10-implementations/envoy-wasm/envoy.yaml
+++ b/registry.k8s.io/explorations/2021-10-implementations/envoy-wasm/envoy.yaml
@@ -1,0 +1,89 @@
+
+
+# Configuring Envoy
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    lastcfg: |
+      ${ENVOY_LAST_CFG}
+  labels:
+    app: k8s-reg-envoy-wasm
+  name: k8s-reg-envoy-wasm
+spec:
+  replicas: 10
+  selector:
+    matchLabels:
+      app: k8s-reg-envoy-wasm
+  template:
+    metadata:
+      annotations:
+        lastcfg: |
+          ${ENVOY_LAST_CFG}
+      labels:
+        app: k8s-reg-envoy-wasm
+    spec:
+      containers:
+      - name: envoy
+        securityContext:
+          runAsUser: 1000
+          runAsGroup: 1000
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+        env:
+          - name: MATCH_IP
+            value: ${MATCH_IP}
+        args:
+        - -c
+        - /etc/envoy/envoy.yaml
+        image: envoy-with-registry-k8s-io-wasm:latest
+        imagePullPolicy: Never
+        volumeMounts:
+          - name: config
+            mountPath: /etc/envoy/envoy.yaml
+            subPath: envoy.yaml
+        ports:
+          - name: http
+            containerPort: 10000
+      volumes:
+      - name: config
+        configMap:
+          name: config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: k8s-reg-envoy-wasm
+  name: k8s-reg-envoy-wasm
+spec:
+  ports:
+  - name: wasm
+    port: 10000
+    protocol: TCP
+    targetPort: 10000
+  selector:
+    app: k8s-reg-envoy-wasm
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: k8s-reg-envoy-wasm
+spec:
+  rules:
+  - host: k8s-reg-envoy-wasm.${SHARINGIO_PAIR_BASE_DNS_NAME}
+    http:
+      paths:
+      - backend:
+          service:
+            name: k8s-reg-envoy-wasm
+            port:
+              number: 10000
+        path: /
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    - k8s-reg-envoy-wasm.${SHARINGIO_PAIR_BASE_DNS_NAME}
+    secretName: letsencrypt-prod

--- a/registry.k8s.io/explorations/2021-10-implementations/envoy-wasm/go.mod
+++ b/registry.k8s.io/explorations/2021-10-implementations/envoy-wasm/go.mod
@@ -1,0 +1,5 @@
+module envoy-wasm-dynamic-host-rewriting
+
+go 1.17
+
+require github.com/tetratelabs/proxy-wasm-go-sdk v0.14.0

--- a/registry.k8s.io/explorations/2021-10-implementations/envoy-wasm/go.sum
+++ b/registry.k8s.io/explorations/2021-10-implementations/envoy-wasm/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/tetratelabs/proxy-wasm-go-sdk v0.14.0 h1:bZz1YG4sfQSyLuzJJz8cI8akIURgoSG5WSq57joAVto=
+github.com/tetratelabs/proxy-wasm-go-sdk v0.14.0/go.mod h1:qZ+4i6e2wHlhnhgpH0VG4QFzqd2BEvQbQFU0npt2e2k=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/registry.k8s.io/explorations/2021-10-implementations/envoy-wasm/main.go
+++ b/registry.k8s.io/explorations/2021-10-implementations/envoy-wasm/main.go
@@ -1,4 +1,18 @@
-// the code
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package main
 

--- a/registry.k8s.io/explorations/2021-10-implementations/envoy-wasm/main.go
+++ b/registry.k8s.io/explorations/2021-10-implementations/envoy-wasm/main.go
@@ -1,0 +1,94 @@
+// the code
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+const (
+	realIPKey       = "x-real-ip"
+	matchIPEnvKey   = "MATCH_IP"
+	authorityEnvKey = "AUTHORITY"
+	locationKey     = "location"
+	authorityKey    = ":authority"
+	statusKey       = ":status"
+	pathKey         = ":path"
+	statusCode      = 302
+	defaultHost     = "k8s.gcr.io"
+	rewriteHost     = "registry-1.docker.io"
+)
+
+var (
+	authority = os.Getenv(authorityEnvKey)
+	matchIP   = os.Getenv(matchIPEnvKey)
+)
+
+func main() {
+	proxywasm.SetVMContext(&vmContext{})
+}
+
+type vmContext struct {
+	// Embed the default VM context here,
+	// so that we don't need to reimplement all the methods.
+	types.DefaultVMContext
+}
+
+// Override types.DefaultVMContext.
+func (*vmContext) NewPluginContext(contextID uint32) types.PluginContext {
+	return &pluginContext{}
+}
+
+type pluginContext struct {
+	// Embed the default plugin context here,
+	// so that we don't need to reimplement all the methods.
+	types.DefaultPluginContext
+}
+
+// Override types.DefaultPluginContext.
+func (*pluginContext) NewHttpContext(contextID uint32) types.HttpContext {
+	return &httpRouting{}
+}
+
+type httpRouting struct {
+	// Embed the default http context here,
+	// so that we don't need to reimplement all the methods.
+	types.DefaultHttpContext
+	bodySize    int
+	endOfStream bool
+}
+
+func (ctx *pluginContext) OnPluginStart(pluginConfigurationSize int) types.OnPluginStartStatus {
+	return types.OnPluginStartStatusOK
+}
+
+// Override types.DefaultHttpContext.
+func (ctx *httpRouting) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
+	host := defaultHost
+	remoteAddr, err := proxywasm.GetHttpRequestHeader(realIPKey)
+	if err != nil {
+		proxywasm.LogCritical(fmt.Sprintf("Error: getting request header: '%v'", realIPKey))
+	}
+	if matchIP == remoteAddr {
+		host = rewriteHost
+	}
+
+	path, _ := proxywasm.GetHttpRequestHeader(pathKey)
+	body := fmt.Sprintf(`<a href="https://%v%v">%v</a>.`, host, path, statusCode)
+	if err := proxywasm.SendHttpResponse(statusCode, [][2]string{
+		{authorityKey, authority},
+		{locationKey, fmt.Sprintf("https://%v%v", host, path)},
+		{statusKey, fmt.Sprintf("%s", statusCode)},
+		{pathKey, path},
+	}, []byte(body)); err != nil {
+		proxywasm.LogErrorf("Error: sending http response: %v", err)
+		proxywasm.ResumeHttpRequest()
+	}
+	return types.ActionPause
+}
+
+func (ctx *pluginContext) OnTick() {}

--- a/registry.k8s.io/explorations/2021-10-implementations/nginx-njs/README.org
+++ b/registry.k8s.io/explorations/2021-10-implementations/nginx-njs/README.org
@@ -1,0 +1,189 @@
+#+TITLE: nginx njs host rewriting
+
+#+begin_quote
+A nginx implementation for registry.k8s.io
+#+end_quote
+
+* Bringing the implementation up
+Configure nginx to use the njs script
+#+begin_src conf :tangle ./nginx.conf
+load_module modules/ngx_http_js_module.so;
+env UPSTREAM_HOST;
+events {}
+pid /tmp/nginx.pid;
+http {
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path       /tmp/proxy_temp_path;
+    fastcgi_temp_path     /tmp/fastcgi_temp;
+    uwsgi_temp_path       /tmp/uwsgi_temp;
+    scgi_temp_path        /tmp/scgi_temp;
+
+    js_include /etc/nginx/njs/http.js;
+    js_set $upstream_host fetch_upstream_host;
+    server {
+      listen 8012;
+      rewrite ^/(.*)$ https://$upstream_host/$1;
+    }
+}
+#+end_src
+
+The http response method
+#+begin_src javascript :tangle ./http.js
+function fetch_upstream_host(r) {
+  var reg = "k8s.gcr.io"
+  if (r.remoteAddress === process.env.MATCH_IP) {
+    reg = "registry-1.docker.io"
+  }
+  r.error(`registry: ${reg}`)
+  return reg
+}
+#+end_src
+
+** Testing in Docker
+#+begin_src tmate :window nginx
+docker \
+    run \
+    -it \
+    --rm \
+    -p 8012:8012 \
+    -v $PWD/nginx.conf:/etc/nginx/nginx.conf \
+    -v $PWD/http.js:/etc/nginx/njs/http.js \
+    -e TEST="Hello from njs in nginx!" \
+    -e MATCH_IP="172.17.0.1" \
+    nginxinc/nginx-unprivileged:1.20
+#+end_src
+
+** Deploying in Kubernetes
+Create a namespace
+#+begin_src shell
+kubectl create namespace k8s-reg-nginx-njs -o yaml --dry-run=client | \
+    kubectl apply -f -
+kubectl label namespace k8s-reg-nginx-njs cert-manager-tls=sync --overwrite
+#+end_src
+
+#+RESULTS:
+#+begin_example
+namespace/k8s-reg-nginx-njs created
+namespace/k8s-reg-nginx-njs labeled
+#+end_example
+
+Create a ConfigMap for the config
+#+BEGIN_SRC shell :results silent
+kubectl -n k8s-reg-nginx-njs \
+    create configmap config \
+    --from-file=nginx\.conf=./nginx.conf \
+    --from-file=http\.js=./http.js \
+    --dry-run=client -o yaml | kubectl apply -f -
+#+END_SRC
+
+Configure the nginx deployment
+#+begin_src yaml :tangle ./nginx.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    lastcfg: |
+      ${NGINX_LAST_CFG}
+  labels:
+    app: k8s-reg-nginx-njs
+  name: k8s-reg-nginx-njs
+spec:
+  replicas: 10
+  selector:
+    matchLabels:
+      app: k8s-reg-nginx-njs
+  template:
+    metadata:
+      annotations:
+        lastcfg: |
+          ${NGINX_LAST_CFG}
+      labels:
+        app: k8s-reg-nginx-njs
+    spec:
+      containers:
+      - name: nginx
+        image: nginxinc/nginx-unprivileged:1.20
+        securityContext:
+          runAsUser: 101
+          runAsGroup: 101
+          readOnlyRootFilesystem: false
+          allowPrivilegeEscalation: false
+        env:
+          - name: MATCH_IP
+            value: "${MATCH_IP}"
+        volumeMounts:
+          - name: config
+            mountPath: /etc/nginx/nginx.conf
+            subPath: nginx.conf
+          - name: config
+            mountPath: /etc/nginx/njs/http.js
+            subPath: http.js
+        ports:
+          - name: http
+            containerPort: 8012
+      volumes:
+      - name: config
+        configMap:
+          name: config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: k8s-reg-nginx-njs
+  name: k8s-reg-nginx-njs
+spec:
+  ports:
+  - name: k8s-reg-nginx-njs
+    port: 8012
+    protocol: TCP
+    targetPort: 8012
+  selector:
+    app: k8s-reg-nginx-njs
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: k8s-reg-nginx-njs
+spec:
+  rules:
+  - host: k8s-reg-nginx-njs.${SHARINGIO_PAIR_BASE_DNS_NAME}
+    http:
+      paths:
+      - backend:
+          service:
+            name: k8s-reg-nginx-njs
+            port:
+              number: 8012
+        path: /
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    - k8s-reg-nginx-njs.${SHARINGIO_PAIR_BASE_DNS_NAME}
+    secretName: letsencrypt-prod
+#+end_src
+
+#+BEGIN_SRC shell :results silent
+export \
+  NGINX_LAST_CFG=$(cat nginx.conf http.js | sha256sum) \
+  MATCH_IP="$(kubectl -n "${SHARINGIO_PAIR_NAME}" get pod "${SHARINGIO_PAIR_NAME}-humacs-0" -o=jsonpath='{.status.podIP}')"
+envsubst < nginx.yaml | kubectl -n k8s-reg-nginx-njs apply -f -
+#+END_SRC
+
+* Links
+- https://www.rkatz.xyz/post/2021-09-13-nginx-njs-experiments/
+- https://gist.github.com/runlevel5/5d038e91ea1f874a1dd1608d4e7fcace
+- https://nginx.org/en/docs/njs/node_modules.html
+- https://www.digitalocean.com/community/tutorials/how-to-create-temporary-and-permanent-redirects-with-nginx
+
+* Notes
+Minimal configuration at one 24 lines collectively! (for demo)
+
+* Pros
+- supports any useful JavaScript modules
+- classic or familiar configuration
+
+* Cons
+- less secure from interpreted language
+- speed of JavaScript

--- a/registry.k8s.io/explorations/2021-10-implementations/nginx-njs/http.js
+++ b/registry.k8s.io/explorations/2021-10-implementations/nginx-njs/http.js
@@ -1,0 +1,12 @@
+
+
+// The http response method
+
+function fetch_upstream_host(r) {
+  var reg = "k8s.gcr.io"
+  if (r.remoteAddress === process.env.MATCH_IP) {
+    reg = "registry-1.docker.io"
+  }
+  r.error(`registry: ${reg}`)
+  return reg
+}

--- a/registry.k8s.io/explorations/2021-10-implementations/nginx-njs/nginx.conf
+++ b/registry.k8s.io/explorations/2021-10-implementations/nginx-njs/nginx.conf
@@ -1,0 +1,21 @@
+# Bringing the implementation up
+# Configure nginx to use the njs script
+
+load_module modules/ngx_http_js_module.so;
+env UPSTREAM_HOST;
+events {}
+pid /tmp/nginx.pid;
+http {
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path       /tmp/proxy_temp_path;
+    fastcgi_temp_path     /tmp/fastcgi_temp;
+    uwsgi_temp_path       /tmp/uwsgi_temp;
+    scgi_temp_path        /tmp/scgi_temp;
+
+    js_include /etc/nginx/njs/http.js;
+    js_set $upstream_host fetch_upstream_host;
+    server {
+      listen 8012;
+      rewrite ^/(.*)$ https://$upstream_host/$1;
+    }
+}

--- a/registry.k8s.io/explorations/2021-10-implementations/nginx-njs/nginx.yaml
+++ b/registry.k8s.io/explorations/2021-10-implementations/nginx-njs/nginx.yaml
@@ -1,0 +1,88 @@
+
+
+# Configure the nginx deployment
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    lastcfg: |
+      ${NGINX_LAST_CFG}
+  labels:
+    app: k8s-reg-nginx-njs
+  name: k8s-reg-nginx-njs
+spec:
+  replicas: 10
+  selector:
+    matchLabels:
+      app: k8s-reg-nginx-njs
+  template:
+    metadata:
+      annotations:
+        lastcfg: |
+          ${NGINX_LAST_CFG}
+      labels:
+        app: k8s-reg-nginx-njs
+    spec:
+      containers:
+      - name: nginx
+        image: nginxinc/nginx-unprivileged:1.20
+        securityContext:
+          runAsUser: 101
+          runAsGroup: 101
+          readOnlyRootFilesystem: false
+          allowPrivilegeEscalation: false
+        env:
+          - name: MATCH_IP
+            value: "${MATCH_IP}"
+        volumeMounts:
+          - name: config
+            mountPath: /etc/nginx/nginx.conf
+            subPath: nginx.conf
+          - name: config
+            mountPath: /etc/nginx/njs/http.js
+            subPath: http.js
+        ports:
+          - name: http
+            containerPort: 8012
+      volumes:
+      - name: config
+        configMap:
+          name: config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: k8s-reg-nginx-njs
+  name: k8s-reg-nginx-njs
+spec:
+  ports:
+  - name: k8s-reg-nginx-njs
+    port: 8012
+    protocol: TCP
+    targetPort: 8012
+  selector:
+    app: k8s-reg-nginx-njs
+  type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: k8s-reg-nginx-njs
+spec:
+  rules:
+  - host: k8s-reg-nginx-njs.${SHARINGIO_PAIR_BASE_DNS_NAME}
+    http:
+      paths:
+      - backend:
+          service:
+            name: k8s-reg-nginx-njs
+            port:
+              number: 8012
+        path: /
+        pathType: ImplementationSpecific
+  tls:
+  - hosts:
+    - k8s-reg-nginx-njs.${SHARINGIO_PAIR_BASE_DNS_NAME}
+    secretName: letsencrypt-prod


### PR DESCRIPTION
Add historical explorations for registry.k8s.io, originally found in https://github.com/ii/registry.k8s.io in the same format

Replaces https://github.com/kubernetes-sigs/oci-proxy/pull/2