### PR TITLE
AWS: Add accounts for security governance

### DIFF
--- a/infra/aws/terraform/management-account/accounts.tf
+++ b/infra/aws/terraform/management-account/accounts.tf
@@ -1,0 +1,41 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module "security_audit" {
+  source = "../modules/org-account"
+
+  account_name = "k8s-infra-security-audit"
+  email = "k8s-infra-aws-admins+security-audit@kubernetes.io"
+  iam_user_access_to_billing = "ALLOW"
+  parent_id = aws_organizations_organizational_unit.security.id
+}
+
+module "security_incident_response" {
+  source = "../modules/org-account"
+
+  account_name = "k8s-infra-security-incident-response"
+  email = "k8s-infra-aws-admins+incident-response@kubernetes.io"
+  parent_id = aws_organizations_organizational_unit.security.id
+}
+
+module "security_logs" {
+  source = "../modules/org-account"
+
+  account_name = "k8s-infra-security-logs"
+  email = "k8s-infra-aws-admins+security-logs@kubernetes.io"
+  iam_user_access_to_billing = "ALLOW"
+  parent_id = aws_organizations_organizational_unit.security.id
+}

--- a/infra/aws/terraform/management-account/organizational-units.tf
+++ b/infra/aws/terraform/management-account/organizational-units.tf
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "aws_organizations_organizational_unit" "security" {
+  name      = "Security"
+  parent_id = aws_organizations_organization.default.roots[0].id
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/infra/aws/terraform/management-account/providers.tf
+++ b/infra/aws/terraform/management-account/providers.tf
@@ -1,0 +1,143 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+provider "aws" {
+  region = "us-east-2"
+}
+
+# us-* providers
+
+provider "aws" {
+  alias  = "us-east-1"
+  region = "us-east-1"
+}
+
+provider "aws" {
+  alias  = "us-east-2"
+  region = "us-east-2"
+}
+
+provider "aws" {
+  alias  = "us-west-1"
+  region = "us-west-1"
+}
+
+provider "aws" {
+  alias  = "us-west-2"
+  region = "us-west-2"
+}
+
+# af-* providers
+
+provider "aws" {
+  alias  = "af-south-1"
+  region = "af-south-1"
+}
+
+# ap-* providers
+
+provider "aws" {
+  alias  = "ap-east-1"
+  region = "ap-east-1"
+}
+
+provider "aws" {
+  alias  = "ap-southeast-3"
+  region = "ap-southeast-3"
+}
+
+provider "aws" {
+  alias  = "ap-south-1"
+  region = "ap-south-1"
+}
+
+provider "aws" {
+  alias  = "ap-northeast-3"
+  region = "ap-northeast-3"
+}
+
+provider "aws" {
+  alias  = "ap-northeast-2"
+  region = "ap-northeast-2"
+}
+
+provider "aws" {
+  alias  = "ap-southeast-1"
+  region = "ap-southeast-1"
+}
+
+provider "aws" {
+  alias  = "ap-southeast-2"
+  region = "ap-southeast-2"
+}
+
+provider "aws" {
+  alias  = "ap-northeast-1"
+  region = "ap-northeast-1"
+}
+
+# ca-* providers
+
+provider "aws" {
+  alias  = "ca-central-1"
+  region = "ca-central-1"
+}
+
+# eu-* providers
+
+provider "aws" {
+  alias  = "eu-central-1"
+  region = "eu-central-1"
+}
+
+provider "aws" {
+  alias  = "eu-west-1"
+  region = "eu-west-1"
+}
+
+provider "aws" {
+  alias  = "eu-west-2"
+  region = "eu-west-2"
+}
+
+provider "aws" {
+  alias  = "eu-south-1"
+  region = "eu-south-1"
+}
+
+provider "aws" {
+  alias  = "eu-west-3"
+  region = "eu-west-3"
+}
+
+provider "aws" {
+  alias  = "eu-north-1"
+  region = "eu-north-1"
+}
+
+# me-* providers
+
+provider "aws" {
+  alias  = "me-south-1"
+  region = "me-south-1"
+}
+
+# sa-* providers
+
+provider "aws" {
+  alias  = "sa-east-1"
+  region = "sa-east-1"
+}

--- a/infra/aws/terraform/management-account/variables.tf
+++ b/infra/aws/terraform/management-account/variables.tf
@@ -17,10 +17,15 @@ limitations under the License.
 variable "aws_service_access_principals" {
   type = list(any)
   default = [
+    "access-analyzer.amazonaws.com",
     "account.amazonaws.com",
     "cloudtrail.amazonaws.com",
+    "compute-optimizer.amazonaws.com",
     "config.amazonaws.com",
     "config-multiaccountsetup.amazonaws.com",
+    "detective.amazonaws.com",
+    "fms.amazonaws.com",
+    "guardduty.amazonaws.com",
     "health.amazonaws.com",
     "ram.amazonaws.com",
     "reporting.trustedadvisor.amazonaws.com",

--- a/infra/aws/terraform/modules/org-account/main.tf
+++ b/infra/aws/terraform/modules/org-account/main.tf
@@ -1,0 +1,42 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "aws_organizations_account" "this" {
+  # Names cannot be changed. It will trigger a deletion of the account, which may fail due to a
+  # ConstraintViolationException error or similar
+  name = var.account_name
+
+  # Email must be unique across AWS as a whole
+  email = var.email
+
+  iam_user_access_to_billing = var.iam_user_access_to_billing
+  parent_id                  = var.parent_id
+
+  # Gives the primary account access to the new account
+  role_name = var.role_name
+
+  tags = var.tags
+
+  # There is not an AWS Organizations API for reading those fields so ignoring them is required to prevent future errors
+  lifecycle {
+    ignore_changes = [
+      email,
+      iam_user_access_to_billing,
+      name,
+      role_name
+    ]
+  }
+}

--- a/infra/aws/terraform/modules/org-account/outputs.tf
+++ b/infra/aws/terraform/modules/org-account/outputs.tf
@@ -1,0 +1,21 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+output "account" {
+  description = "An AWS organization account resource"
+  value       = aws_organizations_account.this
+}

--- a/infra/aws/terraform/modules/org-account/provider.tf
+++ b/infra/aws/terraform/modules/org-account/provider.tf
@@ -1,0 +1,15 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/

--- a/infra/aws/terraform/modules/org-account/variables.tf
+++ b/infra/aws/terraform/modules/org-account/variables.tf
@@ -1,0 +1,44 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+variable "account_name" {
+  description = "A friendly name for the member account."
+}
+
+variable "email" {
+  description = "The email address of the owner to assign to the new member account"
+}
+
+variable "iam_user_access_to_billing" {
+  default     = "DENY"
+  description = "If set to `ALLOW`, the new account enables IAM users to access account billing information if they have the required permissions. If set to `DENY`, then only the root user of the new account can access account billing information."
+}
+
+variable "parent_id" {
+  default     = null
+  description = "Parent Organizational Unit ID or Root ID for the account"
+}
+
+variable "role_name" {
+  default     = null # Use AWS default, ie OrganizationAccountAccessRole
+  description = "The name of an IAM role that Organizations automatically preconfigures in the new member account. This role trusts the master account, allowing users in the master account to assume the role, as permitted by the master account administrator. The role has administrator permissions in the new member account. The Organizations API provides no method for reading this information after account creation, so Terraform cannot perform drift detection on its value and will always show a difference for a configured value after import unless `ignore_changes` is used."
+}
+
+variable "tags" {
+  default     = {}
+  description = "Key-value mapping of resource tags."
+}
+

--- a/infra/aws/terraform/modules/org-account/versions.tf
+++ b/infra/aws/terraform/modules/org-account/versions.tf
@@ -1,0 +1,15 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/


### PR DESCRIPTION
Follow guidelines from AWS official docs suggestions we should have different accounts as acting delegated administrors for the different security products we plan to use.

/hold

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>