### PR TITLE
prow: Bump GCP provider for the build clusters

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/00-provider.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/00-provider.tf
@@ -30,11 +30,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90.1"
+      version = "~> 4.16.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.90.1"
+      version = "~> 4.16.0"
     }
   }
 }

--- a/infra/gcp/terraform/modules/gke-cluster/versions.tf
+++ b/infra/gcp/terraform/modules/gke-cluster/versions.tf
@@ -17,15 +17,15 @@
  */
 
 terraform {
-  required_version = "~> 1.0.0"
+  required_version = "~> 1.1.0"
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90.1"
+      version = "~> 4.16.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.90.1"
+      version = "~> 4.16.0"
     }
   }
 }

--- a/infra/gcp/terraform/modules/gke-nodepool/versions.tf
+++ b/infra/gcp/terraform/modules/gke-nodepool/versions.tf
@@ -17,15 +17,15 @@
  */
 
 terraform {
-  required_version = "~> 1.0.0"
+  required_version = "~> 1.1.0"
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90.1"
+      version = "~> 4.16.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.90.1"
+      version = "~> 4.16.0"
     }
   }
 }

--- a/infra/gcp/terraform/modules/gke-project/versions.tf
+++ b/infra/gcp/terraform/modules/gke-project/versions.tf
@@ -17,15 +17,15 @@
  */
 
 terraform {
-  required_version = "~> 1.0.0"
+  required_version = "~> 1.1.0"
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90.1"
+      version = "~> 4.16.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.90.1"
+      version = "~> 4.16.0"
     }
   }
 }

--- a/infra/gcp/terraform/modules/workload-identity-service-account/versions.tf
+++ b/infra/gcp/terraform/modules/workload-identity-service-account/versions.tf
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 terraform {
-  required_version = "~> 1.0.0"
+  required_version = "~> 1.1.0"
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90.1"
+      version = "~> 4.16.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.90.1"
+      version = "~> 4.16.0"
     }
   }
 }


### PR DESCRIPTION
Followup of:
  - https://github.com/kubernetes/k8s.io/pull/3021

Upgrade Terraform provider for GCP to 4.16.

I did an upgrade to the 4.0.0 of the provider to ensure we are not
impacated.
Changelog of 4.0.O: https://github.com/hashicorp/terraform-provider-google/blob/main/CHANGELOG.md#400-november-02-2021

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>