### PR TITLE
proper build of nginx base image golang 1.19.4/alpine 3.17.0

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -100,6 +100,7 @@
     "sha256:3f5e28bb248d5170e77b77fc2a1a385724aeff41a0b34b5afad7dd9cf93de000": ["0b5e0685112e4537ee20a0bdbba451e9f6158aa3"]
     "sha256:2686073c2ec9e3eae0afd2c26947a38a1d3676bee2f33c0f7245bd326e25a459": ["e3e0d9c1f487cf00c02a2a0ca579f4aff9698e59"]
     "sha256:a51abd4fd2beb5a93f88ff9859c930d0437250bef90118572ad1127c5b30dfa2": ["c648595cd73a2d605cd7d9575b72b367755c7ec8"]
+    "sha256:da6b877ed96dada46ed6e379051c2dd461dd5d329af7a7531820ad3e16197e20": ["21aa7f55a3325c1c26de0dfb62ede4c0a809a994"]
 
 # image to run tests
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/test-runner


### PR DESCRIPTION
Signed-off-by: James Strong <james.strong@chainguard.dev>

A new build of nginx from a new commit. 

https://console.cloud.google.com/cloud-build/builds;region=global/724bb464-598e-4ad9-bdca-6564037ae5c4;step=0?project=k8s-staging-ingress-nginx
