### PR TITLE
Initial Azure AD PoC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 
 # Ignore vscode config files
 .vscode
+
+
+# Terraform
+.terraform
+terraform.tfstate
+terraform.tfstate.backup

--- a/infra/azure/README.md
+++ b/infra/azure/README.md
@@ -1,0 +1,7 @@
+# infra/azure
+
+Scripts, Terraform and documentation for infrastructure that the Kubernetes community runs on AWS.
+
+## Folders
+
+- [azure-ad](./azure-ad/) :: Azure AD Config with access to AWS and other systems that require SAML

--- a/infra/azure/azure-ad/.terraform.lock.hcl
+++ b/infra/azure/azure-ad/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azuread" {
+  version = "2.34.1"
+  hashes = [
+    "h1:MCH4XrjAUwJhM7Zq5J2VxuS4m4x1P5/YXwCBjKvdD54=",
+    "zh:1c117e63562bffe42ed5ae8f2c51c2c54f298b2df32a10c0a8c651c95557962f",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:32418ea3675011c6eec02cda1844fdaa175d449e916b9a3e4931cc156f9947c2",
+    "zh:75795d8381e1332d6011a87939cab240be79319ba3a0c0373554a6cf83045e8b",
+    "zh:aeb2be299bbacc6be935205b6351aaa689a0cbccbf2272cbe37796776f7efdd7",
+    "zh:b3a6424d1bc9cc5d3872626761b0fd246d99cd988f5a0843a87ec571cbcdaefa",
+    "zh:c4471f39c2098f2eaeaaeb7d6411ad0553d1bb250ac7f21189303af3a165718e",
+    "zh:ce5ef6b67c64321f9f60a374accf13df6606f0a716b55d81980b25bd173b912d",
+    "zh:ebf4f4398c8e4dbef1e421ee6d8cbfe59ab88460926770c34fdca6483a8f3891",
+    "zh:f6bd021dbed979f9c41ec3a06c4ffab85dca0972a4f59f365c3c30ef8fe7c222",
+    "zh:fc9e85e8aed5d9e2307c38e6c617b0b227e8009a2314779b18f8bd376bb49549",
+    "zh:fdc99b9d7dfae4c1a7869fa6de91478afdb477d95a9f87325003e985dd19de23",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.4.3"
+  hashes = [
+    "h1:tL3katm68lX+4lAncjQA9AXL4GR/VM+RPwqYf4D2X8Q=",
+    "zh:41c53ba47085d8261590990f8633c8906696fa0a3c4b384ff6a7ecbf84339752",
+    "zh:59d98081c4475f2ad77d881c4412c5129c56214892f490adf11c7e7a5a47de9b",
+    "zh:686ad1ee40b812b9e016317e7f34c0d63ef837e084dea4a1f578f64a6314ad53",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:84103eae7251384c0d995f5a257c72b0096605048f757b749b7b62107a5dccb3",
+    "zh:8ee974b110adb78c7cd18aae82b2729e5124d8f115d484215fd5199451053de5",
+    "zh:9dd4561e3c847e45de603f17fa0c01ae14cae8c4b7b4e6423c9ef3904b308dda",
+    "zh:bb07bb3c2c0296beba0beec629ebc6474c70732387477a65966483b5efabdbc6",
+    "zh:e891339e96c9e5a888727b45b2e1bb3fcbdfe0fd7c5b4396e4695459b38c8cb1",
+    "zh:ea4739860c24dfeaac6c100b2a2e357106a89d18751f7693f3c31ecf6a996f8d",
+    "zh:f0c76ac303fd0ab59146c39bc121c5d7d86f878e9a69294e29444d4c653786f8",
+    "zh:f143a9a5af42b38fed328a161279906759ff39ac428ebcfe55606e05e1518b93",
+  ]
+}

--- a/infra/azure/azure-ad/README.md
+++ b/infra/azure/azure-ad/README.md
@@ -1,0 +1,9 @@
+
+
+Format of the users will be GITHUB_USERNAME@kubernetes.io
+
+You'll need to reset your initial password by using the email you added in the csv file as the recovery method.
+
+1st login should prompt you to configure MFA.
+
+Once your user is created, you should be able to access AWS accounts at https://d-9c67038314.awsapps.com/start

