### PR TITLE
Add jeefy as org auditor

### DIFF
--- a/groups/sig-k8s-infra/groups.yaml
+++ b/groups/sig-k8s-infra/groups.yaml
@@ -253,6 +253,7 @@ groups:
     members:
       - cy@borg.dev
       - ihor@cncf.io
+      - jeefy@cncf.io
       - jonjohnson@google.com
       - k8s-infra-ii-coop@kubernetes.io
       - sig-k8s-infra-leads@kubernetes.io


### PR DESCRIPTION
Jeefy will be the new point of contact from CNCF.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>