### PR TITLE
promote baseimage built by pr 8870

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -88,6 +88,7 @@
     "sha256:283c8c6132ebaeb155c927ea6e8ae0cd834a4a05d4807eceafa1b6e44d875911": ["e1a16f6e74ef43cdfd59de75b3394d6b20ef7645"]
     "sha256:b555a13dcc9165157a61b2279ed7f309e406c3267c93472cb6967215eacf4ab3": ["18ee046b432502aedfed9321f0a9b50bfc009a67"]
     "sha256:94ff9b435a5f3f4570bbdaed4a3a523f63a54ce2ad6b132b5640bae2af5d9d90": ["c5766dc011965f22fac2f4437e86d0fd9960a50c"]
+    "sha256:f0d8d32a20f8c1a7c98b504a03b162931d93edd60ecc2c745917a32e9e3e92ad": ["f0490cbfbf29a7a05caaac29998dde56173ac2bb"]
 
 # image to run tests
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/test-runner


### PR DESCRIPTION
- This PR promotes the base-image built because of https://github.com/kubernetes/ingress-nginx/pull/8870

/assign @tao12345666333 @rikatz @strongjz 