### PR TITLE
Add staging gcp project for tejolote

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -144,6 +144,7 @@ restrictions:
       - "^k8s-infra-staging-publishing-bot@kubernetes.io$"
       - "^k8s-infra-staging-bom@kubernetes.io$"
       - "^k8s-infra-staging-tg-exporter@kubernetes.io$"
+      - "^k8s-infra-staging-tejolote@kubernetes.io$"
       - "^k8s-infra-staging-zeitgeist@kubernetes.io$"
       - "^release-comms@kubernetes.io$"
       - "^release-managers-private@kubernetes.io$"

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -504,3 +504,14 @@ groups:
       ReconcileMembers: "true"
     members:
       - k8s-infra-release-editors@kubernetes.io
+
+  - email-id: k8s-infra-staging-tejolote@kubernetes.io
+    name: k8s-infra-staging-tejolote
+    description: |-
+      ACL for staging Tejolote project
+
+      This project is used to test and stage tejolote project.
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - k8s-infra-release-editors@kubernetes.io

--- a/infra/gcp/infra.yaml
+++ b/infra/gcp/infra.yaml
@@ -334,6 +334,7 @@ infra:
       k8s-staging-sp-operator:
       k8s-staging-storage-migrator:
       k8s-staging-zeitgeist:
+      k8s-staging-tejolote:
       k8s-staging-test-infra:
       k8s-staging-tg-exporter:
       k8s-staging-gmsa-webhook:

--- a/k8s.gcr.io/images/k8s-staging-tejolote/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-tejolote/OWNERS
@@ -1,0 +1,14 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+options:
+  no_parent_owners: true
+approvers:
+  - release-engineering-approvers
+  - sig-testing-leads
+  - sig-k8s-infra-leads
+reviewers:
+  - release-engineering-reviewers
+
+labels:
+  - sig/release
+  - area/release-eng

--- a/k8s.gcr.io/images/k8s-staging-tejolote/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-tejolote/images.yaml
@@ -1,0 +1,1 @@
+# No images yet

--- a/k8s.gcr.io/manifests/k8s-staging-tejolote/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-tejolote/promoter-manifest.yaml
@@ -1,0 +1,50 @@
+# google group for gcr.io/k8s-staging-tejolote is k8s-infra-staging-tejolote@kubernetes.io
+registries:
+  - name: gcr.io/k8s-staging-tejolote
+    src: true
+  - name: us.gcr.io/k8s-artifacts-prod/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: eu.gcr.io/k8s-artifacts-prod/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia.gcr.io/k8s-artifacts-prod/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia-northeast1-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia-northeast2-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: australia-southeast1-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-north1-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-southwest1-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west1-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-central1-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-east1-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-east4-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-east5-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-south1-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-west1-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-west2-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
we need to start releasing and promoting the artifacts we generate in the tejolote project (https://github.com/kubernetes-sigs/tejolote)

so we need to create a staging gcp project with bucket for that :)

/assign @ameukam @saschagrunert @puerco @jeremyrickard 
cc @justaugustus  @kubernetes/release-engineering 