### PR TITLE
Add registry-k8s-io sync scripts

### DIFF
--- a/registry.k8s.io/hack/initial-copy-between-s3.sh
+++ b/registry.k8s.io/hack/initial-copy-between-s3.sh
@@ -30,12 +30,14 @@ REGIONS=(
 
 SOURCE=s3:prod-registry-k8s-io-us-east-2
 
+CALLER_ID="$(aws sts get-caller-identity --output json | jq -r .UserId)"
+
 for REGION in "${REGIONS[@]}"; do
     DESTINATION="s3dest:prod-registry-k8s-io-${REGION:-}"
     unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
     JSON=$(aws sts assume-role \
         --role-arn "arn:aws:iam::513428760722:role/registry.k8s.io_s3writer"  \
-        --role-session-name registry.k8s.io_s3writer \
+        --role-session-name "${CALLER_ID:-}-registry.k8s.io_s3writer" \
         --duration-seconds 43200 \
         --output json || exit 1)
 

--- a/registry.k8s.io/hack/initial-copy-between-s3.sh
+++ b/registry.k8s.io/hack/initial-copy-between-s3.sh
@@ -41,10 +41,10 @@ for REGION in "${REGIONS[@]}"; do
         --duration-seconds 43200 \
         --output json || exit 1)
 
-    export \
-        AWS_ACCESS_KEY_ID=$(echo "${JSON}" | jq --raw-output ".Credentials[\"AccessKeyId\"]") \
-        AWS_SECRET_ACCESS_KEY=$(echo "${JSON}" | jq --raw-output ".Credentials[\"SecretAccessKey\"]") \
-        AWS_SESSION_TOKEN=$(echo "${JSON}" | jq --raw-output ".Credentials[\"SessionToken\"]")
+    AWS_ACCESS_KEY_ID=$(echo "${JSON}" | jq --raw-output ".Credentials[\"AccessKeyId\"]")
+    AWS_SECRET_ACCESS_KEY=$(echo "${JSON}" | jq --raw-output ".Credentials[\"SecretAccessKey\"]")
+    AWS_SESSION_TOKEN=$(echo "${JSON}" | jq --raw-output ".Credentials[\"SessionToken\"]")
+    export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
 
     RCLONE_CONFIG="$(mktemp -t rclone-"${REGION:-}"-XXXXX.conf)"
     echo "Wrote rclone config to '${RCLONE_CONFIG:-}'"
@@ -71,5 +71,5 @@ session_token = $AWS_SESSION_TOKEN
 region = ${REGION}
 EOF
     echo "Running sync between '${SOURCE:-}' and '${DESTINATION:-}'"
-    tmate -F -v -S $TMATE_SOCKET new-window -d -c "$PWD" -n sync-to-"${REGION:-}" "rclone sync --config \"${RCLONE_CONFIG:-}\" -P \"${SOURCE:-}\" \"${DESTINATION:-}\""
+    tmate -F -v -S "$TMATE_SOCKET" new-window -d -c "$PWD" -n sync-to-"${REGION:-}" "rclone sync --config \"${RCLONE_CONFIG:-}\" -P \"${SOURCE:-}\" \"${DESTINATION:-}\""
 done

