### PR TITLE
add new capdo alerts group

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -83,6 +83,7 @@ restrictions:
       - "^k8s-infra-staging-cluster-api-azure@kubernetes.io$"
       - "^k8s-infra-staging-cluster-api-gcp@kubernetes.io$"
       - "^sig-cluster-lifecycle-cluster-api-gcp-alerts@kubernetes.io$"
+      - "^sig-cluster-lifecycle-cluster-api-do-alerts@kubernetes.io$"
       - "^k8s-infra-staging-cluster-api-nested@kubernetes.io$"
       - "^k8s-infra-staging-cluster-addons@kubernetes.io$"
       - "^k8s-infra-staging-etcdadm@kubernetes.io$"

--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -259,7 +259,6 @@ groups:
     members:
       - ahmadnurus.sh@gmail.com
       - ctadeu@gmail.com
-      - detiber@gmail.com
       - jeremylevanmorris@gmail.com
       - ttr314@googlemail.com
 

--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -304,6 +304,23 @@ groups:
       - davanum@gmail.com
       - richmcase@gmail.com
 
+  - email-id: sig-cluster-lifecycle-cluster-api-do-alerts@kubernetes.io
+    name: sig-cluster-lifecycle-cluster-api-do-alerts
+    description: |-
+      Receive alerts for CAPDO failing tests
+    settings:
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      MessageModerationLevel: "MODERATE_ALL_MESSAGES"
+      ReconcileMembers: "false"
+    owners:
+      - ahmadnurus.sh@gmail.com
+      - ctadeu@gmail.com
+      - jeremylevanmorris@gmail.com
+      - ttr314@googlemail.com
+
   - email-id: k8s-infra-staging-cluster-api-nested@kubernetes.io
     name: k8s-infra-staging-cluster-api-nested
     description: |-


### PR DESCRIPTION
Create a new group that people can subscribe to if they want to receive alerts for failing tests in CAPDO.

Relates to: https://github.com/kubernetes/test-infra/issues/28364


/assign @ameukam @dims 
cc @timoreimann @MorrisLaw @prksu 