### PR TITLE
Freeze the old `k8s.gcr.io` image registry

### DIFF
--- a/registry.k8s.io/manifests/k8s-staging-addon-manager/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-addon-manager/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-addon-manager
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/addon-manager
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/addon-manager
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/addon-manager
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/addon-manager
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/addon-manager

--- a/registry.k8s.io/manifests/k8s-staging-apisnoop/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-apisnoop/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-apisnoop
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/apisnoop
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/apisnoop
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/apisnoop
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/apisnoop
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/apisnoop

--- a/registry.k8s.io/manifests/k8s-staging-artifact-promoter/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-artifact-promoter/promoter-manifest.yaml
@@ -1,12 +1,6 @@
 registries:
 - name: gcr.io/k8s-staging-artifact-promoter
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/artifact-promoter
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/artifact-promoter
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/artifact-promoter
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/artifact-promoter
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/artifact-promoter

--- a/registry.k8s.io/manifests/k8s-staging-autoscaling/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-autoscaling/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-autoscaling
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/autoscaling
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/autoscaling
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/autoscaling
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/autoscaling
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/autoscaling

--- a/registry.k8s.io/manifests/k8s-staging-bom/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-bom/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
   - name: gcr.io/k8s-staging-bom
     src: true
-  - name: us.gcr.io/k8s-artifacts-prod/bom
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-  - name: eu.gcr.io/k8s-artifacts-prod/bom
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-  - name: asia.gcr.io/k8s-artifacts-prod/bom
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/bom
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/bom

--- a/registry.k8s.io/manifests/k8s-staging-build-image/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-build-image/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-build-image
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/build-image
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/build-image
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/build-image
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/build-image
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/build-image

--- a/registry.k8s.io/manifests/k8s-staging-capi-cloudstack/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-capi-cloudstack/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-capi-cloudstack
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/capi-cloudstack
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/capi-cloudstack
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/capi-cloudstack
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/capi-cloudstack
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/capi-cloudstack

--- a/registry.k8s.io/manifests/k8s-staging-capi-docker/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-capi-docker/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-capi-docker
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/capi-docker
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/capi-docker
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/capi-docker
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/capi-docker
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/capi-docker

--- a/registry.k8s.io/manifests/k8s-staging-capi-ibmcloud/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-capi-ibmcloud/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
   - name: gcr.io/k8s-staging-capi-ibmcloud
     src: true
-  - name: us.gcr.io/k8s-artifacts-prod/capi-ibmcloud
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-  - name: eu.gcr.io/k8s-artifacts-prod/capi-ibmcloud
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-  - name: asia.gcr.io/k8s-artifacts-prod/capi-ibmcloud
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/capi-ibmcloud
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/capi-ibmcloud

--- a/registry.k8s.io/manifests/k8s-staging-capi-openstack/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-capi-openstack/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-capi-openstack
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/capi-openstack
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/capi-openstack
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/capi-openstack
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/capi-openstack
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/capi-openstack

--- a/registry.k8s.io/manifests/k8s-staging-capi-operator/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-capi-operator/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-capi-operator
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/capi-operator
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/capi-operator
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/capi-operator
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/capi-operator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/capi-operator

--- a/registry.k8s.io/manifests/k8s-staging-cloud-provider-gcp/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-cloud-provider-gcp/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-cloud-provider-gcp
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/cloud-provider-gcp
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/cloud-provider-gcp
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/cloud-provider-gcp
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/cloud-provider-gcp
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/cloud-provider-gcp

--- a/registry.k8s.io/manifests/k8s-staging-cloud-provider-ibm/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-cloud-provider-ibm/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-cloud-provider-ibm
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/cloud-provider-ibm
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/cloud-provider-ibm
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/cloud-provider-ibm
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/cloud-provider-ibm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/cloud-provider-ibm

--- a/registry.k8s.io/manifests/k8s-staging-cluster-api-aws/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-cluster-api-aws/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-cluster-api-aws
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/cluster-api-aws
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/cluster-api-aws
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/cluster-api-aws
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-aws
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-aws

--- a/registry.k8s.io/manifests/k8s-staging-cluster-api-azure/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-cluster-api-azure/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-cluster-api-azure
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/cluster-api-azure
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/cluster-api-azure
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/cluster-api-azure
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-azure
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-azure

