### PR TITLE
registry.k8s.io: remove asia-southeast1

### DIFF
--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/terraform.tfvars
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/terraform.tfvars
@@ -66,18 +66,6 @@ cloud_run_config = {
       }
     ]
   }
-  asia-southeast1 = {
-    environment_variables = [
-      {
-        name  = "UPSTREAM_REGISTRY_ENDPOINT",
-        value = "https://asia-southeast1-docker.pkg.dev"
-      },
-      {
-        name  = "UPSTREAM_REGISTRY_PATH",
-        value = "k8s-artifacts-prod/images"
-      }
-    ]
-  }
   australia-southeast1 = {
     environment_variables = [
       {


### PR DESCRIPTION
Related to:
- https://github.com/kubernetes/registry.k8s.io/issues/116

The Cloud Run service in this region pointing at the matching AR region, but we have no AR instance there.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>