### PR TITLE
registry.k8s.io: Add southamerica-east1 region

### DIFF
--- a/infra/gcp/bash/ensure-prod-storage.sh
+++ b/infra/gcp/bash/ensure-prod-storage.sh
@@ -91,7 +91,7 @@ readonly PROD_PROJECT_DISABLED_SERVICES=(
 # Regions for prod GCR.
 GCR_PROD_REGIONS=(global us eu asia)
 # Regions for prod AR. gcloud artifacts locations list --format json | jq '.[] | select(.name!="europe" and .name!="asia" and .name!="us") | .name' -r | xargs
-AR_PROD_REGIONS=(asia-east1 asia-south1 asia-northeast1 asia-northeast2 australia-southeast1 europe-north1 europe-southwest1 europe-west1 europe-west2 europe-west4 europe-west8 europe-west9 southamerica-west1 us-central1 us-east1 us-east4 us-east5 us-south1 us-west1 us-west2 us-west3 us-west4)
+AR_PROD_REGIONS=(asia-east1 asia-south1 asia-northeast1 asia-northeast2 australia-southeast1 europe-north1 europe-southwest1 europe-west1 europe-west2 europe-west4 europe-west8 europe-west9 southamerica-east1 southamerica-west1 us-central1 us-east1 us-east4 us-east5 us-south1 us-west1 us-west2 us-west3 us-west4)
 
 # Minimum time we expect to keep prod GCS artifacts.
 PROD_RETENTION="10y"


### PR DESCRIPTION
Add a AR repo for southamerica-east1 (Sao Polo) which has a S3-equivalent. This should allow reduce latency for environments pulling this region.

/hold
