### PR TITLE
Update registry.k8s.io s3 bucket sync scripts

### DIFF
--- a/registry.k8s.io/hack/initial-copy-between-s3.sh
+++ b/registry.k8s.io/hack/initial-copy-between-s3.sh
@@ -22,20 +22,26 @@
 #   sync all:       ./initial-copy-between-s3.sh
 #   specify region: ./initial-copy-between-s3.sh <REGION>
 
+# Extra usage
+#   launch parallel sync using tmate
+#     for REGION in $(./hack/initial-copy-between-s3.sh regions | yq e '.regions[]' -P - | xargs); do tmate -F -v -S "${TMATE_SOCKET:-/tmp/tmate.socket}" new-window -d -c "$PWD" -n sync-to-"${REGION:-}" "bash -x ./hack/initial-copy-between-s3.sh \"${REGION:-}\""; done
+
 function sync-a-region {
     REGION="${1:-}"
     DESTINATION="s3dest:prod-registry-k8s-io-${REGION:-}"
-    unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
-    JSON=$(aws sts assume-role \
-        --role-arn "arn:aws:iam::513428760722:role/registry.k8s.io_s3writer"  \
-        --role-session-name "${CALLER_ID:-}-registry.k8s.io_s3writer" \
-        --duration-seconds 43200 \
-        --output json || exit 1)
+    if [ ! -f /var/run/secrets/aws-iam-token/serviceaccount/token ]; then
+      unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+      JSON=$(aws sts assume-role \
+          --role-arn "arn:aws:iam::513428760722:role/registry.k8s.io_s3writer"  \
+          --role-session-name "${CALLER_ID:-}-registry.k8s.io_s3writer" \
+          --duration-seconds 43200 \
+          --output json || exit 1)
 
-    AWS_ACCESS_KEY_ID=$(echo "${JSON}" | jq --raw-output ".Credentials[\"AccessKeyId\"]")
-    AWS_SECRET_ACCESS_KEY=$(echo "${JSON}" | jq --raw-output ".Credentials[\"SecretAccessKey\"]")
-    AWS_SESSION_TOKEN=$(echo "${JSON}" | jq --raw-output ".Credentials[\"SessionToken\"]")
-    export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+      AWS_ACCESS_KEY_ID=$(echo "${JSON}" | jq --raw-output ".Credentials[\"AccessKeyId\"]")
+      AWS_SECRET_ACCESS_KEY=$(echo "${JSON}" | jq --raw-output ".Credentials[\"SecretAccessKey\"]")
+      AWS_SESSION_TOKEN=$(echo "${JSON}" | jq --raw-output ".Credentials[\"SessionToken\"]")
+      export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+    fi
 
     RCLONE_CONFIG="$(mktemp -t rclone-"${REGION:-}"-XXXXX.conf)"
     echo "Wrote rclone config to '${RCLONE_CONFIG:-}'"
@@ -48,17 +54,13 @@ bucket_acl = private
 [s3]
 type = s3
 provider = AWS
-access_key_id = $AWS_ACCESS_KEY_ID
-secret_access_key = $AWS_SECRET_ACCESS_KEY
-session_token = $AWS_SESSION_TOKEN
+env_auth = true
 region = us-east-2
 
 [s3dest]
 type = s3
 provider = AWS
-access_key_id = $AWS_ACCESS_KEY_ID
-secret_access_key = $AWS_SECRET_ACCESS_KEY
-session_token = $AWS_SESSION_TOKEN
+env_auth = true
 region = ${REGION}
 EOF
     echo "Running sync between '${SOURCE:-}' and '${DESTINATION:-}'"
@@ -78,6 +80,13 @@ REGIONS=(
     us-west-1
     us-west-2
 )
+if [ "${1}" = "regions" ]; then
+    echo "regions:"
+    for REGION in "${REGIONS[@]}"; do
+        echo "- ${REGION:-}"
+    done
+    exit 0
+fi
 SOURCE=s3:prod-registry-k8s-io-us-east-2
 
 CALLER_ID="$(aws sts get-caller-identity --output json | jq -r .UserId)"


### PR DESCRIPTION
Changes include:
- add `regions` subcommand to registry.k8s.io/hack/initial-copy-between-s3.sh
- use `env_auth` with rclone configs, if `/var/run/secrets/aws-iam-token/serviceaccount/token` is found in the environment

Conditionally allowing `env_auth` means that the scripts will continue to work as normal outside the ProwJobs for now.

Related: https://github.com/kubernetes/test-infra/pull/27415, https://github.com/kubernetes/k8s.io/pull/4196