### PR TITLE
greenhouse: remove GKE nodepool

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/00-provider.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/00-provider.tf
@@ -30,11 +30,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90.1"
+      version = "~> 4.16.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.90.1"
+      version = "~> 4.16.0"
     }
   }
 }

--- a/infra/gcp/terraform/k8s-infra-prow-build/external-ips.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/external-ips.tf
@@ -22,14 +22,6 @@ resource "google_compute_address" "boskos_metrics" {
   address_type = "EXTERNAL"
 }
 
-resource "google_compute_address" "greenhouse_metrics" {
-  name         = "greenhouse-metrics"
-  description  = "to allow monitoring.k8s.prow.io to scrape greenhouse metrics"
-  project      = module.project.project_id
-  region       = local.cluster_location
-  address_type = "EXTERNAL"
-}
-
 resource "google_compute_address" "kubernetes_external_secrets_metrics" {
   name         = "kubernetes-external-secrets-metrics"
   description  = "to allow monitoring.k8s.prow.io to scrape kubernetes-external-secrets metrics"

--- a/infra/gcp/terraform/k8s-infra-prow-build/main.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/main.tf
@@ -100,24 +100,3 @@ module "prow_build_nodepool_n1_highmem_8_localssd" {
   service_account           = module.prow_build_cluster.cluster_node_sa.email
 }
 
-# Why the large machine type?
-# - To maximize IOPs, which are CPU-limited for network attached storage
-#
-# NOTE: updating taints requires recreating the underlying resource, see module docs
-module "greenhouse_nodepool" {
-  source          = "../modules/gke-nodepool"
-  project_name    = module.project.project_id
-  cluster_name    = module.prow_build_cluster.cluster.name
-  location        = module.prow_build_cluster.cluster.location
-  name            = "greenhouse"
-  labels          = { dedicated = "greenhouse" }
-  taints          = [{ key = "dedicated", value = "greenhouse", effect = "NO_SCHEDULE" }]
-  initial_count   = 1
-  min_count       = 1
-  max_count       = 1
-  image_type      = "UBUNTU_CONTAINERD"
-  machine_type    = "n1-standard-32"
-  disk_size_gb    = 100
-  disk_type       = "pd-standard"
-  service_account = module.prow_build_cluster.cluster_node_sa.email
-}

--- a/infra/gcp/terraform/k8s-infra-prow-build/versions.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/versions.tf
@@ -20,5 +20,5 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 1.0.0"
+  required_version = "~> 1.1.0"
 }


### PR DESCRIPTION
Part of:
  - https://github.com/kubernetes/test-infra/issues/24247

Remove GKE nodepool dedicated to greenhouse. k8s deployments and services
have been removed.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>
