### PR TITLE
Work around char limits for principalSet

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/iam.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/iam.tf
@@ -19,14 +19,14 @@ resource "google_iam_workload_identity_pool" "eks_cluster" {
 
   workload_identity_pool_id = "prow-eks"
   display_name              = "EKS Prow Cluster"
-  description = "Identity pool for CI on AWS using EKS clusters"
+  description               = "Identity pool for CI on AWS using EKS clusters"
 }
 
 resource "google_iam_workload_identity_pool_provider" "eks_cluster" {
   project = module.project.project_id
 
-  display_name = "AWS OIDC provider"
-  description = "Identity pool for CI on AWS using EKS clusters"
+  display_name                       = "AWS OIDC provider"
+  description                        = "Identity pool for CI on AWS using EKS clusters"
   workload_identity_pool_id          = google_iam_workload_identity_pool.eks_cluster.workload_identity_pool_id
   workload_identity_pool_provider_id = "oidc"
   attribute_mapping = {
@@ -35,6 +35,6 @@ resource "google_iam_workload_identity_pool_provider" "eks_cluster" {
   oidc {
     # From EKS cluster created in https://github.com/kubernetes/k8s.io/tree/main/infra/aws/terraform/prow-build-cluster
     issuer_uri        = "https://oidc.eks.us-east-2.amazonaws.com/id/F8B73554FE6FBAF9B19569183FB39762"
-    allowed_audiences = ["https://sts.googleapis.com"]
+    allowed_audiences = ["sts.googleapis.com"]
   }
 }

--- a/infra/gcp/terraform/k8s-infra-prow-build/serviceaccounts.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/serviceaccounts.tf
@@ -27,7 +27,7 @@ locals {
       project_roles     = ["roles/secretmanager.secretAccessor"],
       cluster_namespace = "kubernetes-external-secrets"
       additional_workload_identity_principals = [
-        "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.eks_cluster.name}/attribute.sub/system:serviceaccount:external-secrets:external-secrets"
+        "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.eks_cluster.name}/*"
       ]
     }
   }


### PR DESCRIPTION
@ameukam @xmudrii 

Our actual principal is 165 char long instead of 127 which is the limit set by Google. This change allows us to get going while I workout how to configure conditions in [CEL](https://github.com/google/cel-spec/blob/master/doc/intro.md#introduction) and shorten the sub field with CEL.