### PR TITLE
Sync CAPZ owners with Azure provider project

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cluster-api-azure/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api-azure/OWNERS
@@ -5,14 +5,11 @@ approvers:
 - alexeldeib
 - CecileRobertMichon
 - devigned
-- nader-ziada
+- mboersma
 - shysank
 reviewers:
-- cpanato
 - jackfrancis
 - jsturtevant
-- juan-lee
-- mboersma
 
 labels:
 - sig/cluster-lifecycle


### PR DESCRIPTION
Syncs up with recent changes to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES

cc: @cpanato @jont828 @juan-lee @nader-ziada 