### PR TITLE
AWS: enable global policies

### DIFF
--- a/infra/aws/terraform/management-account/organization.tf
+++ b/infra/aws/terraform/management-account/organization.tf
@@ -21,5 +21,12 @@ limitations under the License.
 
 resource "aws_organizations_organization" "default" {
   aws_service_access_principals = var.aws_service_access_principals
-  feature_set                   = "ALL"
+
+  enabled_policy_types = [
+    "AISERVICES_OPT_OUT_POLICY",
+    "SERVICE_CONTROL_POLICY",
+    "TAG_POLICY",
+  ]
+
+  feature_set = "ALL"
 }

--- a/infra/aws/terraform/management-account/variables.tf
+++ b/infra/aws/terraform/management-account/variables.tf
@@ -17,7 +17,16 @@ limitations under the License.
 variable "aws_service_access_principals" {
   type = list(any)
   default = [
-    "account.amazonaws.com"
+    "account.amazonaws.com",
+    "cloudtrail.amazonaws.com",
+    "config.amazonaws.com",
+    "config-multiaccountsetup.amazonaws.com",
+    "health.amazonaws.com",
+    "ram.amazonaws.com",
+    "reporting.trustedadvisor.amazonaws.com",
+    "securityhub.amazonaws.com",
+    "servicequotas.amazonaws.com",
+    "tagpolicies.tag.amazonaws.com"
   ]
   description = "List of service access principals for the organization"
 }


### PR DESCRIPTION
Ensure org policies are enabled to give the capabilities to:
- opt-out of AWS AI services
- standardize tags accross the organization
- enable service control policies

Also enable services to perform actions accross the organization.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>