### PR TITLE
Add myself to k8s-infra-gcp-auditors

### DIFF
--- a/groups/sig-k8s-infra/groups.yaml
+++ b/groups/sig-k8s-infra/groups.yaml
@@ -245,6 +245,7 @@ groups:
       - sig-k8s-infra-leads@kubernetes.io
       - sj7trunks@pendulus.net
       - cy@borg.dev
+      - jonjohnson@google.com
 
   #
   # k8s-infra org-wide infrastructure admin groups


### PR DESCRIPTION
Hello! I'm on the GCR team. I'm proctoring the rollout of redirecting k8s.gcr.io to registry.k8s.io.

It would be very helpful to have this role for the next couple weeks, especially during kubecon, in case something goes wrong.