### PR TITLE
chore: group changes for capg

### DIFF
--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -269,9 +269,8 @@ groups:
     members:
       - ctadeu@gmail.com
       - davanum@gmail.com
-      - detiber@gmail.com
       - justinsb@google.com
-      - prignanov@vmware.com
+      - richmcase@gmail.com
 
   - email-id: k8s-infra-staging-cluster-api-nested@kubernetes.io
     name: k8s-infra-staging-cluster-api-nested


### PR DESCRIPTION
This change updates the staging group for CAPG to match the current maintainers of CAPG.

/cc @cpanato @dims 

Signed-off-by: Richard Case <richard.case@suse.com>