### PR TITLE
eks-prow-build-cluster: use AMD-based instances

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -28,7 +28,7 @@ vpc_intra_subnet          = ["10.2.0.0/18", "10.2.64.0/18", "10.2.128.0/18"]
 
 # Ubuntu EKS optimized AMI: https://cloud-images.ubuntu.com/aws-eks/
 node_ami            = "ami-03de35fda144b3672"
-node_instance_types = ["r5d.4xlarge"]
+node_instance_types = ["r5ad.4xlarge"]
 node_volume_size    = 100
 
 # TODO(xmudrii): Increase this later.


### PR DESCRIPTION
This PR is supposed to commit changes related to https://github.com/kubernetes/k8s.io/issues/5066#issuecomment-1494625945

This change is already reconciled since yesterday.

/assign @pkprzekwas 