### PR TITLE
Grant justinsb access to the logs behind k8s.gcr.io

### DIFF
--- a/groups/sig-k8s-infra/groups.yaml
+++ b/groups/sig-k8s-infra/groups.yaml
@@ -403,6 +403,7 @@ groups:
       ReconcileMembers: "true"
     members:
       - k8s-infra-ii-coop@kubernetes.io
+      - justinsb@google.com # checking if there is some slice of traffic that we can redirect from k8s.gcr.io.  Remove Feb-28.
 
   - email-id: k8s-infra-group-admins@kubernetes.io
     name: k8s-infra-group-admins


### PR DESCRIPTION
I would like to investigate whether there is a slice of traffic we can
redirect from k8s.gcr.io.  Only need access for about a week.

I will keep PII confidential and I will not retain raw information
past Feb 28.
