### PR TITLE
drop some lingering slackin references

### DIFF
--- a/apps/slack-infra/README.md
+++ b/apps/slack-infra/README.md
@@ -7,7 +7,6 @@ Cluster resources to deploy the following apps from [kubernetes-sigs/slack-infra
 - slack-moderator-words
 - slack-welcomer
 - slack-post-message
-- slackin
 
 None of the resources have a namespace defined
 

--- a/apps/slack-infra/resources/ingress.yaml
+++ b/apps/slack-infra/resources/ingress.yaml
@@ -7,11 +7,6 @@ metadata:
     kubernetes.io/ingress.class: gce
     networking.gke.io/managed-certificates: slack-infra
 spec:
-  defaultBackend:
-    service:
-      name: slackin2
-      port:
-        number: 80
   rules:
   - http:
       paths:


### PR DESCRIPTION
TODO: we still have a secret for this as well https://github.com/kubernetes/k8s.io/blob/2fc2591dd76af7b693d3a0c79930c684795b22e0/audit/projects/kubernetes-public/secrets/slackin-token/description.json#L7

notably, this PR drops slackin from the slack-infra ingress.

next up: will go delete the deployment / service etc, we already deleted the configs but not the deployed objects 
see also: https://github.com/kubernetes/k8s.io/pull/4156 #4112 