### PR TITLE
Add support for binary artifact promotion of the cloud-provider-aws project

### DIFF
--- a/artifacts/filestores/k8s-staging-provider-aws/filepromoter-manifest.yaml
+++ b/artifacts/filestores/k8s-staging-provider-aws/filepromoter-manifest.yaml
@@ -1,0 +1,6 @@
+# google group for gcr.io/k8s-staging-provider-aws is k8s-infra-staging-provider-aws@kubernetes.io
+filestores:
+- base: gs://k8s-staging-provider-aws/releases/
+  src: true
+- base: gs://k8s-artifacts-prod/binaries/cloud-provider-aws/
+  service-account: k8s-infra-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/artifacts/manifests/k8s-staging-provider-aws/OWNERS
+++ b/artifacts/manifests/k8s-staging-provider-aws/OWNERS
@@ -1,0 +1,20 @@
+# Should be in sync with https://github.com/kubernetes/cloud-provider-aws/blob/master/OWNERS
+
+approvers:
+- justinsb
+- nckturner
+- M00nF1sh
+- andrewsykim
+- wongma7
+- jaypipes
+- olemarkus
+- hakman
+reviewers:
+- justinsb
+- nckturner
+- M00nF1sh
+- andrewsykim
+- wongma7
+- jaypipes
+- olemarkus
+- hakman

--- a/artifacts/manifests/k8s-staging-provider-aws/v1.26.0.yaml
+++ b/artifacts/manifests/k8s-staging-provider-aws/v1.26.0.yaml
@@ -1,0 +1,5 @@
+files:
+- name: v1.26.0/cloud-provider-aws-1.26.0.tar.gz
+  sha256: 75ede52bf2975928f87ae04e441fd28f1af5a610bac52548841cbb91caa3c107
+- name: v1.26.0/cloud-provider-aws-1.26.0.zip
+  sha256: f301370a1647a4e9fbcb44e9cd51a5123776652398def2897e26d4cef287f510


### PR DESCRIPTION
The AWS CCM project comes with a kubelet credentials provider binary we'd like to use the binary promotion for.
I believe this PR contains the necessary files to create the staging bucket and add support for binary promotion.