### PR TITLE
AWS: ignore credits in the global budget.

### DIFF
--- a/infra/aws/terraform/management-account/budgets.tf
+++ b/infra/aws/terraform/management-account/budgets.tf
@@ -26,7 +26,7 @@ resource "aws_budgets_budget" "everything" {
   limit_unit        = "USD"
 
   cost_types {
-    include_credit             = true
+    include_credit             = false
     include_discount           = true
     include_other_subscription = true
     include_recurring          = true
@@ -41,7 +41,7 @@ resource "aws_budgets_budget" "everything" {
 
   notification {
     comparison_operator        = "GREATER_THAN"
-    threshold                  = "1"
+    threshold                  = "30"
     threshold_type             = "PERCENTAGE"
     notification_type          = "ACTUAL"
     subscriber_email_addresses = ["sig-k8s-infra-leads@kubernetes.io"]


### PR DESCRIPTION
The credits donated rebalance the AWS organization's monthly spend. Thus the defined threshold is never respected.
Also increase the percentage of the threshold