### PR TITLE
eks-prow-build-cluster: fix port number in Grafana's config

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/grafana/config.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/grafana/config.yaml
@@ -29,7 +29,7 @@ data:
     provisioning = /etc/grafana/provisioning
 
     [server]
-    http_port = 3001
+    http_port = 3000
 
     [security]
     disable_gravatar = true


### PR DESCRIPTION
This PR makes sure of using the right port in EKS prow build cluster's Grafana instance configuration.

Part of https://github.com/kubernetes/k8s.io/issues/4686
/assign @ameukam @xmudrii 