### PR TITLE
Adding staging repo for k8s-staging-cluster-api-cloudstack

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -67,6 +67,7 @@ restrictions:
       - "^sig-cluster-lifecycle-kubeadm-alerts@kubernetes.io$"
       - "^k8s-infra-kops-maintainers@kubernetes.io$"
       - "^k8s-infra-staging-addon-manager@kubernetes.io$"
+      - "^k8s-infra-staging-capi-cloudstack@kubernetes.io$"
       - "^k8s-infra-staging-capi-docker@kubernetes.io$"
       - "^k8s-infra-staging-capi-ibmcloud@kubernetes.io$"
       - "^k8s-infra-staging-capi-kubeadm@kubernetes.io$"

--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -103,6 +103,16 @@ groups:
       - jsand@google.com
       - zihongz@google.com
 
+  - email-id: k8s-infra-staging-capi-cloudstack@kubernetes.io
+    name: k8s-infra-staging-capi-cloudstack
+    description: |-
+      ACL for staging CAPI for Apache CloudStack
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - david.njumani@gmail.com
+      - rohityadav89@gmail.com
+
   - email-id: k8s-infra-staging-capi-docker@kubernetes.io
     name: k8s-infra-staging-capi-docker
     description: |-

--- a/infra/gcp/infra.yaml
+++ b/infra/gcp/infra.yaml
@@ -262,6 +262,7 @@ infra:
       k8s-staging-boskos:
       k8s-staging-bom:
       k8s-staging-build-image:
+      k8s-staging-capi-cloudstack:
       k8s-staging-capi-docker:
       k8s-staging-capi-ibmcloud:
       k8s-staging-capi-kubeadm:

--- a/k8s.gcr.io/images/k8s-staging-capi-cloudstack/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-capi-cloudstack/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- davidjumani
+- rohityadavcloud

--- a/k8s.gcr.io/images/k8s-staging-capi-cloudstack/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-capi-cloudstack/images.yaml
@@ -1,0 +1,1 @@
+# No images yet

--- a/k8s.gcr.io/manifests/k8s-staging-capi-cloudstack/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-capi-cloudstack/promoter-manifest.yaml
@@ -1,0 +1,10 @@
+# google group for gcr.io/k8s-staging-capi-cloudstack is k8s-infra-staging-capi-cloudstack@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-capi-cloudstack
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/capi-cloudstack
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/capi-cloudstack
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/capi-cloudstack
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
Hi,

We've just migrated the [Cluster API Provider for CloudStack](https://github.com/kubernetes-sigs/cluster-api-provider-cloudstack) repo and would like a GCR staging repo to host container images.
I've followed the steps [here](https://github.com/kubernetes/k8s.io/tree/main/k8s.gcr.io#creating-staging-repos) and have raised this PR to create the google group as well as the corresponding GCR repo