### PR TITLE
releng: Add Joseph to groups for RMA access

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -59,6 +59,7 @@ groups:
       - ameukam@gmail.com
       - jameswangel@gmail.com
       - jeremy.r.rickard@gmail.com
+      - joseph.r.sandoval@gmail.com
       - max@koerbaecher.io
       - onlydole@gmail.com
       - pal.nabarun95@gmail.com
@@ -262,6 +263,7 @@ groups:
       - gmccloskey@google.com
       - gveronicalg@gmail.com
       - jameswangel@gmail.com
+      - joseph.r.sandoval@gmail.com
       - kikis.github@gmail.com
       - max@koerbaecher.io
       - mudrinic.mare@gmail.com


### PR DESCRIPTION
This PR adds @jrsapi  to associated groups as part of RMA onboarding

* Adds Joseph to `release-managers@` and `k8s-infra-release-viewers@`
* The issue refs Jeremy but he was already in the groups for his other hat

Ref: https://github.com/kubernetes/sig-release/issues/1965

/cc @Verolop 

Signed-off-by: Jeremy Rickard <jeremyrrickard@gmail.com>