--- a/registry.k8s.io/hack/initial-copy-between-s3.sh
+++ b/registry.k8s.io/hack/initial-copy-between-s3.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+REGIONS=(
+    ap-northeast-1
+    ap-south-1
+    ap-southeast-1
+
+    eu-central-1
+    eu-west-1
+
+    us-east-1
+    us-east-2
+    us-west-1
+    us-west-2
+)
+
+SOURCE=s3:prod-registry-k8s-io-us-east-2
+
+for REGION in "${REGIONS[@]}"; do
+    DESTINATION="s3dest:prod-registry-k8s-io-${REGION:-}"
+    unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+    JSON=$(aws sts assume-role \
+        --role-arn "arn:aws:iam::513428760722:role/registry.k8s.io_s3writer"  \
+        --role-session-name registry.k8s.io_s3writer \
+        --duration-seconds 43200 \
+        --output json || exit 1)
+
+    export \
+        AWS_ACCESS_KEY_ID=$(echo "${JSON}" | jq --raw-output ".Credentials[\"AccessKeyId\"]") \
+        AWS_SECRET_ACCESS_KEY=$(echo "${JSON}" | jq --raw-output ".Credentials[\"SecretAccessKey\"]") \
+        AWS_SESSION_TOKEN=$(echo "${JSON}" | jq --raw-output ".Credentials[\"SessionToken\"]")
+
+    RCLONE_CONFIG="$(mktemp -t rclone-"${REGION:-}"-XXXXX.conf)"
+    echo "Wrote rclone config to '${RCLONE_CONFIG:-}'"
+
+    cat << EOF > "${RCLONE_CONFIG:-}"
+[gcs]
+type = google cloud storage
+bucket_acl = private
+
+[s3]
+type = s3
+provider = AWS
+access_key_id = $AWS_ACCESS_KEY_ID
+secret_access_key = $AWS_SECRET_ACCESS_KEY
+session_token = $AWS_SESSION_TOKEN
+region = us-east-2
+
+[s3dest]
+type = s3
+provider = AWS
+access_key_id = $AWS_ACCESS_KEY_ID
+secret_access_key = $AWS_SECRET_ACCESS_KEY
+session_token = $AWS_SESSION_TOKEN
+region = ${REGION}
+EOF
+    echo "Running sync between '${SOURCE:-}' and '${DESTINATION:-}'"
+    tmate -F -v -S $TMATE_SOCKET new-window -d -c "$PWD" -n sync-to-"${REGION:-}" "rclone sync --config \"${RCLONE_CONFIG:-}\" -P \"${SOURCE:-}\" \"${DESTINATION:-}\""
+done

--- a/registry.k8s.io/hack/initial-copy-between-s3.sh
+++ b/registry.k8s.io/hack/initial-copy-between-s3.sh
@@ -14,8 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Requirements
+# Dependencies
 # - tmate :: the script must be run inside of an existing tmate session
