### PR TITLE
adjust IAM permissions for k8s-infra-auditors

### DIFF
--- a/infra/gcp/bash/roles/specs/audit.viewer.yaml
+++ b/infra/gcp/bash/roles/specs/audit.viewer.yaml
@@ -5,60 +5,22 @@ description: View access to resources
 name: audit.viewer
 include:
   roles:
-  # view/read-only roles for specific services of interest
-  # TODO: consider using roles/viewer instead of per-service?
-  #
-  # read access to bigquery data resources, but not their contents (e.g. datasets, tables, views)
-  - roles/bigquery.metadataViewer
-  # read access to bigquery resource resources (e.g. jobs, reservations)
-  - roles/bigquery.resourceViewer
-  # read access to cloud assets metadata
-  - roles/cloudasset.viewer
-  # TODO: determine if viewing builds could expose anything sensitive
-  # - roles/cloudbuild.builds.viewer
-  # read access to cloudkms public keys
-  # ref: https://cloud.google.com/kms/docs/reference/permissions-and-roles#access-control-guidelines
-  - roles/cloudkms.publicKeyViewer
-  # full access to trace console, but is filtered back to read-only
-  # ref: https://cloud.google.com/trace/docs/iam#roles
-  - roles/cloudtrace.user
-  # read access to compute
-  - roles/compute.viewer
-  # read access to compute
-  - roles/container.clusterViewer
-  # read access to dns
-  - roles/dns.reader
-  # read access to logs (NB: removing permissions to create/run/delete queries)
-  - roles/logging.viewer
-  # read access to monitoring
-  - roles/monitoring.viewer
-  # read access to org policies
-  - roles/orgpolicy.policyViewer
-  # read access to pubsub schemas, snapshots, subscriptions, topics (but not messages)
-  - roles/pubsub.viewer
-  # read access to run configurations, olocations, reviewers, routes, services
-  - roles/run.viewer
-  # read access to secrets metadata (not their contents)
-  - roles/secretmanager.viewer
-  # read access to service states and operations
-  - roles/serviceusage.serviceUsageViewer
+  # view/read-only access to entire kubernetes.io GCP organization except sensitive PII data via IAM Deny Policy
+  - roles/viewer
 
-  # meta roles (regardless of roles/viewer)
-  #
+  # meta/org-level roles (regardless of roles/viewer)
   # read access for the project hierarchy (org, folders, projects)
   - roles/browser
   # *.list and *.getIamPolicy
   - roles/iam.securityReviewer
-
-  # specific permissions that don't come from a well-scoped pre-defined role
-  permissions:
-  # for gsutil _ get: cors, iam, label, logging, lifecycle, retention, ubla
-  - storage.buckets.get
+  # Security Command Center read-only permissions
+  - roles/cloudsecurityscanner.viewer
+  - roles/securitycenter.adminViewer
+  - roles/securitycenter.assetsViewer
+  - roles/securitycenter.bigQueryExportsViewer
 
   # use regexes to filter permissions pulled in from the above
   permissionRegexes:
-  # only include (get|list).* (e.g. get, getIamPolicy, etc.)
-  - \.(list|get)[^\.]*$
   # include some exceptions from service-specific roles:
   # ...everything from roles/cloudasset.viewer
   - ^cloudasset.assets.(analyze|export|search)[^\.]*$
@@ -68,13 +30,14 @@ include:
   - serviceusage.services.use
 exclude:
   permissionRegexes:
-  # permissions that would modify logging queries
-  - ^logging.queries.(create|delete|update)$
+  # WE ARE USING IAM DENY POLICIES FOR GCS SERVICES ON PROJECTS WHERE THIS
+  # GROUP IS NOT ALLOWED TO READ. THIS IS USUALLY PII PROJECTS.
+  - bigquery.models.getData # Remove when IAM Deny supports this permissions
+  - bigquery.tables.getData # Remove when IAM Deny supports this permissions
   # permissions with custom roles support level NOT_SUPPORTED
   # ref: https://cloud.google.com/iam/docs/custom-roles-permissions-support
   - ^cloudonefs.
   - ^gcp.redisenterprise.
   - ^datastore.
   - ^domains.registrations.
-  - ^gkehub.
   - ^servicemanagement.consumerSettings

--- a/infra/gcp/terraform/k8s-infra-public-pii/iam.tf
+++ b/infra/gcp/terraform/k8s-infra-public-pii/iam.tf
@@ -1,0 +1,15 @@
+resource "google_iam_deny_policy" "gcs_deny" {
+  provider = google-beta
+  parent   = urlencode("cloudresourcemanager.googleapis.com/projects/${google_project.project.project_id}")
+  name     = "deny-pii-access-to-infra-auditors"
+  display_name = "Deny GCS Data to k8s-infra-auditors"
+  rules {
+    description = "First rule"
+    deny_rule {
+      denied_principals = ["principalSet://goog/group/k8s-infra-auditors@kubernetes.io"]
+      denied_permissions = [
+        "storage.googleapis.com/objects.get", // Reading blobs
+        ]
+    }
+  }
+}


### PR DESCRIPTION
Regenerating IAM roles and taking advantage of new GCP features.

IAM Deny policies doesn't support the full range of permissions like GCS does.

https://cloud.google.com/iam/docs/deny-overview
https://cloud.google.com/iam/docs/deny-permissions-support
https://cloud.google.com/iam/docs/principal-identifiers#v2

The script doesn't work for me.