### PR TITLE
Allow kgolab to write to k8s-staging-autoscaling GCR

### DIFF
--- a/groups/sig-autoscaling/groups.yaml
+++ b/groups/sig-autoscaling/groups.yaml
@@ -37,6 +37,7 @@ groups:
       - jtuznik@google.com
       - danielmk@google.com
       - guyjtempleton@googlemail.com
+      - kgolab@google.com
 
   #
   # k8s-infra gcs write access

--- a/k8s.gcr.io/images/k8s-staging-autoscaling/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-autoscaling/OWNERS
@@ -11,3 +11,4 @@ approvers:
 - jbartosik
 - towca
 - gjtempleton
+- kgolab


### PR DESCRIPTION
Reason: to help with releases, in particular to release new Addon Resizer for https://github.com/kubernetes/autoscaler/pull/5234.