### PR TITLE
(For Feb 28): Revert "Grant justinsb access to the logs behind k8s.gcr.io"

### DIFF
--- a/groups/sig-k8s-infra/groups.yaml
+++ b/groups/sig-k8s-infra/groups.yaml
@@ -403,7 +403,6 @@ groups:
       ReconcileMembers: "true"
     members:
       - k8s-infra-ii-coop@kubernetes.io
-      - justinsb@google.com # checking if there is some slice of traffic that we can redirect from k8s.gcr.io.  Remove Feb-28.
 
   - email-id: k8s-infra-group-admins@kubernetes.io
     name: k8s-infra-group-admins


### PR DESCRIPTION
This reverts commit 161bbe8aa3eb1b46c2694ea646d5e9c95d7c49e0.

Access was granted for a defined purpose and a defined period of time;
this revert closes out that access.

Please merge on or around Feb 28th, as agreed.
