### PR TITLE
Cleanup 1.22 release team shadows from sig-testing groups.yaml

### DIFF
--- a/groups/sig-testing/groups.yaml
+++ b/groups/sig-testing/groups.yaml
@@ -159,12 +159,6 @@ groups:
     - thejoycekung@gmail.com
     - neolit123@gmail.com
     - philjohnson96@gmail.com
-    # release-ci-signal
-    - ania0102@gmail.com # 1.22 CI Signal Shadow
-    - max@koerbaecher.io # 1.22 CI Signal Lead
-    - ramses.green.2@gmail.com # 1.22 CI Signal Shadow
-    - salahi.hossein@gmail.com # 1.22 CI Signal Shadow
-    - soniasingla.1812@gmail.com # 1.22 CI Signal Shadow
 
   #
   # sig-testing k8s-infra owners


### PR DESCRIPTION
The current release cycle is 1.26, this PR removes 1.22 release team shadows from sig-testing/groups.yaml