### PR TITLE
Add OWNERS for eks-prow-build-cluster

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/OWNERS
+++ b/infra/aws/terraform/prow-build-cluster/OWNERS
@@ -1,0 +1,14 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+filters:
+  ".*":
+    approvers:
+    - pkprzekwas
+    - xmudrii
+    labels:
+    - sig/k8s-infra
+    - area/infra
+    - area/infra/aws
+  "\\.sh$":
+    labels:
+    - area/bash


### PR DESCRIPTION
This PR adds @pkprzekwas and me as OWNERS for the prow-build EKS cluster. This has been discussed with @ameukam and @dims. This will allow us to approve PR related to this cluster as it's mostly two of us that are applying and coordinating relevant changes.

/assign @ameukam @dims 
/hold
@pkprzekwas is still not org member