### PR TITLE
Use IPv6 for prow-build-cluster

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/eks.tf
+++ b/infra/aws/terraform/prow-build-cluster/eks.tf
@@ -30,9 +30,18 @@ module "eks" {
   # Manage aws-auth ConfigMap.
   manage_aws_auth_configmap = true
 
-  # We do not really care if we use IPv4 or IPv6 as we don't depend much on
-  # pod-to-pod networking.
-  cluster_ip_family = "ipv4"
+  # We use IPv6 because we require a large number of nodes and pods.
+  # With IPv4, we can use only /16 VPC, which is a blocker for running
+  # 100+ nodes.
+  cluster_ip_family = "ipv6"
+
+  # We are using the IRSA created below for permissions
+  # However, we have to deploy with the policy attached FIRST (when creating a fresh cluster)
+  # and then turn this off after the cluster/node group is created. Without this initial policy,
+  # the VPC CNI fails to assign IPs and nodes cannot join the cluster
+  # See https://github.com/aws/containers-roadmap/issues/1666 for more context
+  # TODO - remove this policy once AWS releases a managed version similar to AmazonEKS_CNI_Policy (IPv4)
+  create_cni_ipv6_iam_policy = true
 
   vpc_id                   = module.vpc.vpc_id
   subnet_ids               = module.vpc.private_subnets

--- a/infra/aws/terraform/prow-build-cluster/irsa.tf
+++ b/infra/aws/terraform/prow-build-cluster/irsa.tf
@@ -25,7 +25,7 @@ module "vpc_cni_irsa" {
 
   role_name_prefix      = "VPC-CNI-IRSA"
   attach_vpc_cni_policy = true
-  vpc_cni_enable_ipv4   = true
+  vpc_cni_enable_ipv4   = false
   vpc_cni_enable_ipv6   = true
 
   oidc_providers = {

--- a/infra/aws/terraform/prow-build-cluster/terraform.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.tfvars
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-vpc_cidr = "10.128.0.0/10"
+vpc_cidr = "10.0.0.0/16"
 
 cluster_name    = "prow-build-cluster"
 cluster_region  = "us-east-2"


### PR DESCRIPTION
Slack discussions:
- https://kubernetes.slack.com/archives/CCK68P2Q2/p1677588727123469
- https://kubernetes.slack.com/archives/CCK68P2Q2/p1677623521849229

We tried to use a larger VPC in #4844 but that didn't work because the maximum VPC CIDR is `/16`:

```
╷
│ Error: expected "cidr_block" to contain a network Value with between 16 and 28 significant bits, got: 10
│
│   with module.vpc.aws_vpc.this[0],
│   on .terraform/modules/vpc/main.tf line 23, in resource "aws_vpc" "this":
│   23:   cidr_block          = var.use_ipam_pool ? null : var.cidr
│
╵
```

We have two options:

- Use multiple CIDRs in VPC
- Use IPv6

The first solution seems a bit hacky and might not be easy to accomplish with Terraform. IPv6 seems to be more future-proof and as we don't really depend on pod networking (test pods are not communicating between each other and/or with other resources in the cluster), using IPv6 should be safe.

The only concern about IPv6 is that GitHub doesn't support it yet, but I believe that NAT Gateway is going to mitigate this problem for us.

/assign @ameukam @upodroid @pkprzekwas