### PR TITLE
Update Owners on kube-state-metrics

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-kube-state-metrics/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-kube-state-metrics/OWNERS
@@ -1,9 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- brancz
 - dgrisonnet
 - fpetkovski
-- lilic
 - mrueg
-- tariq1890


### PR DESCRIPTION
Removing emeritus approvers here.

CC: @dgrisonnet @fpetkovski 
