### PR TITLE
oci-proxy: set alerts for sandbox and prod.

### DIFF
--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/monitoring.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/monitoring.tf
@@ -1,0 +1,38 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "google_monitoring_notification_channel" "emails" {
+  display_name = "k8s-infra-alerts@kubernetes.io"
+  project      = google_project.project.project_id
+  type         = "email"
+  labels = {
+    email_address = "k8s-infra-alerts@kubernetes.io"
+  }
+}
+
+module "alerts" {
+  project_id         = google_project.project.project_id
+  source             = "../modules/monitoring/uptime-alert"
+  documentation_text = "${local.domain} is down"
+  domain             = local.domain
+
+  notification_channels = [
+    # Manually created. Monitoring channels can't be created with Terraform.
+    # See: https://github.com/hashicorp/terraform-provider-google/issues/1134
+    "${google_project.project.id}/notificationChannels/15334306215710275143",
+    google_monitoring_notification_channel.emails.name,
+  ]
+}

--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/oci-proxy-prod.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/oci-proxy-prod.tf
@@ -45,6 +45,7 @@ resource "google_project_service" "project" {
     "containerregistry.googleapis.com",
     "logging.googleapis.com",
     "oslogin.googleapis.com",
+    "monitoring.googleapis.com",
     "pubsub.googleapis.com",
     "run.googleapis.com",
     "storage-api.googleapis.com",

--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/provider.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/provider.tf
@@ -29,11 +29,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.13.0"
+      version = "~> 4.32.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.13.0"
+      version = "~> 4.32.0"
     }
   }
 }

--- a/infra/gcp/terraform/k8s-infra-oci-proxy/monitoring.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy/monitoring.tf
@@ -1,0 +1,38 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "google_monitoring_notification_channel" "emails" {
+  display_name = "k8s-infra-alerts@kubernetes.io"
+  project      = google_project.project.project_id
+  type         = "email"
+  labels = {
+    email_address = "k8s-infra-alerts@kubernetes.io"
+  }
+}
+
+module "alerts" {
+  project_id         = google_project.project.project_id
+  source             = "../modules/monitoring/uptime-alert"
+  documentation_text = "${local.domain} is down"
+  domain             = local.domain
+
+  notification_channels = [
+    # Manually created. Monitoring channels can't be created with Terraform.
+    # See: https://github.com/hashicorp/terraform-provider-google/issues/1134
+    "${google_project.project.id}/notificationChannels/3237876589275698022",
+    google_monitoring_notification_channel.emails.name,
+  ]
+}

--- a/infra/gcp/terraform/k8s-infra-oci-proxy/oci-proxy-sandbox.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy/oci-proxy-sandbox.tf
@@ -54,6 +54,7 @@ resource "google_project_service" "project" {
     "compute.googleapis.com",
     "containerregistry.googleapis.com",
     "logging.googleapis.com",
+    "monitoring.googleapis.com",
     "oslogin.googleapis.com",
     "pubsub.googleapis.com",
     "storage-api.googleapis.com",

--- a/infra/gcp/terraform/k8s-infra-oci-proxy/provider.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy/provider.tf
@@ -29,11 +29,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.30.0"
+      version = "~> 4.32.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.30.0"
+      version = "~> 4.32.0"
     }
   }
 }

