### PR TITLE
feat: changes to the CAPA staging group

### DIFF
--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -200,15 +200,11 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
-      - andrewrudoi@gmail.com
-      - davanum@gmail.com
-      - detiber@gmail.com
-      - fpandini@vmware.com
-      - goldsteina@vmware.com
-      - jeewan@vmware.com
-      - prignanov@vmware.com
       - richmcase@gmail.com
       - sedefsavas@gmail.com
+      - ankita.swamy20@gmail.com
+      - skarlso777@gmail.com
+      - daniel.lipovetsky@gmail.com
 
   - email-id: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
     name: sig-cluster-lifecycle-cluster-api-aws-alerts
@@ -224,6 +220,9 @@ groups:
     owners:
       - richmcase@gmail.com
       - sedefsavas@gmail.com
+      - ankita.swamy20@gmail.com
+      - skarlso777@gmail.com
+      - daniel.lipovetsky@gmail.com
 
   - email-id: k8s-infra-staging-cluster-api-do@kubernetes.io
     name: k8s-infra-staging-cluster-api-do


### PR DESCRIPTION
Changes to the membership of `k8s-infra-staging-cluster-api-aws` based on the maintainers of CAPA as of 2022-10-19.

Until https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3775 merges:

/hold

Signed-off-by: Richard Case <richard.case@outlook.com>