### PR TITLE
Allow Prow's control plane ESO to access AWS Secrets Manager

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/secrets_manager.tf
+++ b/infra/aws/terraform/prow-build-cluster/secrets_manager.tf
@@ -32,3 +32,11 @@ resource "aws_iam_policy" "secretsmanager_read" {
   path   = "/"
   policy = data.aws_iam_policy_document.secretsmanager_read.json
 }
+
+# We allow ESO pods in the Prow control plane cluster to read from AWS Secrets Manager.
+resource "aws_iam_role_policy" "eso_eks_admin" {
+  name = "eso_read_policy"
+  role = aws_iam_role.eso_read.id
+
+  policy = data.aws_iam_policy_document.secretsmanager_read.json
+}


### PR DESCRIPTION
This PR allows Prow's control plane ESO (External Secrets Operator) to access AWS Secrets Manager. We'll store kubeconfig for the `prow-build-cluster` EKS cluster in AWS Secrets Manager, and the Prow control plane can read it from there using ESO. That's the way supported by Google for clusters running in the private account.

/assign @upodroid 