### PR TITLE
releng: temporary release manager access for jeremyrickard to cut alpha2

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -41,6 +41,7 @@ groups:
       - ctadeu@gmail.com
       - gveronicalg@gmail.com
       - jameswangel@gmail.com
+      - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
       - pal.nabarun95@gmail.com


### PR DESCRIPTION
Related:

https://github.com/kubernetes/sig-release/issues/1951

Requesting permissions to cut alpha release scheduled for June 28, 2022.

Signed-off-by: Jeremy Rickard <jeremyrrickard@gmail.com>