### PR TITLE
Add staging service accounts to `roles/iam.serviceAccountTokenCreator`

### DIFF
--- a/infra/gcp/bash/ensure-staging-storage.sh
+++ b/infra/gcp/bash/ensure-staging-storage.sh
@@ -289,6 +289,25 @@ function ensure_staging_gcb() {
     ensure_project_role_binding "${project}" "${principal}" "roles/cloudbuild.builds.builder"
     ensure_gcs_role_binding "${bucket}" "${principal}" "objectCreator"
     ensure_gcs_role_binding "${bucket}" "${principal}" "objectViewer"
+
+    local sa_name="gcb-image-builder"
+    local sa_email="${sa_name}@${project}.iam.gserviceaccount.com"
+    local sa_principal="serviceAccount:${sa_email}"
+    color 6 "Ensuring ${sa_email} exists and can sign artifacts in project: ${project}"
+    ensure_service_account \
+      "${project}" \
+      "${sa_name}" \
+      "used by prow to build container images and sign artifacts for ${project}"
+
+    ensure_serviceaccount_role_binding \
+        "${sa_email}" \
+        "${sa_principal}" \
+        "roles/iam.serviceAccountTokenCreator"
+
+    ensure_project_role_binding \
+        "${project}" \
+        "${sa_principal}" \
+        "roles/cloudbuild.builds.editor"
 }
 
 # TODO(spiffxp): rename this to just prow@project and deprecate/rm the gcb-builder-foo


### PR DESCRIPTION
The idea is to use the GCB service account to be able to sign images in
staging and promote them later into production. This way we can use
cloudbuild.yaml to specify something like:

```
env:
  GOOGLE_SERVICE_ACCOUNT_NAME=448637284062@cloudbuild.gserviceaccount.com
```

We have to obtain the project ID since it is created randomly for each
staging project.

Refers to https://github.com/kubernetes-sigs/security-profiles-operator/pull/984
Should fix the permission issue mentioned in https://github.com/kubernetes-sigs/security-profiles-operator/pull/984#issuecomment-1154820860

/assign @puerco @ameukam 