### PR TITLE
Move Sippy to OpenShift hosted cluster

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -275,9 +275,10 @@ sbom:
 sigs:
   type: CNAME
   value: redirect.k8s.io.
+# Sippy hosted by OpenShift folks (@dgoodwin, @stbenjam, @deads2k)
 sippy:
-  type: A
-  value: 35.244.255.27
+  type: CNAME
+  value: default.apps.cr.j7t7.p1.openshiftapps.com.
 slack:
   type: A
   value: 34.107.195.71


### PR DESCRIPTION
We'd like to host the kube sippy near the OpenShift one
as they share a database instance.  The existing sippy
hosted on k8s.io can be removed, it's currently broken anyway.

The new one is at https://kube-sippy.dptools.openshift.org/sippy-ng/,
this change updates the DNS for sippy.k8s.io to point there as well.
