### PR TITLE
add distribution lists for github bots

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -192,6 +192,8 @@ restrictions:
       - "^k8s-infra-staging-test-infra@kubernetes.io$"
       - "^k8s-infra-push-kind@kubernetes.io$"
       - "^k8s-infra-prow-viewers@kubernetes.io$"
+      - "^k8s-ci-robot@kubernetes.io$"
+      - "^k8s-github-robot@kubernetes.io$"
       - "^k8s-infra-ci-robot@kubernetes.io$"
       - "^k8s-infra-cherrypick-robot@kubernetes.io$"
       - "^k8s-infra-prow-oncall@kubernetes.io$"

--- a/groups/sig-testing/groups.yaml
+++ b/groups/sig-testing/groups.yaml
@@ -169,6 +169,32 @@ groups:
   # required for membership in these groups.
   #
 
+  - email-id: k8s-ci-robot@kubernetes.io
+    name: k8s-ci-robot
+    description: |-
+      Github admins for github account k8s-ci-robot
+    settings:
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW"
+    members:
+    - sig-k8s-infra-leads@kubernetes.io
+    - github@kubernetes.io
+    - sig-testing-leads@kubernetes.io
+
+  - email-id: k8s-github-robot@kubernetes.io
+    name: k8s-github-robot
+    description: |-
+      Github admins for github account k8s-github-robot
+    settings:
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW"
+    members:
+    - sig-k8s-infra-leads@kubernetes.io
+    - github@kubernetes.io
+    - sig-testing-leads@kubernetes.io
+
   - email-id: k8s-infra-ci-robot@kubernetes.io
     name: k8s-infra-ci-robot
     description: |-
@@ -179,6 +205,7 @@ groups:
       WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW"
     members:
     - sig-k8s-infra-leads@kubernetes.io
+    - github@kubernetes.io
 
   - email-id: k8s-infra-cherrypick-robot@kubernetes.io
     name: k8s-infra-cherrypick-robot


### PR DESCRIPTION
Add distribution lists for github accounts currently owned by Google teams. Those MLs will allow credentials rotation and ownership transfer to the community.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>