### PR TITLE
Revert "fix linting errors"

### DIFF
--- a/infra/gcp/bash/ensure-prod-storage.sh
+++ b/infra/gcp/bash/ensure-prod-storage.sh
@@ -108,7 +108,7 @@ function ensure_prod_gcr() {
 
     color 6 "Ensuring prod GCR for regions: ${GCR_PROD_REGIONS[*]}"
     for region in "${GCR_PROD_REGIONS[@]}"; do
-        if [ "$region" == "global" ]; then
+        if [ $region == "global" ]; then
             local gcr_bucket="gs://artifacts.${project}.appspot.com"
         else
             local gcr_bucket="gs://${region}.artifacts.${project}.appspot.com"

--- a/infra/gcp/bash/ensure-prod-storage.sh
+++ b/infra/gcp/bash/ensure-prod-storage.sh
@@ -89,7 +89,7 @@ readonly PROD_PROJECT_DISABLED_SERVICES=(
 )
 
 # Regions for prod GCR.
-GCR_PROD_REGIONS=(global us eu asia)
+GCR_PROD_REGIONS=(us eu asia)
 # Regions for prod AR. gcloud artifacts locations list --format json | jq '.[] | select(.name!="europe" and .name!="asia" and .name!="us") | .name' -r | xargs
 AR_PROD_REGIONS=(asia-east1 asia-east2 asia-south1 asia-northeast1 asia-northeast2 australia-southeast1 europe-north1 europe-southwest1 europe-west1 europe-west2 europe-west3 europe-west4 europe-west8 europe-west9 southamerica-east1 southamerica-west1 us-central1 us-east1 us-east4 us-east5 us-south1 us-west1 us-west2 us-west3 us-west4)
 
@@ -108,11 +108,7 @@ function ensure_prod_gcr() {
 
     color 6 "Ensuring prod GCR for regions: ${GCR_PROD_REGIONS[*]}"
     for region in "${GCR_PROD_REGIONS[@]}"; do
-        if [ $region == "global" ]; then
-            local gcr_bucket="gs://artifacts.${project}.appspot.com"
-        else
-            local gcr_bucket="gs://${region}.artifacts.${project}.appspot.com"
-        fi
+        local gcr_bucket="gs://${region}.artifacts.${project}.appspot.com"
 
         color 3 "region: ${region}"
         color 6 "Ensuring a GCR repo exists in region: ${region} for project: ${project}"

--- a/infra/gcp/bash/lib.sh
+++ b/infra/gcp/bash/lib.sh
@@ -339,9 +339,7 @@ function empower_gcr_admins() {
         return 1
     fi
     local project="$1"
-    local region="${2:-}"
-
-    if [ "$region" == "global" ]; then
+    if [ $region == "global" ]; then
         local region=""
     else
         local region="${2:-}"
@@ -430,7 +428,7 @@ function empower_image_promoter() {
         return 1
     fi
     local project="$1"
-    if [ "$region" == "global" ]; then
+    if [ $region == "global" ]; then
         local region=""
     else
         local region="${2:-}"

--- a/infra/gcp/bash/lib.sh
+++ b/infra/gcp/bash/lib.sh
@@ -339,11 +339,7 @@ function empower_gcr_admins() {
         return 1
     fi
     local project="$1"
-    if [ $region == "global" ]; then
-        local region=""
-    else
-        local region="${2:-}"
-    fi
+    local region="${2:-}"
     local bucket
     bucket=$(gcs_bucket_for_gcr "${project}" "${region}")
 
@@ -428,11 +424,7 @@ function empower_image_promoter() {
         return 1
     fi
     local project="$1"
-    if [ $region == "global" ]; then
-        local region=""
-    else
-        local region="${2:-}"
-    fi
+    local region="${2:-}"
     local acct
     acct=$(svc_acct_email "${project}" "${IMAGE_PROMOTER_SVCACCT}")
 

--- a/infra/gcp/bash/lib_gcr.sh
+++ b/infra/gcp/bash/lib_gcr.sh
@@ -64,11 +64,7 @@ function ensure_gcr_repo() {
         return 1
     fi
     local project="$1"
-    if [ $region == "global" ]; then
-        local region=""
-    else
-        local region="${2:-}"
-    fi
+    local region="${2:-}"
 
     local bucket
     bucket=$(gcs_bucket_for_gcr "${project}" "${region}")
@@ -77,18 +73,14 @@ function ensure_gcr_repo() {
         host=$(gcr_host_for_region "${region}")
         local image="ceci-nest-pas-une-image"
         local dest="${host}/${project}/${image}"
-        docker pull us-central1-docker.pkg.dev/k8s-artifacts-prod/images/pause
-        docker tag us-central1-docker.pkg.dev/k8s-artifacts-prod/images/pause "${dest}"
+        docker pull k8s.gcr.io/pause
+        docker tag k8s.gcr.io/pause "${dest}"
         docker push "${dest}"
         gcloud --project "${project}" \
             container images delete --quiet "${dest}:latest"
     fi
 
-    if [ -z "${region}" ]; then
-        return # we don't want to make gcr.io/k8s-artifacts-prod public
-    else
-        ensure_public_gcs_bucket "${project}" "${bucket}"
-    fi
+    ensure_public_gcs_bucket "${project}" "${bucket}"
 }
 
 # Grant write privileges on a GCR to a group

--- a/infra/gcp/bash/lib_gcr.sh
+++ b/infra/gcp/bash/lib_gcr.sh
@@ -64,9 +64,7 @@ function ensure_gcr_repo() {
         return 1
     fi
     local project="$1"
-    local region="${2:-}"
-
-    if [ "$region" == "global" ]; then
+    if [ $region == "global" ]; then
         local region=""
     else
         local region="${2:-}"


### PR DESCRIPTION
This reverts commits 
- 72e3224.
- d635868

We now use [geranos](https://github.com/kubernetes/registry.k8s.io/tree/main/cmd/geranos) to sync image layers to AWS S3. The need of having a GCR private repo to synchronization is not relevant anymore.  