### PR TITLE
add myself to k8s-infra-staging-cloud-provider-gcp group

### DIFF
--- a/groups/sig-cloud-provider/groups.yaml
+++ b/groups/sig-cloud-provider/groups.yaml
@@ -70,6 +70,7 @@ groups:
       - mattcary@google.com
       - saikatroyc@google.com
       - jinxu@google.com
+      - andrewsy@google.com
 
   - email-id: k8s-infra-staging-cloud-provider-ibm@kubernetes.io
     name: k8s-infra-staging-cloud-provider-ibm


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <andrewsy@google.com>

Currently working on getting images published for `k8s.io/cloud-provider-gcp` to a staging registry, which requries ACL to test/validate build scripts.