--- a/infra/gcp/terraform/modules/monitoring/uptime-alert/main.tf
+++ b/infra/gcp/terraform/modules/monitoring/uptime-alert/main.tf
@@ -1,0 +1,118 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "google_monitoring_uptime_check_config" "uptime_check" {
+  project = var.project_id
+  display_name = format("Uptime - %s", var.domain)
+
+  http_check {
+    mask_headers   = "false"
+    path           = "/"
+    port           = "443"
+    request_method = "GET"
+    use_ssl        = "true"
+    validate_ssl   = "true"
+  }
+
+  monitored_resource {
+    labels = {
+      host       = var.domain
+      project_id = var.project_id
+    }
+
+    type = "uptime_url"
+  }
+
+  period  = "60s"
+  timeout = "10s"
+}
+
+resource "google_monitoring_alert_policy" "uptime_alert" {
+  provider = google-beta
+  project = var.project_id
+
+  display_name          = "${var.domain}-uptime"
+  combiner              = "OR"
+
+  conditions {
+    display_name = "Failure of uptime check on ${var.domain}"
+    condition_threshold {
+      comparison      = "COMPARISON_GT"
+      duration        = "${var.failing_duration}s"
+      filter          = "metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" AND metric.label.check_id=\"${var.domain}\" AND resource.type=\"uptime_url\""
+      threshold_value = 1
+
+      aggregations {
+        alignment_period     = "300s"
+        cross_series_reducer = "REDUCE_COUNT_FALSE"
+        group_by_fields      = ["resource.*"]
+        per_series_aligner   = "ALIGN_NEXT_OLDER"
+      }
+
+      trigger {
+        count   = 1
+        percent = var.trigger_percent
+      }
+    }
+  }
+
+  documentation {
+    content = var.documentation_text
+  }
+
+  notification_channels = var.notification_channels
+  enabled = true
+
+}
+
+# SSL certificate expiring soon for uptime checks
+resource "google_monitoring_alert_policy" "ssl_cert_expiration_alert" {
+    project = var.project_id
+
+  display_name = "SSL/TLS certificate expiration check"
+  combiner     = "OR"
+
+  conditions {
+     display_name = "SSL Certificate for ${var.domain} expiring soon"
+    condition_threshold {
+      comparison      = "COMPARISON_LT"
+      duration        = "600s"
+      filter          = "metric.type=\"monitoring.googleapis.com/uptime_check/time_until_ssl_cert_expires\" AND resource.type=\"uptime_url\" AND metric.label.check_id=\"${google_monitoring_uptime_check_config.uptime_check.uptime_check_id}\""
+      # 2 weeks
+      threshold_value = 15
+
+      aggregations {
+        alignment_period     = "1200s"
+        cross_series_reducer = "REDUCE_MEAN"
+        group_by_fields      = ["resource.label.*"]
+        per_series_aligner   = "ALIGN_NEXT_OLDER"
+      }
+
+      trigger {
+        count = 1
+        percent = 0
+      }
+    }
+  }
+
+  documentation {
+    content = "The SSL/TLS certificate for ${var.domain} is expiring in fewer than 15 days"
+  }
+
+    notification_channels = var.notification_channels
+
+  enabled = true
+}

--- a/infra/gcp/terraform/modules/monitoring/uptime-alert/outputs.tf
+++ b/infra/gcp/terraform/modules/monitoring/uptime-alert/outputs.tf
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+

--- a/infra/gcp/terraform/modules/monitoring/uptime-alert/variables.tf
+++ b/infra/gcp/terraform/modules/monitoring/uptime-alert/variables.tf
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+# Required variables
+variable "domain" {
+  description = "The google_monitoring_uptime_check_config ID to associate with"
+  type        = string
+}
+variable "notification_channels" {
+  description = "A list of channels to send alert notifications to"
+  type        = list(any)
+}
+variable "documentation_text" {
+  description = "A text included with the alert"
+  type        = string
+}
+
+# Optional variables
+variable "failing_duration" {
+  description = "The amount of time in seconds that the check has to fail before it alerts"
+  type        = number
+  default     = 120
+}
+variable "trigger_percent" {
+  description = "The percent of alerts that are failing before the alert triggers"
+  type        = number
+  default     = null
+}
+
+variable "project_id" {
+  type = string
+  validation {
+    condition     = length(var.project_id) > 6 && length(var.project_id) <=30
+    error_message = "Must specify PROJECT_ID variable."
+  }
+}

--- a/infra/gcp/terraform/modules/monitoring/uptime-alert/versions.tf
+++ b/infra/gcp/terraform/modules/monitoring/uptime-alert/versions.tf
@@ -1,0 +1,30 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  required_version = "~> 1.1.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.32.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 4.32.0"
+    }
+  }
+}


### PR DESCRIPTION
Add a terraform module to ensure alerts are created for:
- SSL certificate expiration: an alert is sent if the certificate for
  given domain is not renewed less than 15 days before the expiration
  date.
- uptime check: given a hostname, ensure the host is alive on port 443
  for the root path (/). A check is done every minute.

Ensure alerts are created using the terraform module.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>