### PR TITLE
node: test images: promote sample-device-plugin image

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-e2e-test-images/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-e2e-test-images/images.yaml
@@ -149,6 +149,8 @@
 - name: sample-device-plugin
   dmap:
     "sha256:e84f6ca27c51ddedf812637dd2bcf771ad69fdca1173e5690c372370d0f93c40": ["1.3"]
+    "sha256:d25324ceac9ad0189f041889e19b9ebb364c8e63d41f1758c4d9d0b244bb0b8d": ["1.4"]
+    "sha256:714aa86405b19c6a0187a03afb33d026c68d01417f8a49786d7d29ae0df8f630": ["1.5"]
 - name: volume/gluster
   dmap:
     "sha256:660af738347dd94cdd8069647136c84f11d03fc6dde3af0e746b302d3dfd10ec": ["1.2"]


### PR DESCRIPTION
Promotes sample device plugin image.

**Context**:
Recently sample device plugin was updated (https://github.com/kubernetes/kubernetes/pull/115107) to enable the e2e node tests (or any other entity with full access to the node filesystem) to control the registration process.

This feature is useful because it is not possible to control the order in which the pods are recovered after node reboot/kubelet restart. This is used in https://github.com/kubernetes/kubernetes/pull/114640 where e2e test is implemented to simulate scenarios where application pods requesting devices come up before the device plugin pod on node reboot/ kubelet restart.

NOTE: While we are at it, we also promote 1.4 version of the sample device plugin image.

**How the sha was obtained?**
```

$ docker run  mplatform/manifest-tool  -- inspect --raw gcr.io/k8s-staging-e2e-test-images/sample-device-plugin:1.5  | jq .digest
"sha256:714aa86405b19c6a0187a03afb33d026c68d01417f8a49786d7d29ae0df8f630"

$ docker run  mplatform/manifest-tool  -- inspect --raw gcr.io/k8s-staging-e2e-test-images/sample-device-plugin:1.4  | jq .digest
"sha256:d25324ceac9ad0189f041889e19b9ebb364c8e63d41f1758c4d9d0b244bb0b8d"
```