### PR TITLE
AWS: Add a service-linked role for IAM Access Analyzer

### DIFF
--- a/infra/aws/terraform/management-account/iam-roles.tf
+++ b/infra/aws/terraform/management-account/iam-roles.tf
@@ -1,0 +1,20 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+resource "aws_iam_service_linked_role" "access_analyzer" {
+  aws_service_name = "access-analyzer.amazonaws.com"
+}


### PR DESCRIPTION
Follow-up:
  - https://github.com/kubernetes/k8s.io/pull/4694

According to
https://docs.aws.amazon.com/IAM/latest/UserGuide/access-analyzer-getting-started.html, a service-linked role is required to enable IAM Access Analyzer at the org level.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>