### PR TITLE
remove stream-team group

### DIFF
--- a/groups/sig-contributor-experience/groups.yaml
+++ b/groups/sig-contributor-experience/groups.yaml
@@ -125,26 +125,6 @@ groups:
       - jberkus@redhat.com
       - marky.r.jackson@gmail.com
 
-  - email-id: stream-team@kubernetes.io
-    name: stream-team
-    description: |-
-      Team with access to streamyard and YouTube.
-    settings:
-      WhoCanPostMessage: "ANYONE_CAN_POST"
-      MembersCanPostAsTheGroup: "true"
-      ReconcileMembers: "true"
-    owners:
-      - alison@alisondowdney.com
-      - killen.bob@gmail.com
-    members:
-      - jberkus@redhat.com
-      - chris@chrisshort.net
-      - david.andrew.mckay@gmail.com
-      - ihor@cncf.io
-      - hh@ii.coop
-      - caleb@ii.coop
-      - stephen@ii.coop
-
   #
   # k8s-staging write access for SIG-owned subprojects
   #


### PR DESCRIPTION
We used streamyard only a handful of times, and with the spinning down of MoC and Office Hours, it no longer has a purpose.

The streamyard account has been deleted and this will complete it's removal.

/assign @cblecker 