### PR TITLE
fine-tune registry.k8s.io

### DIFF
--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/oci-proxy.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/oci-proxy.tf
@@ -115,8 +115,8 @@ resource "google_cloud_run_service" "oci-proxy" {
       # a region we can scale to another 1 core instance
       container_concurrency = 800
 
-      // 30 seconds less than cloud scheduler maximum.
-      timeout_seconds = 570
+      // we only serve cheap redirects, 60s is a rather long request
+      timeout_seconds = 60
     }
   }
 

--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/oci-proxy.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/oci-proxy.tf
@@ -97,7 +97,7 @@ resource "google_cloud_run_service" "oci-proxy" {
           }
         }
 
-        // ensure this macth the value for template.spec.containers.resources.limits
+        // ensure this match the value for template.spec.containers.resources.limits
         env {
           name  = "GOMAXPROCS"
           value = "1"
@@ -110,7 +110,10 @@ resource "google_cloud_run_service" "oci-proxy" {
         }
       }
 
-      container_concurrency = 1000
+      # we can probably hit 1k QPS/core (cloud run's maximum configurable)
+      # but we are leaving in a little overhead, if we actually hit 1k qps in
+      # a region we can scale to another 1 core instance
+      container_concurrency = 800
 
       // 30 seconds less than cloud scheduler maximum.
       timeout_seconds = 570


### PR DESCRIPTION
based on metrics against some less-trivial real live traffic

We peaked at ~500qps and ~50% CPU in us-east4 with today's additional k8s.gcr.io traffic.

Slightly reducing container_concurrency (we don't actually want to hit 100% CPU ...) and tuning down request timeout.

We're still configured to scale up to 8000 qps/region which should be more than plenty.