### PR TITLE
chore: promote ingress-nginx test-runner

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -116,6 +116,7 @@
     "sha256:4468eb8cc9aa0ec3971ddf3811efe363e6f8e9082e95b567a5c27d91f89fb1e3": ["v20220416-controller-v1.2.0-beta.0-4-g2e1a4790b"]
     "sha256:4fbcbeebd4c24587699b027ad0f0aa7cd9d76b58177a3b50c228bae8141bcf95": ["v20220524-g8963ed17e"]
     "sha256:2a34e322b7ff89abdfa0b6202f903bf5618578b699ff609a3ddabac0aae239c8": ["v20220624-g3348cd71e"]
+    "sha256:0a199f7b8d4e84026b08c989d9058f3c9b7936af4e2487a6be1ff9077b684d0c": ["v20220726-controller-v1.3.0-29-gfe116d62c"]
 
 # custom cfssl image for e2e tests
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/cfssl


### PR DESCRIPTION
bump ginkgo to v2