### PR TITLE
registry.k8s.io: Add a BigQuery DataSet for logs

### DIFF
--- a/infra/gcp/terraform/k8s-infra-public-pii/main.tf
+++ b/infra/gcp/terraform/k8s-infra-public-pii/main.tf
@@ -18,6 +18,7 @@ locals {
   project_id  = "k8s-infra-public-pii"
   bucket_name = "k8s-infra-artifacts-gcslogs"
   dataset-id  = replace(local.bucket_name, "-", "_")
+  registry-k8s-io-bq-id = "registry_k8s_io_logs"
 }
 
 
@@ -53,12 +54,22 @@ resource "google_project_service" "project" {
 
 // BigQuery dataset for audit logs
 resource "google_bigquery_dataset" "audit-logs-gcs" {
+  project                     = google_project.project.project_id
   dataset_id                  = local.dataset-id
   friendly_name               = local.dataset-id
   delete_contents_on_destroy  = false
-  default_table_expiration_ms = 34560000000 #30 days
+  default_table_expiration_ms = 400 * 24 * 60 * 60 * 1000 # 400 days
   location                    = "US"
+}
+
+// BigQuery dataset for registry.k8s.io logs
+resource "google_bigquery_dataset" "registry_k8s_io_logs" {
   project                     = google_project.project.project_id
+  dataset_id                  = local.registry-k8s-io-bq-id
+  friendly_name               = local.registry-k8s-io-bq-id
+  delete_contents_on_destroy  = false
+  default_table_expiration_ms = 90 * 24 * 60 * 60 * 1000 #90 days
+  location                    = "US"
 }
 
 

--- a/infra/gcp/terraform/k8s-infra-public-pii/provider.tf
+++ b/infra/gcp/terraform/k8s-infra-public-pii/provider.tf
@@ -31,11 +31,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90.1"
+      version = "~> 4.32.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.90.1"
+      version = "~> 4.32.0"
     }
   }
 }

--- a/infra/gcp/terraform/k8s-infra-public-pii/versions.tf
+++ b/infra/gcp/terraform/k8s-infra-public-pii/versions.tf
@@ -20,5 +20,5 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 1.0.0"
+  required_version = "~> 1.1.0"
 }


### PR DESCRIPTION
Add a BigQuery DataSet for logs storage of all the requests sent to registry.k8s.io.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>