### PR TITLE
Adding adminnetworkpolicy-api.sigs.k8s.io for ANP API

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -418,3 +418,7 @@ gateway-api.sigs:
 cloud-provider-azure.sigs:
   type: CNAME
   value: kubernetes-sigs-cloud-provide-azure.netlify.app.
+# https://github.com/kubernetes-sigs/network-policy-api docs (@astoycos)
+adminnetworkpolicy-api.sigs:
+  type: CNAME
+  value: kubernetes-sigs-adminnetworkpolicy-api.netlify.app.


### PR DESCRIPTION
Add dns name for the new AdminNetworkPolicy API

Related to https://github.com/kubernetes/org/issues/3643