### PR TITLE
AWS: Add account for infrastructure services.

### DIFF
--- a/infra/aws/terraform/management-account/accounts.tf
+++ b/infra/aws/terraform/management-account/accounts.tf
@@ -39,3 +39,12 @@ module "security_logs" {
   iam_user_access_to_billing = "ALLOW"
   parent_id = aws_organizations_organizational_unit.security.id
 }
+
+module "infra_shared_services" {
+  source = "../modules/org-account"
+
+  account_name = "k8s-infra-shared-services"
+  email = "k8s-infra-aws-admins+infra-shared-services@kubernetes.io"
+  iam_user_access_to_billing = "ALLOW"
+  parent_id = aws_organizations_organizational_unit.infrastructure.id
+}

--- a/infra/aws/terraform/management-account/organizational-units.tf
+++ b/infra/aws/terraform/management-account/organizational-units.tf
@@ -22,3 +22,12 @@ resource "aws_organizations_organizational_unit" "security" {
     prevent_destroy = true
   }
 }
+
+resource "aws_organizations_organizational_unit" "infrastructure" {
+  name      = "Infrastructure"
+  parent_id = aws_organizations_organization.default.roots[0].id
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}


### PR DESCRIPTION
Add an account to support services and resources that can be used across different accounts.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>