### PR TITLE
capi: Add dns for Cluster API v1.4 release. Update main cname to v1.4

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -348,7 +348,7 @@ docs.prow:
 # https://github.com/kubernetes-sigs/cluster-api docs (@dwat, @jdetiber, @justinsb)
 cluster-api.sigs:
   type: CNAME
-  value: release-1-3--kubernetes-sigs-cluster-api.netlify.app.
+  value: release-1-4--kubernetes-sigs-cluster-api.netlify.app.
 # https://github.com/kubernetes-sigs/cluster-api-provider-aws docs (@randomvariable, @detiber, @ncdc, @rudoi, @vincepri)
 cluster-api-aws.sigs:
   type: CNAME
@@ -395,6 +395,9 @@ release-1-2.cluster-api.sigs:
 release-1-3.cluster-api.sigs:
   type: CNAME
   value: release-1-3--kubernetes-sigs-cluster-api.netlify.app.
+release-1-4.cluster-api.sigs:
+  type: CNAME
+  value: release-1-4--kubernetes-sigs-cluster-api.netlify.app.
 # https://github.com/kubernetes-sigs/cluster-api development docs (@CecileRobertMichon, @vincepri)
 main.cluster-api.sigs:
   type: CNAME


### PR DESCRIPTION
Adds Cluster API [v1.4 release](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/release/releases/release-1.4.md) 

@sbueringer You have the [rights to update Netlify step 2](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/release/release-tasks.md#ensure-the-book-for-the-new-release-is-available) if I recall correctly once this is merged?

cc @ykakarap @joekr