### PR TITLE
Update registry.k8s.io s3 bucket sync scripts

### DIFF
--- a/registry.k8s.io/hack/initial-copy-to-s3.sh
+++ b/registry.k8s.io/hack/initial-copy-to-s3.sh
@@ -18,6 +18,9 @@
 # - rclone
 # - awscli
 
+# Usage
+#   ./hack/initial-copy-to-s3.sh
+
 SOURCE=gcs:us.artifacts.k8s-artifacts-prod.appspot.com
 DESTINATION=s3:prod-registry-k8s-io-us-east-2
 


### PR DESCRIPTION
Changes include:
- add specifying of a region to copy-between-s3: for use in ProwJobs
- reverts back to inline synchronous object syncing
- remove tmate dependency

Related: https://github.com/kubernetes/test-infra/pull/27344, https://github.com/kubernetes/k8s.io/pull/4170, https://github.com/kubernetes/k8s.io/issues/4094