### PR TITLE
added new base-nginx-image

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -83,6 +83,7 @@
     "sha256:18f91105e4099941d2efee71a8ec52c6ef7702d5f7e8214b7cb5f25cc10a0b41": ["cd6f88af3f976a180ed966dadf273473ae768dfa"]
     "sha256:03e983f8adb9fdb56bc0b258c9d17e24a183c0728111102b21a31756b5031209": ["ac3bbaf068d099e438444fbfa1b3bd1c31a6a183"]
     "sha256:15f91034a03550dfab6ec50a7be4abbb683d087e234ad7fef5adedef54e46a5a": ["0ff500c23f34e939305de709cb6d47da34b66611"]
+    "sha256:283c8c6132ebaeb155c927ea6e8ae0cd834a4a05d4807eceafa1b6e44d875911": ["e1a16f6e74ef43cdfd59de75b3394d6b20ef7645"]
 
 # image to run tests
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/test-runner


### PR DESCRIPTION
- This PR promotes the new nginx base-image that is built on alpine v3.16.0, to provide security updates