### PR TITLE
promoting baseimage with alpine-v3.16.2

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -89,6 +89,7 @@
     "sha256:b555a13dcc9165157a61b2279ed7f309e406c3267c93472cb6967215eacf4ab3": ["18ee046b432502aedfed9321f0a9b50bfc009a67"]
     "sha256:94ff9b435a5f3f4570bbdaed4a3a523f63a54ce2ad6b132b5640bae2af5d9d90": ["c5766dc011965f22fac2f4437e86d0fd9960a50c"]
     "sha256:f0d8d32a20f8c1a7c98b504a03b162931d93edd60ecc2c745917a32e9e3e92ad": ["f0490cbfbf29a7a05caaac29998dde56173ac2bb"]
+    "sha256:46c27294e467f46d0006ad1eb5fd3f7005eb3cbd00dd43be2ed9b02edfc6e828": ["9fdbef829c327b95a3c6d6816a301df41bda997f"]
 
 # image to run tests
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/test-runner
@@ -126,6 +127,7 @@
   dmap:
     "sha256:be2f69024f7b7053f35b86677de16bdaa5d3ff0f81b17581ef0b0c6804188b03": ["v20200627-g1fcf4444c"]
     "sha256:c0bd134f1c7190079180e6d4fa2ba64c049961a49b96db20aa39fabc896d26d5": ["v20220801-g00ee51f09"]
+    "sha256:c1b273763048944dd7d22d37adfc65be4fa6a5f6068204292573c6cdc5ea3457": ["v20220818-g9fdbef829"]
 
 # custom echo HTTP server image for e2e tests
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/echo
@@ -185,3 +187,4 @@
     "sha256:ce61e2cf0b347dffebb2dcbf57c33891d2217c1bad9c0959c878e5be671ef941": ["v20220415-controller-v1.2.0-beta.0-2-g81c2afd97"]
     "sha256:a260876fd03d17aa0951a9bb67bfd0140154151e33e23e2dbe030bc732cd0009": ["v20220523-ge0b2db057"]
     "sha256:482562feba02ad178411efc284f8eb803a185e3ea5588b6111ccbc20b816b427": ["v20220801-g00ee51f09"]
+    "sha256:f623ffcd2f923d291d6038481a35ea6ba35e8971062557489c32e2bc1f0810f0": ["v20220818-g9fdbef829"]


### PR DESCRIPTION
- Because of zlib CVE being critical, built new base image on alpine v3.16.2
- This PR promotes that above mentioned baseimage

/triage accepted
/assign @tao12345666333 @strongjz 