### PR TITLE
deploy registry.k8s.io v0.2.0

### DIFF
--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/oci-proxy.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/oci-proxy.tf
@@ -86,7 +86,11 @@ resource "google_cloud_run_service" "oci-proxy" {
     spec {
       service_account_name = google_service_account.oci-proxy.email
       containers {
-        image = "us-central1-docker.pkg.dev/k8s-artifacts-prod/images/infra-tools/archeio@${var.digest}"
+        // NOTE: We deploy from staging because:
+        // - We pin by digest anyhow (so it's comparably secure)
+        // - We need to be able to deploy registry fixes ASAP
+        // - We will eventually auto-deploy staging by overriding the project and digest on the production config to avoid skew
+        image = "gcr.io/k8s-staging-infra-tools/archeio@${var.digest}"
 
         dynamic "env" {
           for_each = each.value.environment_variables

--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/terraform.tfvars
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/terraform.tfvars
@@ -16,7 +16,8 @@ limitations under the License.
 
 domain     = "registry.k8s.io"
 project_id = "k8s-infra-oci-proxy-prod"
-digest     = "sha256:43904e32c58803bed1dbf6457e1b5abdd1409c976bb951f5bb32cf3b37772b2f"
+// gcr.io/k8s-staging-infra-tools/archeio:v20230310-v0.2.0@sha256:bc742c5f47a69e21e828768991853faddbe13a7f69a9da4d7d2ad16e0e55892c
+digest = "sha256:bc742c5f47a69e21e828768991853faddbe13a7f69a9da4d7d2ad16e0e55892c"
 cloud_run_config = {
   asia-east1 = {
     // TODO: switch DEFAULT_AWS_BASE_URL to cloudfront or else refine the region mapping


### PR DESCRIPTION
picks up fix for https://github.com/kubernetes/registry.k8s.io/issues/162 and latest IP data

I'm also switching to deploy from staging (we already deploy pinned by digest) to enable us to ship fixes faster to this production service (without blocking on image promotion) and more closely align our staging and production deployments.

Pulls from cloud run are GCP <=> GCP either way, and we were only using a single AR prod region and not pulling circularly through the registry.k8s.io frontend anyhow.