### PR TITLE
artifacts-sandbox terraform: Add cloudfront distribution

### DIFF
--- a/infra/aws/terraform/test-artifacts.k8s.io/cloudfront.tf
+++ b/infra/aws/terraform/test-artifacts.k8s.io/cloudfront.tf
@@ -1,0 +1,76 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "aws_cloudfront_distribution" "artifacts" {
+  enabled             = true
+  is_ipv6_enabled     = true
+
+  origin_group {
+    origin_id = "groupS3"
+
+    failover_criteria {
+      status_codes = [500, 502]
+    }
+
+    member {
+      origin_id = "primaryS3"
+    }
+
+    member {
+      origin_id = "failoverS3"
+    }
+  }
+
+  origin {
+    domain_name = "test-artifacts-k8s-io-us-east-2.s3.us-east-2.amazonaws.com"
+    origin_id   = "primaryS3"
+  }
+
+  origin {
+    domain_name = "test-artifacts-k8s-io-eu-west-2.s3.eu-west-2.amazonaws.com"
+    origin_id   = "failoverS3"
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    viewer_protocol_policy = "redirect-to-https"
+
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+
+    target_origin_id = "groupS3"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}


### PR DESCRIPTION
We can add a cloudfront distribution, it's a good option for when we don't have a bucket local to the user.  TBD whether we should send the user to cloudfront when we do have a cheaper/faster bucket.