### PR TITLE
registry.k8s.io: Add a Logs router sink

### DIFF
--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/logs.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/logs.tf
@@ -1,0 +1,30 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "google_logging_project_sink" "bigquery_sink" {
+  project     = google_project.project.project_id
+  name        = "registry-k8s-io-logs-sink"
+  destination = "bigquery.googleapis.com/projects/k8s-infra-public-pii/datasets/registry_k8s_io_logs"
+
+  bigquery_options {
+    use_partitioned_tables = false
+  }
+
+  unique_writer_identity = true
+
+  filter = "resource.type = \"cloud_run_revision\" AND log_name= \"projects/${google_project.project.project_id}/logs/run.googleapis.com%2Frequests\""
+
+}

--- a/infra/gcp/terraform/k8s-infra-public-pii/main.tf
+++ b/infra/gcp/terraform/k8s-infra-public-pii/main.tf
@@ -72,6 +72,15 @@ resource "google_bigquery_dataset" "registry_k8s_io_logs" {
   location                    = "US"
 }
 
+resource "google_bigquery_dataset_iam_member" "registry_k8s_io_logs" {
+  project = google_project.project.project_id
+  dataset_id = google_bigquery_dataset.registry_k8s_io_logs.dataset_id
+  role = "roles/bigquery.dataEditor"
+  # Logs router Sink identity in k8s-infra-oci-proxy-prod
+  # Not existing data resource to extract the writer identity
+  member = "serviceAccount:p102333525888-824068@gcp-sa-logging.iam.gserviceaccount.com"
+}
+
 
 # A bucket to store logs in audit logs for GCS
 resource "google_storage_bucket" "audit-logs-gcs" {


### PR DESCRIPTION
Follow-up of:
  - https://github.com/kubernetes/k8s.io/pull/4133

Add a Logs router sink to ensure Cloud Run logs are forwarded to a
BigQuery dataset.
An IAM permission is granted to the sink to write logs in the dataset.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>