### PR TITLE
infra/aws: Add reg.k8s.io S3 buckets replication rules

### DIFF
--- a/infra/aws/terraform/registry.k8s.io/main.tf
+++ b/infra/aws/terraform/registry.k8s.io/main.tf
@@ -36,7 +36,6 @@ module "us-west-1" {
     aws = aws.us-west-1
   }
 
-  region = "us-west-1"
   prefix = var.prefix
 }
 
@@ -47,7 +46,6 @@ module "us-west-2" {
     aws = aws.us-west-2
   }
 
-  region = "us-west-2"
   prefix = var.prefix
 }
 
@@ -58,7 +56,6 @@ module "us-east-1" {
     aws = aws.us-east-1
   }
 
-  region = "us-east-1"
   prefix = var.prefix
 }
 
@@ -69,8 +66,68 @@ module "us-east-2" {
     aws = aws.us-east-2
   }
 
-  region = "us-east-2"
   prefix = var.prefix
+
+  s3_replication_iam_role_arn = "arn:aws:iam::513428760722:role/registry.k8s.io_s3writer"
+
+  s3_replication_rules = [
+    {
+      id                               = "registry-k8s-io-us-east-2-to-registry-k8s-io-us-west-1"
+      status                           = "Enabled"
+      priority                         = 1
+      destination_bucket_arn           = "arn:aws:s3:::${var.prefix}registry-k8s-io-us-west-1"
+      destination_bucket_storage_class = "STANDARD"
+    },
+    {
+      id                               = "registry-k8s-io-us-east-2-to-registry-k8s-io-us-west-2"
+      status                           = "Enabled"
+      priority                         = 2
+      destination_bucket_arn           = "arn:aws:s3:::${var.prefix}registry-k8s-io-us-west-2"
+      destination_bucket_storage_class = "STANDARD"
+    },
+    {
+      id                               = "registry-k8s-io-us-east-2-to-registry-k8s-io-us-east-1"
+      status                           = "Enabled"
+      priority                         = 3
+      destination_bucket_arn           = "arn:aws:s3:::${var.prefix}registry-k8s-io-us-east-1"
+      destination_bucket_storage_class = "STANDARD"
+    },
+    {
+      id                               = "registry-k8s-io-us-east-2-to-registry-k8s-io-eu-west-1"
+      status                           = "Enabled"
+      priority                         = 4
+      destination_bucket_arn           = "arn:aws:s3:::${var.prefix}registry-k8s-io-eu-west-1"
+      destination_bucket_storage_class = "STANDARD"
+    },
+    {
+      id                               = "registry-k8s-io-us-east-2-to-registry-k8s-io-eu-central-1"
+      status                           = "Enabled"
+      priority                         = 5
+      destination_bucket_arn           = "arn:aws:s3:::${var.prefix}registry-k8s-io-eu-central-1"
+      destination_bucket_storage_class = "STANDARD"
+    },
+    {
+      id                               = "registry-k8s-io-us-east-2-to-registry-k8s-io-ap-southeast-1"
+      status                           = "Enabled"
+      priority                         = 6
+      destination_bucket_arn           = "arn:aws:s3:::${var.prefix}registry-k8s-io-ap-southeast-1"
+      destination_bucket_storage_class = "STANDARD"
+    },
+    {
+      id                               = "registry-k8s-io-us-east-2-to-registry-k8s-io-ap-northeast-1"
+      status                           = "Enabled"
+      priority                         = 7
+      destination_bucket_arn           = "arn:aws:s3:::${var.prefix}registry-k8s-io-ap-northeast-1"
+      destination_bucket_storage_class = "STANDARD"
+    },
+    {
+      id                               = "registry-k8s-io-us-east-2-to-registry-k8s-io-ap-south-1"
+      status                           = "Enabled"
+      priority                         = 8
+      destination_bucket_arn           = "arn:aws:s3:::${var.prefix}registry-k8s-io-ap-south-1"
+      destination_bucket_storage_class = "STANDARD"
+    },
+  ]
 }
 
 module "eu-west-1" {
@@ -80,7 +137,6 @@ module "eu-west-1" {
     aws = aws.eu-west-1
   }
 
-  region = "eu-west-1"
   prefix = var.prefix
 }
 
@@ -91,7 +147,6 @@ module "eu-central-1" {
     aws = aws.eu-central-1
   }
 
-  region = "eu-central-1"
   prefix = var.prefix
 }
 
@@ -102,7 +157,6 @@ module "ap-southeast-1" {
     aws = aws.ap-southeast-1
   }
 
