### PR TITLE
update SIG release groups for 1.27 leads

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -63,12 +63,12 @@ groups:
       - joseph.r.sandoval@gmail.com
       - pal.nabarun95@gmail.com
       - cicih@google.com
-      - xandergrzyw@gmail.com
-      - leonard.pahlke@googlemail.com # 1.26 Release Lead
-      - nwaddington@cncf.io # 1.26 Release Lead Shadow
-      - nng.grace@gmail.com # 1.26 Release Lead Shadow
-      - kat.cosgrove@gmail.com # 1.26 Release Lead Shadow
-      - priyankasaggu11929@gmail.com # 1.26 Release Lead Shadow
+      - xandergrzyw@gmail.com # 1.27 Release Lead
+      - kat.cosgrove@gmail.com # 1.27 Release Lead Shadow
+      - priyankasaggu11929@gmail.com # 1.27 Release Lead Shadow
+      - hebaelayoty@gmail.com # 1.27 Release Lead Shadow
+      - salahi.hossein@gmail.com # 1.27 Release Lead Shadow
+      - james.laverack@jetstack.io # 1.27 Emeritus Advisor
 
   - email-id: k8s-infra-staging-artifact-promoter@kubernetes.io
     name: k8s-infra-staging-artifact-promoter
@@ -197,17 +197,13 @@ groups:
       - k8s@auggie.dev
       - saschagrunert@gmail.com
     members:
-      - leonard.pahlke@googlemail.com # 1.26 Release Lead
-      - pal.nabarun95@gmail.com # 1.26 RT EA
-      - nwaddington@cncf.io # 1.26 Release Lead Shadow
-      - nng.grace@gmail.com # 1.26 Release Lead Shadow
-      - kat.cosgrove@gmail.com # 1.26 Release Lead Shadow
-      - priyankasaggu11929@gmail.com # 1.26 Release Lead Shadow
-      - fsmunoz@gmail.com # 1.26 Release Comms Lead
-      - harshitasao@gmail.com # 1.26 Comms Shadow
-      - bradmccoydev@gmail.com # 1.26 Comms Shadow
-      - daespejo@vmware.com # 1.26 Comms Shadow
-      - d.panigrahi.nitrkl@gmail.com # 1.26 Comms Shadow
+      - xandergrzyw@gmail.com # 1.27 Release Lead
+      - kat.cosgrove@gmail.com # 1.27 Release Lead Shadow
+      - priyankasaggu11929@gmail.com # 1.27 Release Lead Shadow
+      - hebaelayoty@gmail.com # 1.27 Release Lead Shadow
+      - salahi.hossein@gmail.com # 1.27 Release Lead Shadow
+      - harshitasao@gmail.com # 1.27 Comms Lead
+      - james.laverack@jetstack.io # 1.27 Emeritus Advisor
 
   - email-id: release-managers-private@kubernetes.io
     name: release-managers-private
@@ -252,18 +248,19 @@ groups:
       - antheabjung@gmail.com
       - augustus@cisco.com
       - bentheelder@google.com
-      - leonard.pahlke@googlemail.com # 1.26 Release Lead
       #- pal.nabarun95@gmail.com (already added via release manager) # 1.26 RT EA
-      - nwaddington@cncf.io # 1.26 Release Lead Shadow
-      - nng.grace@gmail.com # 1.26 Release Lead Shadow
-      - kat.cosgrove@gmail.com # 1.26 Release Lead Shadow
-      - priyankasaggu11929@gmail.com # 1.26 Release Lead Shadow
+      - kat.cosgrove@gmail.com # 1.27 Release Lead Shadow
+      - priyankasaggu11929@gmail.com # 1.27 Release Lead Shadow
       - gmccloskey@google.com
+      - hebaelayoty@gmail.com # 1.27 Release Lead Shadow
       - jameswangel@gmail.com
       - joseph.r.sandoval@gmail.com
       - mudrinic.mare@gmail.com
       - pal.nabarun95@gmail.com
+      - salahi.hossein@gmail.com # 1.27 Release Lead Shadow
       - spiffxp@google.com
+      - xandergrzyw@gmail.com # 1.27 Release Lead
+      - james.laverack@jetstack.io # 1.27 Emeritus Advisor
 
   - email-id: security-release-team@kubernetes.io
     name: security-release-team
@@ -310,46 +307,19 @@ groups:
       - k8s@auggie.dev
       - saschagrunert@gmail.com
     managers:
