### PR TITLE
oci-proxy: disable CDN for the sandbox environment

### DIFF
--- a/infra/gcp/terraform/k8s-infra-oci-proxy/network.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy/network.tf
@@ -59,7 +59,7 @@ module "lb-http" {
           group = neg.id
         }
       ]
-      enable_cdn              = true
+      enable_cdn              = false
       security_policy         = null
       custom_request_headers  = null
       custom_response_headers = null

--- a/infra/gcp/terraform/k8s-infra-oci-proxy/oci-proxy-sandbox.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy/oci-proxy-sandbox.tf
@@ -131,7 +131,7 @@ resource "google_cloud_run_service" "regions" {
       containers {
         image = local.image
       }
-      container_concurrency = 5 # TODO(ameukam): adjust for production.
+      container_concurrency = 5
       // 30 seconds less than cloud scheduler maximum.
       timeout_seconds = 570
     }
@@ -149,7 +149,13 @@ resource "google_cloud_run_service" "regions" {
   lifecycle {
     ignore_changes = [
       // This gets added by the Cloud Run API post deploy and causes diffs, can be ignored...
+      template[0].metadata[0].annotations["client.knative.dev/user-image"],
       template[0].metadata[0].annotations["run.googleapis.com/sandbox"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-name"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-version"],
+      // Ignore changes done on the container specification
+      // since this cloud run service is handled by https://github.com/kubernetes-sigs/oci-proxy/blob/main/hack/make-rules/deploy.sh
+      template[0].spec[0].containers[0],
     ]
   }
 }

--- a/infra/gcp/terraform/k8s-infra-oci-proxy/provider.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy/provider.tf
@@ -29,11 +29,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.9.0"
+      version = "~> 4.30.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.9.0"
+      version = "~> 4.30.0"
     }
   }
 }


### PR DESCRIPTION
The CDN service is not needed at the moment to serve docker client
requests.
Also:
- ignore changes done on the Cloud Run service.
- Bumping the Google provider to a recent version

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>