### PR TITLE
add myself and arnaud to oci-proxy OWNERS

### DIFF
--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/OWNERS
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+- ameukam
+- bentheelder

--- a/infra/gcp/terraform/k8s-infra-oci-proxy/OWNERS
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+- ameukam
+- bentheelder


### PR DESCRIPTION
we already have terraform-wide OWNERS, I'd like to be able to approve fixes to the oci-proxy configs specifically

@ameukam has done most of the approval for this, so adding him as well explicitly, even though he's in the infra/gcp/terraform/OWNERS


https://github.com/kubernetes/k8s.io/commits/main/infra/gcp/terraform/k8s-infra-oci-proxy-prod

