### PR TITLE
Add cpanato to the prow oncall team.

### DIFF
--- a/groups/sig-testing/groups.yaml
+++ b/groups/sig-testing/groups.yaml
@@ -220,6 +220,7 @@ groups:
     # sig-k8s-infra members
     - ameukam@gmail.com
     - cblecker@gmail.com
+    - ctadeu@gmail.com
     - davanum@gmail.com
     - eddiezane@gmail.com
     - thockin@google.com


### PR DESCRIPTION
Scope of intervention is only scoped the build environments owned by the
community and not the Google infrastructure.

Request: https://groups.google.com/g/kubernetes-sig-k8s-infra/c/aqOTH38vAuE/m/Q5VpNqedAwAJ

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>