### PR TITLE
AWS: add a production account for registry.k8s.io

### DIFF
--- a/infra/aws/terraform/management-account/organization-accounts-workloads-prod.tf
+++ b/infra/aws/terraform/management-account/organization-accounts-workloads-prod.tf
@@ -21,3 +21,12 @@ module "artifacts-k8s-io" {
   email                      = "k8s-infra-aws-admins+artifacts-k8s-io-prod@kubernetes.io"
   parent_id                  = aws_organizations_organizational_unit.production.id
 }
+
+module "registry-k8s-io" {
+  source = "../modules/org-account"
+
+  account_name               = "k8s-infra-registry-k8s-io-prod"
+  email                      = "k8s-infra-aws-admins+registry-k8s-io-prod@kubernetes.io"
+  iam_user_access_to_billing = true
+  parent_id                  = aws_organizations_organizational_unit.production.id
+}


### PR DESCRIPTION
Add a account that will be use to keep a CloudFront distribution and a S3 bucket for image layers served by registry.k8s.io

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>