### PR TITLE
Increase the number of worker nodes in the EKS prow-build-cluster

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/terraform.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.tfvars
@@ -30,9 +30,9 @@ node_instance_types = ["r5ad.4xlarge"]
 node_volume_size    = 100
 
 # TODO(xmudrii): Increase this later.
-node_min_size                   = 1
-node_max_size                   = 1
-node_desired_size               = 1
+node_min_size                   = 15
+node_max_size                   = 20
+node_desired_size               = 15
 node_max_unavailable_percentage = 100 # To ease testing
 
 cluster_autoscaler_version = "v1.25.0"


### PR DESCRIPTION
This PR increases the number of worker nodes in the EKS prow-build cluster to:
- minimum 15
- desired 15
- maximum 20

We'll further increase the number of nodes after we sort out issues with AWS limits. This change is already reconciled.

/assign @ameukam @dims 