### PR TITLE
make oci-proxy verbosity configurable

### DIFF
--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/oci-proxy.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/oci-proxy.tf
@@ -92,6 +92,7 @@ resource "google_cloud_run_service" "oci-proxy" {
         // - We will eventually auto-deploy staging by overriding the project and digest on the production config to avoid skew
         // If you're interested in running this image yourself releases are available at registry.k8s.io/infra-tools/archeio
         image = "gcr.io/k8s-staging-infra-tools/archeio@${var.digest}"
+        args  = ["-v=${var.verbosity}"]
 
         dynamic "env" {
           for_each = each.value.environment_variables

--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/terraform.tfvars
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/terraform.tfvars
@@ -19,6 +19,9 @@ project_id = "k8s-infra-oci-proxy-prod"
 // gcr.io/k8s-staging-infra-tools/archeio:v20230310-v0.2.0@sha256:bc742c5f47a69e21e828768991853faddbe13a7f69a9da4d7d2ad16e0e55892c
 // If you're interested in running this image yourself releases are available at registry.k8s.io/infra-tools/archeio
 digest = "sha256:bc742c5f47a69e21e828768991853faddbe13a7f69a9da4d7d2ad16e0e55892c"
+// we increase this in staging, but not in production
+// we already get a lot of info from build-in cloud run logs
+verbosity = "0"
 cloud_run_config = {
   asia-east1 = {
     // TODO: switch DEFAULT_AWS_BASE_URL to cloudfront or else refine the region mapping

--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/variables.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/variables.tf
@@ -23,6 +23,11 @@ variable "project_id" {
 variable "digest" {
   type = string
 }
+
+variable "verbosity" {
+  type = string
+}
+
 variable "cloud_run_config" {
   type = map(object({
     environment_variables = list(object({


### PR DESCRIPTION
needed for deploying staging with production config

ref: https://github.com/kubernetes/registry.k8s.io/pull/210 (blocked primarily on this change)