### PR TITLE
Add mailing list for CEL related discussions

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -21,6 +21,7 @@ restrictions:
     allowedGroups:
       - "^k8s-infra-staging-etcd@kubernetes.io$"
       - "^k8s-infra-staging-storage-migrator@kubernetes.io$"
+      - "^sig-api-machinery-cel-dev@kubernetes.io$"
   - path: "sig-apps/groups.yaml"
     allowedGroups:
       - "^k8s-infra-staging-examples@kubernetes.io$"

--- a/groups/sig-api-machinery/groups.yaml
+++ b/groups/sig-api-machinery/groups.yaml
@@ -7,6 +7,41 @@ groups:
   # and is not intended to govern access to infrastructure
   #
 
+  - email-id: sig-api-machinery-cel-dev@kubernetes.io
+    name: sig-api-machinery-cel-dev
+    description: |-
+      Discussion of SIG api-machinery CEL based features
+    settings:
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      ReconcileMembers: "true"
+    owners:
+      - jpbetz@google.com
+      - cic37@google.com
+      - deads@redhat.com
+      - lavalamp@google.com
+    members:
+      - cquirogapichincha@gmail.com
+      - sttts@redhat.com
+      - bluddy@redhat.com
+      - rita.z.zhang@gmail.com
+      - angoldst@redhat.com
+      - mok@vmware.com
+      - zielenski@google.com
+      - andrewsy@google.com
+      - apelisse@google.com
+      - bentheelder@google.com
+      - cicih@google.com
+      - davishaba@google.com
+      - soorena@google.com
+      - jhf@google.com
+      - jim@nirmata.com
+      - liggitt@google.com
+      - kermitalexandr@google.com
+      - leilajal@google.com
+      - smythe@google.com
+      - stevenlinde@google.com
+      - stclair@google.com
+
   #
   # k8s-staging write access for SIG-owned subprojects
   #


### PR DESCRIPTION
We already have a mailing list (https://groups.google.com/a/google.com/g/wg-sig-api-machinery-cel-dev-external) but it is not external or community managed, so we'd like to move to this list.

cc @kubernetes/sig-api-machinery-leads 