### PR TITLE
registry.k8s.io: change variable name

### DIFF
--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/variables.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/variables.tf
@@ -20,7 +20,7 @@ variable "domain" {
 variable "project_id" {
   type = string
 }
-variable "tag" {
+variable "digest" {
   type = string
 }
 variable "cloud_run_config" {


### PR DESCRIPTION
Follow-up of: 
  - https://github.com/kubernetes/k8s.io/pull/4361

Digests are used instead of tags for rollouts.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>