### PR TITLE
Use prod buckets

### DIFF
--- a/infra/aws/terraform/README.md
+++ b/infra/aws/terraform/README.md
@@ -5,3 +5,24 @@ Contains the Terraform for provisioning various resources under different AWS ac
 ## Folders
 
 - [registry.k8s.io](./registry.k8s.io/) :: resources and components backing registry.k8s.io
+
+## Notes
+
+### Warning for providers
+
+An error may be displayed upon plan or apply commands, this error can be safely ignored as buckets provision.
+
+```bash
+╷
+│ Warning: Provider aws is undefined
+│
+│   on main.tf line 35, in module "us-west-1":
+│   35:     aws = aws.us-west-1
+│
+│ Module module.us-west-1 does not declare a provider named aws.
+│ If you wish to specify a provider configuration for the module, add an entry for aws in the required_providers block within the
+│ module.
+│
+│ (and 7 more similar warnings elsewhere)
+╵
+```

--- a/infra/aws/terraform/registry.k8s.io/README.md
+++ b/infra/aws/terraform/registry.k8s.io/README.md
@@ -24,6 +24,14 @@ The variable _prefix_ can be set to prefix all variables with a value
 terraform apply -var prefix=test-
 ```
 
+## State management
+
+The state of the Terraform is currently stored in a private bucket in the CNCF account
+
+```bash
+aws s3 mb s3://registry-k8s-io-tfstate --region us-east-2
+```
+
 ## Notes
 
 - currently all provider blocks will assume the role of registry.k8s.io_s3writer inside of the registry.k8s.io account (513428760722)

--- a/infra/aws/terraform/registry.k8s.io/README.md
+++ b/infra/aws/terraform/registry.k8s.io/README.md
@@ -8,12 +8,13 @@ Terraform to provision AWS infra for supporting registry.k8s.io
 - create an IAM role to provide write access into each bucket
 - provide a way for testing the buckets
 
-## Extending regions
+## Applying the Terraform
 
-Supporting more AWS regions is simple, the steps are:
+In order to apply the Terraform in production, the variable of _prefix_ must be set to `prod-`, i.e
 
-1. add a new _aws_ provider with a region and alias in the [providers.tf](./providers.tf) file
-2. add a new module block for the region in the [main.tf](./main.tf) file, including the correct region name for all three values (module name, provider+alias and region variable)
+```bash
+terraform apply -var prefix=prod-
+```
 
 ## Testing
 
@@ -22,3 +23,14 @@ The variable _prefix_ can be set to prefix all variables with a value
 ```bash
 terraform apply -var prefix=test-
 ```
+
+## Notes
+
+- currently all provider blocks will assume the role of registry.k8s.io_s3writer inside of the registry.k8s.io account (513428760722)
+
+## Extending regions
+
+Supporting more AWS regions is simple, the steps are:
+
+1. add a new _aws_ provider with a region and alias in the [providers.tf](./providers.tf) file
+2. add a new module block for the region in the [main.tf](./main.tf) file, including the correct region name for all three values (module name, provider+alias and region variable)

--- a/infra/aws/terraform/registry.k8s.io/main.tf
+++ b/infra/aws/terraform/registry.k8s.io/main.tf
@@ -17,9 +17,10 @@ limitations under the License.
 // prefix prefixes every resource so that the resources
 // can be created without using the same names. Useful
 // for testing and staging
+
 variable "prefix" {
   type        = string
-  default     = ""
+  default     = "test-"
   description = "The prefix for all resources"
 
   validation {
@@ -35,9 +36,8 @@ module "us-west-1" {
     aws = aws.us-west-1
   }
 
-  region        = "us-west-1"
-  prefix        = var.prefix
-  iam_user_name = aws_iam_user.registry-k8s-io-access.name
+  region = "us-west-1"
+  prefix = var.prefix
 }
 
 module "us-west-2" {
@@ -47,9 +47,8 @@ module "us-west-2" {
     aws = aws.us-west-2
   }
 
-  region        = "us-west-2"
-  prefix        = var.prefix
-  iam_user_name = aws_iam_user.registry-k8s-io-access.name
+  region = "us-west-2"
+  prefix = var.prefix
 }
 
 module "us-east-1" {
@@ -59,9 +58,8 @@ module "us-east-1" {
     aws = aws.us-east-1
   }
 
-  region        = "us-east-1"
-  prefix        = var.prefix
-  iam_user_name = aws_iam_user.registry-k8s-io-access.name
+  region = "us-east-1"
+  prefix = var.prefix
 }
 
 module "us-east-2" {
@@ -71,9 +69,8 @@ module "us-east-2" {
     aws = aws.us-east-2
   }
 
-  region        = "us-east-2"
-  prefix        = var.prefix
-  iam_user_name = aws_iam_user.registry-k8s-io-access.name
+  region = "us-east-2"
+  prefix = var.prefix
 }
 
 module "eu-central-1" {
@@ -83,9 +80,8 @@ module "eu-central-1" {
     aws = aws.eu-central-1
   }
 
-  region        = "eu-central-1"
-  prefix        = var.prefix
-  iam_user_name = aws_iam_user.registry-k8s-io-access.name
+  region = "eu-central-1"
+  prefix = var.prefix
 }
 
 module "ap-southeast-1" {
@@ -95,9 +91,8 @@ module "ap-southeast-1" {
     aws = aws.ap-southeast-1
   }
 
-  region        = "ap-southeast-1"
-  prefix        = var.prefix
-  iam_user_name = aws_iam_user.registry-k8s-io-access.name
+  region = "ap-southeast-1"
+  prefix = var.prefix
 }
 
 module "ap-northeast-1" {
@@ -107,9 +102,8 @@ module "ap-northeast-1" {
     aws = aws.ap-northeast-1
   }
 
-  region        = "ap-northeast-1"
-  prefix        = var.prefix
-  iam_user_name = aws_iam_user.registry-k8s-io-access.name
+  region = "ap-northeast-1"
+  prefix = var.prefix
 }
 
 module "ap-south-1" {
@@ -119,7 +113,6 @@ module "ap-south-1" {
     aws = aws.ap-south-1
   }
 
-  region        = "ap-south-1"
-  prefix        = var.prefix
-  iam_user_name = aws_iam_user.registry-k8s-io-access.name
+  region = "ap-south-1"
+  prefix = var.prefix
 }

--- a/infra/aws/terraform/registry.k8s.io/providers.tf
+++ b/infra/aws/terraform/registry.k8s.io/providers.tf
@@ -15,6 +15,12 @@ limitations under the License.
 */
 
 terraform {
+  backend "s3" {
+    bucket = "registry-k8s-io-tfstate"
+    key    = "terraform.tfstate"
+    region = "us-east-2"
+  }
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/infra/aws/terraform/registry.k8s.io/providers.tf
+++ b/infra/aws/terraform/registry.k8s.io/providers.tf
@@ -25,44 +25,80 @@ terraform {
 
 provider "aws" {
   region = "us-west-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::513428760722:role/registry.k8s.io_s3writer"
+  }
 }
 
 provider "aws" {
   alias  = "us-west-1"
   region = "us-west-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::513428760722:role/registry.k8s.io_s3writer"
+  }
 }
 
 provider "aws" {
   alias  = "us-west-2"
   region = "us-west-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::513428760722:role/registry.k8s.io_s3writer"
+  }
 }
 
 provider "aws" {
   alias  = "us-east-1"
   region = "us-east-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::513428760722:role/registry.k8s.io_s3writer"
+  }
 }
 
 provider "aws" {
   alias  = "us-east-2"
   region = "us-east-2"
+
+  assume_role {
+    role_arn = "arn:aws:iam::513428760722:role/registry.k8s.io_s3writer"
+  }
 }
 
 provider "aws" {
   alias  = "eu-central-1"
   region = "eu-central-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::513428760722:role/registry.k8s.io_s3writer"
+  }
 }
 
 provider "aws" {
   alias  = "ap-southeast-1"
   region = "ap-southeast-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::513428760722:role/registry.k8s.io_s3writer"
+  }
 }
 
 provider "aws" {
   alias  = "ap-northeast-1"
   region = "ap-northeast-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::513428760722:role/registry.k8s.io_s3writer"
+  }
 }
 
 provider "aws" {
   alias  = "ap-south-1"
   region = "ap-south-1"
+
+  assume_role {
+    role_arn = "arn:aws:iam::513428760722:role/registry.k8s.io_s3writer"
+  }
 }

--- a/infra/aws/terraform/registry.k8s.io/providers.tf
+++ b/infra/aws/terraform/registry.k8s.io/providers.tf
@@ -29,6 +29,10 @@ terraform {
   }
 }
 
+# The role_arn (arn:aws:iam::513428760722:role/registry.k8s.io_s3writer)
+# used in each provider block is managed in
+# https://github.com/cncf-infra/aws-infra/blob/2ac2e63c162134a9e6036d84beee2d5adf6b4ff2/terraform/iam/main.tf
+
 provider "aws" {
   region = "us-west-1"
 

--- a/infra/aws/terraform/registry.k8s.io/s3/bucket.tf
+++ b/infra/aws/terraform/registry.k8s.io/s3/bucket.tf
@@ -23,14 +23,6 @@ resource "aws_s3_bucket_acl" "registry-k8s-io" {
   acl    = "public-read"
 }
 
-resource "aws_s3_bucket_ownership_controls" "registry-k8s-io" {
-  bucket = aws_s3_bucket.registry-k8s-io.bucket
-
-  rule {
-    object_ownership = "BucketOwnerEnforced"
-  }
-}
-
 resource "aws_s3_bucket_policy" "registry-k8s-io-public-read" {
   bucket = aws_s3_bucket.registry-k8s-io.bucket
 
@@ -60,29 +52,15 @@ resource "aws_s3_bucket_policy" "registry-k8s-io-public-read" {
   })
 }
 
-resource "aws_iam_user_policy" "registry-k8s-io-rw" {
-  name = "${aws_s3_bucket.registry-k8s-io.bucket}-access"
-  user = var.iam_user_name
+resource "aws_s3_bucket_ownership_controls" "registry-k8s-io" {
+  bucket = aws_s3_bucket.registry-k8s-io.bucket
 
-  policy = jsonencode({
-    "Version" : "2012-10-17",
-    "Statement" : [
-      {
-        "Action" : [
-          "s3:ListBucket"
-        ],
-        "Effect" : "Allow",
-        "Resource" : "${aws_s3_bucket.registry-k8s-io.arn}/"
-      },
-      {
-        "Action" : [
-          "s3:PutObject",
-          "s3:GetObject",
-          "s3:DeleteObject"
-        ],
-        "Effect" : "Allow",
-        "Resource" : "${aws_s3_bucket.registry-k8s-io.arn}/*"
-      }
-    ]
-  })
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+  depends_on = [
+    aws_s3_bucket.registry-k8s-io,
+    aws_s3_bucket_acl.registry-k8s-io,
+    aws_s3_bucket_policy.registry-k8s-io-public-read
+  ]
 }

--- a/infra/aws/terraform/registry.k8s.io/s3/variables.tf
+++ b/infra/aws/terraform/registry.k8s.io/s3/variables.tf
@@ -22,7 +22,3 @@ variable "prefix" {
   type    = string
   default = ""
 }
-
-variable "iam_user_name" {
-  type = string
-}


### PR DESCRIPTION
- adds useful documentation for managing the buckets
- ensures the use of the registry.k8s.io AWS account
- updates the default bucket name
- removes the iam role

Co-Authored-By: jaypipes <jaypipes@gmail.com>