### PR TITLE
Add s3-sync role for syncing registry.k8s.io objects

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-serviceaccounts.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-serviceaccounts.yaml
@@ -127,3 +127,9 @@ metadata:
     iam.gke.io/gcp-service-account: gcb-builder-cluster-api-gcp@k8s-staging-cluster-api-gcp.iam.gserviceaccount.com
   name: gcb-builder-cluster-api-gcp
   namespace: test-pods
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: s3-sync
+  namespace: test-pods


### PR DESCRIPTION
Adds a service account to the trusted cluster, for running s3 syncing between GCS and S3 for registry.k8s.io objects.
Related: 
- https://github.com/cncf-infra/aws-infra/pull/15
- https://github.com/kubernetes/k8s.io/issues/4094