### PR TITLE
migrate registry in k8s.io subproject from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/apps/gcsweb/README.md
+++ b/apps/gcsweb/README.md
@@ -30,7 +30,7 @@ need a documented link to browse.
 `gcsweb` is built from source code at
 https://github.com/kubernetes/test-infra/tree/master/gcsweb into Docker
 container, which is then uploaded to private container storage at
-https://registry.k8s.io/gcsweb-amd64 and fetched during processing
+registry.k8s.io/gcsweb and fetched during processing
 of `deployment.yaml` by `kubectl apply`.
 
 ##### How to deploy

--- a/apps/gcsweb/README.md
+++ b/apps/gcsweb/README.md
@@ -30,7 +30,7 @@ need a documented link to browse.
 `gcsweb` is built from source code at
 https://github.com/kubernetes/test-infra/tree/master/gcsweb into Docker
 container, which is then uploaded to private container storage at
-https://k8s.gcr.io/gcsweb-amd64 and fetched during processing
+https://registry.k8s.io/gcsweb-amd64 and fetched during processing
 of `deployment.yaml` by `kubectl apply`.
 
 ##### How to deploy

--- a/apps/gcsweb/deployment.yaml
+++ b/apps/gcsweb/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: gcsweb
-          image: k8s.gcr.io/gcsweb:v1.1.0
+          image: registry.k8s.io/gcsweb:v1.1.0
           args:
             - -upgrade-proxied-http-to-https
             # buckets owned by kubernetes.io

--- a/dns/Makefile
+++ b/dns/Makefile
@@ -18,7 +18,7 @@ CANARY_ZONES := $(foreach z,$(PROD_ZONES),canary.$(z))
 ALL_ZONES := $(CANARY_ZONES) $(PROD_ZONES)
 ZONE_CONFIGS := zone-configs
 OCTODNS_CONFIG := octodns-config.yaml
-DOCKER_IMAGE ?= k8s.gcr.io/infra-tools/octodns:v20200616-67ce585
+DOCKER_IMAGE ?= registry.k8s.io/infra-tools/octodns:v20200616-67ce585
 
 check-canary check-prod validate-config: TMPCFG := $(shell mktemp -d /tmp/octodns.XXXXXX)
 check-canary check-prod validate-config: TMP_OCTODNS_CFG := $(shell mktemp /tmp/octodns.XXXXXX)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
This PR will update the uses of deprecating k8s.gcr.io registry to registry.k8s.io

**Which issue(s) this PR fixes:**

Fixes # https://github.com/kubernetes/k8s.io/issues/4738

**Special notes for your reviewer:**
Search results: https://cs.k8s.io/?q=k8s.gcr.io&i=nope&files=&excludeFiles=vendor%2F&repos=kubernetes/k8s.io

**Does this PR introduce a user-facing change?:**

NONE