### PR TITLE
prow-build-cluster: switch back to IPv4

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/eks.tf
+++ b/infra/aws/terraform/prow-build-cluster/eks.tf
@@ -30,18 +30,9 @@ module "eks" {
   # Manage aws-auth ConfigMap.
   manage_aws_auth_configmap = true
 
-  # We use IPv6 because we require a large number of nodes and pods.
-  # With IPv4, we can use only /16 VPC, which is a blocker for running
-  # 100+ nodes.
-  cluster_ip_family = "ipv6"
-
-  # We are using the IRSA created below for permissions
-  # However, we have to deploy with the policy attached FIRST (when creating a fresh cluster)
-  # and then turn this off after the cluster/node group is created. Without this initial policy,
-  # the VPC CNI fails to assign IPs and nodes cannot join the cluster
-  # See https://github.com/aws/containers-roadmap/issues/1666 for more context
-  # TODO - remove this policy once AWS releases a managed version similar to AmazonEKS_CNI_Policy (IPv4)
-  create_cni_ipv6_iam_policy = true
+  # We use IPv4 for the best compatibility with the existing setup.
+  # Additionally, Ubuntu EKS optimized AMI doesn't support IPv6 well.
+  cluster_ip_family = "ipv4"
 
   vpc_id                   = module.vpc.vpc_id
   subnet_ids               = module.vpc.private_subnets
@@ -74,7 +65,7 @@ module "eks" {
     # and then turn this off after the cluster/node group is created. Without this initial policy,
     # the VPC CNI fails to assign IPs and nodes cannot join the cluster
     # See https://github.com/aws/containers-roadmap/issues/1666 for more context
-    iam_role_attach_cni_policy = false
+    iam_role_attach_cni_policy = true
   }
 
   eks_managed_node_groups = {
@@ -96,7 +87,7 @@ module "eks" {
       # Force version update if existing pods are unable to be drained due to a PodDisruptionBudget issue.
       force_update_version = true
       update_config = {
-        max_unavailable_percentage = 33
+        max_unavailable_percentage = var.node_max_unavailable_percentage
       }
 
       # Required to ensure Prow works well.

--- a/infra/aws/terraform/prow-build-cluster/eks.tf
+++ b/infra/aws/terraform/prow-build-cluster/eks.tf
@@ -65,7 +65,7 @@ module "eks" {
     # and then turn this off after the cluster/node group is created. Without this initial policy,
     # the VPC CNI fails to assign IPs and nodes cannot join the cluster
     # See https://github.com/aws/containers-roadmap/issues/1666 for more context
-    iam_role_attach_cni_policy = true
+    iam_role_attach_cni_policy = false
   }
 
   eks_managed_node_groups = {

--- a/infra/aws/terraform/prow-build-cluster/irsa.tf
+++ b/infra/aws/terraform/prow-build-cluster/irsa.tf
@@ -25,7 +25,7 @@ module "vpc_cni_irsa" {
 
   role_name_prefix      = "VPC-CNI-IRSA"
   attach_vpc_cni_policy = true
-  vpc_cni_enable_ipv4   = false
+  vpc_cni_enable_ipv4   = true
   vpc_cni_enable_ipv6   = true
 
   oidc_providers = {

--- a/infra/aws/terraform/prow-build-cluster/terraform.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.tfvars
@@ -14,18 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-vpc_cidr = "10.0.0.0/16"
-
 cluster_name    = "prow-build-cluster"
 cluster_region  = "us-east-2"
-cluster_version = "1.23"
+cluster_version = "1.25"
+
+vpc_cidr                  = "10.0.0.0/16"
+vpc_secondary_cidr_blocks = ["10.1.0.0/16", "10.2.0.0/16"]
+vpc_public_subnet         = ["10.0.0.0/18", "10.0.64.0/18", "10.0.128.0/18"]
+vpc_private_subnet        = ["10.1.0.0/18", "10.1.64.0/18", "10.1.128.0/18"]
+vpc_intra_subnet          = ["10.2.0.0/18", "10.2.64.0/18", "10.2.128.0/18"]
 
 # Ubuntu EKS optimized AMI: https://cloud-images.ubuntu.com/aws-eks/
-node_ami = "ami-0a8fed39d4c2b85c1"
-#node_instance_types = ["r5ad.4xlarge"] # Revert to this instance size after bumping up limits.
-node_instance_types = ["r5ad.2xlarge"]
+node_ami            = "ami-03de35fda144b3672"
+node_instance_types = ["r5ad.4xlarge"]
 node_volume_size    = 100
-# TODO: Update this after support ticket gets approved.
-node_min_size     = 2
-node_max_size     = 4
-node_desired_size = 3
+
+# TODO(xmudrii): Increase this later.
+node_min_size     = 1
+node_max_size     = 1
+node_desired_size = 1
+node_max_unavailable_percentage = 100 # To ease testing

--- a/infra/aws/terraform/prow-build-cluster/variables.tf
+++ b/infra/aws/terraform/prow-build-cluster/variables.tf
@@ -19,6 +19,26 @@ variable "vpc_cidr" {
   description = "CIDR of the VPC"
 }
 
+variable "vpc_secondary_cidr_blocks" {
+  type        = list(string)
+  description = "Additional CIDRs to attach to the VPC"
+}
+
+variable "vpc_public_subnet" {
+  type        = list(string)
+  description = "Public subnets (one per AZ)"
+}
+
+variable "vpc_private_subnet" {
+  type        = list(string)
+  description = "Private subnets (one per AZ)"
+}
+
+variable "vpc_intra_subnet" {
+  type        = list(string)
+  description = "Intra subnets (one per AZ, subnet without access to external services)"
+}
+
 variable "cluster_name" {
   type        = string
   description = "Name of the EKS cluster"
@@ -62,4 +82,9 @@ variable "node_max_size" {
 variable "node_desired_size" {
   type        = number
   description = "Desired number of nodes in the EKS node group"
+}
+
+variable "node_max_unavailable_percentage" {
+  type        = number
+  description = "Maximum unavailable nodes in a node group"
 }

--- a/infra/aws/terraform/prow-build-cluster/vpc.tf
+++ b/infra/aws/terraform/prow-build-cluster/vpc.tf
@@ -18,20 +18,25 @@ limitations under the License.
 # VPC
 ###############################################
 
+# VPC is IPv4/IPv6 Dual-Stack, but our cluster is IPv4 because EKS doesn't
+# support dual-stack yet.
+
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
   version = "~> 3.0"
 
   name = "${var.cluster_name}-vpc"
-  cidr = var.vpc_cidr
+
+  cidr                  = var.vpc_cidr
+  secondary_cidr_blocks = var.vpc_secondary_cidr_blocks
 
   azs             = local.azs
-  private_subnets = [for k, v in local.azs : cidrsubnet(var.vpc_cidr, 4, k)]
-  public_subnets  = [for k, v in local.azs : cidrsubnet(var.vpc_cidr, 4, k + length(local.azs))]
+  private_subnets = var.vpc_private_subnet
+  public_subnets  = var.vpc_public_subnet
 
   # intra_subnets are private subnets without the internet access 
   # (https://registry.terraform.io/modules/terraform-aws-modules/vpc/aws/latest#private-versus-intra-subnets)
-  intra_subnets = [for k, v in local.azs : cidrsubnet(var.vpc_cidr, 4, k + (length(local.azs) * 2))]
+  intra_subnets = var.vpc_intra_subnet
 
   # Enable IPv6 for this subnet.
   enable_ipv6                     = true


### PR DESCRIPTION
As discussed on the SIG K8s infra meeting held on 2023-03-01:

- We are switching back `prow-build-cluster` to IPv4 because:
  - we want to ensure the best compatibility and avoid any potential issues that can be caused by running workload in an IPv6-only cluster
  - there are issues with Ubuntu EKS optimized AMI and IPv6 and we don't want to spend too much time debugging and fixing that
- We are going to use one `/16` VPC with multiple CIDRs
  - `10.0.0.0/16` is going to used for **public** subnets
  - `10.1.0.0/16` is going to used for **private** subnets
  - `10.2.0.0/16` is going to used for **intra** subnets
- Each subnet is going to be `/18` giving us about 16k IP addresses **per availability zone**
  - This should be more than enough for our needs

Additionally:

- The cluster is upgraded to Kubernetes 1.25. We'll use containerd as a container runtime
  - Ubuntu AMI that we use doesn't seem to support Docker anyways, at least, it doesn't come with it installed
  - 1.23 is going to reach EOL at some point (October 2023) and we'll need to migrate anyways
  - I believe that Docker is not a requirement for DinD and I want to test that
    - GKE cluster is also running `ubuntu_containerd` image

/assign @ameukam @upodroid 
/hold
will merge the PR after reconciling changes