### PR TITLE
Upgrade nginx version

### DIFF
--- a/apps/k8s-io/deployment.yaml
+++ b/apps/k8s-io/deployment.yaml
@@ -34,11 +34,14 @@ spec:
           # Map all keys to files.
       containers:
       - name: nginx
-        image: nginx:1.10-alpine  # = :stable-alpine as of 8/23/2016
+        image: nginx:1.22-alpine  # = :stable-alpine as of 14/06/2022
         resources:
           limits:
             cpu: 1
             memory: 512Mi
+          requests:
+            cpu: 0.5
+            memory: 256Mi
         ports:
         - name: http
           containerPort: 80


### PR DESCRIPTION
Fixes: #3131

/cc @ameukam 

Looks like this is deployed manually. 

The change works:

```
 REDACTED  MCW0CDP3YY  ~  Desktop  Git  k8s.io   upgrade-nginx  $   curl 35.234.138.59 -I -H "Host: k8s.io"
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Tue, 14 Jun 2022 10:50:34 GMT
Content-Type: text/html
Content-Length: 162
Connection: keep-alive
Location: https://k8s.io/

 REDACTED  MCW0CDP3YY  ~  Desktop  Git  k8s.io   upgrade-nginx  $   curl 35.234.138.59 -I -H "Host: apt.k8s.io"
HTTP/1.1 302 Moved Temporarily
Server: nginx
Date: Tue, 14 Jun 2022 10:50:38 GMT
Content-Type: text/html
Content-Length: 138
Connection: keep-alive
Location: https://packages.cloud.google.com/apt/

 REDACTED  MCW0CDP3YY  ~  Desktop  Git  k8s.io   upgrade-nginx  $   curl 35.234.138.59 -I -H "Host: yt.k8s.io"
HTTP/1.1 302 Moved Temporarily
Server: nginx
Date: Tue, 14 Jun 2022 10:50:45 GMT
Content-Type: text/html
Content-Length: 138
Connection: keep-alive
Location: https://www.youtube.com/c/kubernetescommunity
```

Should we add this [sidecar](https://github.com/nginxinc/nginx-prometheus-exporter) to gather metrics? 