### PR TITLE
releng: revoke ameukam access

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -37,7 +37,6 @@ groups:
       ReconcileMembers: "true"
     members:
       - k8s-infra-release-admins@kubernetes.io
-      - ameukam@gmail.com
       - adolfo.garcia@uservers.net
       - ctadeu@gmail.com
       - gveronicalg@gmail.com


### PR DESCRIPTION
Related: 
  - https://github.com/kubernetes/sig-release/issues/1941

patch releases are done. revoking access allowed in https://github.com/kubernetes/k8s.io/pull/3841

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>