### PR TITLE
AWS: fix cur reports

### DIFF
--- a/infra/aws/terraform/management-account/cost_usage.tf
+++ b/infra/aws/terraform/management-account/cost_usage.tf
@@ -37,21 +37,21 @@ resource "aws_cur_report_definition" "no_integrations" {
   }
 }
 
-resource "aws_cur_report_definition" "integrations" {
+resource "aws_cur_report_definition" "athena_integration" {
   provider = aws.us-east-1
 
-  report_name                = "k8s-infra-cur-integrations-definition"
+  report_name                = "k8s-infra-cur-athena-definition"
   time_unit                  = "HOURLY"
-  format                     = "textORcsv"
-  compression                = "ZIP"
+  format                     = "Parquet"
+  compression                = "Parquet"
   additional_schema_elements = ["RESOURCES"]
-  additional_artifacts       = ["REDSHIFT", "ATHENA"]
+  additional_artifacts       = ["ATHENA"]
   refresh_closed_reports     = true
   report_versioning          = "OVERWRITE_REPORT"
 
   # S3 configuration
-  s3_bucket = module.cur_reports_integrations_s3_bucket.s3_bucket_id
-  s3_region = module.cur_reports_integrations_s3_bucket.s3_bucket_region
+  s3_bucket = module.cur_reports_integration_athena_s3_bucket.s3_bucket_id
+  s3_region = module.cur_reports_integration_athena_s3_bucket.s3_bucket_region
   s3_prefix = "CUR"
 
   lifecycle {

--- a/infra/aws/terraform/management-account/provider.tf
+++ b/infra/aws/terraform/management-account/provider.tf
@@ -30,7 +30,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.50.0"
+      version = "~> 4.52.0"
     }
   }
 }

--- a/infra/aws/terraform/management-account/s3.tf
+++ b/infra/aws/terraform/management-account/s3.tf
@@ -17,9 +17,6 @@ limitations under the License.
 # Cost and Usage
 
 module "cur_reports_s3_bucket" {
-  providers = {
-    aws = aws.shared-services
-  }
 
   source = "terraform-aws-modules/s3-bucket/aws"
 
@@ -45,14 +42,11 @@ module "cur_reports_s3_bucket" {
   }
 }
 
-module "cur_reports_integrations_s3_bucket" {
-  providers = {
-    aws = aws.shared-services
-  }
+module "cur_reports_integration_athena_s3_bucket" {
 
   source = "terraform-aws-modules/s3-bucket/aws"
 
-  bucket = "cur_reports_integrations_s3_bucket"
+  bucket = "k8s-infra-cur-reports-athena-bucket"
 
   # S3 bucket-level Public Access Block configuration
   block_public_acls       = true
@@ -62,7 +56,7 @@ module "cur_reports_integrations_s3_bucket" {
 
   attach_deny_insecure_transport_policy = true
   attach_policy                         = true
-  policy                                = data.aws_iam_policy_document.cur_reports_integrations_s3_bucket.json
+  policy                                = data.aws_iam_policy_document.cur_reports_integration_athena_s3_bucket.json
 
   # Note: Object Lock configuration can be enabled only on new buckets
   # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object_lock_configuration
@@ -130,7 +124,7 @@ data "aws_iam_policy_document" "cur_reports_s3_bucket" {
   }
 }
 
-data "aws_iam_policy_document" "cur_reports_integrations_s3_bucket" {
+data "aws_iam_policy_document" "cur_reports_integration_athena_s3_bucket" {
   version = "2008-10-17"
 
   statement {
@@ -146,7 +140,7 @@ data "aws_iam_policy_document" "cur_reports_integrations_s3_bucket" {
       "s3:GetBucketPolicy",
       "s3:GetBucketAcl"
     ]
-    resources = [module.cur_reports_integrations_s3_bucket.s3_bucket_arn]
+    resources = [module.cur_reports_integration_athena_s3_bucket.s3_bucket_arn]
 
     condition {
       test     = "StringEquals"
@@ -165,7 +159,7 @@ data "aws_iam_policy_document" "cur_reports_integrations_s3_bucket" {
     sid       = "AWSBillingDeliveryWrite"
     effect    = "Allow"
     actions   = ["s3:PutObject"]
-    resources = ["${module.cur_reports_integrations_s3_bucket.s3_bucket_arn}/*"]
+    resources = ["${module.cur_reports_integration_athena_s3_bucket.s3_bucket_arn}/*"]
 
     principals {
       type        = "Service"


### PR DESCRIPTION
Follow-up:
  - https://github.com/kubernetes/k8s.io/pull/4688
  
- Ensure `Parquet` format is used for CUR report with integration with Athena
- Ensure the buckets are in the management account. This a hard requirement during CUR report setup

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>