### PR TITLE
Revert tag move of kueue v0.1

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-kueue/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-kueue/images.yaml
@@ -1,4 +1,4 @@
 - name: kueue
   dmap:
-    "sha256:fde718661874ad8b0b82a97af3afc481bf0dfc4bcb362490ddf7dadcded9a47d": ["v0.1.1", "v0.1"]
-    "sha256:430bb4d26a05e4de56e3e10d8bc5ebb8de28f77d575d99a4cacc8edadcf7567b": ["v0.1.0"]
+    "sha256:fde718661874ad8b0b82a97af3afc481bf0dfc4bcb362490ddf7dadcded9a47d": ["v0.1.1"]
+    "sha256:430bb4d26a05e4de56e3e10d8bc5ebb8de28f77d575d99a4cacc8edadcf7567b": ["v0.1.0", "v0.1"]


### PR DESCRIPTION
It's not supported by the promotion bot.

https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-k8sio-image-promo/1536425226437398528

We should keep the old tag as some people might already be using it.

kubernetes-sigs/kueue#272