### PR TITLE
Update release-team-shadows in sig-release group for 1.25 Release Team

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -374,38 +374,39 @@ groups:
       - lauri.d.apple@gmail.com
       - saschagrunert@gmail.com
     managers:
-      - joseph.r.sandoval@gmail.com # 1.24 Emeritus Advisor
-      - james.laverack@jetstack.io # 1.24 Release Lead
+      - cicih@google.com # 1.25 Release Lead
+      - rlejano@gmail.com # 1.25 Emeritus Advisor
     members:
-      - max@koerbaecher.io # 1.24 RT Lead Shadow
-      - xander@grzy.dev # 1.24 RT Lead Shadow
-      - jeeves.butler@gmail.com # 1.24 RT Lead Shadow
-      - cicih@google.com # 1.24 RT Lead Shadow
-      - ryler.hockenbury@gmail.com # 1.24 Enhancements Shadow
-      - salahi.hossein@gmail.com # 1.24 Enhancements Shadow
-      - jhf@google.com # 1.24 Enhancements Shadow
-      - priyankasaggu11929@gmail.com # 1.24 Enhancements Shadow
-      - voigt.christoph@gmail.com # 1.24 CI Signal Shadow
-      - lauralorenz@google.com # 1.24 CI Signal Shadow
-      - s-kitagawa@mercari.com # 1.24 CI Signal Shadow
-      - niveditaprasad81@gmail.com # 1.24 CI Signal Shadow
-      - diptochuck123@gmail.com # 1.24 Bug Triage Shadow
-      - hebaelayoty@gmail.com # 1.24 Bug Triage Shadow
-      - igor.segodnya@gmail.com # 1.24 Bug Triage Shadow
-      - panjwaniritu45@gmail.com # 1.24 Bug Triage Shadow
-      - mehabhalodiya@gmail.com # 1.24 Docs Shadow
-      - striker57@gmail.com # 1.24 Docs Shadow
-      - edidiongasikpo@gmail.com # 1.24 Docs Shadow
-      - victor@cloudflavor.io # 1.24 Docs Shadow
-      - parulsahoo5jan@gmail.com # 1.24 Release Notes Shadow
-      - arshsharma461@gmail.com # 1.24 Release Notes Shadow
-      - francois.le.pape@gmail.com # 1.24 Release Notes Shadow
-      - csantana23@gmail.com # 1.24 Release Notes Shadow
-      - odr.saul@gmail.com # 1.24 Communications Shadow
-      - d.panigrahi.nitrkl@gmail.com # 1.24 Communications Shadow
-      - kat.cosgrove@gmail.com # 1.24 Communications Shadow
-      - parthvi.vala@gmail.com # 1.24 Communications Shadow
-      - jameswangel@gmail.com # Release Manager Associate // 1.24 Release Branch Manager Shadow
+      - nng.grace@gmail.com # 1.25 RT Lead Shadow
+      - leonard.pahlke@googlemail.com # 1.25 RT Lead Shadow
+      - jeeves.butler@gmail.com # 1.25 RT Lead Shadow
+      - xander@grzy.dev # 1.25 RT Lead Shadow
+      - atharvashinde179@gmail.com # 1.25 Enhancements Shadow
+      - jason@janusworx.com # 1.25 Enhancements Shadow
+      - marosset@microsoft.com # 1.25 Enhancements Shadow
+      - parulsahoo5jan@gmail.com # 1.25 Enhancements Shadow
+      - ryler.hockenbury@gmail.com # 1.25 Enhancements Shadow
+      - agnoam@gmail.com # 1.25 CI Signal Shadow
+      - jyotima@amazon.com # 1.25 CI Signal Shadow
+      - niveditaprasad81@gmail.com # 1.25 CI Signal Shadow
+      - shuhei.kitagawa@gmail.com # 1.25 CI Signal Shadow
+      - harshitasao@gmail.com # 1.25 Bug Triage Shadow
+      - hkamel.msft@gmail.com # 1.25 Bug Triage Shadow
+      - justin.chizer@gmail.com # 1.25 Bug Triage Shadow
+      - marky.r.jackson@gmail.com # 1.25 Bug Triage Shadow
+      - salahi.hossein@gmail.com # 1.25 Bug Triage Shadow
+      - cathchu@google.com # 1.25 Docs Shadow
+      - edidiongasikpo@gmail.com # 1.25 Docs Shadow
+      - guillen.carolina@gmail.com # 1.25 Docs Shadow
+      - sethpmccombs@gmail.com # 1.25 Docs Shadow
+      - diptochuck123@gmail.com # 1.25 Release Notes Shadow
+      - orsenthil@gmail.com # 1.25 Release Notes Shadow
+      - ramses.green.2@gmail.com # 1.25 Release Notes Shadow
+      - ranidivya063@gmail.com # 1.25 Release Notes Shadow
+      - anammedina21@gmail.com # 1.25 Communications Shadow
+      - d.panigrahi.nitrkl@gmail.com # 1.25 Communications Shadow
+      - fsmunoz@gmail.com # 1.25 Communications Shadow
+      - garima.negy@gmail.com # 1.25 Communications Shadow
 
   # RBAC groups:
   # - grant access to the `namespace-user` role for a single namespace on the `aaa` cluster


### PR DESCRIPTION
This PR replaces the 1.24 shadows with 1.25 shadows in the release-team-shadows sig-release group
/cc @cici37 