### PR TITLE
kubernetes-public: add bucket k8s-cve-feed

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-serviceaccounts.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-serviceaccounts.yaml
@@ -22,6 +22,14 @@ kind: ServiceAccount
 apiVersion: v1
 metadata:
   annotations:
+    iam.gke.io/gcp-service-account: k8s-cve-feed@k8s-infra-prow-build-trusted.iam.gserviceaccount.com
+  name: k8s-cve-feed
+  namespace: test-pods
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
     iam.gke.io/gcp-service-account: k8s-metrics@k8s-infra-prow-build-trusted.iam.gserviceaccount.com
   name: k8s-metrics
   namespace: test-pods

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/serviceaccounts.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/serviceaccounts.tf
@@ -38,6 +38,9 @@ locals {
     }
     // also assigned roles by:
     // - terraform/kubernetes-public
+    k8s-cve-feed = {
+      description = "write to gs://k8s-cve-feed"
+    }
     k8s-keps = {
       description   = "write to gs://k8s-keps"
     }

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/versions.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/versions.tf
@@ -20,5 +20,5 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 1.0.0"
+  required_version = "~> 1.1.0"
 }

--- a/infra/gcp/terraform/kubernetes-public/00-inputs.tf
+++ b/infra/gcp/terraform/kubernetes-public/00-inputs.tf
@@ -27,7 +27,7 @@ locals {
 }
 
 terraform {
-  required_version = "~> 1.0.0"
+  required_version = "~> 1.1.0"
 
   backend "gcs" {
     bucket = "k8s-infra-tf-public-clusters"
@@ -36,10 +36,10 @@ terraform {
 
   required_providers {
     google = {
-      version = "~> 3.90.1"
+      version = "~> 4.16.0"
     }
     google-beta = {
-      version = "~> 3.90.1"
+      version = "~> 4.16.0"
     }
   }
 }

--- a/infra/gcp/terraform/kubernetes-public/k8s-cve-feed.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-cve-feed.tf
@@ -1,0 +1,97 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This file defines:
+- GCS bucket to serve K8s cve feed
+- IAM bindings
+*/
+
+locals {
+  cve_feed_bucket_owners = "security-tooling-private@kubernetes.io"
+}
+
+// Use a data source for the service account
+data "google_service_account" "k8s_cve_feed_sa" {
+  account_id = "k8s-cve-feed@k8s-infra-prow-build-trusted.iam.gserviceaccount.com"
+}
+
+// Create a GCS bucket for CVE feed
+resource "google_storage_bucket" "cve_feed_bucket" {
+  name                        = "k8s-cve-feed"
+  project                     = data.google_project.project.project_id
+  location                    = "US"
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+}
+
+data "google_iam_policy" "cve_feed_bucket_iam_bindings" {
+  // Ensure prow owners have admin privileges, and keep existing
+  // legacy bindings since we're overwriting all existing bindings below
+  binding {
+    members = [
+      "group:${local.prow_owners}",
+      "group:${local.cve_feed_bucket_owners}",
+    ]
+    role = "roles/storage.admin"
+  }
+  // Preserve legacy storage bindings, give storage.admin members legacy bucket owner
+  binding {
+    members = [
+      "group:${local.prow_owners}",
+      "group:${local.cve_feed_bucket_owners}",
+      "projectEditor:${data.google_project.project.project_id}",
+      "projectOwner:${data.google_project.project.project_id}",
+    ]
+    role = "roles/storage.legacyBucketOwner"
+  }
+  // Ensure k8s-cve-feed service account have write access to the bucket
+  binding {
+    members = [
+      "serviceAccount:${data.google_service_account.k8s_cve_feed_sa.email}",
+    ]
+    role = "roles/storage.legacyBucketWriter"
+  }
+  // Preserve legacy storage bindings
+  binding {
+    members = [
+      "projectViewer:${data.google_project.project.project_id}",
+    ]
+    role = "roles/storage.legacyBucketReader"
+  }
+  // Ensure k8s-cve-feed service account have write/update/delete access to objects
+  binding {
+    role = "roles/storage.objectAdmin"
+    members = [
+      "group:${local.prow_owners}",
+      "group:${local.cve_feed_bucket_owners}",
+      "serviceAccount:${data.google_service_account.k8s_cve_feed_sa.email}",
+    ]
+  }
+  // Ensure bucket contents are world readable
+  binding {
+    role = "roles/storage.objectViewer"
+    members = [
+      "allUsers"
+    ]
+  }
+}
+
+// Authoritative iam-policy: replaces any existing policy attached to the bucket
+resource "google_storage_bucket_iam_policy" "cve_feed_bucket_iam_policy" {
+  bucket      = google_storage_bucket.cve_feed_bucket.name
+  policy_data = data.google_iam_policy.cve_feed_bucket_iam_bindings.policy_data
+}


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/k8s.io/issues/3494

Add a world-readable bucket for official k8s CVE list along a service   
account.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>