### PR TITLE
feat: updates for CAPA image promotion

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cluster-api-aws/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api-aws/OWNERS
@@ -1,16 +1,16 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- chuckha
-- davidewatson
-- detiber
-- ingvagabund
-- justinsb
-- timothysc
-- vincepri
-- randomvariable
 - richardcase
 - sedefsavas
+- Skarlso
+- Ankitasw
+- dlipovetsky
 
 emeritus_approvers:
+- chuckha
+- detiber
 - ncdc
+- randomvariable
+- rudoi
+- vincepri


### PR DESCRIPTION
Changes to the **OWNERS** for the CAPA image promotion. Correct as of 2022-10-19.

Until https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3775 merges:

/hold

Signed-off-by: Richard Case <richard.case@outlook.com>