### PR TITLE
move slack tools to their own subdomain so they don't conflict with the inviter redirect

### DIFF
--- a/apps/slack-infra/resources/certificate.yaml
+++ b/apps/slack-infra/resources/certificate.yaml
@@ -4,5 +4,5 @@ metadata:
   name: slack-infra
 spec:
   domains:
-  - slack.k8s.io
-  - slack.kubernetes.io
+  - slack-infra.k8s.io
+  - slack-infra.kubernetes.io

--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -283,6 +283,11 @@ sippy:
 slack:
   type: CNAME
   value: redirect.k8s.io.
+# Slack tools like the moderator
+# see apps/slack-infra and https://sigs.k8s.io/slack-infra
+slack-infra:
+  type: A
+  value: 34.107.195.71
 # Prow (@ixdy).
 submit-queue:
   type: CNAME

--- a/dns/zone-configs/kubernetes.io._0_base.yaml
+++ b/dns/zone-configs/kubernetes.io._0_base.yaml
@@ -178,6 +178,11 @@ sigs:
 slack:
   type: CNAME
   value: redirect.k8s.io.
+# Slack tools like the moderator
+# see apps/slack-infra and https://sigs.k8s.io/slack-infra
+slack-infra:
+  type: A
+  value: 34.107.195.71
 # Prow (@ixdy).
 submit-queue:
   type: CNAME


### PR DESCRIPTION
Should be easier to manage going forward, see:
- https://github.com/kubernetes/community/issues/6841
- https://github.com/kubernetes/k8s.io/pull/4105

I spoke to katharine about reconfiguring the apps to point to this seperate domain, we can do that once this is deployed.

TODO (follow-up):
- actually delete deployed resources from https://github.com/kubernetes/k8s.io/pull/4112
- remove slackin from ingress config
- consider not tagging all apps slackin2 since that's not really accurate 🤷‍♂️ 