### PR TITLE
Create conduct-emeritus email list

### DIFF
--- a/groups/committee-code-of-conduct/groups.yaml
+++ b/groups/committee-code-of-conduct/groups.yaml
@@ -12,3 +12,17 @@ groups:
       - lancashiredanielle@gmail.com
       - xandergrzyw@gmail.com
       - detiber@gmail.com
+  - email-id: conduct-emeritus@kubernetes.io
+    name: conduct-emeritus
+    description: |-
+      Private list for current and emeritus members of the Code of Conduct Committee
+    settings:
+      ReconcileMembers: "true"
+    owners:
+      - hilliary.lipsig@gmail.com
+      - jeremy.r.rickard@gmail.com
+      - lancashiredanielle@gmail.com
+      - xandergrzyw@gmail.com
+      - detiber@gmail.com
+    members:
+      - tpepper@vmware.com

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -2,6 +2,7 @@ restrictions:
   - path: "committee-code-of-conduct/groups.yaml"
     allowedGroups:
       - "^conduct@kubernetes.io$"
+      - "^conduct-emeritus@kubernetes.io$"
   - path: "committee-security-response/groups.yaml"
     allowedGroups:
       - "^distributors-announce@kubernetes.io$"


### PR DESCRIPTION
Creating list for CoC emeritus folks. I've only added the current members as owners + @tpepper as an example. I'll let the CoCC folks add the rest of the addresses.