### PR TITLE
release: Promote CAPA v2.0.2 image

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cluster-api-aws/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api-aws/images.yaml
@@ -68,6 +68,7 @@
     "sha256:71b9389f0ff3376849d0d828cefb79e1cf008d77ad8ab97948cf00b57147c70e": [ "v2.0.0-beta.1" ]
     "sha256:6271d2bff0fbb816d1931cedc5327fa16545df3b56b2c0695ebab210caf2ec36": ["v2.0.0"]
     "sha256:290985e74649f920c2b91dc56d11efe22e6ca6ecfde001f2d58395620b621477": ["v2.0.1"]
+    "sha256:2ac290027403eebdbc5bc92e8c6d666eaf7d7ac04de07903fe9cef3d8945d6c0": ["v2.0.2"]
 - name: eks-bootstrap-controller
   dmap:
     "sha256:0dda3f1be2c56b0ffee4668c67a9da2a5af33a5aa66c7db91c98534140265408": ["v0.6.0"]


### PR DESCRIPTION
Adds the v2.0.2 images for CAPA.