### PR TITLE
oci-proxy: HCL code for production infrastructure

### DIFF
--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/cloud-armor.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/cloud-armor.tf
@@ -31,7 +31,7 @@ resource "google_compute_security_policy" "cloud-armor" {
         }
     }
 
-    preview = true
+    preview = false
   }
 
   rule {
@@ -43,7 +43,7 @@ resource "google_compute_security_policy" "cloud-armor" {
         }
     }
 
-    preview = true
+    preview = false
   }
 
     rule {
@@ -55,7 +55,7 @@ resource "google_compute_security_policy" "cloud-armor" {
         }
     }
 
-    preview = true
+    preview = false
   }
 
 
@@ -78,7 +78,7 @@ resource "google_compute_security_policy" "cloud-armor" {
         }
     }
 
-    preview = true
+    preview = false
   }
 
   rule {
@@ -90,7 +90,7 @@ resource "google_compute_security_policy" "cloud-armor" {
         }
     }
 
-    preview = true
+    preview = false
   }
 
   rule {
@@ -102,7 +102,7 @@ resource "google_compute_security_policy" "cloud-armor" {
         }
     }
 
-    preview = true
+    preview = false
   }
 
   rule {
@@ -114,7 +114,7 @@ resource "google_compute_security_policy" "cloud-armor" {
         }
     }
 
-    preview = true
+    preview = false
   }
 
   rule {
@@ -126,7 +126,7 @@ resource "google_compute_security_policy" "cloud-armor" {
         }
     }
 
-    preview = true
+    preview = false
   }
 
   rule {
@@ -138,7 +138,7 @@ resource "google_compute_security_policy" "cloud-armor" {
         }
     }
 
-    preview = true
+    preview = false
   }
 
   # Reject all traffic that hasn't been whitelisted.

--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/cloud-armor.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/cloud-armor.tf
@@ -1,0 +1,160 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+# This file contains the Cloud Armor policies
+
+resource "google_compute_security_policy" "cloud-armor" {
+     project = google_project.project.project_id
+     name = "security-policy-oci-proxy"
+
+
+  rule {
+    action   = "deny(403)"
+    priority = "910"
+    match {
+        expr {
+            expression = "evaluatePreconfiguredExpr('methodenforcement-stable')"
+        }
+    }
+
+    preview = true
+  }
+
+  rule {
+    action   = "deny(403)"
+    priority = "900"
+    match {
+        expr {
+            expression = "evaluatePreconfiguredExpr('protocolattack-stable')"
+        }
+    }
+
+    preview = true
+  }
+
+    rule {
+    action   = "deny(403)"
+    priority = "920"
+    match {
+        expr {
+            expression = "evaluatePreconfiguredExpr('scannerdetection-stable')"
+        }
+    }
+
+    preview = true
+  }
+
+
+  rule {
+    action   = "deny(403)"
+    priority = "990"
+    match {
+        expr {
+            expression = "evaluatePreconfiguredExpr('xss-stable')"
+        }
+    }
+  }
+
+  rule {
+    action   = "deny(403)"
+    priority = "970"
+    match {
+        expr {
+            expression = "evaluatePreconfiguredExpr('sqli-stable')"
+        }
+    }
+
+    preview = true
+  }
+
+  rule {
+    action   = "deny(403)"
+    priority = "960"
+    match {
+        expr {
+            expression = "evaluatePreconfiguredExpr('lfi-stable')"
+        }
+    }
+
+    preview = true
+  }
+
+  rule {
+    action   = "deny(403)"
+    priority = "930"
+    match {
+        expr {
+            expression = "evaluatePreconfiguredExpr('rce-stable')"
+        }
+    }
+
+    preview = true
+  }
+
+  rule {
+    action   = "deny(403)"
+    priority = "940"
+    match {
+        expr {
+            expression = "evaluatePreconfiguredExpr('rfi-stable')"
+        }
+    }
+
+    preview = true
+  }
+
+  rule {
+    action   = "deny(403)"
+    priority = "950"
+    match {
+        expr {
+            expression = "evaluatePreconfiguredExpr('sessionfixation-stable')"
+        }
+    }
+
+    preview = true
+  }
+
+  rule {
+    action   = "deny(403)"
+    priority = "980"
+    match {
+        expr {
+            expression = "evaluatePreconfiguredExpr('php-stable')"
+        }
+    }
+
+    preview = true
+  }
+
+  # Reject all traffic that hasn't been whitelisted.
+  rule {
+    action   = "allow"
+    description = "Default rule, higher priority overrides it"
+    priority = "2147483647"
+
+    match {
+      config {
+        src_ip_ranges = ["*"]
+      }
+      versioned_expr = "SRC_IPS_V1"
+    }
+
+    preview = false
+  }
+}
+

