### PR TITLE
Update OWNER_ALIASES and add Jason to Code of Conduct Group

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -153,11 +153,11 @@ aliases:
     - mylesagray
     - phenixblue
   committee-code-of-conduct:
-    - celestehorgan
-    - cpanato
-    - karenhchu
-    - palnabarun
-    - vllry
+    - detiber
+    - endocrimes
+    - hlipsig
+    - jeremyrickard
+    - salaxander
   committee-security-response:
     - cjcullen
     - enj

--- a/groups/committee-code-of-conduct/groups.yaml
+++ b/groups/committee-code-of-conduct/groups.yaml
@@ -10,5 +10,5 @@ groups:
       - hilliary.lipsig@gmail.com
       - jeremy.r.rickard@gmail.com
       - lancashiredanielle@gmail.com
-      - pal.nabarun95@gmail.com
       - xandergrzyw@gmail.com
+      - detiber@gmail.com


### PR DESCRIPTION
As part of onboarding new Kubernetes Code of Conduct Committee members, this PR updates the OWNER_ALIASES to reflect the new members and off board departing members. This email also onboards @detiber  to the google group

part of https://github.com/kubernetes/community/issues/6916

Signed-off-by: Jeremy Rickard <jeremyrrickard@gmail.com>