-      - leonard.pahlke@googlemail.com # 1.26 Release Lead
-      - pal.nabarun95@gmail.com # 1.26 RT EA
-      - nwaddington@cncf.io # 1.26 Release Lead Shadow
-      - nng.grace@gmail.com # 1.26 Release Lead Shadow
-      - kat.cosgrove@gmail.com # 1.26 Release Lead Shadow
-      - priyankasaggu11929@gmail.com # 1.26 Release Lead Shadow
+      - xandergrzyw@gmail.com # 1.27 Release Lead
+      - kat.cosgrove@gmail.com # 1.27 Release Lead Shadow
+      - priyankasaggu11929@gmail.com # 1.27 Release Lead Shadow
+      - salahi.hossein@gmail.com # 1.27 Release Lead Shadow
+      - hebaelayoty@gmail.com # 1.27 Release Lead Shadow
+      - james.laverack@jetstack.io # 1.27 Emeritus Advisor
     members:
       - sig-release-leads@kubernetes.io
-      - ryler.hockenbury@gmail.com # 1.26 Enhancements Lead
-      - marosset@microsoft.com # 1.26 Enhancements Shadow
-      - parulsahoo5jan@gmail.com # 1.26 Enhancements Shadow
-      - atharvashinde179@gmail.com # 1.26 Enhancements Shadow
-      - ruheenaansari34@gmail.com # 1.26 Enhancements Shadow
-      - niveditaprasad81@gmail.com # 1.26 CI Signal Lead
-      - shuhei.kitagawa@gmail.com # 1.26 CI Signal Lead Shadow
-      - mehabhalodiya@gmail.com # 1.26 CI Signal Lead Shadow
-      - namanlakhwani@gmail.com # 1.26 CI Signal Lead Shadow
-      - haritwal.bhawana@gmail.com # 1.26 CI Signal Lead Shadow
-      - salahi.hossein@gmail.com # 1.26 Bug Triage Lead
-      - subhasmitaswain232@gmail.com # 1.26 Bug Triage Shadow
-      - neoaggelos@gmail.com # 1.26 Bug Triage Shadow
-      - hesham.aboelmagd@gmail.com # 1.26 Bug Triage Shadow
-      - cailyn.edwards@shopify.com # 1.26 Bug Triage Shadow
-      - xandergrzyw@gmail.com # 1.26 Bug Triage Shadow, Release Manager Associate
-      - guillen.carolina@gmail.com # 1.26 Docs Lead
-      - cathchu@google.com # 1.26 Docs Shadow
-      - m.r.boxell@gmail.com # 1.26 Docs Shadow
-      - rishit.dagli@gmail.com # 1.26 Docs Shadow
-      - jkm.mutua@gmail.com # 1.26 Docs Shadow
-      - ramses.green.2@gmail.com # 1.26 Release Notes Lead
-      - harsha2k4@gmail.com # 1.26 Release Notes Shadow
-      - AnaMMedina21@gmail.com # 1.26 Release Notes Shadow
-      - laxmikantpandhare@gmail.com # 1.26 Release Notes Shadow
-      - ii.sayantani.ii@gmail.com # 1.26 Release Notes Shadow
-      - fsmunoz@gmail.com # 1.26 Communications Lead
-      - harshitasao@gmail.com # 1.26 Communications Shadow
-      - bradmccoydev@gmail.com # 1.26 Communications Shadow
-      - daespejo@vmware.com # 1.26 Communications Shadow
-      - d.panigrahi.nitrkl@gmail.com # 1.26 Communications Shadow
-      - cicih@google.com  # Release Manager Associate
+      - marosset@microsoft.com # 1.27 Enhancements Lead
+      - neoaggelos@gmail.com # 1.27 Bug Triage Lead
+      - m.r.boxell@gmail.com # 1.27 Docs Lead
+      - harsha2k4@gmail.com # 1.27 Release Notes Lead
+      - harshitasao@gmail.com # 1.27 Communications Lead
 
   - email-id: release-team-shadows@kubernetes.io
     name: release-team-shadows
@@ -367,38 +337,12 @@ groups:
       - k8s@auggie.dev
       - saschagrunert@gmail.com
     managers:
-      - leonard.pahlke@googlemail.com # 1.26 Release Lead
-      - pal.nabarun95@gmail.com # 1.26 Emeritus Advisor
+      - xandergrzyw@gmail.com # 1.27 Release Lead
     members:
-      - nwaddington@cncf.io # 1.26 Release Lead Shadow
-      - nng.grace@gmail.com # 1.26 Release Lead Shadow
-      - kat.cosgrove@gmail.com # 1.26 Release Lead Shadow
-      - priyankasaggu11929@gmail.com # 1.26 Release Lead Shadow
-      - marosset@microsoft.com # 1.26 Enhancements Shadow
-      - parulsahoo5jan@gmail.com # 1.26 Enhancements Shadow
-      - atharvashinde179@gmail.com # 1.26 Enhancements Shadow
-      - ruheenaansari34@gmail.com # 1.26 Enhancements Shadow
-      - shuhei.kitagawa@gmail.com # 1.26 CI Signal Lead Shadow
-      - mehabhalodiya@gmail.com # 1.26 CI Signal Lead Shadow
-      - namanlakhwani@gmail.com # 1.26 CI Signal Lead Shadow
-      - haritwal.bhawana@gmail.com # 1.26 CI Signal Lead Shadow
-      - subhasmitaswain232@gmail.com # 1.26 Bug Triage Shadow
-      - neoaggelos@gmail.com # 1.26 Bug Triage Shadow
-      - hesham.aboelmagd@gmail.com # 1.26 Bug Triage Shadow
-      - cailyn.edwards@shopify.com # 1.26 Bug Triage Shadow
-      - xandergrzyw@gmail.com # 1.26 Bug Triage Shadow
-      - cathchu@google.com # 1.26 Docs Shadow
-      - m.r.boxell@gmail.com # 1.26 Docs Shadow
-      - rishit.dagli@gmail.com # 1.26 Docs Shadow
-      - jkm.mutua@gmail.com # 1.26 Docs Shadow
-      - harsha2k4@gmail.com # 1.26 Release Notes Shadow
-      - AnaMMedina21@gmail.com # 1.26 Release Notes Shadow
-      - laxmikantpandhare@gmail.com # 1.26 Release Notes Shadow
-      - ii.sayantani.ii@gmail.com # 1.26 Release Notes Shadow
-      - harshitasao@gmail.com # 1.26 Communications Shadow
-      - bradmccoydev@gmail.com # 1.26 Communications Shadow
-      - daespejo@vmware.com # 1.26 Communications Shadow
-      - d.panigrahi.nitrkl@gmail.com # 1.26 Communications Shadow
+      - kat.cosgrove@gmail.com # 1.27 Release Lead Shadow
+      - priyankasaggu11929@gmail.com # 1.27 Release Lead Shadow
+      - salahi.hossein@gmail.com # 1.27 Release Lead Shadow
+      - hebaelayoty@gmail.com # 1.27 Release Lead Shadow
 
   # RBAC groups:
   # - grant access to the `namespace-user` role for a single namespace on the `aaa` cluster
@@ -431,12 +375,7 @@ groups:
     members:
       - k8s-infra-release-viewers@kubernetes.io
       - bartek@smykla.com
-      - salahi.hossein@gmail.com # 1.26 Bug Triage Lead
-      - subhasmitaswain232@gmail.com # 1.26 Bug Triage Shadow
-      - neoaggelos@gmail.com # 1.26 Bug Triage Shadow
-      - hesham.aboelmagd@gmail.com # 1.26 Bug Triage Shadow
-      - cailyn.edwards@shopify.com # 1.26 Bug Triage Shadow
-      - xandergrzyw@gmail.com # 1.26 Bug Triage Shadow
+      - neoaggelos@gmail.com # 1.27 Bug Triage Lead
 
   - email-id: k8s-infra-staging-bom@kubernetes.io
     name: k8s-infra-staging-bom
@@ -477,13 +416,12 @@ groups:
       - k8s@auggie.dev
       - saschagrunert@gmail.com
     members:
-      - kat.cosgrove@gmail.com # 1.26 Release Lead Shadow
-      - leonard.pahlke@googlemail.com # 1.26 RT Lead
-      - nng.grace@gmail.com # 1.25 Release Lead Shadow
-      - nwaddington@cncf.io # 1.26 Release Lead Shadow
-      - priyankasaggu11929@gmail.com # 1.26 Release Lead Shadow
-      - pal.nabarun95@gmail.com # 1.26 RT EA
-      - ryler.hockenbury@gmail.com # 1.26 Enhancements Lead
+      - kat.cosgrove@gmail.com # 1.27 Release Lead Shadow
+      - priyankasaggu11929@gmail.com # 1.27 Release Lead Shadow
+      - hebaelayoty@gmail.com # 1.27 Release Lead Shadow
+      - xandergrzyw@gmail.com # 1.27 Release Lead
+      - salahi.hossein@gmail.com # 1.27 Release Lead Shadow
+      - marosset@microsoft.com # 1.27 Enhancements Lead
 
   - email-id: k8s-infra-staging-zeitgeist@kubernetes.io
     name: k8s-infra-staging-zeitgeist


### PR DESCRIPTION
Initial PR to update the SIG release groups for 1.27 leads. There will be an additional PR to add shadows once the selection is completed, but in the meantime we need to get the leads the needed access.