### PR TITLE
Mirror artifacts to S3

### DIFF
--- a/artifacts/mirroring-staging/README.md
+++ b/artifacts/mirroring-staging/README.md
@@ -1,0 +1,7 @@
+# Kubernetes Artifacts - Mirroring
+
+TODO
+
+```
+kpromo run files --manifests artifacts/mirroring/
+```

--- a/artifacts/mirroring-staging/filestores/k8s-staging-cri-tools/filepromoter-manifest.yaml
+++ b/artifacts/mirroring-staging/filestores/k8s-staging-cri-tools/filepromoter-manifest.yaml
@@ -1,0 +1,7 @@
+filestores:
+- base: gs://k8s-artifacts-prod/binaries/cri-tools/
+  src: true
+- base: s3://test-artifacts-k8s-io-us-east-2/binaries/cri-tools/
+- base: s3://test-artifacts-k8s-io-us-west-2/binaries/cri-tools/
+- base: s3://test-artifacts-k8s-io-eu-west-2/binaries/cri-tools/
+- base: s3://test-artifacts-k8s-io-ap-southeast-1/binaries/cri-tools/

--- a/artifacts/mirroring-staging/filestores/k8s-staging-kops/filepromoter-manifest.yaml
+++ b/artifacts/mirroring-staging/filestores/k8s-staging-kops/filepromoter-manifest.yaml
@@ -1,0 +1,7 @@
+filestores:
+- base: gs://k8s-artifacts-prod/binaries/kops/
+  src: true
+- base: s3://test-artifacts-k8s-io-us-east-2/binaries/kops/
+- base: s3://test-artifacts-k8s-io-us-west-2/binaries/kops/
+- base: s3://test-artifacts-k8s-io-eu-west-2/binaries/kops/
+- base: s3://test-artifacts-k8s-io-ap-southeast-1/binaries/kops/

--- a/artifacts/mirroring-staging/filestores/k8s-staging-provider-aws/filepromoter-manifest.yaml
+++ b/artifacts/mirroring-staging/filestores/k8s-staging-provider-aws/filepromoter-manifest.yaml
@@ -1,0 +1,7 @@
+filestores:
+- base: gs://k8s-artifacts-prod/binaries/cloud-provider-aws/
+  src: true
+- base: s3://test-artifacts-k8s-io-us-east-2/binaries/cloud-provider-aws/
+- base: s3://test-artifacts-k8s-io-us-west-2/binaries/cloud-provider-aws/
+- base: s3://test-artifacts-k8s-io-eu-west-2/binaries/cloud-provider-aws/
+- base: s3://test-artifacts-k8s-io-ap-southeast-1/binaries/cloud-provider-aws/

--- a/artifacts/mirroring-staging/manifests
+++ b/artifacts/mirroring-staging/manifests
@@ -1,0 +1,1 @@
+../manifests/

--- a/artifacts/mirroring/README.md
+++ b/artifacts/mirroring/README.md
@@ -1,0 +1,7 @@
+# Kubernetes Artifacts - Mirroring
+
+TODO
+
+```
+kpromo run files --manifests artifacts/mirroring/
+```

--- a/artifacts/mirroring/filestores/k8s-staging-cri-tools/filepromoter-manifest.yaml
+++ b/artifacts/mirroring/filestores/k8s-staging-cri-tools/filepromoter-manifest.yaml
@@ -2,3 +2,6 @@ filestores:
 - base: gs://k8s-artifacts-prod/binaries/cri-tools/
   src: true
 - base: s3://test-artifacts-k8s-io-us-east-2/binaries/cri-tools/
+- base: s3://test-artifacts-k8s-io-us-west-2/binaries/cri-tools/
+- base: s3://test-artifacts-k8s-io-eu-west-2/binaries/cri-tools/
+- base: s3://test-artifacts-k8s-io-ap-southeast-1/binaries/cri-tools/

--- a/artifacts/mirroring/filestores/k8s-staging-cri-tools/filepromoter-manifest.yaml
+++ b/artifacts/mirroring/filestores/k8s-staging-cri-tools/filepromoter-manifest.yaml
@@ -1,0 +1,4 @@
+filestores:
+- base: gs://k8s-artifacts-prod/binaries/cri-tools/
+  src: true
+- base: s3://test-artifacts-k8s-io-us-east-2/binaries/cri-tools/

--- a/artifacts/mirroring/filestores/k8s-staging-cri-tools/filepromoter-manifest.yaml
+++ b/artifacts/mirroring/filestores/k8s-staging-cri-tools/filepromoter-manifest.yaml
@@ -1,7 +1,7 @@
 filestores:
 - base: gs://k8s-artifacts-prod/binaries/cri-tools/
   src: true
-- base: s3://test-artifacts-k8s-io-us-east-2/binaries/cri-tools/
-- base: s3://test-artifacts-k8s-io-us-west-2/binaries/cri-tools/
-- base: s3://test-artifacts-k8s-io-eu-west-2/binaries/cri-tools/
-- base: s3://test-artifacts-k8s-io-ap-southeast-1/binaries/cri-tools/
+- base: s3://prod-artifacts-k8s-io-us-east-2/binaries/cri-tools/
+- base: s3://prod-artifacts-k8s-io-us-west-2/binaries/cri-tools/
+- base: s3://prod-artifacts-k8s-io-eu-west-2/binaries/cri-tools/
+- base: s3://prod-artifacts-k8s-io-ap-southeast-1/binaries/cri-tools/

