### PR TITLE
Allow Prow GKE Service Accounts to assume AWS roles

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/eks.tf
+++ b/infra/aws/terraform/prow-build-cluster/eks.tf
@@ -33,7 +33,7 @@ module "eks" {
   # Configure aws-auth
   aws_auth_roles = [
     {
-      "rolearn"  = aws_iam_role.eks_admin.id
+      "rolearn"  = aws_iam_role.eks_admin.arn
       "username" = "eks-admin"
       "groups" = [
         "system:masters"

--- a/infra/aws/terraform/prow-build-cluster/eks.tf
+++ b/infra/aws/terraform/prow-build-cluster/eks.tf
@@ -30,6 +30,17 @@ module "eks" {
   # Manage aws-auth ConfigMap.
   manage_aws_auth_configmap = true
 
+  # Configure aws-auth
+  aws_auth_roles = [
+    {
+      "rolearn"  = aws_iam_role.eks_admin.id
+      "username" = "eks-admin"
+      "groups" = [
+        "system:masters"
+      ]
+    }
+  ]
+
   # We use IPv4 for the best compatibility with the existing setup.
   # Additionally, Ubuntu EKS optimized AMI doesn't support IPv6 well.
   cluster_ip_family = "ipv4"

--- a/infra/aws/terraform/prow-build-cluster/prow.tf
+++ b/infra/aws/terraform/prow-build-cluster/prow.tf
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// This IAM configuration allows Prow GKE Clusters to assume a role on AWS
+# This IAM configuration allows Prow GKE Clusters to assume a role on AWS
 
 
 # Recognize federated identities from the prow trusted cluster
@@ -24,8 +24,7 @@ resource "aws_iam_openid_connect_provider" "k8s_prow" {
   thumbprint_list = ["08745487e891c19e3078c1f2a07e452950ef36f6"]
 }
 
-# s3writer iam role for artifacts management
-# We allow the kubernetes service account to assume this role
+# We allow Prow Pods with specific service acccounts on the a particular cluster to assume this role
 resource "aws_iam_role" "eks_admin" {
   name = "Prow-EKS-Admin"
   assume_role_policy = jsonencode({

--- a/infra/aws/terraform/prow-build-cluster/prow.tf
+++ b/infra/aws/terraform/prow-build-cluster/prow.tf
@@ -1,0 +1,58 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This IAM configuration allows Prow GKE Clusters to assume a role on AWS
+
+
+# Recognize federated identities from the prow trusted cluster
+resource "aws_iam_openid_connect_provider" "k8s_prow" {
+  url             = "https://container.googleapis.com/v1/projects/k8s-prow/locations/us-central1-f/clusters/prow"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["08745487e891c19e3078c1f2a07e452950ef36f6"]
+}
+
+# s3writer iam role for artifacts management
+# We allow the kubernetes service account to assume this role
+resource "aws_iam_role" "eks_admin" {
+  name = "Prow-EKS-Admin"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "Federated" : aws_iam_openid_connect_provider.k8s_prow
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringEquals" : {
+            "container.googleapis.com/v1/projects/k8s-prow/locations/us-central1-f/clusters/prow:sub" : [
+                // Prow Services that interact with Kubernetes can be found at https://github.com/kubernetes/test-infra/blob/master/.ko.yaml
+                "system:serviceaccount:default:deck",
+                "system:serviceaccount:default:config-bootstrapper",
+                "system:serviceaccount:default:crier",
+                "system:serviceaccount:default:sinker",
+                "system:serviceaccount:default:prow-controller-manager"
+            ]
+          }
+        }
+      }
+    ]
+  })
+
+  max_session_duration = 43200
+
+}

--- a/infra/aws/terraform/prow-build-cluster/prow.tf
+++ b/infra/aws/terraform/prow-build-cluster/prow.tf
@@ -39,12 +39,14 @@ resource "aws_iam_role" "eks_admin" {
         "Condition" : {
           "StringEquals" : {
             "container.googleapis.com/v1/projects/k8s-prow/locations/us-central1-f/clusters/prow:sub" : [
-                // Prow Services that interact with Kubernetes can be found at https://github.com/kubernetes/test-infra/blob/master/.ko.yaml
+                // https://github.com/kubernetes/test-infra/tree/master/config/prow/cluster 
+                // all services that load kubeconfig should be listed here
                 "system:serviceaccount:default:deck",
                 "system:serviceaccount:default:config-bootstrapper",
                 "system:serviceaccount:default:crier",
                 "system:serviceaccount:default:sinker",
                 "system:serviceaccount:default:prow-controller-manager"
+                "system:serviceaccount:default:hook"
             ]
           }
         }

--- a/infra/aws/terraform/prow-build-cluster/prow.tf
+++ b/infra/aws/terraform/prow-build-cluster/prow.tf
@@ -45,7 +45,7 @@ resource "aws_iam_role" "eks_admin" {
                 "system:serviceaccount:default:config-bootstrapper",
                 "system:serviceaccount:default:crier",
                 "system:serviceaccount:default:sinker",
-                "system:serviceaccount:default:prow-controller-manager"
+                "system:serviceaccount:default:prow-controller-manager",
                 "system:serviceaccount:default:hook"
             ]
           }

--- a/infra/aws/terraform/prow-build-cluster/prow.tf
+++ b/infra/aws/terraform/prow-build-cluster/prow.tf
@@ -33,7 +33,7 @@ resource "aws_iam_role" "eks_admin" {
       {
         "Effect" : "Allow",
         "Principal" : {
-          "Federated" : aws_iam_openid_connect_provider.k8s_prow
+          "Federated" : aws_iam_openid_connect_provider.k8s_prow.arn
         },
         "Action" : "sts:AssumeRoleWithWebIdentity",
         "Condition" : {


### PR DESCRIPTION
/cc @xmudrii @ameukam 

This is the AWS piece of getting Prow to run pods on EKS. The GKE bit is to adjust the manifests to have the correct env and a projected service account token with the correct claims.

/sig testing
/sig k8s-infra