+# - rclone
+# - awscli
 
 REGIONS=(
     ap-northeast-1

--- a/registry.k8s.io/hack/initial-copy-between-s3.sh
+++ b/registry.k8s.io/hack/initial-copy-between-s3.sh
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Requirements
+# - tmate :: the script must be run inside of an existing tmate session
+
 REGIONS=(
     ap-northeast-1
     ap-south-1
@@ -71,5 +74,5 @@ session_token = $AWS_SESSION_TOKEN
 region = ${REGION}
 EOF
     echo "Running sync between '${SOURCE:-}' and '${DESTINATION:-}'"
-    tmate -F -v -S "$TMATE_SOCKET" new-window -d -c "$PWD" -n sync-to-"${REGION:-}" "rclone sync --config \"${RCLONE_CONFIG:-}\" -P \"${SOURCE:-}\" \"${DESTINATION:-}\""
+    tmate -F -v -S "${TMATE_SOCKET:-/tmp/tmate.socket}" new-window -d -c "$PWD" -n sync-to-"${REGION:-}" "rclone sync --config \"${RCLONE_CONFIG:-}\" -P \"${SOURCE:-}\" \"${DESTINATION:-}\""
 done

--- a/registry.k8s.io/hack/initial-copy-to-s3.sh
+++ b/registry.k8s.io/hack/initial-copy-to-s3.sh
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Dependencies
+# - rclone
+# - awscli
+
 SOURCE=gcs:us.artifacts.k8s-artifacts-prod.appspot.com
 DESTINATION=s3:prod-registry-k8s-io-us-east-2
 

--- a/registry.k8s.io/hack/initial-copy-to-s3.sh
+++ b/registry.k8s.io/hack/initial-copy-to-s3.sh
@@ -27,10 +27,10 @@ while true; do
     --duration-seconds 43200 \
     --output json || exit 1)
 
-  export \
-    AWS_ACCESS_KEY_ID=$(echo "${JSON}" | jq --raw-output ".Credentials[\"AccessKeyId\"]") \
-    AWS_SECRET_ACCESS_KEY=$(echo "${JSON}" | jq --raw-output ".Credentials[\"SecretAccessKey\"]") \
-    AWS_SESSION_TOKEN=$(echo "${JSON}" | jq --raw-output ".Credentials[\"SessionToken\"]")
+  AWS_ACCESS_KEY_ID=$(echo "${JSON}" | jq --raw-output ".Credentials[\"AccessKeyId\"]")
+  AWS_SECRET_ACCESS_KEY=$(echo "${JSON}" | jq --raw-output ".Credentials[\"SecretAccessKey\"]")
+  AWS_SESSION_TOKEN=$(echo "${JSON}" | jq --raw-output ".Credentials[\"SessionToken\"]")
+  export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
 
   RCLONE_CONFIG="$(mktemp)"
   echo "Wrote rclone config to '${RCLONE_CONFIG:-}'"
@@ -49,8 +49,7 @@ session_token = $AWS_SESSION_TOKEN
 region = us-east-2
 EOF
   echo "Running sync between '${SOURCE:-}' and '${DESTINATION:-}'"
-  rclone sync --config "${RCLONE_CONFIG:-}" -P "${SOURCE:-}" "${DESTINATION:-}"
-  if [ $? -eq 0 ]; then
+  if rclone sync --config "${RCLONE_CONFIG:-}" -P "${SOURCE:-}" "${DESTINATION:-}"; then
     exit 0;
   fi
 done

--- a/registry.k8s.io/hack/initial-copy-to-s3.sh
+++ b/registry.k8s.io/hack/initial-copy-to-s3.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SOURCE=gcs:us.artifacts.k8s-artifacts-prod.appspot.com
+DESTINATION=s3:prod-registry-k8s-io-us-east-2
+
+while true; do
+  unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+  JSON=$(aws sts assume-role \
+    --role-arn "arn:aws:iam::513428760722:role/registry.k8s.io_s3writer"  \
+    --role-session-name registry.k8s.io_s3writer \
+    --duration-seconds 43200 \
+    --output json || exit 1)
+
+  export \
+    AWS_ACCESS_KEY_ID=$(echo "${JSON}" | jq --raw-output ".Credentials[\"AccessKeyId\"]") \
+    AWS_SECRET_ACCESS_KEY=$(echo "${JSON}" | jq --raw-output ".Credentials[\"SecretAccessKey\"]") \
+    AWS_SESSION_TOKEN=$(echo "${JSON}" | jq --raw-output ".Credentials[\"SessionToken\"]")
+
+  RCLONE_CONFIG="$(mktemp)"
+  echo "Wrote rclone config to '${RCLONE_CONFIG:-}'"
+
+  cat << EOF > "${RCLONE_CONFIG:-}"
+[gcs]
+type = google cloud storage
+bucket_acl = private
+
+[s3]
+type = s3
+provider = AWS
+access_key_id = $AWS_ACCESS_KEY_ID
+secret_access_key = $AWS_SECRET_ACCESS_KEY
+session_token = $AWS_SESSION_TOKEN
+region = us-east-2
+EOF
+  echo "Running sync between '${SOURCE:-}' and '${DESTINATION:-}'"
+  rclone sync --config "${RCLONE_CONFIG:-}" -P "${SOURCE:-}" "${DESTINATION:-}"
+  if [ $? -eq 0 ]; then
+    exit 0;
+  fi
+done

--- a/registry.k8s.io/hack/initial-copy-to-s3.sh
+++ b/registry.k8s.io/hack/initial-copy-to-s3.sh
@@ -17,11 +17,13 @@
 SOURCE=gcs:us.artifacts.k8s-artifacts-prod.appspot.com
 DESTINATION=s3:prod-registry-k8s-io-us-east-2
 
+CALLER_ID="$(aws sts get-caller-identity --output json | jq -r .UserId)"
+
 while true; do
   unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
   JSON=$(aws sts assume-role \
     --role-arn "arn:aws:iam::513428760722:role/registry.k8s.io_s3writer"  \
-    --role-session-name registry.k8s.io_s3writer \
+    --role-session-name "${CALLER_ID:-}-registry.k8s.io_s3writer" \
     --duration-seconds 43200 \
     --output json || exit 1)
 


### PR DESCRIPTION
These are the scripts that I have built and optimized for manual syncing k8s.gcr.io GCS bucket and the registry.k8s.io S3 buckets

- `initial-copy-to-s3.sh` copies from GCS to S3 (_us-east-2_)
- `initial-copy-between-s3.sh` copies from _us-east-2_ to the other buckets and uses tmate to run in parallel

The scripts are intended to be run by any IAM user with ability to assume the _registry.k8s.io_s3writer_ role in the _registry.k8s.io_ account, such as the _registry.k8s.io-ci_ user in the _k8s-infra-accounts_ account.