### PR TITLE
Fixed badly formatted link

### DIFF
--- a/infra/gcp/README.md
+++ b/infra/gcp/README.md
@@ -107,4 +107,4 @@ scripts or terraform modules are responsible for which GCP projects
 
 ## terraform
 
-See [infra/gcp/terraform/README.md][/infra/gcp/terraform/README.md]
+See [infra/gcp/terraform/README.md](/infra/gcp/terraform/README.md)


### PR DESCRIPTION
There is a file under `infra/gcp` that had a badly formatted link