### PR TITLE
AWS: Add a budget configuration for the organization

### DIFF
--- a/infra/aws/terraform/management-account/budgets.tf
+++ b/infra/aws/terraform/management-account/budgets.tf
@@ -1,0 +1,49 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_budgets_budget" "everything" {
+  name              = "k8s-infra-monthly"
+  account_id        = data.aws_caller_identity.current.account_id
+  budget_type       = "COST"
+  time_unit         = "MONTHLY"
+  time_period_start = "2021-06-01_00:00"
+  limit_amount      = "250000.0"
+  limit_unit        = "USD"
+
+  cost_types {
+    include_credit             = true
+    include_discount           = true
+    include_other_subscription = true
+    include_recurring          = true
+    include_refund             = true
+    include_subscription       = true
+    include_support            = true
+    include_tax                = true
+    include_upfront            = true
+    use_amortized              = false
+    use_blended                = false
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = "1"
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = ["sig-k8s-infra-leads@kubernetes.io"]
+  }
+}


### PR DESCRIPTION
Add a budget and a budget alert for the monthly usage of the organization. The threshold is set 1% of the monthly so we can monitor usage grow.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>