### PR TITLE
Refresh k8s-staging-kas-network-proxy owners.

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-kas-network-proxy/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-kas-network-proxy/OWNERS
@@ -1,8 +1,17 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+# Match https://github.com/kubernetes-sigs/apiserver-network-proxy/blob/master/OWNERS
+
+reviewers:
+  - jefftree
+  - tallclair
+
 approvers:
-  - cheftako
-  - mcrute
   - anfernee
+  - cheftako
+  - jkh52
+
+emeritus_approvers:
   - andrewsykim
   - caesarxuchao
+  - mcrute


### PR DESCRIPTION
Follows https://github.com/kubernetes-sigs/apiserver-network-proxy/pull/416
