### PR TITLE
Add aws iam-bentheelder.tf

### DIFF
--- a/infra/aws/terraform/management-account/iam-bentheelder.tf
+++ b/infra/aws/terraform/management-account/iam-bentheelder.tf
@@ -1,3 +1,20 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
 resource "aws_iam_user" "bentheelder" {
   name = "bentheelder"
 }

--- a/infra/aws/terraform/management-account/iam-bentheelder.tf
+++ b/infra/aws/terraform/management-account/iam-bentheelder.tf
@@ -18,7 +18,11 @@ limitations under the License.
 resource "aws_iam_user" "bentheelder" {
   name = "bentheelder"
 }
-resource "aws_iam_user_policy_attachment" "benthelder_billing" {
+resource "aws_iam_user_policy_attachment" "bentheelder_billing" {
   user       = aws_iam_user.bentheelder.name
   policy_arn = "arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess"
+}
+resource "aws_iam_user_login_profile" "bentheelder_login" {
+  user    = aws_iam_user.bentheelder.name
+  password_reset_required = true
 }

--- a/infra/aws/terraform/management-account/iam-bentheelder.tf
+++ b/infra/aws/terraform/management-account/iam-bentheelder.tf
@@ -1,0 +1,7 @@
+resource "aws_iam_user" "bentheelder" {
+  name = "bentheelder"
+}
+resource "aws_iam_user_policy_attachment" "benthelder_billing" {
+  user       = aws_iam_user.bentheelder.name
+  policy_arn = "arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess"
+}


### PR DESCRIPTION
- [Request / Issue](#orgf0d2125)
- [Steps for running #sig-k8s-infra terraform for AWS](#org6977efc)
- [Check out k8s.io/infra/aws/terraform](#org1900e43)
- [Ensure AWS cli authentication](#org4f94048)
  - [Ensure you are using the right profile and organization](#org9c8efb7)
  - [Appropriate Account level](#orgf4af7f3)
- [Ensure terraform version is 1.3.9](#org002a386)
- [Ensure Terraform init](#orged56b00)
  - [terraform state S3 shared configuration](#orga9c052e)
  - [terraform init](#org6f430a9)
- [terraform state inspection](#org30e1930)
- [List of Current IAM Users (Not really accounts)](#org897c5cb)
- [S3 Related Policies sorted by arn](#org9da35c0)
- [List of Policies sorted by arn](#orgd6a07da)
- [Ben IAM User Terrafrom Code](#org3c465e4)
  - [aws<sub>iam</sub><sub>user</sub> ben](#org87050b7)
- [terraform plan](#org4ce2d9f)
- [TODO: Figure out how to get password / console access via iam + tf](#orgac18570)
- [paste to issue or ticket (private hackmd for now)](#orgbbbbe6e)
- [terraform apply](#org3b15b42)
- [Retrieve bentheelder inital password](#org83e0184)



<a id="orgf0d2125"></a>

# Request / Issue

<https://github.com/kubernetes/k8s.io/issues/5043>


<a id="org6977efc"></a>

# Steps for running #sig-k8s-infra terraform for AWS

-   [X] Check out the **main** or appropriate branch
-   [X] Ensure aws cli authentication
-   [X] Ensure terraform version is 1.3.9
-   [X] Ensure terraform init
-   [X] Inspect terraform state
-   [X] Inspect terraform plan
-   [X] Possibly paste plan to issue / ticket?
-   [ ] Upon inspection and approval of plan: \`terraform apply\`


<a id="org1900e43"></a>

# Check out k8s.io/infra/aws/terraform

```shell
git checkout https://github.com/kubernetes/k8s.io/
cd k8s.io/aws/terraform/management-account
```


<a id="org4f94048"></a>

# Ensure AWS cli authentication


<a id="org9c8efb7"></a>

## Ensure you are using the right profile and organization

```shell
export AWS_PROFILE=hh@kubernetes
aws organizations describe-organization
```

```json
{
    "Organization": {
        "Id": "o-kz4vlkihvy",
        "Arn": "arn:aws:organizations::348685125169:organization/o-kz4vlkihvy",
        "FeatureSet": "ALL",
        "MasterAccountArn": "arn:aws:organizations::348685125169:account/o-kz4vlkihvy/348685125169",
        "MasterAccountId": "348685125169",
        "MasterAccountEmail": "kubernetes-aws-admins@lists.cncf.io",
        "AvailablePolicyTypes": [
            {
                "Type": "SERVICE_CONTROL_POLICY",
                "Status": "ENABLED"
            }
        ]
    }
}
```


<a id="orgf4af7f3"></a>

## Appropriate Account level

This is probably too high level of an account to run this, we should choose an account focused on running terraform. I&rsquo;ll run it this once, but we need a better plan.


<a id="org002a386"></a>

# Ensure terraform version is 1.3.9

I am noting that terraform has a newer version at 1.4.2!

Documentation available from <https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html>

```shell
export TF_VERSION=1.3.9
tfswitch
```

    Reading required version from terraform file
    Reading required version from constraint: ~> 1.3.0
    Matched version: 1.3.9
    Switched terraform to version "1.3.9"

```shell
terraform version
```

    Terraform v1.3.9
    on darwin_arm64
    + provider registry.terraform.io/hashicorp/aws v4.52.0
    
    Your version of Terraform is out of date! The latest version
    is 1.4.2. You can update by downloading from https://www.terraform.io/downloads.html


<a id="orged56b00"></a>

# Ensure Terraform init


<a id="orga9c052e"></a>

## terraform state S3 shared configuration

<https://developer.hashicorp.com/terraform/language/settings/backends/s3#data-source-configuration>


<a id="org6f430a9"></a>

## terraform init

```shell
export AWS_PROFILE=hh@kubernetes
terraform init
```

    Initializing modules...
    
    Initializing the backend...
    
    Initializing provider plugins...
    - Reusing previous version of hashicorp/aws from the dependency lock file
    - Using previously-installed hashicorp/aws v4.52.0
    
    Terraform has been successfully initialized!
    
    You may now begin working with Terraform. Try running "terraform plan" to see
    any changes that are required for your infrastructure. All Terraform commands
    should now work.
    
    If you ever set or change modules or backend configuration for Terraform,
    rerun this command to reinitialize your working directory. If you forget, other
    commands will detect it and remind you to do so if necessary.


<a id="org30e1930"></a>

# terraform state inspection

```shell
export AWS_PROFILE=hh@kubernetes
terraform state list
```

    data.aws_caller_identity.current
    data.aws_iam_policy_document.cur_reports_integration_athena_s3_bucket
    data.aws_iam_policy_document.cur_reports_s3_bucket
    aws_budgets_budget.everything
    aws_cur_report_definition.athena_integration
    aws_cur_report_definition.no_integrations
    aws_iam_service_linked_role.access_analyzer
    aws_organizations_delegated_administrator.access_analyzer
    aws_organizations_delegated_administrator.cloudtrail
    aws_organizations_delegated_administrator.config
    aws_organizations_delegated_administrator.config_multiaccount
    aws_organizations_delegated_administrator.detective
    aws_organizations_delegated_administrator.fms
    aws_organizations_delegated_administrator.guardduty
    aws_organizations_delegated_administrator.identity_center
    aws_organizations_delegated_administrator.securityhub
    aws_organizations_delegated_administrator.storage_lens
    aws_organizations_organization.default
    aws_organizations_organizational_unit.boskos
    aws_organizations_organizational_unit.infrastructure
    aws_organizations_organizational_unit.non_production
    aws_organizations_organizational_unit.policy_staging
    aws_organizations_organizational_unit.production
    aws_organizations_organizational_unit.security
    aws_organizations_organizational_unit.workloads
    module.artifacts-k8s-io.aws_organizations_account.this
    module.aws-playground-01.aws_organizations_account.this
    module.cur_reports_integration_athena_s3_bucket.data.aws_caller_identity.current
    module.cur_reports_integration_athena_s3_bucket.data.aws_canonical_user_id.this
    module.cur_reports_integration_athena_s3_bucket.data.aws_iam_policy_document.combined[0]
    module.cur_reports_integration_athena_s3_bucket.data.aws_iam_policy_document.deny_insecure_transport[0]
    module.cur_reports_integration_athena_s3_bucket.data.aws_region.current
    module.cur_reports_integration_athena_s3_bucket.aws_s3_bucket.this[0]
    module.cur_reports_integration_athena_s3_bucket.aws_s3_bucket_policy.this[0]
    module.cur_reports_integration_athena_s3_bucket.aws_s3_bucket_public_access_block.this[0]
    module.cur_reports_integration_athena_s3_bucket.aws_s3_bucket_versioning.this[0]
    module.cur_reports_s3_bucket.data.aws_caller_identity.current
    module.cur_reports_s3_bucket.data.aws_canonical_user_id.this
    module.cur_reports_s3_bucket.data.aws_iam_policy_document.combined[0]
    module.cur_reports_s3_bucket.data.aws_iam_policy_document.deny_insecure_transport[0]
    module.cur_reports_s3_bucket.data.aws_region.current
    module.cur_reports_s3_bucket.aws_s3_bucket.this[0]
    module.cur_reports_s3_bucket.aws_s3_bucket_policy.this[0]
    module.cur_reports_s3_bucket.aws_s3_bucket_public_access_block.this[0]
    module.cur_reports_s3_bucket.aws_s3_bucket_versioning.this[0]
    module.infra_network.aws_organizations_account.this
    module.infra_shared_services.aws_organizations_account.this
    module.k8s-infra-sandbox-capa.aws_organizations_account.this
    module.k8s_infra_e2e_boskos_001.aws_organizations_account.this
    module.k8s_infra_e2e_boskos_002.aws_organizations_account.this
    module.k8s_infra_e2e_boskos_003.aws_organizations_account.this
    module.policy_staging_account_1.aws_organizations_account.this
    module.registry-k8s-io.aws_organizations_account.this
    module.security_audit.aws_organizations_account.this
    module.security_engineering.aws_organizations_account.this
    module.security_incident_response.aws_organizations_account.this
    module.security_logs.aws_organizations_account.this


<a id="org897c5cb"></a>

# List of Current IAM Users (Not really accounts)

```shell
export AWS_PROFILE=hh@kubernetes
aws iam list-users --output=table --query 'Users[*].[UserName,Arn]'
```

    -----------------------------------------------------
    |                     ListUsers                     |
    +--------+------------------------------------------+
    |  arnaud|  arn:aws:iam::348685125169:user/arnaud   |
    |  dims  |  arn:aws:iam::348685125169:user/dims     |
    |  hh    |  arn:aws:iam::348685125169:user/hh       |
    |  jeefy |  arn:aws:iam::348685125169:user/jeefy    |
    +--------+------------------------------------------+


<a id="org9da35c0"></a>

# S3 Related Policies sorted by arn

We have other options, but I&rsquo;m assuming &ldquo;arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess&rdquo;

```shell
export AWS_PROFILE=hh@kubernetes
aws iam list-policies --output=table --query 'Policies[*].[Arn] | sort_by(@, &[0])' | grep -i s3
```

    |  arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Backup                                              |
    |  arn:aws:iam::aws:policy/AWSBackupServiceRolePolicyForS3Restore                                             |
    |  arn:aws:iam::aws:policy/AmazonS3FullAccess                                                                 |
    |  arn:aws:iam::aws:policy/AmazonS3OutpostsFullAccess                                                         |
    |  arn:aws:iam::aws:policy/AmazonS3OutpostsReadOnlyAccess                                                     |
    |  arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess                                                             |
    |  arn:aws:iam::aws:policy/aws-service-role/IVSRecordToS3                                                     |
    |  arn:aws:iam::aws:policy/aws-service-role/S3StorageLensServiceRolePolicy                                    |
    |  arn:aws:iam::aws:policy/service-role/AmazonDMSRedshiftS3Role                                               |
    |  arn:aws:iam::aws:policy/service-role/AmazonS3ObjectLambdaExecutionRolePolicy                               |
    |  arn:aws:iam::aws:policy/service-role/QuickSightAccessForS3StorageManagementAnalyticsReadOnly               |


<a id="orgd6a07da"></a>

# List of Policies sorted by arn

We have other options, but I&rsquo;m assuming &ldquo;arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess&rdquo;

```shell
export AWS_PROFILE=hh@kubernetes
aws iam list-policies --output=table --query 'Policies[*].[Arn] | sort_by(@, &[0])' | head -20
```

    ---------------------------------------------------------------------------------------------------------------
    |                                                ListPolicies                                                 |
    +-------------------------------------------------------------------------------------------------------------+
    |  arn:aws:iam::348685125169:policy/AssumeRoleAccountMigrated                                                 |
    |  arn:aws:iam::aws:policy/AWSAccountActivityAccess                                                           |
    |  arn:aws:iam::aws:policy/AWSAccountManagementFullAccess                                                     |
    |  arn:aws:iam::aws:policy/AWSAccountManagementReadOnlyAccess                                                 |
    |  arn:aws:iam::aws:policy/AWSAccountUsageReportAccess                                                        |
    |  arn:aws:iam::aws:policy/AWSAgentlessDiscoveryService                                                       |
    |  arn:aws:iam::aws:policy/AWSAppMeshEnvoyAccess                                                              |
    |  arn:aws:iam::aws:policy/AWSAppMeshFullAccess                                                               |
    |  arn:aws:iam::aws:policy/AWSAppMeshPreviewEnvoyAccess                                                       |
    |  arn:aws:iam::aws:policy/AWSAppMeshReadOnly                                                                 |
    |  arn:aws:iam::aws:policy/AWSAppRunnerFullAccess                                                             |
    |  arn:aws:iam::aws:policy/AWSAppRunnerReadOnlyAccess                                                         |
    |  arn:aws:iam::aws:policy/AWSAppSyncAdministrator                                                            |
    |  arn:aws:iam::aws:policy/AWSAppSyncInvokeFullAccess                                                         |
    |  arn:aws:iam::aws:policy/AWSAppSyncSchemaAuthor                                                             |
    |  arn:aws:iam::aws:policy/AWSApplicationDiscoveryAgentAccess                                                 |
    |  arn:aws:iam::aws:policy/AWSApplicationDiscoveryAgentlessCollectorAccess                                    |
    Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='utf-8'>
    BrokenPipeError: [Errno 32] Broken pipe


<a id="org3c465e4"></a>

# Ben IAM User Terrafrom Code

Boilerplate code / Copyright is required at the top of the file.


<a id="org87050b7"></a>

## aws<sub>iam</sub><sub>user</sub> ben

```terraform
/*
Copyright 2023 The Kubernetes Authors.

Licensed under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License.
You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
*/


resource "aws_iam_user" "bentheelder" {
  name = "bentheelder"
}
resource "aws_iam_user_policy_attachment" "bentheelder_billing" {
  user       = aws_iam_user.bentheelder.name
  policy_arn = "arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess"
}
resource "aws_iam_user_login_profile" "bentheelder_login" {
  user    = aws_iam_user.bentheelder.name
  password_reset_required = true
}
```


<a id="org4ce2d9f"></a>

# terraform plan

```shell
export AWS_PROFILE=hh@kubernetes
terraform plan -out terraform.newplan
```

    module.cur_reports_integration_athena_s3_bucket.data.aws_caller_identity.current: Reading...
    module.cur_reports_s3_bucket.data.aws_region.current: Reading...
    module.cur_reports_integration_athena_s3_bucket.data.aws_region.current: Reading...
    module.cur_reports_integration_athena_s3_bucket.data.aws_canonical_user_id.this: Reading...
    module.cur_reports_s3_bucket.data.aws_canonical_user_id.this: Reading...
    module.cur_reports_s3_bucket.data.aws_caller_identity.current: Reading...
    module.cur_reports_s3_bucket.data.aws_region.current: Read complete after 0s [id=us-east-1]
    module.cur_reports_integration_athena_s3_bucket.data.aws_region.current: Read complete after 0s [id=us-east-1]
    module.cur_reports_s3_bucket.aws_s3_bucket.this[0]: Refreshing state... [id=k8s-infra-cur-reports-bucket]
    module.cur_reports_integration_athena_s3_bucket.aws_s3_bucket.this[0]: Refreshing state... [id=k8s-infra-cur-reports-athena-bucket]
    data.aws_caller_identity.current: Reading...
    aws_iam_service_linked_role.access_analyzer: Refreshing state... [id=arn:aws:iam::348685125169:role/aws-service-role/access-analyzer.amazonaws.com/AWSServiceRoleForAccessAnalyzer]
    aws_organizations_organization.default: Refreshing state... [id=o-kz4vlkihvy]
    module.cur_reports_s3_bucket.data.aws_caller_identity.current: Read complete after 1s [id=348685125169]
    module.cur_reports_integration_athena_s3_bucket.data.aws_caller_identity.current: Read complete after 1s [id=348685125169]
    module.cur_reports_integration_athena_s3_bucket.data.aws_canonical_user_id.this: Read complete after 1s [id=eb1b4e99537971cc04f7eb30651c5473710354b068266143cf78ae59f8de3ff5]
    module.cur_reports_s3_bucket.data.aws_canonical_user_id.this: Read complete after 1s [id=eb1b4e99537971cc04f7eb30651c5473710354b068266143cf78ae59f8de3ff5]
    data.aws_caller_identity.current: Read complete after 1s [id=348685125169]
    aws_budgets_budget.everything: Refreshing state... [id=348685125169:k8s-infra-monthly]
    aws_organizations_organizational_unit.workloads: Refreshing state... [id=ou-unv1-ylnwmrk0]
    aws_organizations_organizational_unit.infrastructure: Refreshing state... [id=ou-unv1-pvh1fjp7]
    aws_organizations_organizational_unit.policy_staging: Refreshing state... [id=ou-unv1-pxzbpu89]
    aws_organizations_organizational_unit.security: Refreshing state... [id=ou-unv1-7712vgib]
    module.cur_reports_s3_bucket.aws_s3_bucket_versioning.this[0]: Refreshing state... [id=k8s-infra-cur-reports-bucket]
    module.cur_reports_s3_bucket.data.aws_iam_policy_document.deny_insecure_transport[0]: Reading...
    module.cur_reports_s3_bucket.data.aws_iam_policy_document.deny_insecure_transport[0]: Read complete after 0s [id=214081987]
    data.aws_iam_policy_document.cur_reports_s3_bucket: Reading...
    data.aws_iam_policy_document.cur_reports_s3_bucket: Read complete after 0s [id=1354078299]
    module.cur_reports_s3_bucket.data.aws_iam_policy_document.combined[0]: Reading...
    module.cur_reports_s3_bucket.data.aws_iam_policy_document.combined[0]: Read complete after 0s [id=1714115231]
    module.cur_reports_s3_bucket.aws_s3_bucket_policy.this[0]: Refreshing state... [id=k8s-infra-cur-reports-bucket]
    module.cur_reports_integration_athena_s3_bucket.aws_s3_bucket_versioning.this[0]: Refreshing state... [id=k8s-infra-cur-reports-athena-bucket]
    module.cur_reports_integration_athena_s3_bucket.data.aws_iam_policy_document.deny_insecure_transport[0]: Reading...
    data.aws_iam_policy_document.cur_reports_integration_athena_s3_bucket: Reading...
    module.cur_reports_integration_athena_s3_bucket.data.aws_iam_policy_document.deny_insecure_transport[0]: Read complete after 0s [id=1931211801]
    data.aws_iam_policy_document.cur_reports_integration_athena_s3_bucket: Read complete after 0s [id=1361119985]
    module.cur_reports_integration_athena_s3_bucket.data.aws_iam_policy_document.combined[0]: Reading...
    module.cur_reports_integration_athena_s3_bucket.data.aws_iam_policy_document.combined[0]: Read complete after 0s [id=2704809721]
    module.cur_reports_integration_athena_s3_bucket.aws_s3_bucket_policy.this[0]: Refreshing state... [id=k8s-infra-cur-reports-athena-bucket]
    module.cur_reports_s3_bucket.aws_s3_bucket_public_access_block.this[0]: Refreshing state... [id=k8s-infra-cur-reports-bucket]
    aws_cur_report_definition.no_integrations: Refreshing state... [id=k8s-infra-cur-definition]
    module.cur_reports_integration_athena_s3_bucket.aws_s3_bucket_public_access_block.this[0]: Refreshing state... [id=k8s-infra-cur-reports-athena-bucket]
    aws_cur_report_definition.athena_integration: Refreshing state... [id=k8s-infra-cur-athena-definition]
    aws_organizations_organizational_unit.production: Refreshing state... [id=ou-unv1-l9ebvb3s]
    aws_organizations_organizational_unit.boskos: Refreshing state... [id=ou-unv1-6ib3rho6]
    aws_organizations_organizational_unit.non_production: Refreshing state... [id=ou-unv1-0h3hebxm]
    module.policy_staging_account_1.aws_organizations_account.this: Refreshing state... [id=581954596586]
    module.infra_shared_services.aws_organizations_account.this: Refreshing state... [id=678544613731]
    module.infra_network.aws_organizations_account.this: Refreshing state... [id=203865341587]
    module.security_logs.aws_organizations_account.this: Refreshing state... [id=759415916157]
    module.security_engineering.aws_organizations_account.this: Refreshing state... [id=580784499913]
    module.security_incident_response.aws_organizations_account.this: Refreshing state... [id=573772537124]
    module.security_audit.aws_organizations_account.this: Refreshing state... [id=128476729677]
    aws_organizations_delegated_administrator.identity_center: Refreshing state... [id=678544613731/sso.amazonaws.com]
    module.artifacts-k8s-io.aws_organizations_account.this: Refreshing state... [id=354561287328]
    module.registry-k8s-io.aws_organizations_account.this: Refreshing state... [id=468027687836]
    module.k8s-infra-sandbox-capa.aws_organizations_account.this: Refreshing state... [id=027487054958]
    aws_organizations_delegated_administrator.guardduty: Refreshing state... [id=580784499913/guardduty.amazonaws.com]
    aws_organizations_delegated_administrator.securityhub: Refreshing state... [id=580784499913/securityhub.amazonaws.com]
    aws_organizations_delegated_administrator.config_multiaccount: Refreshing state... [id=580784499913/config-multiaccountsetup.amazonaws.com]
    aws_organizations_delegated_administrator.config: Refreshing state... [id=580784499913/config.amazonaws.com]
    aws_organizations_delegated_administrator.detective: Refreshing state... [id=580784499913/detective.amazonaws.com]
    aws_organizations_delegated_administrator.cloudtrail: Refreshing state... [id=580784499913/cloudtrail.amazonaws.com]
    aws_organizations_delegated_administrator.access_analyzer: Refreshing state... [id=128476729677/access-analyzer.amazonaws.com]
    aws_organizations_delegated_administrator.fms: Refreshing state... [id=128476729677/fms.amazonaws.com]
    aws_organizations_delegated_administrator.storage_lens: Refreshing state... [id=128476729677/storage-lens.s3.amazonaws.com]
    module.k8s_infra_e2e_boskos_003.aws_organizations_account.this: Refreshing state... [id=336527747262]
    module.k8s_infra_e2e_boskos_001.aws_organizations_account.this: Refreshing state... [id=144171684817]
    module.k8s_infra_e2e_boskos_002.aws_organizations_account.this: Refreshing state... [id=867921711297]
    module.aws-playground-01.aws_organizations_account.this: Refreshing state... [id=855606814420]
    
    Terraform used the selected providers to generate the following execution
    plan. Resource actions are indicated with the following symbols:
      + create
    
    Terraform will perform the following actions:
    
      # aws_iam_user.bentheelder will be created
      + resource "aws_iam_user" "bentheelder" {
          + arn           = (known after apply)
          + force_destroy = false
          + id            = (known after apply)
          + name          = "bentheelder"
          + path          = "/"
          + tags_all      = (known after apply)
          + unique_id     = (known after apply)
        }
    
      # aws_iam_user_login_profile.bentheelder_login will be created
      + resource "aws_iam_user_login_profile" "bentheelder_login" {
          + encrypted_password      = (known after apply)
          + id                      = (known after apply)
          + key_fingerprint         = (known after apply)
          + password                = (known after apply)
          + password_length         = 20
          + password_reset_required = true
          + user                    = "bentheelder"
        }
    
      # aws_iam_user_policy_attachment.bentheelder_billing will be created
      + resource "aws_iam_user_policy_attachment" "bentheelder_billing" {
          + id         = (known after apply)
          + policy_arn = "arn:aws:iam::aws:policy/AWSBillingReadOnlyAccess"
          + user       = "bentheelder"
        }
    
    Plan: 3 to add, 0 to change, 0 to destroy.
    
    ─────────────────────────────────────────────────────────────────────────────
    
    Saved the plan to: terraform.newplan
    
    To perform exactly these actions, run the following command to apply:
        terraform apply "terraform.newplan"


<a id="orgac18570"></a>

# TODO: Figure out how to get password / console access via iam + tf

<https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_login_profile>


<a id="orgbbbbe6e"></a>

# paste to issue or ticket (private hackmd for now)


<a id="org3b15b42"></a>

# terraform apply

With permission, I will run the following:

```shell
export AWS_PROFILE=hh@kubernetes
terraform apply terraform.newplan
```


<a id="org83e0184"></a>

# Retrieve bentheelder inital password

<https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_login_profile#password>

```shell
command to retriev ben.password | base64 --decode
```