--- a/registry.k8s.io/manifests/k8s-staging-cluster-api-do/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-cluster-api-do/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-cluster-api-do
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/cluster-api-do
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/cluster-api-do
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/cluster-api-do
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-do
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-do

--- a/registry.k8s.io/manifests/k8s-staging-cluster-api-gcp/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-cluster-api-gcp/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-cluster-api-gcp
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/cluster-api-gcp
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/cluster-api-gcp
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/cluster-api-gcp
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-gcp
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-gcp

--- a/registry.k8s.io/manifests/k8s-staging-cluster-api-helm/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-cluster-api-helm/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-cluster-api-helm
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/cluster-api-helm
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/cluster-api-helm
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/cluster-api-helm
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-helm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-helm

--- a/registry.k8s.io/manifests/k8s-staging-cluster-api-kubeadm/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-cluster-api-kubeadm/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-capi-kubeadm
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/capi-kubeadm
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/capi-kubeadm
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/capi-kubeadm
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/capi-kubeadm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/capi-kubeadm

--- a/registry.k8s.io/manifests/k8s-staging-cluster-api-nested/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-cluster-api-nested/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-cluster-api-nested
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/cluster-api-nested
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/cluster-api-nested
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/cluster-api-nested
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-nested
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-nested

--- a/registry.k8s.io/manifests/k8s-staging-cluster-api/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-cluster-api/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-cluster-api
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/cluster-api
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/cluster-api
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/cluster-api
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api

--- a/registry.k8s.io/manifests/k8s-staging-coredns/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-coredns/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-coredns
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/coredns
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/coredns
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/coredns
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/coredns
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/coredns

--- a/registry.k8s.io/manifests/k8s-staging-cpa/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-cpa/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-cpa
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/cpa
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/cpa
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/cpa
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/cpa
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/cpa

--- a/registry.k8s.io/manifests/k8s-staging-csi-secrets-store/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-csi-secrets-store/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-csi-secrets-store
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/csi-secrets-store
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/csi-secrets-store
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/csi-secrets-store
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/csi-secrets-store
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/csi-secrets-store

--- a/registry.k8s.io/manifests/k8s-staging-descheduler/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-descheduler/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-descheduler
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/descheduler
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/descheduler
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/descheduler
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/descheduler
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/descheduler

--- a/registry.k8s.io/manifests/k8s-staging-dns/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-dns/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-dns
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/dns
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/dns
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/dns
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/dns
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/dns

--- a/registry.k8s.io/manifests/k8s-staging-e2e-test-images/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-e2e-test-images/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-e2e-test-images
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/e2e-test-images
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/e2e-test-images
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/e2e-test-images
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/e2e-test-images
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/e2e-test-images

--- a/registry.k8s.io/manifests/k8s-staging-etcd/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-etcd/promoter-manifest.yaml
@@ -11,15 +11,8 @@ registries:
 - name: gcr.io/k8s-staging-etcd
   src: true
 
-# Promotes to the following GCR/AR locations:
-# - *.gcr.io/k8s-artifacts-prod --> registry.k8s.io
+# Promotes to the following AR locations:
 # - *-docker.pkg.dev/k8s-artifacts-prod/images --> registry.k8s.io
-- name: us.gcr.io/k8s-artifacts-prod
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images
@@ -61,15 +54,8 @@ registries:
 - name: us-west2-docker.pkg.dev/k8s-artifacts-prod/images
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 
-# Promotes to the following GCR/AR locations:
-# - *.gcr.io/k8s-artifacts-prod/kubernetes --> registry.k8s.io/kubernetes
+# Promotes to the following AR locations:
 # - *-docker.pkg.dev/k8s-artifacts-prod/images/kubernetes --> registry.k8s.io/kubernetes
-- name: us.gcr.io/k8s-artifacts-prod/kubernetes
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/kubernetes
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/kubernetes
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/kubernetes
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/kubernetes

--- a/registry.k8s.io/manifests/k8s-staging-etcdadm/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-etcdadm/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-etcdadm
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/etcdadm
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/etcdadm
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/etcdadm
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/etcdadm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/etcdadm

--- a/registry.k8s.io/manifests/k8s-staging-experimental/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-experimental/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-experimental
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/experimental
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/experimental
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/experimental
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/experimental
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/experimental

