### PR TITLE
add aojea to cloud-provider-gcp group

### DIFF
--- a/groups/sig-cloud-provider/groups.yaml
+++ b/groups/sig-cloud-provider/groups.yaml
@@ -64,6 +64,7 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
+      - aojea@google.com
       - msau@google.com
       - saadali@google.com
       - wfender@google.com


### PR DESCRIPTION
I'm trying to automate the image building in the repo and fighting with cloudbuild, but without logs is hard to know what is going wrong