### PR TITLE
Create a new sig-scheduling-leads group

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -161,6 +161,7 @@ restrictions:
       - "^k8s-infra-staging-scheduler-plugins@kubernetes.io$"
       - "^k8s-infra-staging-sched-simulator@kubernetes.io$"
       - "^k8s-infra-staging-kueue@kubernetes.io$"
+      - "^sig-scheduling-leads@kubernetes.io$"
   - path: "sig-security/groups.yaml"
     allowedGroups:
       - "^security-tooling-private@kubernetes.io$"

--- a/groups/sig-scheduling/groups.yaml
+++ b/groups/sig-scheduling/groups.yaml
@@ -18,6 +18,22 @@ groups:
   # Membership should correspond roughly to subproject owners for the set of
   # subproject artifacts being stored in a given staging project
   #
+  - email-id: sig-scheduling-leads@kubernetes.io
+    name: sig-scheduling-leads
+    description: |-
+      SIG Scheduling Leads - private discussion and shared account credentials (e.g. zoom)
+
+      Anyone can e-mail, but only members can view/post messages via the website
+    settings:
+      AllowWebPosting: "true"
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+    members:
+      - acondor@google.com
+      - ahg@google.com
+      - hweicdl@gmail.com
+
   - email-id: k8s-infra-staging-kueue@kubernetes.io
     name: k8s-infra-staging-kueue
     description: |-


### PR DESCRIPTION
There was an old sig-scheduling-leads mailing list named "kubernetes-sig-scheduling-leads@googlegroups.com", which was stale and none of the current scheduling leads had access.

This PR creates a new leads group for sig-scheduling for better communication and sharing private info (like zoom account) among leads.

cc @ahg-g @alculquicondor 