--- a/registry.k8s.io/manifests/k8s-staging-external-dns/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-external-dns/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-external-dns
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/external-dns
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/external-dns
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/external-dns
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/external-dns
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/external-dns

--- a/registry.k8s.io/manifests/k8s-staging-gateway-api/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-gateway-api/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
   - name: gcr.io/k8s-staging-gateway-api
     src: true
-  - name: us.gcr.io/k8s-artifacts-prod/gateway-api
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-  - name: eu.gcr.io/k8s-artifacts-prod/gateway-api
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-  - name: asia.gcr.io/k8s-artifacts-prod/gateway-api
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api

--- a/registry.k8s.io/manifests/k8s-staging-git-sync/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-git-sync/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-git-sync
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/git-sync
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/git-sync
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/git-sync
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/git-sync
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/git-sync

--- a/registry.k8s.io/manifests/k8s-staging-gmsa-webhook/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-gmsa-webhook/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-gmsa-webhook
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/gmsa-webhook
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/gmsa-webhook
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/gmsa-webhook
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/gmsa-webhook
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/gmsa-webhook

--- a/registry.k8s.io/manifests/k8s-staging-infra-tools/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-infra-tools/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-infra-tools
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/infra-tools
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/infra-tools
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/infra-tools
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/infra-tools
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/infra-tools

--- a/registry.k8s.io/manifests/k8s-staging-ingress-controller-conformance/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-ingress-controller-conformance/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
   - name: gcr.io/k8s-staging-ingressconformance
     src: true
-  - name: us.gcr.io/k8s-artifacts-prod/ingressconformance
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-  - name: eu.gcr.io/k8s-artifacts-prod/ingressconformance
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-  - name: asia.gcr.io/k8s-artifacts-prod/ingressconformance
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/ingressconformance
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/ingressconformance

--- a/registry.k8s.io/manifests/k8s-staging-ingress-nginx/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-ingress-nginx/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
   - name: gcr.io/k8s-staging-ingress-nginx
     src: true
-  - name: us.gcr.io/k8s-artifacts-prod/ingress-nginx
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-  - name: eu.gcr.io/k8s-artifacts-prod/ingress-nginx
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-  - name: asia.gcr.io/k8s-artifacts-prod/ingress-nginx
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/ingress-nginx
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/ingress-nginx

--- a/registry.k8s.io/manifests/k8s-staging-jobset/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-jobset/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-jobset
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/jobset
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/jobset
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/jobset
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/jobset
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/jobset

--- a/registry.k8s.io/manifests/k8s-staging-k8s-gsm-tools/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-k8s-gsm-tools/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-k8s-gsm-tools
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/k8s-gsm-tools
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/k8s-gsm-tools
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/k8s-gsm-tools
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/k8s-gsm-tools
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/k8s-gsm-tools

--- a/registry.k8s.io/manifests/k8s-staging-kas-network-proxy/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-kas-network-proxy/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-kas-network-proxy
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/kas-network-proxy
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/kas-network-proxy
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/kas-network-proxy
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/kas-network-proxy
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/kas-network-proxy

--- a/registry.k8s.io/manifests/k8s-staging-kops/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-kops/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-kops
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/kops
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/kops
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/kops
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/kops
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/kops

--- a/registry.k8s.io/manifests/k8s-staging-kube-state-metrics/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-kube-state-metrics/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-kube-state-metrics
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/kube-state-metrics
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/kube-state-metrics
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/kube-state-metrics
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/kube-state-metrics
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/kube-state-metrics

--- a/registry.k8s.io/manifests/k8s-staging-kubebuilder/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-kubebuilder/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
   - name: gcr.io/k8s-staging-kubebuilder
     src: true
-  - name: us.gcr.io/k8s-artifacts-prod/kubebuilder
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-  - name: eu.gcr.io/k8s-artifacts-prod/kubebuilder
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-  - name: asia.gcr.io/k8s-artifacts-prod/kubebuilder
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder

--- a/registry.k8s.io/manifests/k8s-staging-kubernetes/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-kubernetes/promoter-manifest.yaml
@@ -17,15 +17,8 @@ registries:
 - name: gcr.io/k8s-staging-kubernetes
   src: true
 
-# Promotes to the following GCR/AR locations:
-# - *.gcr.io/k8s-artifacts-prod --> registry.k8s.io
+# Promotes to the following AR locations:
 # - *-docker.pkg.dev/k8s-artifacts-prod/images --> registry.k8s.io
