### PR TITLE
promoting images with go v1.19.1

### DIFF
--- a/apps/prow/cluster/crier_deployment.yaml
+++ b/apps/prow/cluster/crier_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20220912-2b319e1ac8
+        image: gcr.io/k8s-prow/crier:v20220915-e6805288df
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml

--- a/apps/prow/cluster/deck_deployment.yaml
+++ b/apps/prow/cluster/deck_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20220912-2b319e1ac8
+        image: gcr.io/k8s-prow/deck:v20220915-e6805288df
         imagePullPolicy: Always
         ports:
         - name: http

--- a/apps/prow/cluster/ghproxy_deployment.yaml
+++ b/apps/prow/cluster/ghproxy_deployment.yaml
@@ -51,7 +51,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20220912-2b319e1ac8
+          image: gcr.io/k8s-prow/ghproxy:v20220915-e6805288df
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/apps/prow/cluster/hook_deployment.yaml
+++ b/apps/prow/cluster/hook_deployment.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20220912-2b319e1ac8
+        image: gcr.io/k8s-prow/hook:v20220915-e6805288df
         imagePullPolicy: Always
         args:
         - --config-path=/etc/config/config.yaml

--- a/apps/prow/cluster/horologium_deployment.yaml
+++ b/apps/prow/cluster/horologium_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20220912-2b319e1ac8
+        image: gcr.io/k8s-prow/horologium:v20220915-e6805288df
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/apps/prow/cluster/prow_controller_manager_deployment.yaml
+++ b/apps/prow/cluster/prow_controller_manager_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20220912-2b319e1ac8
+        image: gcr.io/k8s-prow/prow-controller-manager:v20220915-e6805288df
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/apps/prow/cluster/sinker_deployment.yaml
+++ b/apps/prow/cluster/sinker_deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - --dry-run=false
         - --job-config-path=/etc/job-config
         - --kubeconfig=/etc/kubeconfig/kubeconfig
-        image: gcr.io/k8s-prow/sinker:v20220912-2b319e1ac8
+        image: gcr.io/k8s-prow/sinker:v20220915-e6805288df
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/apps/prow/cluster/statusreconciler_deployment.yaml
+++ b/apps/prow/cluster/statusreconciler_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20220912-2b319e1ac8
+        image: gcr.io/k8s-prow/status-reconciler:v20220915-e6805288df
         imagePullPolicy: Always
         args:
         - --config-path=/etc/config/config.yaml

--- a/apps/prow/cluster/tide_deployment.yaml
+++ b/apps/prow/cluster/tide_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20220912-2b319e1ac8
+        image: gcr.io/k8s-prow/tide:v20220915-e6805288df
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/apps/prow/config.yaml
+++ b/apps/prow/config.yaml
@@ -16,10 +16,10 @@ plank:
       timeout: 2h
       grace_period: 15s
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220912-2b319e1ac8"
-        initupload: "gcr.io/k8s-prow/initupload:v20220912-2b319e1ac8"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220912-2b319e1ac8"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20220912-2b319e1ac8"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20220915-e6805288df"
+        initupload: "gcr.io/k8s-prow/initupload:v20220915-e6805288df"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20220915-e6805288df"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20220915-e6805288df"
       default_service_account_name: "prowjob-default-sa"
       gcs_configuration:
         bucket: k8s-infra-prow-results

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/default/ghproxy-deployment.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/default/ghproxy-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20220912-2b319e1ac8
+          image: gcr.io/k8s-prow/ghproxy:v20220915-e6805288df
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/test-pods/boskos-janitor.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/test-pods/boskos-janitor.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: boskos-janitor
       containers:
       - name: boskos-janitor
-        image: gcr.io/k8s-staging-boskos/janitor:v20220830-b922054
+        image: gcr.io/k8s-staging-boskos/janitor:v20220914-04c2067
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
         - --resource-type=gce-project,gpu-project,scalability-project,scalability-scale-project

--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/test-pods/boskos-reaper-deployment.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/test-pods/boskos-reaper-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos-reaper
-        image: gcr.io/k8s-staging-boskos/reaper:v20220830-b922054
+        image: gcr.io/k8s-staging-boskos/reaper:v20220914-04c2067
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
         - --resource-type=gce-project,gpu-project,scalability-project,scalability-scale-project

--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/test-pods/boskos.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/test-pods/boskos.yaml
@@ -199,7 +199,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos
-        image: gcr.io/k8s-staging-boskos/boskos:v20220830-b922054
+        image: gcr.io/k8s-staging-boskos/boskos:v20220914-04c2067
         args:
         - --config=/etc/config/config
         - --namespace=test-pods

--- a/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -125,6 +125,7 @@
     "sha256:608ef1c1e5783e4a0c4fe57d8f85aa30eb0a3d25e5b1492197e8a95382d5e09d": ["v20220819-ga98c63787"]
     "sha256:038fc60379b6ce9a0134c2ff9134edccad1f8ecbd9c6ebed9660711d05b0ed95": ["v20220823-ge19026fe4"]
     "sha256:116f05f2cc293e96c9f4abd7f7add365fe23ceb85486fe94b973eddd75a76fbf": ["v20220905-g79a311d3b"]
+    "sha256:f3f26f1e2aef8b2013b731f041fd69bcd950d3118eecf4429551848f47305c0f": ["v20220916-gd32f8c343"]
 
 # custom cfssl image for e2e tests
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/cfssl
@@ -174,6 +175,7 @@
     "sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660": ["v1.1.1"]
     "sha256:2188def723c8fcb2635fbe54607ac3b4efba581c4fcc3d2279ec9c57da1b2f6f": ["v1.2.0"]
     "sha256:549e71a6ca248c5abd51cdb73dbc3083df62cf92ed5e6147c780e30f7e007a47": ["v1.3.0"]
+    "sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f": ["v20220916-gd32f8c343"]
 
 # nginx-errors
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/custom-error-pages
@@ -183,6 +185,7 @@
     "sha256:06cd2dbe317505e940d0521cc69d237752800ef0b191cb4265eb0d3d2c1080e7": ["0.49.0"]
     "sha256:1c31c80828e7800c4eb556e07fdc90c451482767659eb26310e0ad208d28c9cf": ["1.2.0"]
     "sha256:37257a3cbc1aba523cad8f0cf5b946df3aff9e74483e7fa9ce8df2d965e71ec7": ["1.3.0"]
+    "sha256:09c421ac743bace19ab77979b82186941c5125c95e62cdb40bdf41293b5c275c": ["v20220916-gd32f8c343"]
 
 # opentelemetry
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/opentelemetry


### PR DESCRIPTION
- Built new images because of https://github.com/kubernetes/ingress-nginx/pull/9057
- Lot of related info is here as well https://github.com/kubernetes/ingress-nginx/issues/8932
- This PR promotes the new images that now contain go v1.19.1
- This PR makes a significant promotion in the test-runner image because that sha has to be updated in the ingress-nginx project's main, for the ingres-nginx-controller's binary to get compiled with go v1.19.1. Reason being the build system uses a docker environ to compile the binary and the docker-environ is built using the test-runner image being promoted here

/tirage accepted

/assign @tao12345666333 @strongjz @rikatz 