--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/network.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/network.tf
@@ -35,3 +35,79 @@ resource "google_compute_global_address" "default_ipv6" {
     google_project_service.project["compute.googleapis.com"],
   ]
 }
+
+data "google_compute_global_address" "default_ipv4" {
+  project = google_project.project.project_id
+  name    = "k8s-infra-oci-proxy-prod"
+}
+
+data "google_compute_global_address" "default_ipv6" {
+  project = google_project.project.project_id
+  name    = "k8s-infra-oci-proxy-prod-v6"
+}
+
+resource "google_compute_region_network_endpoint_group" "oci-proxy" {
+  for_each = google_cloud_run_service.oci-proxy
+
+  provider              = google-beta
+  project               = google_project.project.project_id
+  name                  = "${local.project_id}--${each.key}--neg"
+  network_endpoint_type = "SERVERLESS"
+  region                = google_cloud_run_service.oci-proxy[each.key].location
+  cloud_run {
+    service = google_cloud_run_service.oci-proxy[each.key].name
+  }
+}
+
+module "lb-http" {
+  source  = "GoogleCloudPlatform/lb-http/google//modules/serverless_negs"
+  version = "~> 6.2.0"
+
+  project = google_project.project.project_id
+  name    = local.project_id
+
+  # ...
+  backends = {
+    default = {
+      description = null
+      groups = [
+        for neg in google_compute_region_network_endpoint_group.oci-proxy :
+        {
+          group = neg.id
+        }
+      ]
+      enable_cdn              = true
+      security_policy         = null
+      custom_request_headers  = null
+      custom_response_headers = null
+
+      iap_config = {
+        enable               = false
+        oauth2_client_id     = ""
+        oauth2_client_secret = ""
+      }
+
+      log_config = {
+        enable      = true
+        sample_rate = "1.0"
+      }
+    }
+  }
+
+  create_address      = false
+  create_ipv6_address = false
+  enable_ipv6         = true
+  https_redirect      = true
+  #TODO(ameukam): current the TF resource google_compute_global_address don't have
+  #the value of IP in his attribute. But it's accessible with the data source:
+  #https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_global_address
+  address      = data.google_compute_global_address.default_ipv4.address
+  ipv6_address = data.google_compute_global_address.default_ipv6.address
+  managed_ssl_certificate_domains = [
+    local.domain
+  ]
+  random_certificate_suffix = true
+  ssl                       = true
+  use_ssl_certificates      = false
+  security_policy = google_compute_security_policy.cloud-armor.self_link
+}

--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/oci-proxy-prod.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/oci-proxy-prod.tf
@@ -88,7 +88,7 @@ resource "google_cloud_run_service" "oci-proxy" {
   template {
     metadata {
       annotations = {
-        "autoscaling.knative.dev/maxScale" = "3" // Control costs.
+        "autoscaling.knative.dev/maxScale" = "5" // Control costs.
         "run.googleapis.com/launch-stage"  = "BETA"
       }
     }
@@ -97,7 +97,7 @@ resource "google_cloud_run_service" "oci-proxy" {
       containers {
         image = local.image
       }
-      container_concurrency = 5 # TODO(ameukam): adjust for production.
+      container_concurrency = 10
       // 30 seconds less than cloud scheduler maximum.
       timeout_seconds = 570
     }

--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/prod.auto.tfvars
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/prod.auto.tfvars
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+tag = "v20220204-786ae98"

--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/variables.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/variables.tf
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+variable "tag" {
+  type    = string
+  default = "latest"
+}
+
+variable "cloud_run_regions" {
+  type = list(string)
+  default = [
+    # Tier 1 pricing: https://cloud.google.com/run/pricing#tables
+    "asia-east1",
+    "asia-northeast1",
+    "europe-north1",
+    "europe-west1",
+    "europe-west4",
+    "us-central1",
+    "us-east1",
+    "us-east4"
+  ]
+}


### PR DESCRIPTION
Related:
  - https://github.com/kubernetes-sigs/oci-proxy/issues/76

Part of:
 - https://github.com/kubernetes/k8s.io/issues/3411

Deploy oci-proxy in specific GCP regions for registry.k8s.io
This is already deployed.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>