### PR TITLE
Add CAPZ contributors to k8s-staging-cluster-api-azure/OWNERS

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-cluster-api-azure/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-cluster-api-azure/OWNERS
@@ -10,6 +10,12 @@ approvers:
 reviewers:
 - Jont828
 - jsturtevant
+- nojnhuh
+- nawazkh
+- willie-yao
+- dtzar
+- marosset
+- sonasingh46
 
 labels:
 - sig/cluster-lifecycle


### PR DESCRIPTION
This PR adds the set of active CAPZ contributors to the list of allowed reviewers for publishing CAPZ staging images.