### PR TITLE
oci-proxy: extend to more GCP regions

### DIFF
--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/oci-proxy-prod.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/oci-proxy-prod.tf
@@ -97,6 +97,7 @@ resource "google_cloud_run_service" "oci-proxy" {
       service_account_name = google_service_account.oci-proxy.email
       containers {
         image = local.image
+         args = [ "-v=2" ]
       }
       container_concurrency = 10
       // 30 seconds less than cloud scheduler maximum.

--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/variables.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/variables.tf
@@ -22,14 +22,20 @@ variable "tag" {
 variable "cloud_run_regions" {
   type = list(string)
   default = [
-    # Tier 1 pricing: https://cloud.google.com/run/pricing#tables
     "asia-east1",
     "asia-northeast1",
+    "asia-south1",
+    "asia-southeast1",
     "europe-north1",
     "europe-west1",
+    "europe-west2",
+    "europe-west3",
     "europe-west4",
     "us-central1",
     "us-east1",
-    "us-east4"
+    "us-east4",
+    "us-east5",
+    "us-west1",
+    "us-west2"
   ]
 }

--- a/infra/gcp/terraform/k8s-infra-oci-proxy/oci-proxy-sandbox.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy/oci-proxy-sandbox.tf
@@ -131,7 +131,7 @@ resource "google_cloud_run_service" "regions" {
       service_account_name = google_service_account.oci-proxy.email
       containers {
         image = local.image
-        args = [ "-v3" ]
+        args = [ "-v=3" ]
       }
       container_concurrency = 5
       // 30 seconds less than cloud scheduler maximum.


### PR DESCRIPTION
Deploy oci-proxy to more GCP regions to match the AWS regions of the
production S3 buckets.
This is an opinionated approach to match GCP regions and AWS regions.

Also increase verbosity in production

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>