### PR TITLE
AWS: create cost and usage reports

### DIFF
--- a/infra/aws/terraform/management-account/accounts.tf
+++ b/infra/aws/terraform/management-account/accounts.tf
@@ -17,34 +17,34 @@ limitations under the License.
 module "security_audit" {
   source = "../modules/org-account"
 
-  account_name = "k8s-infra-security-audit"
-  email = "k8s-infra-aws-admins+security-audit@kubernetes.io"
+  account_name               = "k8s-infra-security-audit"
+  email                      = "k8s-infra-aws-admins+security-audit@kubernetes.io"
   iam_user_access_to_billing = "ALLOW"
-  parent_id = aws_organizations_organizational_unit.security.id
+  parent_id                  = aws_organizations_organizational_unit.security.id
 }
 
 module "security_incident_response" {
   source = "../modules/org-account"
 
   account_name = "k8s-infra-security-incident-response"
-  email = "k8s-infra-aws-admins+security-incident-response@kubernetes.io"
-  parent_id = aws_organizations_organizational_unit.security.id
+  email        = "k8s-infra-aws-admins+security-incident-response@kubernetes.io"
+  parent_id    = aws_organizations_organizational_unit.security.id
 }
 
 module "security_logs" {
   source = "../modules/org-account"
 
-  account_name = "k8s-infra-security-logs"
-  email = "k8s-infra-aws-admins+security-logs@kubernetes.io"
+  account_name               = "k8s-infra-security-logs"
+  email                      = "k8s-infra-aws-admins+security-logs@kubernetes.io"
   iam_user_access_to_billing = "ALLOW"
-  parent_id = aws_organizations_organizational_unit.security.id
+  parent_id                  = aws_organizations_organizational_unit.security.id
 }
 
 module "infra_shared_services" {
   source = "../modules/org-account"
 
-  account_name = "k8s-infra-shared-services"
-  email = "k8s-infra-aws-admins+infra-shared-services@kubernetes.io"
+  account_name               = "k8s-infra-shared-services"
+  email                      = "k8s-infra-aws-admins+infra-shared-services@kubernetes.io"
   iam_user_access_to_billing = "ALLOW"
-  parent_id = aws_organizations_organizational_unit.infrastructure.id
+  parent_id                  = aws_organizations_organizational_unit.infrastructure.id
 }

