### PR TITLE
oci-proxy: deploy to more GCP regions

### DIFF
--- a/infra/gcp/terraform/k8s-infra-oci-proxy/oci-proxy-sandbox.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy/oci-proxy-sandbox.tf
@@ -130,6 +130,7 @@ resource "google_cloud_run_service" "regions" {
       service_account_name = google_service_account.oci-proxy.email
       containers {
         image = local.image
+        args = [ "-v3" ]
       }
       container_concurrency = 5
       // 30 seconds less than cloud scheduler maximum.

--- a/infra/gcp/terraform/k8s-infra-oci-proxy/variables.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy/variables.tf
@@ -22,7 +22,22 @@ variable "tag" {
 variable "cloud_run_regions" {
   type = list(string)
   default = [
+    # asia
+    "asia-east1",
+    "asia-northeast1",
+    "asia-northeast2",
+    # europe
+    "europe-north1",
+    "europe-southwest1",
+    "europe-west1",
+    "europe-west8",
+    "europe-west9",
+    # us
     "us-central1",
+    "us-east1",
+    "us-east4",
+    "us-east5",
+    "us-south1",
     "us-west1"
   ]
 }


### PR DESCRIPTION
Increase the number of regions where oci-proxy is deployed for the
sandbox environments. This is done to prepare the regions extension for
production.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>