### PR TITLE
ensure we also test manifests for registry.k8s.io/

### DIFF
--- a/hack/verify-manifests.sh
+++ b/hack/verify-manifests.sh
@@ -22,4 +22,6 @@ REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)
 readonly REPO_ROOT
 
 cd "${REPO_ROOT}"/k8s.gcr.io/manifests
-go test
+go test ./...
+cd "${REPO_ROOT}"/registry.k8s.io/manifests
+go test ./...

--- a/registry.k8s.io/manifests/go.mod
+++ b/registry.k8s.io/manifests/go.mod
@@ -1,4 +1,4 @@
-module k8s.io/k8s.io/k8s.gcr.io/manifests
+module k8s.io/k8s.io/registry.k8s.io/manifests
 
 go 1.19
 


### PR DESCRIPTION
cc @upodroid @dims @ameukam 

It appears the tests from https://github.com/kubernetes/k8s.io/pull/4368 were copied over along with the rest of `k8s.gcr.io/` in https://github.com/kubernetes/k8s.io/pull/4934, but we're not running them.

ref:  https://github.com/kubernetes/registry.k8s.io/issues/187