-- name: us.gcr.io/k8s-artifacts-prod
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images
@@ -67,15 +60,8 @@ registries:
 - name: us-west2-docker.pkg.dev/k8s-artifacts-prod/images
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 
-# Promotes to the following GCR/AR locations:
-# - *.gcr.io/k8s-artifacts-prod/kubernetes --> registry.k8s.io/kubernetes
+# Promotes to the following AR locations:
 # - *-docker.pkg.dev/k8s-artifacts-prod/images/kubernetes --> registry.k8s.io/kubernetes
-- name: us.gcr.io/k8s-artifacts-prod/kubernetes
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/kubernetes
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/kubernetes
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/kubernetes
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/kubernetes

--- a/registry.k8s.io/manifests/k8s-staging-kueue/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-kueue/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-kueue
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/kueue
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/kueue
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/kueue
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/kueue
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/kueue

--- a/registry.k8s.io/manifests/k8s-staging-kustomize/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-kustomize/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-kustomize
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/kustomize
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/kustomize
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/kustomize
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/kustomize
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/kustomize

--- a/registry.k8s.io/manifests/k8s-staging-kwok/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-kwok/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-kwok
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/kwok
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/kwok
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/kwok
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/kwok
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/kwok

--- a/registry.k8s.io/manifests/k8s-staging-metrics-server/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-metrics-server/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-metrics-server
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/metrics-server
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/metrics-server
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/metrics-server
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/metrics-server
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/metrics-server

--- a/registry.k8s.io/manifests/k8s-staging-multitenancy/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-multitenancy/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-multitenancy
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/multitenancy
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/multitenancy
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/multitenancy
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/multitenancy
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/multitenancy

--- a/registry.k8s.io/manifests/k8s-staging-networking/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-networking/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-networking
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/networking
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/networking
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/networking
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/networking
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/networking

--- a/registry.k8s.io/manifests/k8s-staging-nfd/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-nfd/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-nfd
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/nfd
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/nfd
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/nfd
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/nfd
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/nfd

--- a/registry.k8s.io/manifests/k8s-staging-npd/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-npd/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-npd
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/node-problem-detector
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/node-problem-detector
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/node-problem-detector
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/node-problem-detector
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/node-problem-detector

--- a/registry.k8s.io/manifests/k8s-staging-prometheus-adapter/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-prometheus-adapter/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-prometheus-adapter
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/prometheus-adapter
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/prometheus-adapter
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/prometheus-adapter
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/prometheus-adapter
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/prometheus-adapter

--- a/registry.k8s.io/manifests/k8s-staging-provider-aws/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-provider-aws/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-provider-aws
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/provider-aws
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/provider-aws
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/provider-aws
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/provider-aws
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/provider-aws

--- a/registry.k8s.io/manifests/k8s-staging-provider-os/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-provider-os/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-provider-os
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/provider-os
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/provider-os
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/provider-os
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/provider-os
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/provider-os

--- a/registry.k8s.io/manifests/k8s-staging-publishing-bot/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-publishing-bot/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-publishing-bot
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/publishing-bot
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/publishing-bot
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/publishing-bot
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/publishing-bot
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/publishing-bot

--- a/registry.k8s.io/manifests/k8s-staging-releng/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-releng/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-releng
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/releng
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/releng
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/releng
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/releng
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/releng

--- a/registry.k8s.io/manifests/k8s-staging-scheduler-plugins/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-scheduler-plugins/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-scheduler-plugins
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/scheduler-plugins
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/scheduler-plugins
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/scheduler-plugins
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/scheduler-plugins
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/scheduler-plugins

--- a/registry.k8s.io/manifests/k8s-staging-scl-image-builder/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-scl-image-builder/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-scl-image-builder
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/scl-image-builder
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/scl-image-builder
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/scl-image-builder
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/scl-image-builder
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/scl-image-builder

--- a/registry.k8s.io/manifests/k8s-staging-sig-auth/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-sig-auth/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
   - name: gcr.io/k8s-staging-sig-auth
     src: true
-  - name: us.gcr.io/k8s-artifacts-prod/sig-auth
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-  - name: eu.gcr.io/k8s-artifacts-prod/sig-auth
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-  - name: asia.gcr.io/k8s-artifacts-prod/sig-auth
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/sig-auth
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/sig-auth

