### PR TITLE
update csi sidecars to latest

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-sig-storage/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-sig-storage/images.yaml
@@ -37,6 +37,7 @@
     "sha256:fc39de92284cc45240417f48549ee1c98da7baef7d0290bc29b232756dfce7c0": [ "v2.4.0" ]
     "sha256:4fd21f36075b44d1a423dfb262ad79202ce54e95f5cbc4622a6c1c38ab287ad6": [ "v2.5.0" ]
     "sha256:0103eee7c35e3e0b5cd8cdca9850dc71c793cdeb6669d8be7a89440da2d06ae4": [ "v2.5.1" ]
+    "sha256:f1c25991bac2fbb7f5fcf91ed9438df31e30edee6bed5a780464238aa09ad24c": [ "v2.6.0" ]
 - name: csi-provisioner
   dmap:
     "sha256:438c04395d03fa671f8656d6f951332516754e330d1ac4f9588df1ba2870a366": [ "v1.4.0" ]
@@ -132,6 +133,7 @@
     "sha256:44d8275b3f145bc290fd57cb00de2d713b5e72d2e827d8c5555f8ddb40bf3f02": [ "v2.5.0" ]
     "sha256:406f59599991916d2942d8d02f076d957ed71b541ee19f09fc01723a6e6f5932": [ "v2.6.0" ]
     "sha256:933940f13b3ea0abc62e656c1aa5c5b47c04b15d71250413a6b821bd0c58b94e": [ "v2.7.0" ]
+    "sha256:cacee2b5c36dd59d4c7e8469c05c9e4ef53ecb2df9025fa8c10cdaf61bce62f0": [ "v2.8.0" ]
 - name: local-volume-provisioner
   dmap:
     "sha256:63859b69f9dfc0858e5d8746218e435c36e205c041fb6d8baf71ad132e24737f": [ "v2.4.0" ]


### PR DESCRIPTION
node-driver-registrar image : v2.6.0
liveness-probe:             : v2.8.0

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>