--- a/artifacts/mirroring/filestores/k8s-staging-kops/filepromoter-manifest.yaml
+++ b/artifacts/mirroring/filestores/k8s-staging-kops/filepromoter-manifest.yaml
@@ -2,3 +2,6 @@ filestores:
 - base: gs://k8s-artifacts-prod/binaries/kops/
   src: true
 - base: s3://test-artifacts-k8s-io-us-east-2/binaries/kops/
+- base: s3://test-artifacts-k8s-io-us-west-2/binaries/kops/
+- base: s3://test-artifacts-k8s-io-eu-west-2/binaries/kops/
+- base: s3://test-artifacts-k8s-io-ap-southeast-1/binaries/kops/

--- a/artifacts/mirroring/filestores/k8s-staging-kops/filepromoter-manifest.yaml
+++ b/artifacts/mirroring/filestores/k8s-staging-kops/filepromoter-manifest.yaml
@@ -1,7 +1,7 @@
 filestores:
 - base: gs://k8s-artifacts-prod/binaries/kops/
   src: true
-- base: s3://test-artifacts-k8s-io-us-east-2/binaries/kops/
-- base: s3://test-artifacts-k8s-io-us-west-2/binaries/kops/
-- base: s3://test-artifacts-k8s-io-eu-west-2/binaries/kops/
-- base: s3://test-artifacts-k8s-io-ap-southeast-1/binaries/kops/
+- base: s3://prod-artifacts-k8s-io-us-east-2/binaries/kops/
+- base: s3://prod-artifacts-k8s-io-us-west-2/binaries/kops/
+- base: s3://prod-artifacts-k8s-io-eu-west-2/binaries/kops/
+- base: s3://prod-artifacts-k8s-io-ap-southeast-1/binaries/kops/

--- a/artifacts/mirroring/filestores/k8s-staging-kops/filepromoter-manifest.yaml
+++ b/artifacts/mirroring/filestores/k8s-staging-kops/filepromoter-manifest.yaml
@@ -1,0 +1,4 @@
+filestores:
+- base: gs://k8s-artifacts-prod/binaries/kops/
+  src: true
+- base: s3://test-artifacts-k8s-io-us-east-2/binaries/kops/

--- a/artifacts/mirroring/filestores/k8s-staging-provider-aws/filepromoter-manifest.yaml
+++ b/artifacts/mirroring/filestores/k8s-staging-provider-aws/filepromoter-manifest.yaml
@@ -1,0 +1,4 @@
+filestores:
+- base: gs://k8s-artifacts-prod/binaries/cloud-provider-aws/
+  src: true
+- base: s3://test-artifacts-k8s-io-us-east-2/binaries/cloud-provider-aws/

--- a/artifacts/mirroring/filestores/k8s-staging-provider-aws/filepromoter-manifest.yaml
+++ b/artifacts/mirroring/filestores/k8s-staging-provider-aws/filepromoter-manifest.yaml
@@ -2,3 +2,6 @@ filestores:
 - base: gs://k8s-artifacts-prod/binaries/cloud-provider-aws/
   src: true
 - base: s3://test-artifacts-k8s-io-us-east-2/binaries/cloud-provider-aws/
+- base: s3://test-artifacts-k8s-io-us-west-2/binaries/cloud-provider-aws/
+- base: s3://test-artifacts-k8s-io-eu-west-2/binaries/cloud-provider-aws/
+- base: s3://test-artifacts-k8s-io-ap-southeast-1/binaries/cloud-provider-aws/

--- a/artifacts/mirroring/filestores/k8s-staging-provider-aws/filepromoter-manifest.yaml
+++ b/artifacts/mirroring/filestores/k8s-staging-provider-aws/filepromoter-manifest.yaml
@@ -1,7 +1,7 @@
 filestores:
 - base: gs://k8s-artifacts-prod/binaries/cloud-provider-aws/
   src: true
-- base: s3://test-artifacts-k8s-io-us-east-2/binaries/cloud-provider-aws/
-- base: s3://test-artifacts-k8s-io-us-west-2/binaries/cloud-provider-aws/
-- base: s3://test-artifacts-k8s-io-eu-west-2/binaries/cloud-provider-aws/
-- base: s3://test-artifacts-k8s-io-ap-southeast-1/binaries/cloud-provider-aws/
+- base: s3://prod-artifacts-k8s-io-us-east-2/binaries/cloud-provider-aws/
+- base: s3://prod-artifacts-k8s-io-us-west-2/binaries/cloud-provider-aws/
+- base: s3://prod-artifacts-k8s-io-eu-west-2/binaries/cloud-provider-aws/
+- base: s3://prod-artifacts-k8s-io-ap-southeast-1/binaries/cloud-provider-aws/

--- a/artifacts/mirroring/manifests
+++ b/artifacts/mirroring/manifests
@@ -1,0 +1,1 @@
+../manifests/


### PR DESCRIPTION
This is the configuration I used to populate the S3 sandbox mirrors.

Comments welcome!

Edit: We thought about whether we should use S3 replication vs copying to each bucket separately, this PR does not use S3 replication; we can revisit in future if needed.  ~In particular, I'm not sure if we should use S3 replication vs just copying to each individually.~

Cons of S3 replication:
* S3 replication is a little tricky to set up (https://github.com/kubernetes/k8s.io/pull/4714)
* Having one bucket as the source makes that bucket a (likely) single point of failure (a change is replicated everywhere, if the bucket is down we can't publish to the replicas).
* We likely want to audit the replica buckets also, so we probably need _a_ configuration for them also.

Pros of S3 replication:
* Less bandwidth used during publish - we only need to write to S3 once.  The cost seems insiginficant compared to download costs, but it will be slower to publish to each replica.  But transfers are incremental, so after the initial copy it should be pretty fast.