### PR TITLE
Adding cncf-aws-admins to sig-release-leads

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -294,6 +294,7 @@ groups:
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
       - saschagrunert@gmail.com
+      - cncf-aws-admins@lists.cncf.io
 
   - email-id: release-team@kubernetes.io
     name: release-team


### PR DESCRIPTION
This list is associated with an AWS account that is part of a the migration to a new Kubernetes AWS Org in https://github.com/kubernetes/k8s.io/issues/4626 This is to enable a password reset for that account and ensure someone within #sig-k8s-infra has password access to all Kubernetes AWS Org member accounts.