### PR TITLE
Add Kustomize OCI registry

### DIFF
--- a/groups/sig-cli/groups.yaml
+++ b/groups/sig-cli/groups.yaml
@@ -90,3 +90,15 @@ groups:
       - eddiezane@gmail.com
       - katrina.verey@shopify.com
       - maszulik@redhat.com
+
+  - email-id: k8s-infra-rbac-kustomize-oci@kubernetes.io
+    name: k8s-infra-rbac-kustomize-oci
+    description: |-
+      ACL for Kustomize OCI test registry
+    settings:
+      ReconcileMembers: "true"
+      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # required
+    members:
+      - katrina.verey@shopify.com
+      - natashasarkar@google.com
+      - mikebz@google.com


### PR DESCRIPTION
This PR adds an OCI registry and group for the Kustomize team to use for testing.

Fixes #3725 