### PR TITLE
releng: temporary release manager access for cici37

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -38,6 +38,7 @@ groups:
     members:
       - k8s-infra-release-admins@kubernetes.io
       - adolfo.garcia@uservers.net
+      - cicih@google.com
       - ctadeu@gmail.com
       - gveronicalg@gmail.com
       - jeremy.r.rickard@gmail.com


### PR DESCRIPTION
Requesting elevation of privileges to cut patch releases in 1.26

Related:
ref: https://github.com/kubernetes/sig-release/issues/2034

cc @jeremyrickard 