### PR TITLE
Image promotion for distroless-iptables

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
@@ -376,6 +376,24 @@
     "sha256:be4039f250f26e1321d048e4dd6e81b78a80825c2dd490bacc0ac80ebb94bbc5": ["v12.1.1"]
     "sha256:d58529c7dc4a16cbedcd94d36f77374ebed51191187b6c4cd9e3eae4b49fb454": ["bullseye-v1.1.0"]
     "sha256:e0f13d8b21914d36a52857b8c195eb6e12e5b483423b31300dfb1b5e835e5cf6": ["bullseye-v1.2.0"]
+- name: distroless-iptables
+  dmap:
+    "sha256:691c591a093063b119abc4753ab792b61271c66f2dbbc7d5219f914197274cc2": ["v0.1.0"]
+- name: distroless-iptables-amd64
+  dmap:
+    "sha256:84df7efde3108f76ba88794298e22783f60966f1b3cdfeb103adfe8a8c411519": ["v0.1.0"]
+- name: distroless-iptables-arm
+  dmap:
+    "sha256:37804cb0ec70a91ee68525b8480639ff8ceb3d2a607dac4779e47cee61e8aa58": ["v0.1.0"]
+- name: distroless-iptables-arm64
+  dmap:
+    "sha256:b1a49801b2ad89abadd03e6290079ab47235ea0c0879623fd46be56a69127967": ["v0.1.0"]
+- name: distroless-iptables-ppc64le
+  dmap:
+    "sha256:6600eb78b00d4bea7ae211bd1117babd71f515fc82a3f700a878e192fe72446f": ["v0.1.0"]
+- name: distroless-iptables-s390x
+  dmap:
+    "sha256:c23fa8e118efeab3076df9142b3eca3d7cace33d8f7d4ac91765309e717fba5f": ["v0.1.0"]
 - name: go-runner
   dmap:
     "sha256:004c18fbd8ca3fd431d60654edd0c19eed7e805385afac40d2b5b6b45cbd9e8e": ["v2.3.1-go1.16-buster.0"]


### PR DESCRIPTION
Signed-off-by: Sascha Grunert <sgrunert@redhat.com>

Creating on behalf of Sascha, sig-network is willing to promote distroless-iptables image for further testing