### PR TITLE
infra/aws: create S3 bucket for dev of artifacts.k8s.io

### DIFF
--- a/infra/aws/terraform/test-artifacts.k8s.io/README.md
+++ b/infra/aws/terraform/test-artifacts.k8s.io/README.md
@@ -1,0 +1,29 @@
+# infra/aws/terraform/test-artifacts.k8s.io
+
+Terraform to provision AWS infra for supporting test-artifacts.k8s.io.
+
+This is a cut-down version of artifacts.k8s.io for testing / development.
+
+## Goals
+
+- create publicly-readable regional S3 buckets for serving Kubernetes artifacts.
+
+## Applying the Terraform
+
+```bash
+terraform apply
+```
+
+## State management
+
+The state of the Terraform is currently stored in a private bucket in the CNCF account
+
+```bash
+aws s3 mb s3://test-artifacts-k8s-io-tfstate --region us-east-2
+```
+
+## Notes
+
+This is a very limited configuration for development, aiming to be simple and low-cost.
+
+The staging/prod configuration validation is provided by the artifacts.k8s.io configuration.

--- a/infra/aws/terraform/test-artifacts.k8s.io/main.tf
+++ b/infra/aws/terraform/test-artifacts.k8s.io/main.tf
@@ -1,0 +1,26 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+module "us-east-2" {
+  source = "./s3"
+
+  providers = {
+    aws = aws.us-east-2
+  }
+
+  prefix = "test-"
+}

--- a/infra/aws/terraform/test-artifacts.k8s.io/providers.tf
+++ b/infra/aws/terraform/test-artifacts.k8s.io/providers.tf
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  backend "s3" {
+    bucket = "test-artifacts-k8s-io-tfstate"
+    key    = "terraform.tfstate"
+    region = "us-east-2"
+  }
+
+  required_version = ">= 1.2.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+
+# Provider for AWS non-region-specific operations.
+provider "aws" {
+  # We still have to specify a region to use.
+  region = "us-east-2"
+
+  profile = "default"
+}
+
+# Provider for AWS us-east-2 operations.
+provider "aws" {
+  alias  = "us-east-2"
+  region = "us-east-2"
+
+  profile = "default"
+}

--- a/infra/aws/terraform/test-artifacts.k8s.io/s3/bucket.tf
+++ b/infra/aws/terraform/test-artifacts.k8s.io/s3/bucket.tf
@@ -1,0 +1,123 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "aws_s3_bucket" "artifacts-k8s-io" {
+  bucket = "${var.prefix}artifacts-k8s-io-${data.aws_region.current.name}"
+}
+
+resource "aws_s3_bucket_acl" "artifacts-k8s-io" {
+  bucket = aws_s3_bucket.artifacts-k8s-io.bucket
+  acl    = "public-read"
+}
+
+resource "aws_s3_bucket_policy" "artifacts-k8s-io-public-read" {
+  bucket = aws_s3_bucket.artifacts-k8s-io.bucket
+
+  policy = jsonencode({
+    "Id" : "Public-Access",
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Action" : "s3:ListBucket",
+        "Effect" : "Allow",
+        "Resource" : "${aws_s3_bucket.artifacts-k8s-io.arn}",
+        "Principal" : "*"
+      },
+      {
+        "Action" : "s3:GetObject",
+        "Effect" : "Allow",
+        "Resource" : "${aws_s3_bucket.artifacts-k8s-io.arn}/*",
+        "Principal" : "*"
+      },
+      {
+        "Sid" : "AllowSSLRequestsOnly",
+        "Action" : "s3:*",
+        "Effect" : "Deny",
+        "Resource" : "${aws_s3_bucket.artifacts-k8s-io.arn}/*",
+        "Condition" : {
+          "Bool" : {
+            "aws:SecureTransport" : "false"
+          }
+        },
+        "Principal" : "*"
+      }
+    ]
+  })
+}
+
+resource "aws_s3_bucket_ownership_controls" "artifacts-k8s-io" {
+  bucket = aws_s3_bucket.artifacts-k8s-io.bucket
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+  depends_on = [
+    aws_s3_bucket.artifacts-k8s-io,
+    aws_s3_bucket_acl.artifacts-k8s-io,
+    aws_s3_bucket_policy.artifacts-k8s-io-public-read
+  ]
+}
+
+# Versioning must be enabled for S3 replication
+resource "aws_s3_bucket_versioning" "artifacts-k8s-io" {
+  bucket = aws_s3_bucket.artifacts-k8s-io.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_replication_configuration" "artifacts-k8s-io" {
+  count = length(var.s3_replication_rules) > 0 ? 1 : 0
+
+  # Must have bucket versioning enabled first
+  depends_on = [aws_s3_bucket_versioning.artifacts-k8s-io]
+
+  role = var.s3_replication_iam_role_arn
+
+  bucket = aws_s3_bucket.artifacts-k8s-io.id
+
+  dynamic "rule" {
+    for_each = var.s3_replication_rules
+
+    content {
+      id = rule.value.id
+
+      status = rule.value.status
+
+      # Set priority, filter and delete_marker_replication to use V2 schema for multiple 
+      # destination bucket rules
+      priority = rule.value.priority
+
+      filter {}
+
+      delete_marker_replication {
+        status = "Enabled"
+      }
+
+      
+
+      destination {
+        bucket        = rule.value.destination_bucket_arn
+        storage_class = rule.value.destination_bucket_storage_class
+
+        metrics {
+          status = "Enabled"
+        }
+      }
+    }
+  }
+}
+

--- a/infra/aws/terraform/test-artifacts.k8s.io/s3/data.tf
+++ b/infra/aws/terraform/test-artifacts.k8s.io/s3/data.tf
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+data "aws_region" "current" {}

--- a/infra/aws/terraform/test-artifacts.k8s.io/s3/variables.tf
+++ b/infra/aws/terraform/test-artifacts.k8s.io/s3/variables.tf
@@ -1,0 +1,32 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+variable "prefix" {
+  type    = string
+  default = ""
+}
+
+variable "s3_replication_iam_role_arn" {
+  description = "IAM role assumed by S3 service for replication"
+  type        = string
+  default     = ""
+}
+
+variable "s3_replication_rules" {
+  description = "List of maps for S3 replication rules"
+  type        = list(map(string))
+  default     = []
+}


### PR DESCRIPTION
As suggested in #4460, we create one bucket in the development account.

We create an isolated configuration, the goal is to enable development,
rather than testing the TF configuration.

Verifying the TF configuration is done in #4460.
