### PR TITLE
Promote EBS CSI Driver v1.14.0

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-provider-aws/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-provider-aws/images.yaml
@@ -51,6 +51,7 @@
     "sha256:21c6eedc2a80bfec5dee669d30d9b5ca83e68cd097f0e210917ae91312e590ff": ["v1.12.0"]
     "sha256:c8d9c4a04d8672f1d1b47acc5a5fe13b8a1ee8c344b5c249ecb843edc69ee87f": ["v1.12.1"]
     "sha256:c75878156614efc7c501ea655cd9da1ede35e9aee252436a92ff01f67f1c53fa": ["v1.13.0"]
+    "sha256:10e231cf07c82dfab5141c1afe548dc734e5fc1f67665ec3982a325d1bd31a9a": ["v1.14.0"]
 - name: cloud-controller-manager
   dmap:
     "sha256:f900d8b4a358847cd311950c7802f938dad083f645eee784cd52b7aec0de8dfb": ["v1.18.0-alpha.0"]


### PR DESCRIPTION
```
crane manifest gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:v20221216-v1.14.0       
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1162,
         "digest": "sha256:98be4cd668dd296201f7b2bea6b9d3bc0ebb600355f9f96239a61b9167ccbfe8",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1162,
         "digest": "sha256:1283d23c33626f72445174b434c36508c3cd3123e9ac17e925cbc4b211e2755e",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 957,
         "digest": "sha256:9601d4ec90184d7e0ae5d57e4f01a9d94086b4113713b110ea0f09c4f777841c",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.19042.1889"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 956,
         "digest": "sha256:1486dbb3b62be43f2f4dcd5c11d0a50c89bd3e85b18293c3aac241e8888e4253",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.17763.3770"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 957,
         "digest": "sha256:324eead325ee587af72dfff244f87f1d044b701d1178d878c7fc2347f4fd8bdf",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.20348.1366"
         }
      }
   ]
}%
```

```
docker run --rm gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:v20221216-v1.14.0 --version    
{
  "driverVersion": "v1.14.0",
  "gitCommit": "",
  "buildDate": "2022-12-16T16:37:39+00:00",
  "goVersion": "go1.19.4",
  "compiler": "gc",
  "platform": "linux/amd64"
}
```

- https://console.cloud.google.com/gcr/images/k8s-staging-provider-aws/global/aws-ebs-csi-driver@sha256:10e231cf07c82dfab5141c1afe548dc734e5fc1f67665ec3982a325d1bd31a9a/details?project=k8s-staging-provider-aws&tab=info

Signed-off-by: torredil <torredil@amazon.com>