### PR TITLE
greenhouse: disable service

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/default/greenhouse-service.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/default/greenhouse-service.yaml
@@ -12,16 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
-kind: Service
-metadata:
-  name: bazel-cache
-  namespace: default
-  labels:
-    run: bazel-cache
-spec:
-  ports:
-  - port: 8080
-    protocol: TCP
-  selector:
-    app: greenhouse
+# apiVersion: v1
+# kind: Service
+# metadata:
+#   name: bazel-cache
+#   namespace: default
+#   labels:
+#     run: bazel-cache
+# spec:
+#   ports:
+#   - port: 8080
+#     protocol: TCP
+#   selector:
+#     app: greenhouse


### PR DESCRIPTION
Part of:
  - https://github.com/kubernetes/test-infra/issues/24247

Remove k8s service for greenhouse. This is done before we shutdown the
workload

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>