### PR TITLE
promote e2e-test-runner & e2e-test-echo images

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -120,6 +120,7 @@
     "sha256:2a34e322b7ff89abdfa0b6202f903bf5618578b699ff609a3ddabac0aae239c8": ["v20220624-g3348cd71e"]
     "sha256:0a199f7b8d4e84026b08c989d9058f3c9b7936af4e2487a6be1ff9077b684d0c": ["v20220726-controller-v1.3.0-29-gfe116d62c"]
     "sha256:795923c427f6dda855338c654448b4348fb845db152fbcad9cd8d186385d01c4": ["v20220801-g00ee51f09"]
+    "sha256:608ef1c1e5783e4a0c4fe57d8f85aa30eb0a3d25e5b1492197e8a95382d5e09d": ["v20220819-ga98c63787"]
 
 # custom cfssl image for e2e tests
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/cfssl
@@ -144,6 +145,7 @@
     "sha256:1dffeeb390f650faafa952e174a0e44aea4a2c677044e0e182fd0685e6122c5d": ["v20220331-controller-v1.1.2-31-gf1cb2b73c"]
     "sha256:05948cf43aa41050943b2c887adcc2f7630893b391c1201e99a6c12ed06ba51b": ["v20220624-g3348cd71e"]
     "sha256:f45fb156e1488ae29aa5e98d2faf8731c79bc5a19c2f39a3c4069566ba629a78": ["v20220801-g00ee51f09"]
+    "sha256:778ac6d1188c8de8ecabeddd3c37b72c8adc8c712bad2bd7a81fb23a3514934c": ["v20220819-ga98c63787"]
 
 # fastcgi HTTP server image for e2e tests
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/fastcgi-helloserver


### PR DESCRIPTION
- This related to the ingress-nginx-controller
- The base-image was changed by bumping alpine to v3.16.2 for the critical CVE on zlib
- These 2 images and other images were built afresh also bumping their alpine to v3.16.2
- This PR promotes these images so that the new images can be used in the project (test code)

/triage accepted
/assign @tao12345666333 @strongjz 