### PR TITLE
Drop jeremy from k8s-infra-release-editors

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -41,7 +41,6 @@ groups:
       - ctadeu@gmail.com
       - gveronicalg@gmail.com
       - jameswangel@gmail.com
-      - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
       - pal.nabarun95@gmail.com


### PR DESCRIPTION
Temporary access for 1.25 no longer needed, removing myself

ref: https://github.com/kubernetes/sig-release/issues/1970

Signed-off-by: Jeremy Rickard <jeremyrrickard@gmail.com>