### PR TITLE
Revert "Temporary email lists to support password reset"

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -236,8 +236,6 @@ restrictions:
       - "^sig-k8s-infra@kubernetes.io$"
       - "^sig-k8s-infra-leads@kubernetes.io$"
       - "^sig-k8s-infra-private@kubernetes.io$"
-      - "^k8s-infra-accounts@kubernetes.io$"
-      - "^k8s-infra-aws-registry-k8s-io-admin@kubernetes.io$"
   - path: "wg-batch/groups.yaml"
     allowedGroups:
       - "^wg-batch@kubernetes.io$"

--- a/groups/sig-k8s-infra/groups.yaml
+++ b/groups/sig-k8s-infra/groups.yaml
@@ -5,27 +5,6 @@ groups:
   # Each group here represents a mailing list for the SIG or its subprojects,
   # and is not intended to govern access to infrastructure
   #
-  - email-id: k8s-infra-accounts@kubernetes.io
-    name: k8s-infra-accounts
-    description: |-
-      Temporary email list to reset passwords for AWS account k8s-infra-accounts@kubernetes.io
-    settings:
-      WhoCanPostMessage: "ANYONE_CAN_POST"
-      ReconcileMembers: "true"
-    members:
-      - hh@cncf.io
-      - sig-k8s-infra-accounts@kubernetes.io
-  - email-id: k8s-infra-aws-registry-k8s-io-admin@kubernetes.io
-    name: k8s-infra-aws-registry-k8s-io-admin
-    description: |-
-      Temporary email list to reset passwords for AWS account k8s-infra-aws-registry-k8s-io-admin@kubernetes.io
-    settings:
-      WhoCanPostMessage: "ANYONE_CAN_POST"
-      ReconcileMembers: "true"
-    members:
-      - hh@cncf.io
-      - sig-k8s-infra-accounts@kubernetes.io
-
   - email-id: k8s-infra-alerts@kubernetes.io
     name: k8s-infra-alerts
     description: |-


### PR DESCRIPTION
This reverts commit 9bc2b3bb12f5e738271b99a5cc9e33e033bad41f and https://github.com/kubernetes/k8s.io/pull/4697