### PR TITLE
Remove mikedanese@google.com from k8s-infra-artifact-security

### DIFF
--- a/groups/committee-security-response/groups.yaml
+++ b/groups/committee-security-response/groups.yaml
@@ -136,7 +136,6 @@ groups:
       ReconcileMembers: "true"
     members:
       - security@kubernetes.io
-      - mikedanese@google.com
 
   # RBAC groups:
   # - grant access to the `namespace-user` role for a single namespace on the `aaa` cluster


### PR DESCRIPTION
It is unclear to me why anyone outside of SRC is on this list.