### PR TITLE
node-perf/tf-wide-deep: add version 1.2

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-e2e-test-images/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-e2e-test-images/images.yaml
@@ -87,6 +87,7 @@
 - name: node-perf/tf-wide-deep
   dmap:
     "sha256:d5d5822ef70f81db66c1271662e1b9d4556fb267ac7ae09dee5d91aa10736431": ["1.1"]
+    "sha256:44d13eac1e70b9494b9ef8eee2932c80863a01812cdcc1dfff5d1d43d97a6816": ["1.2"]
 - name: nonewprivs
   dmap:
     "sha256:553fcda2222ccea7cd534c8da34b709feb768d6389eb7333444b13f296bd168f": ["1.1"]


### PR DESCRIPTION
```
[danielle@mimas danielle] $ docker run mplatform/manifest-tool inspect --raw gcr.io/k8s-staging-e2e-test-images/node-perf/tf-wide-deep:1.2
{"mediaType":"application/vnd.docker.distribution.manifest.list.v2+json","digest":"sha256:44d13eac1e70b9494b9ef8eee2932c80863a01812cdcc1dfff5d1d43d97a6816","size":743}
```