### PR TITLE
Add staging gcp project for zeitgeist

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -143,6 +143,7 @@ restrictions:
       - "^k8s-infra-staging-publishing-bot@kubernetes.io$"
       - "^k8s-infra-staging-bom@kubernetes.io$"
       - "^k8s-infra-staging-tg-exporter@kubernetes.io$"
+      - "^k8s-infra-staging-zeitgeist@kubernetes.io$"
       - "^release-comms@kubernetes.io$"
       - "^release-managers-private@kubernetes.io$"
       - "^release-managers@kubernetes.io$"

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -494,3 +494,14 @@ groups:
       - priyankasaggu11929@gmail.com # 1.26 Release Lead Shadow
       - pal.nabarun95@gmail.com # 1.26 RT EA
       - ryler.hockenbury@gmail.com # 1.26 Enhancements Lead
+
+  - email-id: k8s-infra-staging-zeitgeist@kubernetes.io
+    name: k8s-infra-staging-zeitgeist
+    description: |-
+      ACL for staging Zeitgeist project
+
+      This project is used to test and stage Zeitgeist project.
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - k8s-infra-release-editors@kubernetes.io

--- a/infra/gcp/infra.yaml
+++ b/infra/gcp/infra.yaml
@@ -333,6 +333,7 @@ infra:
       k8s-staging-slack-infra:
       k8s-staging-sp-operator:
       k8s-staging-storage-migrator:
+      k8s-staging-zeitgeist:
       k8s-staging-test-infra:
       k8s-staging-tg-exporter:
       k8s-staging-gmsa-webhook:

--- a/k8s.gcr.io/images/k8s-staging-zeitgeist/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-zeitgeist/OWNERS
@@ -1,0 +1,14 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+options:
+  no_parent_owners: true
+approvers:
+  - release-engineering-approvers
+  - sig-testing-leads
+  - sig-k8s-infra-leads
+reviewers:
+  - release-engineering-reviewers
+
+labels:
+  - sig/release
+  - area/release-eng

--- a/k8s.gcr.io/images/k8s-staging-zeitgeist/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-zeitgeist/images.yaml
@@ -1,0 +1,1 @@
+# No images yet

--- a/k8s.gcr.io/manifests/k8s-staging-zeitgeist/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-zeitgeist/promoter-manifest.yaml
@@ -1,0 +1,50 @@
+# google group for gcr.io/k8s-staging-zeitgeist is k8s-infra-staging-zeitgeist@kubernetes.io
+registries:
+  - name: gcr.io/k8s-staging-zeitgeist
+    src: true
+  - name: us.gcr.io/k8s-artifacts-prod/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: eu.gcr.io/k8s-artifacts-prod/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia.gcr.io/k8s-artifacts-prod/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia-northeast1-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia-northeast2-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: australia-southeast1-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-north1-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-southwest1-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west1-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-central1-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-east1-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-east4-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-east5-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-south1-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-west1-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-west2-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
we need to start releasing and promoting the artifacts we generate in the zeitgeist project (https://github.com/kubernetes-sigs/zeitgeist)

so we need to create a staging gcp project with bucket for that :)

Related to https://github.com/kubernetes-sigs/zeitgeist/issues/324

/assign @ameukam @saschagrunert @puerco
cc @justaugustus  @kubernetes/release-engineering 