### PR TITLE
promoting testrunner with ginkgo-v2.5.1

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -133,6 +133,7 @@
     "sha256:116f05f2cc293e96c9f4abd7f7add365fe23ceb85486fe94b973eddd75a76fbf": ["v20220905-g79a311d3b"]
     "sha256:f3f26f1e2aef8b2013b731f041fd69bcd950d3118eecf4429551848f47305c0f": ["v20220916-gd32f8c343"]
     "sha256:9ab6a412b0ea6ae77abc80309608976ec15141e146fa91ef4352400cb9051086": ["v20221012-controller-v1.4.0-14-g93df79676"]
+    "sha256:50c5469f08b664e928a3035ac94a2348955b669d7ac33809abc674c8fd6c19c1": ["v20221125-controller-v1.5.1-21-g9d562c47a"]
 
 # custom cfssl image for e2e tests
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/cfssl


### PR DESCRIPTION
- New testrunner created because of this https://github.com/kubernetes/ingress-nginx/pull/9336 and https://github.com/kubernetes/ingress-nginx/pull/9339
- This PR promotes the new testrunner that has ginkgo bumped to v2.5.1 because dependabot bumped ginkgo in https://github.com/kubernetes/ingress-nginx/pull/9317
- Without this, `make kind-e2e-test` breaks as explained in https://github.com/kubernetes/ingress-nginx/pull/9336

/triage accepted
/assign @rikatz @tao12345666333 @strongjz 