### PR TITLE
infra/aws: Add Policy Staging OU and AWS testing account

### DIFF
--- a/infra/aws/terraform/management-account/organization-accounts-policy-staging.tf
+++ b/infra/aws/terraform/management-account/organization-accounts-policy-staging.tf
@@ -1,0 +1,26 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+module "policy_staging_account_1" {
+  source = "../modules/org-account"
+
+  account_name               = "k8s-infra-policy-staging-account-1"
+  email                      = "k8s-infra-aws-admins+policy-staging-account-1@kubernetes.io"
+  iam_user_access_to_billing = "ALLOW"
+  parent_id                  = aws_organizations_organizational_unit.policy_staging.id
+}
+

--- a/infra/aws/terraform/management-account/organizational-units.tf
+++ b/infra/aws/terraform/management-account/organizational-units.tf
@@ -72,3 +72,12 @@ resource "aws_organizations_organizational_unit" "boskos" {
     prevent_destroy = true
   }
 }
+
+resource "aws_organizations_organizational_unit" "policy_staging" {
+  name      = "Policy Staging"
+  parent_id = aws_organizations_organization.default.roots[0].id
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}


### PR DESCRIPTION
Ref: [4684](https://github.com/kubernetes/k8s.io/issues/4684)

This PR creates an Organizational Unit and an AWS account inside the OU. The goal is to use this resources to test Tag and Service Control Policies before they are attached to production AWS accounts or production OUs.
 