### PR TITLE
prow-build-cluster: deploy AWS Load Balancer Controller

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/irsa.tf
+++ b/infra/aws/terraform/prow-build-cluster/irsa.tf
@@ -56,6 +56,24 @@ module "ebs_csi_irsa" {
   tags = local.tags
 }
 
+# IAM policy used for AWS Load Balancer Controller.
+module "aws_load_balancer_controller_irsa" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "~> 5.11"
+
+  role_name_prefix                       = "LBCONTROLLER-IRSA"
+  attach_load_balancer_controller_policy = true
+
+  oidc_providers = {
+    main = {
+      provider_arn               = module.eks.oidc_provider_arn
+      namespace_service_accounts = ["kube-system:aws-load-balancer-controller"]
+    }
+  }
+
+  tags = local.tags
+}
+
 # IAM policy used for Cluster Autoscaler.
 module "cluster_autoscaler_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"

--- a/infra/aws/terraform/prow-build-cluster/kubernetes.tf
+++ b/infra/aws/terraform/prow-build-cluster/kubernetes.tf
@@ -40,6 +40,39 @@ module "metrics_server" {
   ]
 }
 
+# AWS Load Balancer Controller (ALB/NLB integration).
+resource "helm_release" "aws_lb_controller" {
+  name       = "aws-load-balancer-controller"
+  namespace  = "kube-system"
+  repository = "https://aws.github.io/eks-charts"
+  chart      = "aws-load-balancer-controller"
+  version    = "1.4.8"
+
+  set {
+    name  = "clusterName"
+    value = module.eks.cluster_name
+  }
+
+  set {
+    name  = "serviceAccount.create"
+    value = "true"
+  }
+
+  set {
+    name  = "serviceAccount.name"
+    value = "aws-load-balancer-controller"
+  }
+
+  set {
+    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+    value = module.aws_load_balancer_controller_irsa.iam_role_arn
+  }
+
+  depends_on = [
+    module.eks
+  ]
+}
+
 # AWS Secrets Manager integration
 resource "helm_release" "secrets_store_csi_driver" {
   name       = "secrets-store-csi-driver"

--- a/infra/aws/terraform/prow-build-cluster/vpc.tf
+++ b/infra/aws/terraform/prow-build-cluster/vpc.tf
@@ -56,11 +56,13 @@ module "vpc" {
 
   # Tags to allow ELB (Elastic Load Balancing).
   public_subnet_tags = {
-    "kubernetes.io/role/elb" = 1
+    "kubernetes.io/role/elb"                    = 1
+    "kubernetes.io/cluster/${var.cluster_name}" = "owned"
   }
 
   private_subnet_tags = {
-    "kubernetes.io/role/internal-elb" = 1
+    "kubernetes.io/role/internal-elb"           = 1
+    "kubernetes.io/cluster/${var.cluster_name}" = "owned"
   }
 
   tags = local.tags


### PR DESCRIPTION
As stated in #4686, our EKS build cluster should have ability to use ALB. This PR ensures that by deploying and configuring AWS Load Balancer Controller.

This change is already reconciled and tested.

/assign @ameukam 