### PR TITLE
Grant s3-sync service account permissions to read buckets

### DIFF
--- a/infra/gcp/bash/ensure-prod-storage.sh
+++ b/infra/gcp/bash/ensure-prod-storage.sh
@@ -390,6 +390,10 @@ function ensure_all_prod_special_cases() {
         empower_gke_for_serviceaccount \
             "${project}" "${PROWJOB_POD_NAMESPACE}" \
             "${serviceaccount}" "k8s-infra-gcr-promoter"
+        # Allow S3 sync jobs to use k8s-infra-gcr-promoter to read private GCS buckets
+        empower_gke_for_serviceaccount \
+            "${project}" "${PROWJOB_POD_NAMESPACE}" \
+            "${serviceaccount}" "s3-sync"
 
         # Grant write access to k8s-artifacts-prod-bak GCR (for backups)
         serviceaccount="$(svc_acct_email "${PRODBAK_PROJECT}" "${IMAGE_PROMOTER_SVCACCT}")"

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-serviceaccounts.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-serviceaccounts.yaml
@@ -131,5 +131,8 @@ metadata:
 kind: ServiceAccount
 apiVersion: v1
 metadata:
+  # TODO(upodroid) remove this annotation once the k8s-infra-gcr-promoter k8s SA can assume an AWS IAM Role
+  annotations:
+    iam.gke.io/gcp-service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   name: s3-sync
   namespace: test-pods


### PR DESCRIPTION
/cc @ameukam 

This is another way to fix https://github.com/kubernetes/k8s.io/pull/4814

Instead of making AWS IAM changes for Kubernetes k8s-infra-gcr-promoter service account, we make GCP IAM changes to s3-sync Kubernetes service account.

This is the last infra change required for https://github.com/kubernetes/enhancements/issues/3720