### PR TITLE
groups: stop flapping

### DIFF
--- a/groups/sig-network/groups.yaml
+++ b/groups/sig-network/groups.yaml
@@ -114,7 +114,7 @@ groups:
       - strong.james.e@gmail.com
       - longwuyuan@gmail.com
       - zhangjintao9020@gmail.com
-      - noahispas@googlemail.com
+      - noah.ispas@gmail.com
 
   - email-id: k8s-infra-staging-ingressconformance@kubernetes.io
     name: k8s-infra-staging-ingressconformance


### PR DESCRIPTION
Trying to get https://testgrid.k8s.io/sig-k8s-infra-groups back to green

This reverts https://github.com/kubernetes/k8s.io/pull/3132

Google Workspace used to silently convert this gmail address to a
googlemail address, now it appears to be doing this opposite. Every
other run fails trying to add the unconverted address, and removes the
converted address.