-  region = "ap-southeast-1"
   prefix = var.prefix
 }
 
@@ -113,7 +167,6 @@ module "ap-northeast-1" {
     aws = aws.ap-northeast-1
   }
 
-  region = "ap-northeast-1"
   prefix = var.prefix
 }
 
@@ -124,6 +177,5 @@ module "ap-south-1" {
     aws = aws.ap-south-1
   }
 
-  region = "ap-south-1"
   prefix = var.prefix
 }

--- a/infra/aws/terraform/registry.k8s.io/providers.tf
+++ b/infra/aws/terraform/registry.k8s.io/providers.tf
@@ -21,10 +21,12 @@ terraform {
     region = "us-east-2"
   }
 
+  required_version = ">= 1.0.0"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/infra/aws/terraform/registry.k8s.io/s3/data.tf
+++ b/infra/aws/terraform/registry.k8s.io/s3/data.tf
@@ -14,19 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "prefix" {
-  type    = string
-  default = ""
-}
-
-variable "s3_replication_iam_role_arn" {
-  description = "IAM role assumed by S3 service for replication"
-  type        = string
-  default     = ""
-}
-
-variable "s3_replication_rules" {
-  description = "List of maps for S3 replication rules"
-  type        = list(map(string))
-  default     = []
-}
+data "aws_region" "current" {}


### PR DESCRIPTION
Ref: [#4094](https://github.com/kubernetes/k8s.io/issues/4094)

@ameukam @BobyMCbobs @puerco 

Saw the latest k8s-infra meeting recording and seems you were having trouble setting up S3 bucket replication from Terraform.

I do not know how objects are copied from GCS to AWS main bucket (us-east-2) but this PR should take care of replication from there.

This PR do the following:

1. Terraform's AWS provider upgrade to "~> 4.0"

aws_s3_bucket_replication_configuration resource depends on this upgrade to work properly with aws_s3_bucket resource deprecated replication settings. If this upgrade isn't done terraform's plan will always show changes between the two replication settings.

2. Set S3 module required providers. https://www.terraform.io/language/providers/requirements#requiring-providers
3. Enable bucket versioning (Required by S3 replication service) Ref: [#3667](https://github.com/kubernetes/k8s.io/issues/3667#issue-1211652572)
4.  Eliminates region variable from S3 module and use aws_region data source instead.
5. Added two new variables to S3 module.

 s3_replication_iam_role_arn: IAM role assumed by S3 replication service.

s3_replication_rules: List of configuration maps for S3 replication rules.

us-east-2 bucket (main bucket) is the only S3 bucket that has replication rules for multiple destination buckets ( 1:N replication).

Any written or deleted object in this bucket will be replicated to all other buckets by S3 replication service.

IAM role used for replication 
(arn:aws:iam::513428760722:role/registry.k8s.io_s3admin) should have the following premissions.

```
data "aws_iam_policy_document" "s3_replication" {

  # allow Amazon S3 to retrieve the replication configuration and list the bucket content
  statement {
    effect = "Allow"
    actions = [
      "s3:GetReplicationConfiguration",
      "s3:ListBucket"
    ]

    resources = ["arn:aws:s3:::${var.prefix}registry-k8s-io-us-east-2"]
  }

  # Permissions for these actions are granted on all objects to allow Amazon S3 to get a 
  # specific object version and access control list (ACL) associated with the objects.
  statement {
    effect = "Allow"
    actions = [
      "s3:GetObjectVersionForReplication",
      "s3:GetObjectVersionAcl",
      "s3:GetObjectVersionTagging"
    ]

    resources = ["arn:aws:s3:::${var.prefix}registry-k8s-io-us-east-2/*"]
  }

  # Permissions for these actions on all objects in the destination bucket 
  # allow Amazon S3 to replicate objects or delete markers to the destination bucket
  statement {
    effect = "Allow"
    actions = [
      "s3:ReplicateObject",
      "s3:ReplicateDelete",
      "s3:ReplicateTags"
    ]

    resources = [
      "arn:aws:s3:::${var.prefix}registry-k8s-io-us-east-1/*",
      "arn:aws:s3:::${var.prefix}registry-k8s-io-us-west-1/*",
      "arn:aws:s3:::${var.prefix}registry-k8s-io-us-west-2/*",
      ...
    ]
  }
}

```
Replication rules only apply to objects created and deleted after the rules are created.
For existing object replication we shhould use  [S3 batch replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-batch-replication-batch.html)  

I tested this changes in my AWS account, replication and deletion works as expected.
Please, if you have any questions or suggestions, let me know. 