### PR TITLE
Adding stating repo for k8s-staging-testgrid-json-exporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # Verify scripts may leave programs in this directory
 /bin
 /tmp
+
+# Ignore vscode config files
+.vscode

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -140,6 +140,7 @@ restrictions:
       - "^k8s-infra-staging-releng-test@kubernetes.io$"
       - "^k8s-infra-staging-publishing-bot@kubernetes.io$"
       - "^k8s-infra-staging-bom@kubernetes.io$"
+      - "^k8s-infra-staging-testgrid-json-exporter@kubernetes.io$"
       - "^release-comms@kubernetes.io$"
       - "^release-managers-private@kubernetes.io$"
       - "^release-managers@kubernetes.io$"

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -457,3 +457,15 @@ groups:
       ReconcileMembers: "true"
     members:
       - k8s-infra-release-editors@kubernetes.io
+
+  - email-id: k8s-infra-staging-testgrid-json-exporter@kubernetes.io
+    name: k8s-infra-testgrid-json-exporter
+    description: |-
+      ACL for CI Signal Release Team
+    settings:
+      ReconcileMembers: "true"
+      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW"
+    members:
+      - k8s-infra-release-viewers@kubernetes.io
+      - leonard.pahlke@googlemail.com
+      - salahi.hossein@gmail.com

--- a/infra/gcp/infra.yaml
+++ b/infra/gcp/infra.yaml
@@ -331,4 +331,5 @@ infra:
       k8s-staging-sp-operator:
       k8s-staging-storage-migrator:
       k8s-staging-test-infra:
+      k8s-staging-testgrid-json-exporter:
       k8s-staging-gmsa-webhook:

--- a/k8s.gcr.io/images/k8s-staging-testgrid-json-exporter/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-testgrid-json-exporter/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+options:
+  no_parent_owners: true
+approvers:
+  - release-engineering-approvers
+reviewers:
+  - release-engineering-reviewers
+
+labels:
+  - sig/release
+  - area/release-eng

--- a/k8s.gcr.io/images/k8s-staging-testgrid-json-exporter/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-testgrid-json-exporter/images.yaml
@@ -1,0 +1,1 @@
+# No images yet

--- a/k8s.gcr.io/manifests/k8s-staging-testgrid-json-exporter/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-testgrid-json-exporter/promoter-manifest.yaml
@@ -1,0 +1,10 @@
+# google group for gcr.io/k8s-staging-testgrid-json-exporter is k8s-staging-testgrid-json-exporter@kubernetes.io
+registries:
+- name: gcr.io/k8s-staging-testgrid-json-exporter
+  src: true
+- name: us.gcr.io/k8s-artifacts-prod/testgrid-json-exporter
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: eu.gcr.io/k8s-artifacts-prod/testgrid-json-exporter
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: asia.gcr.io/k8s-artifacts-prod/testgrid-json-exporter
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
Signed-off-by: leonardpahlke <leonard.pahlke@googlemail.com>

We migrated the [testgrid-json-exporter](https://github.com/kubernetes-sigs/testgrid-json-exporter) repo and would like a GCR staging repo to host container images.

Ref: https://github.com/kubernetes-sigs/testgrid-json-exporter/issues/1

/cc @saschagrunert 