### PR TITLE
chore: remove lfx summer 22 mentees

### DIFF
--- a/groups/sig-k8s-infra/groups.yaml
+++ b/groups/sig-k8s-infra/groups.yaml
@@ -178,8 +178,6 @@ groups:
       - ctadeu@gmail.com
       - davanum@gmail.com
       - richmcase@gmail.com
-      - rikiessential1@gmail.com
-      - subhasmitaswain232@gmail.com
 
   # RBAC groups:
   # - grant access to the `namespace-user` role for a single namespace on the `aaa` cluster


### PR DESCRIPTION
This change removed the LFX summer 22 mentees from the CAPG group.