### PR TITLE
promote the right distroless-iptables image

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-build-image/images.yaml
@@ -379,7 +379,7 @@
 - name: distroless-iptables
   dmap:
     "sha256:691c591a093063b119abc4753ab792b61271c66f2dbbc7d5219f914197274cc2": ["v0.1.0"]
-    "sha256:d4c453320b028cc1b01071d2ee5d8cd3810b46b5b29882bde45fd26ddefdd886": ["v0.1.1"]
+    "sha256:38e6b091d238094f081efad3e2b362e6480b2156f5f4fba6ea46835ecdcd47e2": ["v0.1.1"]
 - name: go-runner
   dmap:
     "sha256:38e0ab8d72c2c35e8228291051d007ec9ccc81cca2529b306605f870b1d3c630": ["buster-v1.0.0"]


### PR DESCRIPTION
This time use the right hash for the image from the right registry

```
manifest-tool inspect --raw gcr.io/k8s-staging-build-image/distroless-iptables:v0.1.1 | jq '.[0].Digest'
"sha256:38e6b091d238094f081efad3e2b362e6480b2156f5f4fba6ea46835ecdcd47e2"
```
