### PR TITLE
Add rkatz temporarily to kubebuilder group

### DIFF
--- a/groups/sig-api-machinery/groups.yaml
+++ b/groups/sig-api-machinery/groups.yaml
@@ -84,6 +84,7 @@ groups:
       ReconcileMembers: "true"
     members:
       - camilamacedo86@gmail.com
+      - ricardo.katz@gmail.com
 
   #
   # k8s-infra gcs write access


### PR DESCRIPTION
I'm adding myself to kubebuilder group, so I can watch the image promotion/cloudbuild job while helping kubebuilder folks to migrate.

After that my access can be removed.