### PR TITLE
artifacts.k8s.io: replicate to ap-northeast-1 region

### DIFF
--- a/artifacts/mirroring/filestores/k8s-staging-cri-tools/filepromoter-manifest.yaml
+++ b/artifacts/mirroring/filestores/k8s-staging-cri-tools/filepromoter-manifest.yaml
@@ -8,5 +8,6 @@ filestores:
 - base: s3://prod-artifacts-k8s-io-eu-central-1/binaries/cri-tools/
 - base: s3://prod-artifacts-k8s-io-eu-west-1/binaries/cri-tools/
 - base: s3://prod-artifacts-k8s-io-eu-west-2/binaries/cri-tools/
+- base: s3://prod-artifacts-k8s-io-ap-northeast-1/binaries/cri-tools/
 - base: s3://prod-artifacts-k8s-io-ap-south-1/binaries/cri-tools/
 - base: s3://prod-artifacts-k8s-io-ap-southeast-1/binaries/cri-tools/

--- a/artifacts/mirroring/filestores/k8s-staging-kops/filepromoter-manifest.yaml
+++ b/artifacts/mirroring/filestores/k8s-staging-kops/filepromoter-manifest.yaml
@@ -8,5 +8,6 @@ filestores:
 - base: s3://prod-artifacts-k8s-io-eu-central-1/binaries/kops/
 - base: s3://prod-artifacts-k8s-io-eu-west-1/binaries/kops/
 - base: s3://prod-artifacts-k8s-io-eu-west-2/binaries/kops/
+- base: s3://prod-artifacts-k8s-io-ap-northeast-1/binaries/kops/
 - base: s3://prod-artifacts-k8s-io-ap-south-1/binaries/kops/
 - base: s3://prod-artifacts-k8s-io-ap-southeast-1/binaries/kops/

--- a/artifacts/mirroring/filestores/k8s-staging-provider-aws/filepromoter-manifest.yaml
+++ b/artifacts/mirroring/filestores/k8s-staging-provider-aws/filepromoter-manifest.yaml
@@ -8,5 +8,6 @@ filestores:
 - base: s3://prod-artifacts-k8s-io-eu-central-1/binaries/cloud-provider-aws/
 - base: s3://prod-artifacts-k8s-io-eu-west-1/binaries/cloud-provider-aws/
 - base: s3://prod-artifacts-k8s-io-eu-west-2/binaries/cloud-provider-aws/
+- base: s3://prod-artifacts-k8s-io-ap-northeast-1/binaries/cloud-provider-aws/
 - base: s3://prod-artifacts-k8s-io-ap-south-1/binaries/cloud-provider-aws/
 - base: s3://prod-artifacts-k8s-io-ap-southeast-1/binaries/cloud-provider-aws/


### PR DESCRIPTION
This region seems to be about half of our remaining cache misses.
