### PR TITLE
Add a secret for enhancements subproject

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-externalsecrets.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-externalsecrets.yaml
@@ -69,6 +69,19 @@ spec:
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
+  name: k8s-release-enhancements-triage-github-token
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-infra-prow-build-trusted
+  data:
+  - key: k8s-release-enhancements-triage-github-token
+    name: token
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
   name: k8s-cip-test-prod-service-account
   namespace: test-pods
 spec:

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/secrets.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/secrets.tf
@@ -32,6 +32,10 @@ locals {
       group  = "sig-release"
       owners = "k8s-infra-release-admins@kubernetes.io"
     }
+    k8s-release-enhancements-triage-github-token = {
+      group = "sig-release"
+      owners = "k8s-infra-release-editors@kubernetes.io"
+    }
     k8s-triage-robot-github-token = {
       group  = "sig-contributor-experience"
       owners = "github@kubernetes.io"


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/org/issues/3558

Add a new secret that will contains the Github token for enhancements triage. The secret will be synced the GKE cluster `prow-build-trusted`.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>