### PR TITLE
releng: revoke jeremyrickard access

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -41,7 +41,6 @@ groups:
       - ctadeu@gmail.com
       - gveronicalg@gmail.com
       - jameswangel@gmail.com
-      - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
       - pal.nabarun95@gmail.com


### PR DESCRIPTION
Revoking my access now that v1.25.0-alpha.2 is released 


Ref: https://github.com/kubernetes/sig-release/issues/1951
Ref: https://github.com/kubernetes/sig-release/issues/1953 

Signed-off-by: Jeremy Rickard <jeremyrrickard@gmail.com>

/assign @cpanato @Verolop
/cc @kubernetes/release-engineering 
