### PR TITLE
Add Jont828 as a CAPZ reviewer

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cluster-api-azure/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api-azure/OWNERS
@@ -9,6 +9,7 @@ approvers:
 - shysank
 reviewers:
 - jackfrancis
+- Jont828
 - jsturtevant
 
 labels:


### PR DESCRIPTION
Syncs up with https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES

For some reason this failed the membership check in #3741, but Jonathan is indeed in the Kubernetes org. So let's try again.

cc: @Jont828 @CecileRobertMichon 