### PR TITLE
Add a secret for bug triage release subproject

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-externalsecrets.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-externalsecrets.yaml
@@ -82,6 +82,19 @@ spec:
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
+  name: k8s-release-bug-triage-github-token
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-infra-prow-build-trusted
+  data:
+  - key: k8s-release-bug-triage-github-token
+    name: token
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
   name: k8s-cip-test-prod-service-account
   namespace: test-pods
 spec:

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/secrets.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/secrets.tf
@@ -36,6 +36,10 @@ locals {
       group = "sig-release"
       owners = "k8s-infra-release-editors@kubernetes.io"
     }
+    k8s-release-bug-triage-github-token = {
+      group = "sig-release"
+      owners = "k8s-infra-release-editors@kubernetes.io"
+    }
     k8s-triage-robot-github-token = {
       group  = "sig-contributor-experience"
       owners = "github@kubernetes.io"


### PR DESCRIPTION
Add a new secret that will contain the GitHub token for bug triage. The secret will be synced to the GKE cluster prow-build-trusted.

Signed-off-by: Heba Elayoty <hebaelayoty@gmail.com>