--- a/registry.k8s.io/manifests/k8s-staging-sig-storage/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-sig-storage/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-sig-storage
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/sig-storage
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/sig-storage
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/sig-storage
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/sig-storage
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/sig-storage

--- a/registry.k8s.io/manifests/k8s-staging-slack-infra/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-slack-infra/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-slack-infra
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/slack-infra
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/slack-infra
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/slack-infra
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/slack-infra
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/slack-infra

--- a/registry.k8s.io/manifests/k8s-staging-sp-operator/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-sp-operator/promoter-manifest.yaml
@@ -3,12 +3,6 @@
 registries:
 - name: gcr.io/k8s-staging-sp-operator
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/security-profiles-operator
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/security-profiles-operator
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/security-profiles-operator
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator
@@ -49,12 +43,6 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: us-west2-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: us.gcr.io/k8s-artifacts-prod/security-profiles-operator-bundle
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/security-profiles-operator-bundle
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/security-profiles-operator-bundle
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator-bundle
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator-bundle
@@ -94,12 +82,6 @@ registries:
 - name: us-west1-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator-bundle
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: us-west2-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator-bundle
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: us.gcr.io/k8s-artifacts-prod/security-profiles-operator-catalog
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/security-profiles-operator-catalog
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/security-profiles-operator-catalog
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator-catalog
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-storage-migrator/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-storage-migrator/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-storage-migrator
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/storage-migrator
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/storage-migrator
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/storage-migrator
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/storage-migrator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/storage-migrator

--- a/registry.k8s.io/manifests/k8s-staging-tejolote/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-tejolote/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
   - name: gcr.io/k8s-staging-tejolote
     src: true
-  - name: us.gcr.io/k8s-artifacts-prod/tejolote
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-  - name: eu.gcr.io/k8s-artifacts-prod/tejolote
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-  - name: asia.gcr.io/k8s-artifacts-prod/tejolote
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/tejolote

--- a/registry.k8s.io/manifests/k8s-staging-tg-exporter/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-tg-exporter/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-tg-exporter
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/testgrid-exporter
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/testgrid-exporter
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/testgrid-exporter
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/testgrid-exporter
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/testgrid-exporter

--- a/registry.k8s.io/manifests/k8s-staging-win-op-rdnss/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-win-op-rdnss/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-win-op-rdnss
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/windows-op-readiness
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/windows-op-readiness
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/windows-op-readiness
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/windows-op-readiness
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/windows-op-readiness

--- a/registry.k8s.io/manifests/k8s-staging-win-svc-proxy/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-win-svc-proxy/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
 - name: gcr.io/k8s-staging-win-svc-proxy
   src: true
-- name: us.gcr.io/k8s-artifacts-prod/windows-service-proxy
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: eu.gcr.io/k8s-artifacts-prod/windows-service-proxy
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-- name: asia.gcr.io/k8s-artifacts-prod/windows-service-proxy
-  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/windows-service-proxy
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/windows-service-proxy

--- a/registry.k8s.io/manifests/k8s-staging-zeitgeist/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-zeitgeist/promoter-manifest.yaml
@@ -2,12 +2,6 @@
 registries:
   - name: gcr.io/k8s-staging-zeitgeist
     src: true
-  - name: us.gcr.io/k8s-artifacts-prod/zeitgeist
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-  - name: eu.gcr.io/k8s-artifacts-prod/zeitgeist
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-  - name: asia.gcr.io/k8s-artifacts-prod/zeitgeist
-    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist

--- a/registry.k8s.io/manifests/manifest_test.go
+++ b/registry.k8s.io/manifests/manifest_test.go
@@ -54,9 +54,6 @@ type Manifest struct {
 
 // TODO: If you add any production registries you will have to update this list 🤷
 var ProdRegistries []string = []string{
-	"asia.gcr.io/k8s-artifacts-prod/",
-	"us.gcr.io/k8s-artifacts-prod/",
-	"eu.gcr.io/k8s-artifacts-prod/",
 	"asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/",
 	"asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/",
 	"asia-northeast1-docker.pkg.dev/k8s-artifacts-prod/images/",


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/release/issues/2947
Fixes: https://github.com/kubernetes/enhancements/issues/3720

Merging this PR will freeze the old registry.

/cc @kubernetes/release-engineering @dims @BenTheElder 