### PR TITLE
Enable `iamcredentials.googleapis.com` API for staging projects

### DIFF
--- a/infra/gcp/bash/ensure-staging-storage.sh
+++ b/infra/gcp/bash/ensure-staging-storage.sh
@@ -75,6 +75,8 @@ readonly STAGING_PROJECT_SERVICES=(
     pubsub.googleapis.com
     # storage-api used by: cloudbuild, containerregistry
     storage-api.googleapis.com
+    # used by cloud build for keyless artifact signing
+    iamcredentials.googleapis.com
 )
 
 readonly STAGING_PROJECT_DISABLED_SERVICES=(


### PR DESCRIPTION
To be able to impersonate service accounts we require this API to
support keyless artifact signing via cosign in all projects.

cc @ameukam @puerco @kubernetes/release-engineering 