### PR TITLE
dns: Allow netlify to issue certificates

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -27,6 +27,9 @@
     - flags: 0
       tag: issue
       value: amazon.com
+    - flags: 0
+      tag: issue
+      value: netlify.app
   - type: TXT
     values:
     - google-site-verification=RJbZ_ganmSWvslSKOBG-QHv62XTjJZcigpWIFttStFs


### PR DESCRIPTION
TLS certificate for kubectl.sigs.k8s.io failed to get renewed:

```
 SniCertificate::CertificateNonvalidError: Unable to verify challenge for kubectl.docs.k8s.io: CAA record for kubectl.docs.k8s.io prevents issuance
```

It was reported to me by @thockin. 

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>