### PR TITLE
Move cs.k8s.io to another server

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -133,7 +133,7 @@ conduct:
 # This service runs in a equinix host managed by @dims
 cs:
   type: A
-  value: 139.178.84.205
+  value: 86.109.7.36
 # Canary for Code Search on GKE cluster aaa (@dims @jimdaga)
 cs-canary:
   type: A


### PR DESCRIPTION
we received a `Equinix Machine Deprecation Notice` for the old server we had the `cs.k8s.io` on. So moving hound search into another server.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>