### PR TITLE
Enable running terraform on GCB jobs

### DIFF
--- a/infra/gcp/bash/ensure-terraform.sh
+++ b/infra/gcp/bash/ensure-terraform.sh
@@ -38,7 +38,7 @@ fi
 PROJECT=$(k8s_infra_project "prow" "k8s-infra-terraform")
 
 color 6 "Ensuring project exists: ${PROJECT}"
-# ensure_project "${PROJECT}"
+ensure_project "${PROJECT}"
 
 PROJECT_SERVICES=(
     iam.googleapis.com

--- a/infra/gcp/bash/ensure-terraform.sh
+++ b/infra/gcp/bash/ensure-terraform.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script ensures terraform service accounts for prow jobs and GCB are created.
+# DOCS: https://cloud.google.com/build/docs/securing-builds/configure-user-specified-service-accounts#cross-project_set_up
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+. "${SCRIPT_DIR}/lib.sh"
+
+function usage() {
+    echo "usage: $0" > /dev/stderr
+    echo > /dev/stderr
+}
+
+if [ $# != 0 ]; then
+    usage
+    exit 1
+fi
+
+# The GCP project name.
+PROJECT=$(k8s_infra_project "prow" "k8s-infra-terraform")
+
+color 6 "Ensuring project exists: ${PROJECT}"
+# ensure_project "${PROJECT}"
+
+PROJECT_SERVICES=(
+    iam.googleapis.com
+)
+
+# Enable GCB APIs
+color 6 "Ensure required services are enabled for: ${PROJECT}"
+
+ensure_only_services "${PROJECT}" "${PROJECT_SERVICES[@]}"
+
+# Create various service accounts for Terraform
+color 6 "Creating oci-proxy dev Service Account"
+ensure_service_account \
+    "${PROJECT}" \
+    "oci-proxy-dev" \
+    "oci proxy dev Terraform Account"
+
+color 6 "Creating oci-proxy prod Service Account"
+ensure_service_account \
+    "${PROJECT}" \
+    "oci-proxy-prod" \
+    "oci proxy prod Terraform Account"
+
+oci_proxy_dev_account="$(svc_acct_email "${project}" "${STAGING_SIGNER_SVCACCT}")"
+color 6 "Ensuring GCB service agent of k8s-staging-infra-tools can impersonate ${oci_proxy_dev_account} "
+ensure_serviceaccount_role_binding \
+    "${oci_proxy_dev_account}" \
+    "serviceAccount:service-1017132094926@gcp-sa-cloudbuild.iam.gserviceaccount.com" \
+    "roles/iam.serviceAccountTokenCreator"
+
+oci_proxy_prod_account="$(svc_acct_email "${project}" "${STAGING_SIGNER_SVCACCT}")"
+color 6 "Ensuring GCB service agent of k8s-staging-infra-tools can impersonate ${oci_proxy_prod_account} "
+ensure_serviceaccount_role_binding \
+    "${oci_proxy_prod_account}" \
+    "serviceAccount:service-1017132094926@gcp-sa-cloudbuild.iam.gserviceaccount.com" \
+    "roles/iam.serviceAccountTokenCreator"
+
+color 6 "Empowering ${oci_proxy_dev_account} on the k8s-infra-oci-proxy project"
+ensure_project_role_binding "${PROJECT}" "serviceAccount:${oci_proxy_dev_account}" "roles/owner"
+
+color 6 "Empowering ${oci_proxy_dev_account} on the k8s-infra-oci-proxy-prod project"
+ensure_project_role_binding "${PROJECT}" "serviceAccount:${oci_proxy_prod_account}" "roles/owner"
+

--- a/infra/gcp/infra.yaml
+++ b/infra/gcp/infra.yaml
@@ -224,7 +224,8 @@ infra:
         managed_by: infra/gcp/terraform/k8s-infra-prow-build/main.tf
       k8s-infra-prow-build-trusted:
         managed_by: infra/gcp/terraform/k8s-infra-prow-build-trusted/main.tf
-
+      k8s-infra-terraform:
+        managed_by: infra/gcr/bash/ensure-terraform.sh
   public:
     projects:
       k8s-conform:


### PR DESCRIPTION
Fixes: #3918 
Required for https://github.com/kubernetes-sigs/oci-proxy/pull/95

This PR will allow us to run terraform jobs with privileged service accounts. 

I will raise another PR with the prowjobs in k/test-infra today.

```
in k/test-infra

For oci-proxy in particular:
- presubmit job that runs plan on sandbox/dev project when the terraform folder is changed
- postsubmit job that runs apply on sandbox/dev when the terraform folder is changed
- presubmit job that runs plan on prod instance when prod folder is changed
- postsubmit job that runs apply on prod instance when prod folder is changed
- create an autobumper for sandbox project, prod deployment must be bumped by a human manually.
```

/cc @dims @ameukam @BenTheElder 