### PR TITLE
chore: add lfx mentee to capg group

### DIFF
--- a/groups/sig-k8s-infra/groups.yaml
+++ b/groups/sig-k8s-infra/groups.yaml
@@ -175,6 +175,7 @@ groups:
       - ctadeu@gmail.com
       - davanum@gmail.com
       - richmcase@gmail.com
+      - phongnguyen01.work@gmail.com
 
   # RBAC groups:
   # - grant access to the `namespace-user` role for a single namespace on the `aaa` cluster


### PR DESCRIPTION
Add Phong to the CAPG account so that he can use GCP for the duration of the mentorship.

/cc @cpanato @meobilivang