### PR TITLE
Update archeio to v20220816-v0.0.1-120-g8293873

### DIFF
--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/oci-proxy-prod.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/oci-proxy-prod.tf
@@ -17,7 +17,7 @@ limitations under the License.
 locals {
   project_id = "k8s-infra-oci-proxy-prod"
   domain     = "registry.k8s.io"
-  image      = "gcr.io/k8s-staging-infra-tools/archeio:${var.tag}"
+  image      = "us.gcr.io/k8s-artifacts-prod/infra-tools/archeio:${var.tag}"
 
 }
 
@@ -44,8 +44,8 @@ resource "google_project_service" "project" {
     "compute.googleapis.com",
     "containerregistry.googleapis.com",
     "logging.googleapis.com",
-    "oslogin.googleapis.com",
     "monitoring.googleapis.com",
+    "oslogin.googleapis.com",
     "pubsub.googleapis.com",
     "run.googleapis.com",
     "storage-api.googleapis.com",
@@ -116,7 +116,10 @@ resource "google_cloud_run_service" "oci-proxy" {
   lifecycle {
     ignore_changes = [
       // This gets added by the Cloud Run API post deploy and causes diffs, can be ignored...
-      template[0].metadata[0].annotations["run.googleapis.com/sandbox"],
+      template[0].metadata[0].annotations["client.knative.dev/sandbox"],
+      template[0].metadata[0].annotations["run.googleapis.com/user-image"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-name"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-version"],
     ]
   }
 }

--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/prod.auto.tfvars
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/prod.auto.tfvars
@@ -14,4 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-tag = "v20220204-786ae98"
+tag = "v20220816-v0.0.1-120-g8293873"


### PR DESCRIPTION
Commits: https://github.com/kubernetes-sigs/oci-proxy/compare/v0.0.1...v0.0.2

Update container image source for oci-proxy. Cloud Run only deploy
images from GCR or Artifact registry and custom registries.

```
Expected a Container Registry image path like [region.]gcr.io/repo-path[:tag and/or @digest] or an Artifact Registry image path like [region-]docker.pkg.dev/repo-path[:tag and/or @digest]
```

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>