### PR TITLE
Create summit-team group

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -100,7 +100,6 @@ restrictions:
       - "^lwkd@kubernetes.io$"
       - "^moderators@kubernetes.io$"
       - "^summit-team@kubernetes.io$"
-      - "^stream-team@kubernetes.io$"
       - "^k8s-infra-rbac-elekto@kubernetes.io$"
       - "^k8s-infra-rbac-slack-infra@kubernetes.io$"
       - "^k8s-infra-staging-slack-infra@kubernetes.io$"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -99,6 +99,7 @@ restrictions:
       - "^github@kubernetes.io$"
       - "^lwkd@kubernetes.io$"
       - "^moderators@kubernetes.io$"
+      - "^summit-team@kubernetes.io$"
       - "^stream-team@kubernetes.io$"
       - "^k8s-infra-rbac-elekto@kubernetes.io$"
       - "^k8s-infra-rbac-slack-infra@kubernetes.io$"

--- a/groups/sig-contributor-experience/groups.yaml
+++ b/groups/sig-contributor-experience/groups.yaml
@@ -125,6 +125,29 @@ groups:
       - jberkus@redhat.com
       - marky.r.jackson@gmail.com
 
+  - email-id: summit-team@kubernetes.io
+    name: summit-team
+    description: |-
+      Staff for the upcoming Kubernetes Contributor Summit
+    settings:
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MembersCanPostAsTheGroup: "true"
+      ReconcileMembers: "true"
+    owners:
+      - killen.bob@gmail.com
+    managers:
+      - noah.r.abrahams@gmail.com
+      - puja@giantswarm.io
+      - pnigelbrown@gmail.com
+    members:
+      - balves@linuxfoundation.org
+      - chris@chrisshort.net
+      - detiber@gmail.com
+      - fsmunoz@gmail.com
+      - xandergrzyw@gmail.com
+      - mars.toktonaliev@gmail.com
+      - kmcmahonco@gmail.com
+
   #
   # k8s-staging write access for SIG-owned subprojects
   #


### PR DESCRIPTION
We should have a mailing list for reaching, and communicating as, all the leads of the contributor summit.  This will need to be updated with each new summit's staff.

Also, per a request, removing the stream-team group from the restrictions file.

/assign @mrbobbytables 