### PR TITLE
infra/gcp: add a secret for AWS credentials

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-externalsecrets.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-externalsecrets.yaml
@@ -130,3 +130,16 @@ spec:
   - key: capdo-quayio-registry-secret
     name: config.json
     version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: registry-k8s-io-s3-writer
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-infra-prow-build-trusted
+  data:
+  - key: registry-k8s-io-s3-writer
+    name: credentials
+    version: latest

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/secrets.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/secrets.tf
@@ -36,6 +36,10 @@ locals {
       group  = "sig-contributor-experience"
       owners = "github@kubernetes.io"
     }
+    registry-k8s-io-s3-writer = {
+      group  = "sig-release"
+      owners = "k8s-infra-release-admins@kubernetes.io"
+    }
     service-account = {
       group  = "sig-testing"
       owners = "k8s-infra-prow-oncall@kubernetes.io"


### PR DESCRIPTION
Add a GCP secret that will be used to store credentials used for
synchronisation between GCS buckets and AWS S3 buckets. the current
secret has fake values.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>