### PR TITLE
chore: add new capg alerts group

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -80,6 +80,7 @@ restrictions:
       - "^k8s-infra-staging-cluster-api-do@kubernetes.io$"
       - "^k8s-infra-staging-cluster-api-azure@kubernetes.io$"
       - "^k8s-infra-staging-cluster-api-gcp@kubernetes.io$"
+      - "^sig-cluster-lifecycle-cluster-api-gcp-alerts@kubernetes.io$"
       - "^k8s-infra-staging-cluster-api-nested@kubernetes.io$"
       - "^k8s-infra-staging-cluster-addons@kubernetes.io$"
       - "^k8s-infra-staging-etcdadm@kubernetes.io$"

--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -273,6 +273,22 @@ groups:
       - justinsb@google.com
       - prignanov@vmware.com
 
+  - email-id: sig-cluster-lifecycle-cluster-api-gcp-alerts@kubernetes.io
+    name: sig-cluster-lifecycle-cluster-api-gcp-alerts
+    description: |-
+      Receive alerts for CAPG failing tests
+    settings:
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      MessageModerationLevel: "MODERATE_ALL_MESSAGES"
+      ReconcileMembers: "false"
+    owners:
+      - ctadeu@gmail.com
+      - davanum@gmail.com
+      - richmcase@gmail.com
+
   - email-id: k8s-infra-staging-cluster-api-nested@kubernetes.io
     name: k8s-infra-staging-cluster-api-nested
     description: |-


### PR DESCRIPTION
Create a new group that people cane subscribe to if they want to receive alerts for failing tests in CAPG.

Relates to: https://github.com/kubernetes/test-infra/issues/28364

Signed-off-by: Richard Case <richard.case@suse.com>