### PR TITLE
Bump terraform version required for k8s-infra-monitoring

### DIFF
--- a/infra/gcp/terraform/k8s-infra-monitoring/provider.tf
+++ b/infra/gcp/terraform/k8s-infra-monitoring/provider.tf
@@ -25,11 +25,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90.1"
+      version = "~> 4.16.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.90.1"
+      version = " 4.16.0"
     }
   }
 }

--- a/infra/gcp/terraform/k8s-infra-monitoring/versions.tf
+++ b/infra/gcp/terraform/k8s-infra-monitoring/versions.tf
@@ -20,5 +20,5 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 1.0.0"
+  required_version = "~> 1.1.0"
 }


### PR DESCRIPTION
Followup of:
  - https://github.com/kubernetes/test-infra/pull/26117

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>