### PR TITLE
Remove `lauri.d.apple@gmail.com` from SIG Release groups

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -86,7 +86,6 @@ groups:
       - katrina.verey@shopify.com # SIG CLI
       - ksemenov@vmware.com
       - lachlan.evenson@gmail.com
-      - lauri.d.apple@gmail.com # SIG Release
       - liggitt@google.com
       - marosset@microsoft.com
       - maszulik@redhat.com

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -198,7 +198,6 @@ groups:
       - james.laverack@jetstack.io # 1.24 RT Lead
       - joseph.r.sandoval@gmail.com # 1.24 RT EA
       - kat.cosgrove@gmail.com # 1.24 Release Comms Shadow
-      - lauri.d.apple@gmail.com
       - max@koerbaecher.io # 1.24 RT Lead Shadow
       - xander@grzy.dev # 1.24 RT Lead Shadow
       - jeeves.butler@gmail.com # 1.24 RT Lead Shadow
@@ -260,7 +259,6 @@ groups:
       - jeeves.butler@gmail.com # 1.24 Release Lead Shadow
       - joseph.r.sandoval@gmail.com # 1.24 EA
       - kikis.github@gmail.com
-      - lauri.d.apple@gmail.com
       - max@koerbaecher.io
       - mudrinic.mare@gmail.com
       - pal.nabarun95@gmail.com
@@ -298,7 +296,6 @@ groups:
       - ctadeu@gmail.com
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
-      - lauri.d.apple@gmail.com
       - saschagrunert@gmail.com
 
   - email-id: release-team@kubernetes.io
@@ -314,7 +311,6 @@ groups:
       - ctadeu@gmail.com
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
-      - lauri.d.apple@gmail.com
       - saschagrunert@gmail.com
     managers:
       - james.laverack@jetstack.io # 1.24 RT Lead
@@ -371,7 +367,6 @@ groups:
       - ctadeu@gmail.com
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
-      - lauri.d.apple@gmail.com
       - saschagrunert@gmail.com
     managers:
       - joseph.r.sandoval@gmail.com # 1.24 Emeritus Advisor


### PR DESCRIPTION
Lauri has stepped back from SIG Release some time ago. This cleanup should reflect the current state of the SIG.

Refers to https://github.com/kubernetes/community/pull/6675, https://github.com/kubernetes/org/pull/3450

cc @kubernetes/sig-release-leads 