### PR TITLE
eks-prow-build-cluster: use instance SSDs for containerd and kubelet, and change instance type

### DIFF
--- a/hack/verify-executable.sh
+++ b/hack/verify-executable.sh
@@ -31,6 +31,7 @@ readonly exec_regexes=(
 # files that should NOT be executable (exceptions to the regexes above)
 readonly noexec_regexes=(
     .*/lib.*\.sh # lib_foo.sh should be sourced by other scripts, not executed
+    infra/aws/terraform/prow-build-cluster/bootstrap/node_bootstrap.sh # this script is injected into another script, not executed
 )
 
 # convert arrays to extended regexes

--- a/infra/aws/terraform/prow-build-cluster/bootstrap/node_bootstrap.sh
+++ b/infra/aws/terraform/prow-build-cluster/bootstrap/node_bootstrap.sh
@@ -1,0 +1,122 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## intended to be used as a node pre-bootstrap script
+## based on: https://github.com/awslabs/amazon-eks-ami/pull/1171
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+## sysctl settings (required by Prow)
+sysctl -w fs.inotify.max_user_watches=524288
+
+## Set up ephemeral disks (SSDs) to be used by containerd and kubelet
+
+MNT_DIR="/mnt/k8s-disks"
+disks=($(find -L /dev/disk/by-id/ -xtype l -name '*NVMe_Instance_Storage_*'))
+
+if [[ "${#disks[@]}" -eq 0 ]]; then
+  echo "no ephemeral disks found, skipping disk setup"
+  exit 0
+fi
+
+# Get devices of NVMe instance storage ephemeral disks
+EPHEMERAL_DISKS=($(realpath "${disks[@]}" | sort -u))
+
+# Pick the first NVMe disk. In this case, we care about only one disk,
+# additional disks are not much of use for us.
+# We don't want to deal with RAID because we don't gain much from it.
+dev="${EPHEMERAL_DISKS[0]}"
+
+# Mounts and creates xfs file systems on chosen EC2 instance store NVMe disk
+# without existing file system. Mounts in /mnt/k8s-disks
+if [[ -z "$(lsblk "${dev}" -o fstype --noheadings)" ]]; then
+  mkfs.xfs -l su=8b "${dev}"
+fi
+
+if [[ ! -z "$(lsblk "${dev}" -o MOUNTPOINT --noheadings)" ]]; then
+  echo "${dev} is already mounted."
+  exit 0
+fi
+
+# Get mount point for the disk.
+mount_point="${MNT_DIR}"
+mount_unit_name="$(systemd-escape --path --suffix=mount "${mount_point}")"
+
+mkdir -p "${mount_point}"
+
+# Create systemd service to mount the disk.
+cat > "/etc/systemd/system/${mount_unit_name}" << EOF
+[Unit]
+Description=Mount EC2 Instance Store NVMe disk
+[Mount]
+What=${dev}
+Where=${mount_point}
+Type=xfs
+Options=defaults,noatime
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemd-analyze verify "${mount_unit_name}"
+systemctl enable "${mount_unit_name}" --now
+
+## Create mount points on SSD for containerd and kubelet
+prev_running=""
+needs_linked=""
+
+# Stop containerd and kubelet if they are running.
+for unit in "containerd" "kubelet"; do
+  if [[ "$(systemctl is-active var-lib-${unit}.mount)" != "active" ]]; then
+    if systemctl is-active "${unit}" > /dev/null 2>&1; then
+      prev_running+=" ${unit}"
+    fi
+    needs_linked+=" ${unit}"
+  fi
+done
+
+if [[ ! -z "${prev_running}" ]]; then
+  systemctl stop ${prev_running}
+fi
+
+# Transfer state directories to the disk, if they exist.
+for unit in ${needs_linked}; do
+  var_lib_mount_point="/var/lib/${unit}"
+  unit_mount_point="${mount_point}/${unit}"
+
+  echo "Copying ${var_lib_mount_point}/ to ${unit_mount_point}/"
+  cp -a "${var_lib_mount_point}/" "${unit_mount_point}/"
+  
+  mount_unit_name="$(systemd-escape --path --suffix=mount "${var_lib_mount_point}")"
+  
+  cat > "/etc/systemd/system/${mount_unit_name}" << EOF
+    [Unit]
+    Description=Mount ${unit} on EC2 Instance Store NVMe disk
+    [Mount]
+    What=${unit_mount_point}
+    Where=${var_lib_mount_point}
+    Type=none
+    Options=bind
+    [Install]
+    WantedBy=multi-user.target
+EOF
+  systemd-analyze verify "${mount_unit_name}"
+  systemctl enable "${mount_unit_name}" --now
+done
+
+# Start again stopped services.
+if [[ ! -z "${prev_running}" ]]; then
+  systemctl start ${prev_running}
+fi

--- a/infra/aws/terraform/prow-build-cluster/eks.tf
+++ b/infra/aws/terraform/prow-build-cluster/eks.tf
@@ -128,10 +128,7 @@ module "eks" {
         max_unavailable_percentage = var.node_max_unavailable_percentage
       }
 
-      # Required to ensure Prow works well.
-      pre_bootstrap_user_data = <<-EOT
-        sysctl -w fs.inotify.max_user_watches=524288
-      EOT
+      pre_bootstrap_user_data = file("${path.module}/bootstrap/node_bootstrap.sh")
 
       capacity_type  = "ON_DEMAND"
       instance_types = var.node_instance_types

--- a/infra/aws/terraform/prow-build-cluster/terraform.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.tfvars
@@ -26,13 +26,13 @@ vpc_intra_subnet          = ["10.2.0.0/18", "10.2.64.0/18", "10.2.128.0/18"]
 
 # Ubuntu EKS optimized AMI: https://cloud-images.ubuntu.com/aws-eks/
 node_ami            = "ami-03de35fda144b3672"
-node_instance_types = ["r5ad.4xlarge"]
+node_instance_types = ["r5d.4xlarge"]
 node_volume_size    = 100
 
 # TODO(xmudrii): Increase this later.
-node_min_size                   = 5
-node_max_size                   = 5
-node_desired_size               = 5
+node_min_size                   = 20
+node_max_size                   = 40
+node_desired_size               = 20
 node_max_unavailable_percentage = 100 # To ease testing
 
 cluster_autoscaler_version = "v1.25.0"


### PR DESCRIPTION
As discussed on Slack and previous SIG K8s Infra meetings, this PR is bringing two very important changes to the prow-build EKS cluster:

- We're now using instance NVMe SSDs for containerd and kubelet instead of EBS storage
  - NVMe SSDs are much faster than EBS storage. This ensures that our tests are faster and less flaky
  - This is done by using a pre-bootstrap script which picks the first SSD, creates a xfs filesystem, then mounts it to be used by containerd (`/var/lib/containerd`) and kubelet (`/var/lib/kubelet`)
  - The pre-bootstrap script is based on the script that AWS plans to include in their AL2 AMI: https://github.com/awslabs/amazon-eks-ami/pull/1171
  - This approach utilizes only the first SSD. If there are additional SSDs, those remain unused. I didn't want to fiddle with RAID because that would to some degree increase complexity, but we wouldn't gain much
- We're now using Intel-backed instances instead of AMD-backed instances
  - The Kubernetes unit tests are constantly flaking when running them on the AMD-backend instances
  - We don't know the exact root cause, but they might be very CPU intensive. The AWS docs mention the following regarding AMD-backend instances: `R5a and R5ad instances feature AMD EPYC 7000 series processors with an all core turbo clock speed of 2.5 GHz. The AMD-based instances provide additional options for customers that do not fully utilize the compute resources and can benefit from a cost savings of 10%.`
  - Based on that, we concluded that AMD processors have lower clock speed and might not be suitable for us
- We're now using again 20 instances considering that we have more jobs running in the cluster

Changes are already applied to the cluster. Some references: https://kubernetes.slack.com/archives/CCK68P2Q2/p1679920767006369

/assign @dims @ameukam 