### PR TITLE
Add voelzmo to sig-autoscaling members and staging-image owners

### DIFF
--- a/groups/sig-autoscaling/groups.yaml
+++ b/groups/sig-autoscaling/groups.yaml
@@ -38,6 +38,7 @@ groups:
       - danielmk@google.com
       - guyjtempleton@googlemail.com
       - kgolab@google.com
+      - voelzmo@googlemail.com
 
   #
   # k8s-infra gcs write access

--- a/k8s.gcr.io/images/k8s-staging-autoscaling/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-autoscaling/OWNERS
@@ -12,3 +12,4 @@ approvers:
 - towca
 - gjtempleton
 - kgolab
+- voelzmo


### PR DESCRIPTION
Reason: to help with releases for VPA