### PR TITLE
releng: temporary release manager access for jeremyrickard

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -42,6 +42,7 @@ groups:
       - ctadeu@gmail.com
       - gveronicalg@gmail.com
       - jameswangel@gmail.com
+      - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
       - pal.nabarun95@gmail.com


### PR DESCRIPTION
Requesting elevation of privileges to cut patch releases scheduled for September 20 2022.

Related: 
ref: https://github.com/kubernetes/sig-release/issues/2032



cc: @Verolop @puerco 

Signed-off-by: Jeremy Rickard <jeremyrrickard@gmail.com>