### PR TITLE
Allow anyone to post to k8s-infra-sandbox-capa@kubernetes.io

### DIFF
--- a/groups/sig-k8s-infra/groups.yaml
+++ b/groups/sig-k8s-infra/groups.yaml
@@ -468,6 +468,7 @@ groups:
     description: |-
       ACL for CAPA sandbox
     settings:
+      WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     members:
       - ameukam@gmail.com


### PR DESCRIPTION
In order to reset AWS passwords, k8s infra users must be able to access the reset password link.