### PR TITLE
add DNS for CAPI release-1.2 release branch

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -314,7 +314,7 @@ docs.prow:
 # https://github.com/kubernetes-sigs/cluster-api docs (@dwat, @jdetiber, @justinsb)
 cluster-api.sigs:
   type: CNAME
-  value: release-1-1--kubernetes-sigs-cluster-api.netlify.app.
+  value: release-1-2--kubernetes-sigs-cluster-api.netlify.app.
 # https://github.com/kubernetes-sigs/cluster-api-provider-aws docs (@randomvariable, @detiber, @ncdc, @rudoi, @vincepri)
 cluster-api-aws.sigs:
   type: CNAME
@@ -355,6 +355,9 @@ release-1-0.cluster-api.sigs:
 release-1-1.cluster-api.sigs:
   type: CNAME
   value: release-1-1--kubernetes-sigs-cluster-api.netlify.app.
+release-1-2.cluster-api.sigs:
+  type: CNAME
+  value: release-1-2--kubernetes-sigs-cluster-api.netlify.app.
 # https://github.com/kubernetes-sigs/cluster-api development docs (@CecileRobertMichon, @vincepri)
 main.cluster-api.sigs:
   type: CNAME


### PR DESCRIPTION
DNS updates for Cluster API release-1.2 branch.

Part of: https://github.com/kubernetes-sigs/cluster-api/issues/6615