### PR TITLE
Promote a selection of 1.25.2 and 1.25.3-rc.0 images to experimental repo

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-experimental/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-experimental/images.yaml
@@ -1,1 +1,48 @@
-# No images yet
+- name: conformance
+  dmap:
+    "sha256:63d5989e6e254d760e0fde774b3b40d49cf0b658a330e435515997c45f3f1830": ["v1.25.2"]
+    "sha256:9ea8546111053640958ff38c28faf0cc7092a09156c9833b8197b875cd44a639": ["v1.25.3-rc.0"]
+- name: conformance-amd64
+  dmap:
+    "sha256:414b45e63fc1e22cb5a87b09793425bc2465c69f0cb2a9ea3b196158a511e003": ["v1.25.2"]
+    "sha256:bbdf988baadec180b8be6b54bc63f50a006401c1e83a31b289a5b59457b93ef5": ["v1.25.3-rc.0"]
+- name: conformance-arm
+  dmap:
+    "sha256:a6d46cb5e85e51779ffffb2c7685b0bbd8ece11d762a5e77213a8fbedf7b44d2": ["v1.25.2"]
+    "sha256:b4e122b6a7facb9cb94bfb62a71dff4bb891ffb6cab035e4086be14c86be4da5": ["v1.25.3-rc.0"]
+- name: conformance-arm64
+  dmap:
+    "sha256:2e7b34a9e3e7a8263db39c4dbc287ebc0fa2a5d1484027ae3ff73d5fbaaded05": ["v1.25.2"]
+    "sha256:031de5e174d00ad969767559ed80ab291efcc51d905aeb28efd6fb9955ee4f9a": ["v1.25.3-rc.0"]
+- name: conformance-ppc64le
+  dmap:
+    "sha256:869098c7ee617782336b7fd4a624bf3cf7f18d237a9e6ffe27113a35555833c0": ["v1.25.2"]
+    "sha256:6116e1e4c89028666a1e4fd466b948a41221b049dbc56906daec9b4ce4ca8918": ["v1.25.3-rc.0"]
+- name: conformance-s390x
+  dmap:
+    "sha256:6d8066edf09057f9eeb70232febc9de62c1cceb6df621cf29d6b1e054ea61561": ["v1.25.2"]
+    "sha256:6d0ce2680c2064891ad7ef165600fb18d3bda1dbef0e281610a39f0f677c6cb2": ["v1.25.3-rc.0"]
+- name: kube-apiserver
+  dmap:
+    "sha256:e23d880f1c63bf8d0225c112c684afc46d9fc5b7c06ce3cd0a417e95d61679e3": ["v1.25.2"]
+    "sha256:11cc44684f00310cfdab91de8d26c0340f06226c4b09fa5b75ba9444d8ed082b": ["v1.25.3-rc.0"]
+- name: kube-apiserver-amd64
+  dmap:
+    "sha256:c2a20161bd1b1c9e8f2b466f4e5f63f9de484feee813dba126585d39fccf67d3": ["v1.25.0-rc.0"]
+    "sha256:d5d408d2b96f4017df6b257d1203bb24ec0b9af298f0deedbc7b38f8205019ad": ["v1.26.0-alpha.0"]
+- name: kube-apiserver-arm
+  dmap:
+    "sha256:986bdbe7c02f79361af3323f2770b6ed40770edd4171e7528b67de03bd89e046": ["v1.25.2"]
+    "sha256:3242277303b0a9b44fe1a31dd31a2937cd655f61fd9fd4f933767c08815d3fae": ["v1.25.3-rc.0"]
+- name: kube-apiserver-arm64
+  dmap:
+    "sha256:41a0d9659ef2751f657e82fcb06e7d8ac15d482e8a65bdebd82e0c10b171baec": ["v1.25.2"]
+    "sha256:1551bd447ba4f621863126805112d0fc6b23db89f39cc76a1e048cf8f5ab1f35": ["v1.25.3-rc.0"]
+- name: kube-apiserver-ppc64le
+  dmap:
+    "sha256:4051f36660c7edf25a84fbce4076fcaee1d87ed62adbc57f6ed78df30624163b": ["v1.25.2"]
+    "sha256:59690bd966163b296d7f5972160fd8f396aba223b494c16f24cb69cf137c32c4": ["v1.25.3-rc.0"]
+- name: kube-apiserver-s390x
+  dmap:
+    "sha256:b50bf0ba2f7f13d2be8ef6589f742b85e630fbb50df745e90c563c17d00b8a6b": ["v1.25.2"]
+    "sha256:5a2add3f5758f75203d3af6381d9c8bf406f9e9850d84431e4af1eb43f6403bb": ["v1.25.3-rc.0"]


### PR DESCRIPTION
Promoted a selection of images from https://github.com/kubernetes/k8s.io/pull/4254 to the experimental repository.

#4277 must be merged first.

/hold

/cc @kubernetes/release-engineering @dims 