### PR TITLE
node-feature-discovery: promote v0.11.1 images

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-nfd/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-nfd/images.yaml
@@ -17,6 +17,8 @@
     sha256:f2c37ba2d8375c0ce08aa07fc6267618a9841fee3f1f7de5f1626c9de2f13b62: [v0.10.1-minimal]
     sha256:19e319110e5cf935f191ba5d841a6c40b899a1951dbacf0d098cf83de92d6364: [v0.11.0]
     sha256:21b3ab11605d59290b7976e8175cfa65a0bee31e75146f1fe3e34aa3e3b72fa6: [v0.11.0-minimal]
+    sha256:28c54b2014d150e4fcfd318421a0ebe34a51bc03c1abe45d7095c6d4650a7f0b: [v0.11.1]
+    sha256:06e15a7dda9bab2ebd0df65e7966fc4b33c4435dcf7c7c91d4180285f4d2a730: [v0.11.1-minimal]
 - name: node-feature-discovery-operator
   dmap:
     sha256:36a9a2c9d40b08a72df2878fcb602a86c7cf5b71ee9a786bff67fb84b64dcd16: [v0.2.0]


### PR DESCRIPTION
```
$ skopeo inspect docker://gcr.io/k8s-staging-nfd/node-feature-discovery:v0.11.1 | grep Digest
    "Digest": "sha256:28c54b2014d150e4fcfd318421a0ebe34a51bc03c1abe45d7095c6d4650a7f0b",

$ skopeo inspect docker://gcr.io/k8s-staging-nfd/node-feature-discovery:v0.11.1-minimal | grep Digest
    "Digest": "sha256:06e15a7dda9bab2ebd0df65e7966fc4b33c4435dcf7c7c91d4180285f4d2a730",
```