### PR TITLE
Revert "releng: temporary release manager access for salaxander"

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -47,7 +47,6 @@ groups:
       - mudrinic.mare@gmail.com
       - pal.nabarun95@gmail.com
       - saschagrunert@gmail.com
-      - xandergrzyw@gmail.com
 
   - email-id: k8s-infra-release-viewers@kubernetes.io
     name: k8s-infra-release-viewers


### PR DESCRIPTION
Now that the rc1 release is completed, I am removing this access.

Reverts Kubernetes/k8s.io#4509