### PR TITLE
Create infrastructure for kubebuilder artifacts

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -22,6 +22,7 @@ restrictions:
       - "^k8s-infra-staging-etcd@kubernetes.io$"
       - "^k8s-infra-staging-storage-migrator@kubernetes.io$"
       - "^sig-api-machinery-cel-dev@kubernetes.io$"
+      - "^k8s-infra-staging-kubebuilder@kubernetes.io$"
   - path: "sig-apps/groups.yaml"
     allowedGroups:
       - "^k8s-infra-staging-examples@kubernetes.io$"

--- a/groups/sig-api-machinery/groups.yaml
+++ b/groups/sig-api-machinery/groups.yaml
@@ -75,6 +75,16 @@ groups:
       - wenjiazhang@google.com
       - jingyih@google.com
       - yczhou@google.com
+
+  - email-id: k8s-infra-staging-kubebuilder@kubernetes.io
+    name: k8s-infra-staging-kubebuilder
+    description: |-
+      ACL for pushing kubebuilder artifacts
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - camilamacedo86@gmail.com
+
   #
   # k8s-infra gcs write access
   #

--- a/infra/gcp/infra.yaml
+++ b/infra/gcp/infra.yaml
@@ -306,6 +306,7 @@ infra:
       k8s-staging-krm-functions:
       k8s-staging-kube-state-metrics:
       k8s-staging-kubeadm:
+      k8s-staging-kubebuilder:
       k8s-staging-kueue:
       k8s-staging-kubernetes:
       k8s-staging-kubetest2:

--- a/k8s.gcr.io/images/k8s-staging-kubebuilder/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-kubebuilder/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS file documentation:
+#  https://github.com/kubernetes/community/blob/master/contributors/devel/owners.md
+
+approvers:
+- pwittrock
+- camilamacedo86
+- varshaprasad96
+
+labels:
+- sig/api-machinery

--- a/k8s.gcr.io/images/k8s-staging-kubebuilder/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-kubebuilder/images.yaml
@@ -1,0 +1,5 @@
+# kube-rbac-proxy images
+# https://github.com/kubernetes-sigs/kubebuilder/tree/kube-rbac-proxy-releases/build
+#- name: kube-rbac-proxy
+#  dmap:
+#    "sha256:56633bd00dab33d92ba14c6e709126a762d54a75a6e72437adefeaaca0abb069": ["v0.34.0"] #<- should be the sha image from cloudbuild and the release version

--- a/k8s.gcr.io/manifests/k8s-staging-kubebuilder/promoter-manifest.yaml
+++ b/k8s.gcr.io/manifests/k8s-staging-kubebuilder/promoter-manifest.yaml
@@ -1,0 +1,50 @@
+# google group for gcr.io/k8s-staging-kubebuilder is k8s-infra-staging-kubebuilder@kubernetes.io
+registries:
+  - name: gcr.io/k8s-staging-kubebuilder
+    src: true
+  - name: us.gcr.io/k8s-artifacts-prod/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: eu.gcr.io/k8s-artifacts-prod/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia.gcr.io/k8s-artifacts-prod/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia-northeast1-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia-northeast2-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: australia-southeast1-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-north1-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-southwest1-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west1-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-central1-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-east1-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-east4-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-east5-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-south1-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-west1-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-west2-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
Per #2647

kubebuilder folks need to regain access to old GCP projects, and while discussing with @camilamacedo86 how to achieve this, I've figured out this could be an opportunity for now on to migrate new artifacts to community owned infrastructure.

This PR is split on 4 commits and:
* Creates the new google group for kubebuilder staging under sig-apimachinery
* Creates the required project for kubebuilder staging
* Creates the required image promotion manifests after cloudbuild prow job for kube-rbac-proxy runs
* Creates the required filestore promotion manifest after cloudbuild prowjob for kubebuilder-tools runs **DROPPED THIS COMMIT AS IT NEEDS PREVIOUS STUFF TO BE DONE**

After this PR gets merged, there are still some follow up actions:
* Add two prowjobs post submit for the specific kubebuilder repo branches, to run cloudbuild for kube-rbac-proxy and tools and respectively send the artifacts to the right staging places
* Check/fix cloudbuild yaml files on kubebuilder to use Kubernetes cloudbuild required patterns
* Update kubebuilder release process, to reflect the fact that after cloud build jobs runs, one should go to k8s.io repo, on the image promotion manifests, and request the promotion of the artifacts to the prod buckets/filestore/gcr