### PR TITLE
eks-prow-build-cluster: fix root volume for node groups and setup IAM role with admin access

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/eks.tf
+++ b/infra/aws/terraform/prow-build-cluster/eks.tf
@@ -112,8 +112,10 @@ module "eks" {
       enable_monitoring = true
 
       block_device_mappings = {
-        xvda = {
-          device_name = "/dev/xvda"
+        # This must be sda1 in order to match the root volume,
+        # otherwise a new volume is created.
+        sda1 = {
+          device_name = "/dev/sda1"
           ebs = {
             volume_size           = var.node_volume_size
             volume_type           = "gp3"

--- a/infra/aws/terraform/prow-build-cluster/eks.tf
+++ b/infra/aws/terraform/prow-build-cluster/eks.tf
@@ -32,13 +32,41 @@ module "eks" {
 
   # Configure aws-auth
   aws_auth_roles = [
+    # Allow access to the Prow-EKS-Admin IAM role (used by Prow directly).
     {
       "rolearn"  = aws_iam_role.eks_admin.arn
       "username" = "eks-admin"
       "groups" = [
-        "system:masters"
+        "eks-prow-cluster-admin"
       ]
-    }
+    },
+    # Allow access to the Prow-Cluster-Admin IAM role (used with assume role with other IAM accounts).
+    {
+      "rolearn"  = aws_iam_role.iam_cluster_admin.arn
+      "username" = "eks-cluster-admin"
+      "groups" = [
+        "eks-cluster-admin"
+      ]
+    },
+  ]
+  # Allow EKS access to the root account.
+  aws_auth_users = [
+    {
+      "userarn"  = local.root_account_arn
+      "username" = "root"
+      "groups" = [
+        "eks-cluster-admin"
+      ]
+    },
+  ]
+
+  # Allow access to the KMS key used for secrets encryption to the root account.
+  kms_key_administrators = [
+    local.root_account_arn
+  ]
+  # Allow service access to the KMS key to the Prow-Cluster-Admin role.
+  kms_key_service_users = [
+    aws_iam_role.iam_cluster_admin.arn
   ]
 
   # We use IPv4 for the best compatibility with the existing setup.

--- a/infra/aws/terraform/prow-build-cluster/iam.tf
+++ b/infra/aws/terraform/prow-build-cluster/iam.tf
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+###############################################
+# IAM access
+###############################################
+
+data "aws_iam_user" "user_xmudrii" {
+  user_name = "xmudrii"
+}
+data "aws_iam_user" "user_pprzekwa" {
+  user_name = "pprzekwa"
+}
+
+resource "aws_iam_role" "iam_cluster_admin" {
+  name        = "Prow-Cluster-Admin"
+  description = "IAM role used to delegate access to prow-build-cluster"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+          "AWS" : [
+            data.aws_iam_user.user_xmudrii.arn,
+            data.aws_iam_user.user_pprzekwa.arn,
+          ]
+        },
+        "Action" : "sts:AssumeRole",
+        "Condition" : {}
+      }
+    ]
+  })
+}
+
+# Give administrator access to the admin IAM role so it can be used with Terraform.
+resource "aws_iam_role_policy_attachment" "iam_policy_cluster_admin" {
+  role       = aws_iam_role.iam_cluster_admin.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
+}

--- a/infra/aws/terraform/prow-build-cluster/prow.tf
+++ b/infra/aws/terraform/prow-build-cluster/prow.tf
@@ -39,14 +39,14 @@ resource "aws_iam_role" "eks_admin" {
         "Condition" : {
           "StringEquals" : {
             "container.googleapis.com/v1/projects/k8s-prow/locations/us-central1-f/clusters/prow:sub" : [
-                // https://github.com/kubernetes/test-infra/tree/master/config/prow/cluster 
-                // all services that load kubeconfig should be listed here
-                "system:serviceaccount:default:deck",
-                "system:serviceaccount:default:config-bootstrapper",
-                "system:serviceaccount:default:crier",
-                "system:serviceaccount:default:sinker",
-                "system:serviceaccount:default:prow-controller-manager",
-                "system:serviceaccount:default:hook"
+              // https://github.com/kubernetes/test-infra/tree/master/config/prow/cluster 
+              // all services that load kubeconfig should be listed here
+              "system:serviceaccount:default:deck",
+              "system:serviceaccount:default:config-bootstrapper",
+              "system:serviceaccount:default:crier",
+              "system:serviceaccount:default:sinker",
+              "system:serviceaccount:default:prow-controller-manager",
+              "system:serviceaccount:default:hook"
             ]
           }
         }

--- a/infra/aws/terraform/prow-build-cluster/resources/rbac/cluster-admin-crb.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/rbac/cluster-admin-crb.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eks-cluster-admin
+subjects:
+- kind: Group
+  name: eks-cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/infra/aws/terraform/prow-build-cluster/resources/rbac/prow-admin-crb.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/rbac/prow-admin-crb.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: eks-prow-cluster-admin
+subjects:
+- kind: Group
+  name: eks-prow-cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io

--- a/infra/aws/terraform/prow-build-cluster/terraform.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.tfvars
@@ -30,9 +30,9 @@ node_instance_types = ["r5ad.4xlarge"]
 node_volume_size    = 100
 
 # TODO(xmudrii): Increase this later.
-node_min_size                   = 15
-node_max_size                   = 20
-node_desired_size               = 15
+node_min_size                   = 5
+node_max_size                   = 5
+node_desired_size               = 5
 node_max_unavailable_percentage = 100 # To ease testing
 
 cluster_autoscaler_version = "v1.25.0"


### PR DESCRIPTION
This PR brings two improvements to the eks-prow-build-cluster:

- Root volume is now properly defined, so Terraform is going to modify the default root volume instead of creating a new one
- Create an IAM role with the administrator privileges
  - The idea is that IAM users are supposed to assume that role instead of giving permissions to each IAM user
  - That IAM role is also specified in the aws-auth ConfigMap
  - That IAM role is also specified as service user for the KMS key so it can be used with Terraform
  - Additionally, that IAM role is Administrator in AWS, so it can be used to run Terraform
  - The only problem with this IAM role is upon creating the cluster for the first time. In that case, assume role must be commented in `main.tf` for the first Terraform run


/hold for discussing
/assign @ameukam @upodroid 