### PR TITLE
releng: temporary release manager access for ameukam

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -38,6 +38,7 @@ groups:
     members:
       - k8s-infra-release-admins@kubernetes.io
       - adolfo.garcia@uservers.net
+      - ameukam@gmail.com
       - ctadeu@gmail.com
       - gveronicalg@gmail.com
       - jameswangel@gmail.com


### PR DESCRIPTION
Related:
  - https://github.com/kubernetes/sig-release/issues/2024

Requesting elevation of privileges to cut patch releases scheduled for September 14 2022.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>