### PR TITLE
dns: domain validation of cdn.dl.k8s.io

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -112,6 +112,12 @@ artifacts:
   values:
   - 35.244.192.77
 
+# Domain delegation of cdn.dl.l8s.io to Fastly.
+# Reach out to sig-k8s-infra-leads@kubernetes.io for any issue
+cdn.dl:
+  type: TXT
+  value: fastly-domain-delegation-yyD9G&IG34BM-2022-08-01
+
 # Vanity CNAMEs.
 blog:
   type: CNAME


### PR DESCRIPTION
Part of:
  - https://github.com/kubernetes/k8s.io/issues/4528

In order to be able to use Fastly, we will need use a subdomain to serve the binaries built and store kubernetes-release bucket.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>