--- a/infra/aws/terraform/management-account/cost_usage.tf
+++ b/infra/aws/terraform/management-account/cost_usage.tf
@@ -1,0 +1,60 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+resource "aws_cur_report_definition" "no_integrations" {
+  provider = aws.us-east-1
+
+  report_name                = "k8s-infra-cur-definition"
+  time_unit                  = "HOURLY"
+  format                     = "textORcsv"
+  compression                = "ZIP"
+  additional_schema_elements = ["RESOURCES"]
+  additional_artifacts       = []
+  refresh_closed_reports     = true
+  report_versioning          = "CREATE_NEW_REPORT"
+
+  # S3 configuration
+  s3_bucket = module.cur_reports_s3_bucket.s3_bucket_id
+  s3_region = module.cur_reports_s3_bucket.s3_bucket_region
+  s3_prefix = "CUR"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_cur_report_definition" "integrations" {
+  provider = aws.us-east-1
+
+  report_name                = "k8s-infra-cur-integrations-definition"
+  time_unit                  = "HOURLY"
+  format                     = "textORcsv"
+  compression                = "ZIP"
+  additional_schema_elements = ["RESOURCES"]
+  additional_artifacts       = ["REDSHIFT", "ATHENA"]
+  refresh_closed_reports     = true
+  report_versioning          = "OVERWRITE_REPORT"
+
+  # S3 configuration
+  s3_bucket = module.cur_reports_integrations_s3_bucket.s3_bucket_id
+  s3_region = module.cur_reports_integrations_s3_bucket.s3_bucket_region
+  s3_prefix = "CUR"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/infra/aws/terraform/management-account/provider.tf
+++ b/infra/aws/terraform/management-account/provider.tf
@@ -24,7 +24,7 @@ terraform {
   backend "s3" {
     bucket = "k8s-aws-root-account-terraform-state"
     region = "us-east-2"
-    key = "management-account/terraform.state"
+    key    = "management-account/terraform.state"
   }
 
   required_providers {

--- a/infra/aws/terraform/management-account/providers.tf
+++ b/infra/aws/terraform/management-account/providers.tf
@@ -18,6 +18,15 @@ provider "aws" {
   region = "us-east-2"
 }
 
+provider "aws" {
+  region = "us-east-2"
+  alias  = "shared-services"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${module.infra_shared_services.account_id}:role/OrganizationAccountAccessRole"
+  }
+}
+
 # us-* providers
 
 provider "aws" {

--- a/infra/aws/terraform/management-account/s3.tf
+++ b/infra/aws/terraform/management-account/s3.tf
@@ -1,0 +1,187 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+# Cost and Usage
+
+module "cur_reports_s3_bucket" {
+  providers = {
+    aws = aws.shared-services
+  }
+
+  source = "terraform-aws-modules/s3-bucket/aws"
+
+  bucket = "k8s-infra-cur-reports-bucket"
+
+  # S3 bucket-level Public Access Block configuration
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  attach_deny_insecure_transport_policy = true
+  attach_policy                         = true
+  policy                                = data.aws_iam_policy_document.cur_reports_s3_bucket.json
+
+  # Note: Object Lock configuration can be enabled only on new buckets
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object_lock_configuration
+  object_lock_enabled = true
+
+  versioning = {
+    enabled    = true
+    mfa_delete = false
+  }
+}
+
+module "cur_reports_integrations_s3_bucket" {
+  providers = {
+    aws = aws.shared-services
+  }
+
+  source = "terraform-aws-modules/s3-bucket/aws"
+
+  bucket = "cur_reports_integrations_s3_bucket"
+
+  # S3 bucket-level Public Access Block configuration
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+  attach_deny_insecure_transport_policy = true
+  attach_policy                         = true
+  policy                                = data.aws_iam_policy_document.cur_reports_integrations_s3_bucket.json
+
+  # Note: Object Lock configuration can be enabled only on new buckets
+  # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object_lock_configuration
+  object_lock_enabled = true
+
+  versioning = {
+    enabled    = true
+    mfa_delete = false
+  }
+}
+
+data "aws_iam_policy_document" "cur_reports_s3_bucket" {
+  version = "2008-10-17"
+
+  statement {
+    sid    = "AWSBillingDeliveryAclCheck"
+    effect = "Allow"
+    principals {
+      type = "Service"
+      identifiers = [
+        "billingreports.amazonaws.com"
+      ]
+    }
+    actions = [
+      "s3:GetBucketPolicy",
+      "s3:GetBucketAcl"
+    ]
+    resources = [module.cur_reports_s3_bucket.s3_bucket_arn]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:cur:us-east-1:${data.aws_caller_identity.current.account_id}:definition/*"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+
+  statement {
+    sid       = "AWSBillingDeliveryWrite"
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["${module.cur_reports_s3_bucket.s3_bucket_arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["billingreports.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:cur:us-east-1:${data.aws_caller_identity.current.account_id}:definition/*"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "cur_reports_integrations_s3_bucket" {
+  version = "2008-10-17"
+
+  statement {
+    sid    = "AWSBillingDeliveryAclCheck"
+    effect = "Allow"
+    principals {
+      type = "Service"
+      identifiers = [
+        "billingreports.amazonaws.com"
+      ]
+    }
+    actions = [
+      "s3:GetBucketPolicy",
+      "s3:GetBucketAcl"
+    ]
+    resources = [module.cur_reports_integrations_s3_bucket.s3_bucket_arn]
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:cur:us-east-1:${data.aws_caller_identity.current.account_id}:definition/*"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+
+  statement {
+    sid       = "AWSBillingDeliveryWrite"
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["${module.cur_reports_integrations_s3_bucket.s3_bucket_arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["billingreports.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:cur:us-east-1:${data.aws_caller_identity.current.account_id}:definition/*"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+}


### PR DESCRIPTION
- create encrypted S3 buckets for AWS cost and usage reports
- create AWS CUR reports with and without integrations to AWS AThena.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>