### PR TITLE
updated hash of kube-webhook-certgen

### DIFF
--- a/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/k8s.gcr.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -213,7 +213,7 @@
     "sha256:39c5b2e3310dc4264d638ad28d9d1d96c4cbb2b2dcfb52368fe4e3c63f61e10f": ["v20220916-gd32f8c343"]
     "sha256:ccdb2382b53ed42fd76bfbff90a5b8a5815af0b3b8c6dfb9118a34770d9cac11": ["v20221219-controller-v1.5.1-49-ge3e0d9c1f"]
     "sha256:4d99688e557396f5baa150e019ff7d5b7334f9b9f9a8dab64038c5c2a006f6b5": ["v20221220-controller-v1.5.1-58-g787ea74b6"]
-    "sha256:01d181618f270f2a96c04006f33b2699ad3ccb02da48d0f89b22abce084b292": [v20230312-helm-chart-4.5.2-28-g66a760794"]
+    "sha256:01d181618f270f2a96c04006f33b2699ad3ccb02da48d0f89b22abce084b292f": ["v20230312-helm-chart-4.5.2-28-g66a760794"]
 
 # nginx-errors
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/custom-error-pages


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX16fcbCRGxVbIQxutEuEDpJETTb3nI9Ng%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=XVgYQmE)