### PR TITLE
registry.k8s.io: fixups post deployment

### DIFF
--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/monitoring.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/monitoring.tf
@@ -26,8 +26,8 @@ resource "google_monitoring_notification_channel" "emails" {
 module "alerts" {
   project_id         = google_project.project.project_id
   source             = "../modules/monitoring/uptime-alert"
-  documentation_text = "${local.domain} is down"
-  domain             = local.domain
+  documentation_text = "${var.domain} is down"
+  domain             = var.domain
 
   notification_channels = [
     # Manually created. Monitoring channels can't be created with Terraform.

--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/oci-proxy.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/oci-proxy.tf
@@ -55,7 +55,7 @@ resource "google_project_iam_member" "k8s_infra_oci_proxy_admins" {
 
 resource "google_service_account" "oci-proxy" {
   project      = google_project.project.project_id
-  account_id   = "oci-proxy"
+  account_id   = "oci-proxy-prod"
   display_name = "Minimal Service Account for OCI Proxy"
 }
 

--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/provider.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/provider.tf
@@ -29,11 +29,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.32.0"
+      version = "~> 4.38.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.32.0"
+      version = "~> 4.38.0"
     }
   }
 }

--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/terraform.tfvars
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/terraform.tfvars
@@ -66,6 +66,18 @@ cloud_run_config = {
       }
     ]
   }
+  asia-southeast1 = {
+    environment_variables = [
+      {
+        name  = "UPSTREAM_REGISTRY_ENDPOINT",
+        value = "https://asia.gcr.io"
+      },
+      {
+        name  = "UPSTREAM_REGISTRY_PATH",
+        value = "k8s-artifacts-prod"
+      }
+    ]
+  }
   australia-southeast1 = {
     environment_variables = [
       {
@@ -115,6 +127,18 @@ cloud_run_config = {
     ]
   }
   europe-west2 = {
+    environment_variables = [
+      {
+        name  = "UPSTREAM_REGISTRY_ENDPOINT",
+        value = "https://eu.gcr.io"
+      },
+      {
+        name  = "UPSTREAM_REGISTRY_PATH",
+        value = "k8s-artifacts-prod"
+      }
+    ]
+  }
+  europe-west3 = {
     environment_variables = [
       {
         name  = "UPSTREAM_REGISTRY_ENDPOINT",

--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/versions.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/versions.tf
@@ -20,5 +20,5 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 1.1.0"
+  required_version = "~> 1.2.0"
 }


### PR DESCRIPTION
Follow-up of:
  - https://github.com/kubernetes/k8s.io/pull/4258

- Bump version required for terraform
- Bump Google provider
- Revert change about service account name and Cloud Run regions

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>