### PR TITLE
Adds rob@ii.coop to k8s-infra-ii-coop

### DIFF
--- a/groups/sig-k8s-infra/groups.yaml
+++ b/groups/sig-k8s-infra/groups.yaml
@@ -134,6 +134,7 @@ groups:
       - caleb@ii.coop
       - hh@ii.coop
       - riaan@ii.coop
+      - rob@ii.coop
       - stephen@ii.coop
       - zz@ii.coop
 


### PR DESCRIPTION
Adds me to k8s-infra-ii-coop for ii using my rob@ii.coop email addr

/assign @ameukam @thockin

cc @BobyMCbobs @Riaankl @hh