### PR TITLE
AWS: Redefine delegated administrators

### DIFF
--- a/infra/aws/terraform/management-account/delegated-admins.tf
+++ b/infra/aws/terraform/management-account/delegated-admins.tf
@@ -16,28 +16,42 @@ limitations under the License.
 
 # https://docs.aws.amazon.com/organizations/latest/userguide/orgs_integrate_services_list.html
 
-resource "aws_organizations_delegated_administrator" "config_multiaccount" {
-  account_id        = module.security_audit.account_id
-  service_principal = "config-multiaccountsetup.amazonaws.com"
-}
-
-resource "aws_organizations_delegated_administrator" "config" {
-  account_id        = module.security_audit.account_id
-  service_principal = "config.amazonaws.com"
-}
-
-resource "aws_organizations_delegated_administrator" "guardduty" {
-  account_id        = module.security_audit.account_id
-  service_principal = "guardduty.amazonaws.com"
-}
+# Audit Account
 
 resource "aws_organizations_delegated_administrator" "access_analyzer" {
   account_id        = module.security_audit.account_id
   service_principal = "access-analyzer.amazonaws.com"
 }
 
-resource "aws_organizations_delegated_administrator" "securityhub" {
+resource "aws_organizations_delegated_administrator" "storage_lens" {
   account_id        = module.security_audit.account_id
+  service_principal = "storage-lens.s3.amazonaws.com"
+}
+
+# Security Engineering Account
+
+resource "aws_organizations_delegated_administrator" "config_multiaccount" {
+  account_id        = module.security_engineering.account_id
+  service_principal = "config-multiaccountsetup.amazonaws.com"
+}
+
+resource "aws_organizations_delegated_administrator" "config" {
+  account_id        = module.security_engineering.account_id
+  service_principal = "config.amazonaws.com"
+}
+
+resource "aws_organizations_delegated_administrator" "cloudtrail" {
+  account_id        = module.security_engineering.account_id
+  service_principal = "cloudtrail.amazonaws.com"
+}
+
+resource "aws_organizations_delegated_administrator" "guardduty" {
+  account_id        = module.security_engineering.account_id
+  service_principal = "guardduty.amazonaws.com"
+}
+
+resource "aws_organizations_delegated_administrator" "securityhub" {
+  account_id        = module.security_engineering.account_id
   service_principal = "securityhub.amazonaws.com"
 }
 
@@ -47,6 +61,13 @@ resource "aws_organizations_delegated_administrator" "fms" {
 }
 
 resource "aws_organizations_delegated_administrator" "detective" {
-  account_id        = module.security_audit.account_id
+  account_id        = module.security_engineering.account_id
   service_principal = "detective.amazonaws.com"
+}
+
+# Infra-shared services
+
+resource "aws_organizations_delegated_administrator" "identity_center" {
+  account_id        = module.infra_shared_services.account_id
+  service_principal = "sso.amazonaws.com"
 }


### PR DESCRIPTION
Redefine the delegate administrators for some services. According the [AWS
SRA](https://docs.aws.amazon.com/prescriptive-guidance/latest/security-reference-architecture/security-tooling.html) we should have:
- GuardDuty, CloudTrail, Config and Security Hub in the security eng account
- Identity Center is the infra-shared services account.
- Storage lens S3 and Access Analyzer in the Audit account.