### PR TITLE
Fix CAA records for anything that uses docs wildcard

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -27,9 +27,6 @@
     - flags: 0
       tag: issue
       value: amazon.com
-    - flags: 0
-      tag: issue
-      value: netlify.app
   - type: TXT
     values:
     - google-site-verification=RJbZ_ganmSWvslSKOBG-QHv62XTjJZcigpWIFttStFs

--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -56,7 +56,7 @@ docs:
 # All docs subdomains get sent to netlify (@chenopis)
 '*.docs':
   type: CNAME
-  value: netlifyglobalcdn.com.
+  value: kubernetes.netlify.app.
 # Create a dummy A record so that the Let's Encrypt TXT records are not caught
 # by the wildcard CNAME record. (@ixdy)
 _acme-challenge.docs:

--- a/dns/zone-configs/kubernetes.io._0_base.yaml
+++ b/dns/zone-configs/kubernetes.io._0_base.yaml
@@ -45,7 +45,7 @@ docs:
 # All docs subdomains get sent to netlify (@chenopis)
 '*.docs':
   type: CNAME
-  value: kubernetes.netlifyglobalcdn.com.
+  value: kubernetes.netlify.app.
 # Create a dummy A record so that the Let's Encrypt TXT records are not caught
 # by the wildcard CNAME record. (@ixdy)
 _acme-challenge.docs:


### PR DESCRIPTION
netlifyglobalcdn.com has a CAA record, and CAAs follow our CNAMEs to that record. That record is making us unable to use Let's Encrypt. We don't need an extra issuer domain, as netlify doesn't issue the certs directly.

This should hopefully fix all the cert issuance issues, as netlify.app doesn't have a CAA record.