--- a/infra/azure/azure-ad/provider.tf
+++ b/infra/azure/azure-ad/provider.tf
@@ -1,0 +1,16 @@
+provider "azuread" {
+
+}
+
+terraform {
+  #   backend "gcs" {
+  #     bucket = "k8s-infra-tf-gcp"
+  #     prefix = "azure-ad"
+  #   }
+
+  required_providers {
+    azuread = {
+      source = "hashicorp/azuread"
+    }
+  }
+}

--- a/infra/azure/azure-ad/sig-k8s-infra/OWNERS
+++ b/infra/azure/azure-ad/sig-k8s-infra/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- sig-k8s-infra-leads
+reviewers:
+- sig-k8s-infra-leads
+
+labels:
+- sig/k8s-infra

--- a/infra/azure/azure-ad/sig-k8s-infra/groups.tf
+++ b/infra/azure/azure-ad/sig-k8s-infra/groups.tf
@@ -1,0 +1,17 @@
+resource "azuread_group" "group" {
+  for_each = local.groups
+  display_name     = each.key
+  security_enabled = true
+  members = [for user in try(each.value.members, []) : data.azuread_user.main[user].object_id]
+}
+
+data "azuread_user" "main" {
+  for_each = try(toset(var.users), [])
+  user_principal_name = each.value
+}   
+
+locals {
+  groups =  yamldecode(file("${path.module}/groups.yaml"))
+}
+
+#https://discuss.hashicorp.com/t/using-for-each-and-lookup-in-a-data-block-does-not-return-a-string/34227

--- a/infra/azure/azure-ad/sig-k8s-infra/groups.yaml
+++ b/infra/azure/azure-ad/sig-k8s-infra/groups.yaml
@@ -1,0 +1,9 @@
+aws-admins:
+  members:
+    - upodroid@k8s.borg.dev
+    - ameukam@k8s.borg.dev
+
+aws-readonly:
+  members:
+    - dims@k8s.borg.dev
+

--- a/infra/azure/azure-ad/sig-k8s-infra/variables.tf
+++ b/infra/azure/azure-ad/sig-k8s-infra/variables.tf
@@ -1,0 +1,4 @@
+variable "users" {
+  default = null
+  type = list(string)
+}

--- a/infra/azure/azure-ad/users.csv
+++ b/infra/azure/azure-ad/users.csv
@@ -1,0 +1,3 @@
+first_name,last_name,github_username,email
+Mahamed,Ali,upodroid,cy@borg.dev
+Arnaud,Meukam,ameukam,ameukam@gmail.com

--- a/infra/azure/azure-ad/users.tf
+++ b/infra/azure/azure-ad/users.tf
@@ -1,0 +1,49 @@
+locals {
+  domain_name = "k8s.borg.dev"
+  users       = csvdecode(file("./users.csv"))
+}
+
+resource "random_string" "random" {
+  length           = 16
+  special          = true
+}
+# Create users
+resource "azuread_user" "users" {
+  for_each = { for user in local.users : user.github_username => user }
+
+  user_principal_name = format(
+    "%s@%s",
+    each.value.github_username,
+    local.domain_name
+  )
+
+  password = uuid()
+  force_password_change = true
+  other_mails = [
+    each.value.email
+  ]
+  lifecycle {
+    ignore_changes = [
+      password,
+    ]
+  }
+
+  given_name = each.value.first_name
+  surname = each.value.last_name
+  usage_location = "US"
+
+  display_name = "${each.value.first_name} ${each.value.last_name}"
+}
+
+resource "azuread_group" "aws_group" {
+  # All users that need AWS access must be part of this group for provisioning to work
+  display_name     = "aws-users"
+  security_enabled = true
+  members = values(azuread_user.users)[*].object_id
+}
+
+module "sig_k8s_infra_groups" {
+  source     = "./sig-k8s-infra"
+  users  = values(azuread_user.users)[*].user_principal_name
+  depends_on = [azuread_user.users]
+}


### PR DESCRIPTION
Fixes: #4746 

Accessing our AWS accounts and potential Azure subscriptions require access to a proper Identity Provider with support for SAML & SCIM to eliminate manual user provisioning. Azure AD meets that requirement rather well and I had access to some dev tenants to develop this.

The idea is rather simple, you would commit a line in to the csv file which creates an Azure AD user for you. You can use this user to login to AWS and access any accounts that you have permissions for.

We can use terraform to configure which groups should access which accounts via AWS APIs.

If we want to go forward with this, we'll need to create an Azure AD tenant for kubernetes.io and do one-off manual config of the Enterprise application and tenant.

The terraform code for the groups is a bit buggy, I need some help with that.

/cc @ameukam @jeefy 