### PR TITLE
Load secrets via ESO for eks build clusters

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/test-pods/externalsecrets.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/test-pods/externalsecrets.yaml
@@ -4,78 +4,114 @@
 # NOTE !!!
 # THIS CLUSTER USES EXTERNAL SECRETS OPERATOR INSTEAD OF KUBERNETES EXTERNAL SECRETS.
 # The CRDs are different from other prow clusters. Sample guide that explains the diff https://wiki.cac.washington.edu/display/MCI/Transition+from+KES+to+ESO
-# ---
-# apiVersion: kubernetes-client.io/v1
-# kind: ExternalSecret
-# metadata:
-#   name: service-account             # The name of the Kubernetes Secret
-#   namespace: test-pods
-# spec:
-#   backendType: gcpSecretsManager
-#   projectId: k8s-infra-prow-build
-#   data:
-#   - key: prow-build-service-account # The name of the GSM Secret
-#     name: service-account.json      # The key to write to in the Kubernetes Secret
-#     version: latest                 # The version of the GSM Secret
-# ---
-# apiVersion: kubernetes-client.io/v1
-# kind: ExternalSecret
-# metadata:
-#   name: ssh-key-secret                          # The name of the Kubernetes Secret
-#   namespace: test-pods
-# spec:
-#   backendType: gcpSecretsManager
-#   projectId: k8s-infra-prow-build
-#   data:
-#   - key: prow-build-ssh-key-secret-ssh-public   # The name of the GSM Secret
-#     name: ssh-public                            # The key to write to in the Kubernetes Secret
-#     version: latest                             # The version of the GSM Secret
-#   - key: prow-build-ssh-key-secret-ssh-private  # The name of the GSM Secret
-#     name: ssh-private                           # The key to write to in the Kubernetes Secret
-#     version: latest                             # The version of the GSM Secret
-# ---
-# apiVersion: kubernetes-client.io/v1
-# kind: ExternalSecret
-# metadata:
-#   name: aws-credentials-768319786644           # The name of the Kubernetes Secret
-#   namespace: test-pods
-# spec:
-#   backendType: gcpSecretsManager
-#   projectId: k8s-infra-prow-build
-#   data:
-#   - key: gke_k8s-prow-builds_us-central1-f_prow__test-pods__aws-credentials-768319786644   # The name of the GSM Secret
-#     name: credentials                                                                      # The key to write to in the Kubernetes Secret
-#     version: latest                                                                        # The version of the GSM Secret
-#     property: credentials
-# ---
-# apiVersion: kubernetes-client.io/v1
-# kind: ExternalSecret
-# metadata:
-#   name: aws-credentials-607362164682           # The name of the Kubernetes Secret
-#   namespace: test-pods
-# spec:
-#   backendType: gcpSecretsManager
-#   projectId: k8s-infra-prow-build
-#   data:
-#   - key: gke_k8s-prow-builds_us-central1-f_prow__test-pods__aws-credentials-607362164682   # The name of the GSM Secret
-#     name: credentials                                                                      # The key to write to in the Kubernetes Secret
-#     version: latest                                                                        # The version of the GSM Secret
-#     property: credentials
-# ---
-# apiVersion: kubernetes-client.io/v1
-# kind: ExternalSecret
-# metadata:
-#   name: aws-ssh-key-secret           # The name of the Kubernetes Secret
-#   namespace: test-pods
-# spec:
-#   backendType: gcpSecretsManager
-#   projectId: k8s-infra-prow-build
-#   data:
-#   - key: gke_k8s-prow-builds_us-central1-f_prow__test-pods__aws-ssh-key-secret   # The name of the GSM Secret
-#     name: aws-ssh-private                                                        # The key to write to in the Kubernetes Secret
-#     version: latest                                                              # The version of the GSM Secret
-#     property: aws-ssh-private
-#   - key: gke_k8s-prow-builds_us-central1-f_prow__test-pods__aws-ssh-key-secret   # The name of the GSM Secret
-#     name: aws-ssh-public                                                         # The key to write to in the Kubernetes Secret
-#     version: latest                                                              # The version of the GSM Secret
-#     property: aws-ssh-public
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: k8s-infra-prow-build
+spec:
+  provider:
+    gcpsm:
+      projectID: k8s-infra-prow-build
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: service-account
+  namespace: test-pods
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: k8s-infra-prow-build
+  target:
+    name: service-account # The name of the Kubernetes Secret
+    creationPolicy: Owner
+  data:
+  - secretKey: service-account.json # The key to write to in the Kubernetes Secret
+    remoteRef:
+      key: prow-build-service-account # The name of the GSM Secret
+      version: latest                 # The version of the GSM Secret    
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ssh-key-secret
+  namespace: test-pods
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: k8s-infra-prow-build
+  target:
+    name: ssh-key-secret # The name of the Kubernetes Secret
+    creationPolicy: Owner
+  data:
+  - secretKey: ssh-public # The key to write to in the Kubernetes Secret
+    remoteRef:
+      key: prow-build-ssh-key-secret-ssh-public # The name of the GSM Secret
+      version: latest                           # The version of the GSM Secret
+  - secretKey: ssh-private # The key to write to in the Kubernetes Secret
+    remoteRef:
+      key: prow-build-ssh-key-secret-ssh-private # The name of the GSM Secret
+      version: latest                           # The version of the GSM Secret    
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-credentials-768319786644
+  namespace: test-pods
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: k8s-infra-prow-build
+  target:
+    name: aws-credentials-768319786644 # The name of the Kubernetes Secret
+    creationPolicy: Owner
+  data:
+  - secretKey: credentials # The key to write to in the Kubernetes Secret
+    remoteRef:
+      key: gke_k8s-prow-builds_us-central1-f_prow__test-pods__aws-credentials-768319786644 # The name of the GSM Secret
+      version: latest                           # The version of the GSM Secret
+      property: credentials                       # The version of the GSM Secret    
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-credentials-607362164682
+  namespace: test-pods
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: k8s-infra-prow-build
+  target:
+    name: aws-credentials-607362164682 # The name of the Kubernetes Secret
+    creationPolicy: Owner
+  data:
+  - secretKey: credentials # The key to write to in the Kubernetes Secret
+    remoteRef:
+      key: gke_k8s-prow-builds_us-central1-f_prow__test-pods__aws-credentials-607362164682 # The name of the GSM Secret
+      version: latest                           # The version of the GSM Secret
+      property: credentials                       # The version of the GSM Secret    
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-ssh-key-secret
+  namespace: test-pods
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: k8s-infra-prow-build
+  target:
+    name: aws-ssh-key-secret # The name of the Kubernetes Secret
+    creationPolicy: Owner
+  data:
+  - secretKey: aws-ssh-private # The key to write to in the Kubernetes Secret
+    remoteRef:
+      key: gke_k8s-prow-builds_us-central1-f_prow__test-pods__aws-ssh-key-secret # The name of the GSM Secret
+      version: latest                                                            # The version of the GSM Secret
+      property: aws-ssh-private
+  - secretKey: aws-ssh-public # The key to write to in the Kubernetes Secret
+    remoteRef:
+      key: gke_k8s-prow-builds_us-central1-f_prow__test-pods__aws-ssh-key-secret # The name of the GSM Secret
+      version: latest                                                            # The version of the GSM Secret
+      property: aws-ssh-public

--- a/infra/aws/terraform/prow-build-cluster/resources/test-pods/test-pods-poddisruptionbudget.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/test-pods/test-pods-poddisruptionbudget.yaml
@@ -19,7 +19,7 @@
 #
 # It is still possible to delete the pods via a normal delete call. See https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/#the-eviction-api
 
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: prow-pods


### PR DESCRIPTION
/cc @xmudrii @ameukam 

I wonder what the secret contents look like. You might have to do something like this if they are base64 encoded and stored as json:

```
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: gcs-upload
  namespace: test-pods
spec:
  refreshInterval: 10m
  secretStoreRef:
    kind: ClusterSecretStore
    name: knative-tests
  target:
    creationPolicy: Owner
    template:
      type: Opaque
      engineVersion: v2
      data:
        service-account.json: "{{ .test_account | toString | b64dec}}" # Used by gcsupload decorator
  data:
  - secretKey: test_account
    remoteRef:
      key: prow-google-service-accounts
      property: test_account
```