### PR TITLE
oci-proxy: Add AWS S3 bucket for registry-sandbox.k8s.io

### DIFF
--- a/infra/aws/terraform/registry-sandbox-k8s-io-image-layers/provider.tf
+++ b/infra/aws/terraform/registry-sandbox-k8s-io-image-layers/provider.tf
@@ -1,0 +1,22 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+provider "aws" {
+  profile = "default"
+  region  = "us-west-2"
+  alias   = "origin"
+}

--- a/infra/aws/terraform/registry-sandbox-k8s-io-image-layers/s3-origin-access-logs.tf
+++ b/infra/aws/terraform/registry-sandbox-k8s-io-image-layers/s3-origin-access-logs.tf
@@ -1,0 +1,127 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+locals {
+  expiration_period = 90
+}
+
+data "aws_iam_policy_document" "access_log_policy" {
+  statement {
+    sid = "S3ServerAccessLogsPolicy"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["logging.s3.amazonaws.com"]
+    }
+    actions = [
+      "s3:PutObject",
+    ]
+
+    resources = ["${aws_s3_bucket.access_log.arn}/*"]
+
+    condition {
+      test = "ArnLike"
+      variable = "aws:SourceArn"
+      values = [aws_s3_bucket.origin.arn]
+    }
+
+    condition {
+      test = "StringEquals"
+      variable = "aws:SourceAccount"
+      values = [
+        data.aws_caller_identity.current.id
+      ]
+    }
+  }
+
+  statement {
+    principals {
+      type        = "Service"
+      identifiers = ["logging.s3.amazonaws.com"]
+    }
+    actions = [
+      "s3:GetBucketAcl",
+    ]
+    resources = [aws_s3_bucket.access_log.arn]
+  }
+}
+
+resource "aws_s3_bucket" "access_log" {
+  provider = aws.origin
+
+  bucket        = "${aws_s3_bucket.origin.bucket}-access-log"
+  force_destroy = false
+
+  depends_on = [
+    aws_s3_bucket.origin
+  ]
+}
+
+resource "aws_s3_bucket_policy" "access_log_policy" {
+  bucket = aws_s3_bucket.access_log.id
+  policy = data.aws_iam_policy_document.access_log_policy.json
+}
+
+resource "aws_s3_bucket_ownership_controls" "access_log" {
+  bucket = aws_s3_bucket.access_log.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "access_log" {
+  provider = aws.origin
+
+  bucket = aws_s3_bucket.access_log.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "access_log" {
+  provider = aws.origin
+
+  bucket = aws_s3_bucket.access_log.id
+
+  rule {
+    id     = "auto-delete"
+    status = "Enabled"
+
+    filter {}
+
+    # Objects are deleted after 90 days
+    expiration {
+      days = local.expiration_period
+    }
+  }
+}
+
+
+# Prevent public access
+resource "aws_s3_bucket_public_access_block" "access_log" {
+  provider = aws.origin
+
+  bucket                  = aws_s3_bucket.access_log.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+

--- a/infra/aws/terraform/registry-sandbox-k8s-io-image-layers/s3-origin.tf
+++ b/infra/aws/terraform/registry-sandbox-k8s-io-image-layers/s3-origin.tf
@@ -1,0 +1,119 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+data "aws_caller_identity" "current" {
+  provider = aws.origin
+}
+
+resource "random_pet" "bucket" {
+  length = 5
+}
+
+data "aws_iam_policy_document" "origin_policy" {
+  provider = aws.origin
+
+  statement {
+    actions = ["s3:*"]
+    effect  = "Deny"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+
+    resources = [
+      aws_s3_bucket.origin.arn,
+      "${aws_s3_bucket.origin.arn}/*"
+    ]
+
+  }
+
+  statement {
+    actions = ["s3:GetObject"]
+    effect  = "Allow"
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    resources = [
+      "${aws_s3_bucket.origin.arn}/*"
+    ]
+  }
+}
+
+resource "aws_s3_bucket" "origin" {
+  provider = aws.origin
+
+  bucket = "${random_pet.bucket.id}-image-layers"
+}
+
+resource "aws_s3_bucket_policy" "allow_public_access" {
+  provider = aws.origin
+
+  bucket = aws_s3_bucket.origin.id
+  policy = data.aws_iam_policy_document.origin_policy.json
+}
+
+resource "aws_s3_bucket_cors_configuration" "origin" {
+  provider = aws.origin
+
+  bucket                = aws_s3_bucket.origin.id
+  expected_bucket_owner = data.aws_caller_identity.current.id
+
+  cors_rule {
+    allowed_headers = ["*"]
+    allowed_methods = ["GET", "HEAD"]
+    allowed_origins = ["*"]
+    max_age_seconds = 3000
+  }
+}
+
+resource "aws_s3_bucket_versioning" "origin" {
+  provider = aws.origin
+
+  bucket                = aws_s3_bucket.origin.id
+  expected_bucket_owner = data.aws_caller_identity.current.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "origin" {
+  provider = aws.origin
+
+  bucket = aws_s3_bucket.origin.bucket
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_logging" "origin_access_log" {
+  provider = aws.origin
+
+  bucket = aws_s3_bucket.origin.id
+
+  target_bucket = aws_s3_bucket.access_log.id
+  target_prefix = ""
+}

--- a/infra/aws/terraform/registry-sandbox-k8s-io-image-layers/terraform.tf
+++ b/infra/aws/terraform/registry-sandbox-k8s-io-image-layers/terraform.tf
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This file defines:
+- Required provider versions
+- Storage backend details
+- alias for the provider per region
+*/
+
+terraform {
+  backend "gcs" {
+    bucket = "k8s-infra-tf-aws"
+    prefix = "oci-proxy"
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.12.0"
+    }
+  }
+}

--- a/infra/aws/terraform/registry-sandbox-k8s-io-image-layers/versions.tf
+++ b/infra/aws/terraform/registry-sandbox-k8s-io-image-layers/versions.tf
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This file defines:
+- Required Terraform version
+*/
+
+terraform {
+  required_version = "~> 1.1.2"
+}


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/k8s.io/issues/3620

Ensure a AWS S3 bucket exists so we can test IP based redirection of
[archeio](https://github.com/kubernetes-sigs/oci-proxy/tree/main/cmd/archeio).

The bucket contains a copy of the images layers
served by k8s.gcr.io.

The bucket:
- is world readable
- only allow HTTPS connections
- only allow HTTP methods GET and HEAD
- has versioning enabled

Another private bucket is created for access logging.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>