### PR TITLE
Releng: temp release manager access for gracenng

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -48,6 +48,7 @@ groups:
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
       - mudrinic.mare@gmail.com
+      - nng.grace@gmail.com
       - pal.nabarun95@gmail.com
       - saschagrunert@gmail.com
 


### PR DESCRIPTION
In preparation of the v1.27.0-alpha3 cut on Thursday, March 2.

cc @cici37 

/hold