### PR TITLE
Adding sig-windows-leads@kuernetes.io group

### DIFF
--- a/groups/sig-windows/groups.yaml
+++ b/groups/sig-windows/groups.yaml
@@ -7,6 +7,19 @@ groups:
   # and is not intended to govern access to infrastructure
   #
 
+  - email-id: sig-windows-leads@kubernetes.io
+    name: sig-windows-leads
+    description: |-
+      SIG Windows chairs and technical leads comms
+    settings:
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      ReconcileMembers: "true"
+    owners:
+      - cbelu@cloudbasesolutions.com
+      - jayunit100.apache@gmail.com
+      - jsturtevant@gmail.com
+      - marosset@microsoft.com
+
   #
   # k8s-staging write access for SIG-owned subprojects
   #


### PR DESCRIPTION
Signed-off-by: Mark Rossetti <marosset@microsoft.com>

Adding sig-windows-leads group.

Group reference already exists in restrictions.yaml https://github.com/kubernetes/k8s.io/blob/634769ad9f9bdf7fa0f4a831812e3d07f5588f3f/groups/restrictions.yaml#L189