### PR TITLE
Promote ip-masq-agent 2.7.0 images.

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-networking/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-networking/images.yaml
@@ -1,5 +1,11 @@
 - name: ip-masq-agent
   dmap:
+    "sha256:5cef04a18d5563913bd944270796f8f3f150c390dd0c61a357c936cae011acd3": ["v2.7.0"]
+    "sha256:f74c84736e025bcca1c8657573ca761dbc5b731aebdc0be3d01efb9c13d50c49": ["v2.7.0__linux_amd64"]
+    "sha256:6f788808af0aee7674d051044d162a9d8b72d7c4668ed0ac9aca748b2d47b0b8": ["v2.7.0__linux_arm"]
+    "sha256:0224cbadd17ebfb0c1a7946c556bee7ec00613f11e4ee98deb10264de64b72c1": ["v2.7.0__linux_arm64"]
+    "sha256:6b140e992a17f88a2fe35db20a15b626b17464fe7ef6b69b2c8cbfaae49da5df": ["v2.7.0__linux_ppc64le"]
+    "sha256:24be0d068a976e7d015c50ba853dabd59cc67c9c22493b272730e8289c970ae2": ["v2.7.0__linux_s390x"]
     "sha256:f2a89c4add9ff48a011ad8b59cb7c6ae2e3eaa8aa66cb521a798a07f9d816368": ["v2.6.1"]
     "sha256:0d27fb2864a100a56da9582b3112f98fb06fa1f930c8c47773aa18bb0988d14d": ["v2.6.0"]
 - name: ip-masq-agent-amd64


### PR DESCRIPTION
Resubmit https://github.com/kubernetes/k8s.io/pull/3716.

/assign @MrHohn