### PR TITLE
Promote ip-masq-agent v2.9.0 image

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-networking/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-networking/images.yaml
@@ -1,5 +1,6 @@
 - name: ip-masq-agent
   dmap:
+    "sha256:bb14c14b7a829909ec3e76bc0137269b9e52c4353522f9a5156e3f7903e4cdbe": ["v2.9.0"]
     "sha256:d8cd0c7118e74bb9b1c90b2fd3c0c90d52d5d5ecea63b06e08e869a9d6e59fed": ["v2.8.0"]
     "sha256:e02d4a264ea8a03f6ef0f222a9a979eaeb9954ef603a40e77f3fe8827947a9a6": ["v2.8.0__linux_amd64"]
     "sha256:983102c0bf47a385c82793d475f8bfc454be2b8be7a5864e7617f0229192a52d": ["v2.8.0__linux_arm"]


### PR DESCRIPTION
We are cutting a new release for ip-masq-agent and need to release this image (manifest list).

Ref https://github.com/kubernetes-sigs/ip-masq-agent/issues/94.
cc @stonith @jingyuanliang 