### PR TITLE
Add newly elected CoCC members

### DIFF
--- a/groups/committee-code-of-conduct/groups.yaml
+++ b/groups/committee-code-of-conduct/groups.yaml
@@ -10,5 +10,9 @@ groups:
       - celeste.e.horgan@gmail.com
       - chu.karen.h@gmail.com
       - ctadeu@gmail.com
+      - hilliary.lipsig@gmail.com
+      - jeremy.r.rickard@gmail.com
+      - lancashiredanielle@gmail.com
       - pal.nabarun95@gmail.com
       - vallery@zeitgeistlabs.io
+      - xandergrzyw@gmail.com


### PR DESCRIPTION
TODO for next week: Once the handoff meeting happens next week, emeritus the outgoing members. (Draft PR: https://github.com/kubernetes/k8s.io/pull/4092)