### PR TITLE
promoted the new base-image

### DIFF
--- a/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -115,6 +115,7 @@
     "sha256:a51abd4fd2beb5a93f88ff9859c930d0437250bef90118572ad1127c5b30dfa2": ["c648595cd73a2d605cd7d9575b72b367755c7ec8"]
     "sha256:da6b877ed96dada46ed6e379051c2dd461dd5d329af7a7531820ad3e16197e20": ["21aa7f55a3325c1c26de0dfb62ede4c0a809a994"]
     "sha256:86c1581e69dc92d107f8edd36724890ea682a3afda8c1fb1ba41aabc7bc0128d": ["66a760794f91809bcd897cbdb45435653d73fd92"]
+    "sha256:3b650123c755392f8c0eb9a356b12716327106e624ab5f5b43bc25ab130978fb": ["91057c439cf07ffb62887b8a8bda66ce3cbe39ca"]
 
 # image to run tests
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/test-runner


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX15YHapbRciZoE7fNqU9pZA1Xx9EqPB9s%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=WdBchEy)

The sha of the new baseimage is sha256:3b650123c755392f8c0eb9a356b12716327106e624ab5f5b43bc25ab130978fb
The tag of the new baseimage is 91057c439cf07ffb62887b8a8bda66ce3cbe39ca

The new base image needs to be promoted.  

https://github.com/kubernetes/ingress-nginx/issues/9828