### PR TITLE
infra/aws: Tag Policy and Service Control Policy Terraform module

### DIFF
--- a/infra/aws/terraform/management-account/organization-accounts-policy-staging.tf
+++ b/infra/aws/terraform/management-account/organization-accounts-policy-staging.tf
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-
 module "policy_staging_account_1" {
   source = "../modules/org-account"
 
@@ -24,3 +23,32 @@ module "policy_staging_account_1" {
   parent_id                  = aws_organizations_organizational_unit.policy_staging.id
 }
 
+resource "aws_organizations_policy_attachment" "policy_staging_tag_policy_group" {
+  policy_id = module.organization_tag_policy_group.tag_policy_id
+  target_id = aws_organizations_organizational_unit.policy_staging.id
+}
+
+resource "aws_organizations_policy_attachment" "policy_staging_require_tag_group" {
+  policy_id = module.organization_tag_policy_group.scp_require_tag_id
+  target_id = aws_organizations_organizational_unit.policy_staging.id
+}
+
+resource "aws_organizations_policy_attachment" "policy_staging_deny_tag_deletion_group" {
+  policy_id = module.organization_tag_policy_group.scp_deny_tag_deletion_id
+  target_id = aws_organizations_organizational_unit.policy_staging.id
+}
+
+resource "aws_organizations_policy_attachment" "policy_staging_tag_policy_environment" {
+  policy_id = module.organization_tag_policy_environment.tag_policy_id
+  target_id = aws_organizations_organizational_unit.policy_staging.id
+}
+
+resource "aws_organizations_policy_attachment" "policy_staging_require_tag_environment" {
+  policy_id = module.organization_tag_policy_environment.scp_require_tag_id
+  target_id = aws_organizations_organizational_unit.policy_staging.id
+}
+
+resource "aws_organizations_policy_attachment" "policy_staging_deny_tag_deletion_environment" {
+  policy_id = module.organization_tag_policy_environment.scp_deny_tag_deletion_id
+  target_id = aws_organizations_organizational_unit.policy_staging.id
+}

--- a/infra/aws/terraform/management-account/organization-tag-policies.tf
+++ b/infra/aws/terraform/management-account/organization-tag-policies.tf
@@ -1,0 +1,81 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module "organization_tag_policy_group" {
+  source   = "../modules/tag-policy"
+
+  tag_name = "group"
+  # Values from https://github.com/kubernetes/community/blob/master/sig-list.md
+  tag_values = [
+    "sig-api-machinery",
+    "sig-apps",
+    "sig-architecture",
+    "sig-auth",
+    "sig-autoscaling",
+    "sig-cli",
+    "sig-cloud-provider",
+    "sig-cluster-lifecycle",
+    "sig-contributor-experience",
+    "sig-docs",
+    "sig-instrumentation",
+    "sig-k8s-infra",
+    "sig-multicluster",
+    "sig-network",
+    "sig-node",
+    "sig-release",
+    "sig-scalability",
+    "sig-scheduling",
+    "sig-security",
+    "sig-storage",
+    "sig-testing",
+    "sig-ui",
+    "sig-usability",
+    "sig-windows",
+    "ug-vmware-users",
+    "wg-api-expression",
+    "wg-batch",
+    "wg-data-protection",
+    "wg-iot-edge",
+    "wg-multitenancy",
+    "wg-policy",
+    "wg-reliability",
+    "wg-structured-logging"
+  ]
+
+  enforce_services = [
+    "ec2",
+    "eks",
+    "ecr",
+    "s3"
+  ]
+}
+
+module "organization_tag_policy_environment" {
+  source   = "../modules/tag-policy"
+
+  tag_name = "environment"
+  tag_values = [
+    "staging",
+    "prod"
+  ]
+
+  enforce_services = [
+    "ec2",
+    "eks",
+    "ecr",
+    "s3"
+  ]
+}

--- a/infra/aws/terraform/modules/tag-policy/main.tf
+++ b/infra/aws/terraform/modules/tag-policy/main.tf
@@ -1,0 +1,229 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+locals {
+  resource_actions = {
+    ec2 = {
+      type = "regional"
+      scp  = true
+      resources = {
+        instance = {
+          create_actions = [
+            "RunInstances"
+          ],
+          delete_actions = [
+            "DeleteTags"
+          ]
+        }
+        volume = {
+          create_actions = [
+            "CreateVolume",
+            "RunInstances"
+          ],
+          delete_actions = [
+            "DeleteTags"
+          ]
+        },
+        vpc = {
+          create_actions = [
+            "CreateVpc"
+          ],
+          delete_actions = [
+            "DeleteTags"
+          ]
+        }
+      }
+    },
+    eks = {
+      type = "regional"
+      scp  = true
+      resources = {
+        cluster = {
+          create_actions = [
+            "CreateCluster"
+          ],
+          delete_actions = [
+            "UntagResource"
+          ]
+        }
+      }
+    },
+    ecr = {
+      type = "regional"
+      scp  = true
+      resources = {
+        repository = {
+          create_actions = [
+            "CreateRepository"
+          ],
+          delete_actions = [
+            "UntagResource",
+          ]
+        }
+      }
+    },
+    s3 = {
+      type = "global"
+      scp  = false
+      resources = {
+        bucket = {
+          create_actions = [],
+          delete_actions = []
+        }
+      }
+    }
+  }
+
+  # Filter selected services for tag enforcement
+  selected_services = { for key in var.enforce_services : key => lookup(local.resource_actions, key) }
+
+  # Create Tag policy from selected services
+  selected_services_tag_policy = flatten([
+    for service, config in local.selected_services : [
+      for resource, actions in config.resources : [
+        replace("${service}:${resource}", "all-resources", "*")
+      ]
+    ]
+  ])
+
+  tag_policy = {
+    "tags" : {
+      "${var.tag_name}" : {
+        "tag_key" : {
+          "@@assign" : var.tag_name
+        },
+        "tag_value" : {
+          "@@assign" : var.tag_values
+        },
+        "enforced_for" : {
+          "@@assign" : local.selected_services_tag_policy
+        }
+      }
+    }
+  }
+
+  # ARN type config map for SCPs
+  arn_type = {
+    global   = ":::",
+    account  = "::*:",
+    regional = ":*:*:"
+  }
+
+  # Create list of actions for service request tag SCP
+  create_tag_actions = flatten([
+    for service, config in local.selected_services : [
+      for resource, actions in config.resources : [
+        for action in actions.create_actions : [
+          "${service}:${action}"
+        ]
+      ] if config.scp
+    ]
+  ])
+
+  # Create list of resources for service request tag SCP
+  create_tag_resources = flatten([
+    for service, config in local.selected_services : [
+      for resource, actions in config.resources : [
+        replace("arn:aws:${service}${lookup(local.arn_type, config.type)}${resource}/*", "all-resources", "*")
+      ] if config.scp
+    ]
+  ])
+
+  # Create list of actions for service deny tag deletion SCP
+  delete_tag_actions = flatten([
+    for service, config in local.selected_services : [
+      for resource, actions in config.resources : [
+        for action in actions.delete_actions : [
+          "${service}:${action}"
+        ]
+      ] if config.scp
+    ]
+  ])
+
+  # Create list of resources for service deny tag deletion SCP
+  delete_tag_resources = flatten([
+    for service, config in local.selected_services : [
+      for resource, actions in config.resources : [
+        replace("arn:aws:${service}${lookup(local.arn_type, config.type)}${resource}/*", "all-resources", "*")
+      ] if config.scp
+    ]
+  ])
+}
+
+# ---------------------------- #
+# Tag Policy
+# ---------------------------- #
+
+resource "aws_organizations_policy" "this" {
+  name    = var.tag_name
+  type    = "TAG_POLICY"
+  content = jsonencode(local.tag_policy)
+}
+
+
+output "name" {
+  value = local.selected_services
+}
+
+# --------------------------------- #
+# Request tag Service Control Policy
+# --------------------------------- #
+
+data "aws_iam_policy_document" "request_tag" {
+  statement {
+    sid       = "RequestTag"
+    effect    = "Deny"
+    actions   = local.create_tag_actions
+    resources = local.create_tag_resources
+
+    condition {
+      test     = "Null"
+      variable = "aws:RequestTag/${var.tag_name}"
+      values   = ["true"]
+    }
+  }
+}
+
+resource "aws_organizations_policy" "request_tag" {
+  name        = "request-tag-${var.tag_name}"
+  description = "Request tag ${var.tag_name} Service Control Policy"
+  content     = data.aws_iam_policy_document.request_tag.json
+}
+
+# --------------------------------------- #
+# Deny tag deletion Service Control Policy
+# --------------------------------------- #
+
+data "aws_iam_policy_document" "deny_tag_deletion" {
+  statement {
+    sid       = "DenyDeleteTag"
+    effect    = "Deny"
+    actions   = local.delete_tag_actions
+    resources = local.delete_tag_resources
+
+    condition {
+      test     = "Null"
+      variable = "aws:RequestTag/${var.tag_name}"
+      values   = ["false"]
+    }
+  }
+}
+
+resource "aws_organizations_policy" "deny_tag_deletion" {
+  name        = "deny-tag-deletion-${var.tag_name}"
+  description = "Deny tag deletion ${var.tag_name} Service Control Policy"
+  content     = data.aws_iam_policy_document.deny_tag_deletion.json
+}

--- a/infra/aws/terraform/modules/tag-policy/outputs.tf
+++ b/infra/aws/terraform/modules/tag-policy/outputs.tf
@@ -1,0 +1,27 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+output "tag_policy_id" {
+  value = aws_organizations_policy.this.id
+}
+
+output "scp_require_tag_id" {
+  value = aws_organizations_policy.request_tag.id
+}
+
+output "scp_deny_tag_deletion_id" {
+  value = aws_organizations_policy.deny_tag_deletion.id
+}

--- a/infra/aws/terraform/modules/tag-policy/variables.tf
+++ b/infra/aws/terraform/modules/tag-policy/variables.tf
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+variable "tag_name" {
+  description = "Tag name"
+  type        = string
+}
+
+variable "tag_values" {
+  description = "List of accepted values"
+  type        = list(any)
+}
+
+variable "enforce_services" {
+  description = "List of services for tag enforcement"
+  type        = list(any)
+  default     = []
+}
+


### PR DESCRIPTION
Ref: [#4684](https://github.com/kubernetes/k8s.io/issues/4684)

Enforcing tag policies and utilizing Service Control Policies for tagging at the time of resource creation has the potential to impact our current AWS resource creation practices. It is worth noting that certain AWS services lack the functionality to tag all resources through the AWS console UI during the creation process. For instance, while EC2 allows for the creation of a Security Group during instance creation, the option to tag the group is absent. Consequently, if we decide to enforce Security Groups tags, this may lead to instances failing to launch and an error message indicating insufficient authorization to create the resource. Similarly, ECR repositories do not offer the option to tag repositories during their creation, making ECR console UI ineffective to create repositories. It is essential to exercise caution when enabling tag policy enforcement and service control policies as their efficacy is highly dependent on the agreed upon AWS resource creation methodology.

Tag policy enforcement:  Only has effect on resources that are created with enforced tags. Non-compliant tagging requests on specified resource types are prevented from completing.

Service Control Policy: Enforce tagging at resource creation and deny tag deletion with IAM policies  (with RequestTag conditional).

## S3 tag policy enforcement tests 

### Create S3 resources from AWS console

| Resource | Tag policy Enforced | Service Control Policy | Without tags  | With random tag key and value | With tag key and wrong tag value | With correct key and value |
|---|---|---|---|---|---|---|
| bucket   | Yes | No | Succeded | Succeded | ***Succeded with error notice*** | Succeded |

### Delete/Edit Tags S3 resources

| Resource | Tag policy Enforced | Service Control Policy | Add a new random tag key / value  | Remove the random tag key / value | Remove the enforced tag | Edit enforced tag with wrong value
|---|---|---|---|---|---|---|
| bucket   | Yes | No | Succeded | Succeded | ***Succeded*** | Failed |

I couldn't find a way to enforce tags on bucket creation so the SCP is useless in this case.

## EC2 tag policy enforcement tests 

### Create EC2 resources from AWS console (using "Launch instance" button) 

| Resource | Enforced | Service Control Policy | Without tags  | With random tag key and value | With tag key and wrong tag value | With correct key and value |
|---|---|---|---|---|---|---|
| instance | Yes | Yes | ***Failed*** | Succeded | ***Failed*** | Succeded |
| volume | Yes | Yes | ***Failed*** | Succeded | ***Failed*** | Succeded |

### Create EC2 resources from AWS console (using "Auto Scaling groups")

| Resource | Enforced | Service Control Policy | Without tags  | With random tag key and value | With tag key and wrong tag value | With correct key and value |
|---|---|---|---|---|---|---|
| instance | Yes | Yes | ***Succeded*** | Succeded | ***Failed*** | Succeded |
| volume | Yes | Yes | ***Succeded*** | Succeded | ***Failed*** | Succeded |

### Create EC2 resources from AWS console (using "Spot Requests")

| Resource | Enforced | Service Control Policy | Without tags  | With random tag key and value | With tag key and wrong tag value | With correct key and value |
|---|---|---|---|---|---|---|
| instance | Yes | Yes | ***Failed*** | ***Failed*** | ***Failed*** | ***Failed*** |
| volume | Yes | Yes | ***Failed*** | ***Failed*** | ***Failed*** | ***Failed*** |

### Delete/Edit Tags EC2 resources

| Resource | Enforced | Service Control Policy | Add a new random tag key / value  | Remove the random tag key / value | Remove the enforced tag | Edit enforced tag with wrong value
|---|---|---|---|---|---|---|
| instance | Yes | Yes | Succeded | Succeded | ***Failed*** | ***Failed*** |
| volume | Yes | Yes | Succeded | Succeded | ***Failed*** | ***Failed*** |

## VPC tag policy enforcement tests 

### Create VPC resources from AWS console

| Resource | Tag policy Enforced | Service Control Policy | Without tags  | With random tag key and value | With tag key and wrong tag value | With correct key and value |
|---|---|---|---|---|---|---|
| vpc   | Yes | Yes | ***Failed*** | Succeded | ***Failed***  | Succeded |

### Delete/Edit Tags VPC resources

| Resource | Tag policy Enforced | Service Control Policy | Add a new random tag key / value  | Remove the random tag key / value | Remove the enforced tag | Edit enforced tag with wrong value
|---|---|---|---|---|---|---|
| vpc   | Yes | Yes | Succeded | Succeded | ***Failed*** | ***Failed*** |


## EKS tag policy enforcement tests 

### Create EKS resources from AWS console

| Resource | Tag policy Enforced | Service Control Policy | Without tags  | With random tag key and value | With tag key and wrong tag value | With correct key and value |
|---|---|---|---|---|---|---|
| cluster   | Yes | Yes | ***Failed*** | Succeded | ***Failed***  | Succeded |

### Delete/Edit Tags EKS resources

| Resource | Tag policy Enforced | Service Control Policy | Add a new random tag key / value  | Remove the random tag key / value | Remove the enforced tag | Edit enforced tag with wrong value
|---|---|---|---|---|---|---|
| vpc   | Yes | Yes | Succeded | Succeded | ***Succeded*** | ***Failed*** |


