### PR TITLE
releng: temporary release manager access for ameukam

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -37,6 +37,7 @@ groups:
       ReconcileMembers: "true"
     members:
       - k8s-infra-release-admins@kubernetes.io
+      - ameukam@gmail.com
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
       - gveronicalg@gmail.com


### PR DESCRIPTION
Related:
  - https://github.com/kubernetes/sig-release/issues/1941

Requesting elevation privilegies to cut patches releases scheduled for
June 15, 2022.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>