### PR TITLE
add a regression test for image manifests

### DIFF
--- a/hack/verify-manifests.sh
+++ b/hack/verify-manifests.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
+readonly REPO_ROOT
+
+cd "${REPO_ROOT}"/k8s.gcr.io/manifests
+go test

--- a/k8s.gcr.io/manifests/go.mod
+++ b/k8s.gcr.io/manifests/go.mod
@@ -1,0 +1,10 @@
+module k8s.io/k8s.io/k8s.gcr.io/manifests
+
+go 1.19
+
+require (
+	k8s.io/apimachinery v0.25.3
+	sigs.k8s.io/yaml v1.3.0
+)
+
+require gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/k8s.gcr.io/manifests/go.sum
+++ b/k8s.gcr.io/manifests/go.sum
@@ -1,0 +1,12 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
+k8s.io/apimachinery v0.25.3 h1:7o9ium4uyUOM76t6aunP0nZuex7gDf8VGwkR5RcJnQc=
+k8s.io/apimachinery v0.25.3/go.mod h1:jaF9C/iPNM1FuLl7Zuy5b9v+n35HGSh6AQ4HYRkCqwo=
+sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
+sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=

--- a/k8s.gcr.io/manifests/manifest_test.go
+++ b/k8s.gcr.io/manifests/manifest_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manifest
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"sigs.k8s.io/yaml"
+)
+
+func TestManifestLooksReasonable(t *testing.T) {
+	err := filepath.Walk(".",
+		func(currPath string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			// ignore everything but yaml files
+			if info.IsDir() || !strings.HasSuffix(currPath, ".yaml") {
+				return nil
+			}
+			return manifestLooksReasonable(currPath)
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+type Registry struct {
+	Name string `json:"name"`
+	Src  bool   `json:"src"`
+}
+type Manifest struct {
+	Registries []Registry `json:"registries"`
+}
+
+// TODO: If you add any production registries you will have to update this list 🤷
+var ProdRegistries []string = []string{
+	"asia.gcr.io/k8s-artifacts-prod/",
+	"us.gcr.io/k8s-artifacts-prod/",
+	"eu.gcr.io/k8s-artifacts-prod/",
+	"asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/",
+	"asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/",
+	"asia-northeast1-docker.pkg.dev/k8s-artifacts-prod/images/",
+	"asia-northeast2-docker.pkg.dev/k8s-artifacts-prod/images/",
+	"australia-southeast1-docker.pkg.dev/k8s-artifacts-prod/images/",
+	"europe-north1-docker.pkg.dev/k8s-artifacts-prod/images/",
+	"europe-southwest1-docker.pkg.dev/k8s-artifacts-prod/images/",
+	"europe-west1-docker.pkg.dev/k8s-artifacts-prod/images/",
+	"europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/",
+	"europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/",
+	"europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/",
+	"europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/",
+	"southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/",
+	"us-central1-docker.pkg.dev/k8s-artifacts-prod/images/",
+	"us-east1-docker.pkg.dev/k8s-artifacts-prod/images/",
+	"us-east4-docker.pkg.dev/k8s-artifacts-prod/images/",
+	"us-east5-docker.pkg.dev/k8s-artifacts-prod/images/",
+	"us-south1-docker.pkg.dev/k8s-artifacts-prod/images/",
+	"us-west1-docker.pkg.dev/k8s-artifacts-prod/images/",
+	"us-west2-docker.pkg.dev/k8s-artifacts-prod/images/",
+}
+
+func manifestLooksReasonable(manifestPath string) error {
+	contents, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return err
+	}
+	var m Manifest
+	if err := yaml.Unmarshal(contents, &m); err != nil {
+		return err
+	}
+	// ensure all registries exist and have the same image names
+	nameToRegistries := map[string]sets.String{}
+	numTopLevelImagesFound := 0
+	numSrc := 0
+	for _, r := range m.Registries {
+		// check number of src entries don't constrain values
+		if r.Src {
+			numSrc++
+			continue
+		}
+		// find the matching production registry
+		foundRegistry := false
+		for _, pr := range ProdRegistries {
+			if strings.HasPrefix(r.Name, pr) {
+				imageName := strings.TrimPrefix(r.Name, pr)
+				if _, exists := nameToRegistries[imageName]; !exists {
+					nameToRegistries[imageName] = sets.NewString()
+				}
+				nameToRegistries[imageName].Insert(pr)
+				foundRegistry = true
+				break
+			}
+			// special case for top-level image promotion
+			if r.Name+"/" == pr {
+				numTopLevelImagesFound++
+				foundRegistry = true
+				break
+			}
+		}
+		if !foundRegistry {
+			return fmt.Errorf("%q does not match any known prod registries in %q", r.Name, manifestPath)
+		}
+	}
+	// check results
+	// for each image name we find, ensure it is in all prod registries
+	for imageName, registries := range nameToRegistries {
+		if len(registries) != len(ProdRegistries) {
+			return fmt.Errorf("did not find all production registries, %d found but expected %d for image %q in %q", len(registries), len(ProdRegistries), imageName, manifestPath)
+		}
+	}
+	// if we found any top level promotions, we should find all prod registries
+	if numTopLevelImagesFound != 0 && numTopLevelImagesFound != len(ProdRegistries) {
+		return fmt.Errorf("found %d top-level image promotions but expected 0 or %d in %q", numTopLevelImagesFound, len(ProdRegistries), manifestPath)
+	}
+	// there should be exactly one src registry
+	if numSrc != 1 {
+		return fmt.Errorf("expected exactly one src entry but got %d in %q", numSrc, manifestPath)
+	}
+	return nil
+}


### PR DESCRIPTION
TODO: run this in CI

local:
```console
$ (cd k8s.gcr.io/manifests && go test)
--- FAIL: TestManifestLooksReasonable (0.01s)
    manifest_test.go:44: expected only one base name but got multiple in ["cluster-api-aure" "cluster-api-azure"]: "k8s-staging-cluster-api-azure/promoter-manifest.yaml"
FAIL
exit status 1
FAIL    k8s.io/k8s.io/k8s.gcr.io/manifests      0.194s
```

fixes https://github.com/kubernetes/k8s.io/issues/4367