### PR TITLE
promoted e2e-test-cfssl, e2e-test-fastcgi-helloserver, kube-webhook-c…

### DIFF
--- a/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -166,6 +166,7 @@
     "sha256:c1b273763048944dd7d22d37adfc65be4fa6a5f6068204292573c6cdc5ea3457": ["v20220818-g9fdbef829"]
     "sha256:07d1b6ed91958cc525e240ab3dda8d7cf147f0e1c606033302a877c55f68193d": ["v20221219-controller-v1.5.1-49-ge3e0d9c1f"]
     "sha256:d02c1e18f573449966999fc850f1fed3d37621bf77797562cbe77ebdb06a66ea": ["v20230312-helm-chart-4.5.2-28-g66a760794"]
+    "sha256:ad88a19f61dfbbb8a45e8faeaacb47f03525fb79c0e2f67ded5608ab74570056": ["v20230404-helm-chart-4.6.0-11-gc76179c04"]
 
 
 # custom echo HTTP server image for e2e tests
@@ -193,6 +194,7 @@
     "sha256:723b8187e1768d199b93fd939c37c1ce9427dcbca72ec6415f4d890bca637fcc": ["v20200627-g1fcf4444c"]
     "sha256:da4e0da2b5f7f6531d5c68db016faa6f2ae14eee8fd975cafeba2ab7b4b61527": ["v20221220-controller-v1.5.1-51-g188913182"]
     "sha256:0e08c836cc58f1ea862578de99b13bc4264fe071e816f96dc1d79857bfba7473": ["v20230312-helm-chart-4.5.2-28-g66a760794"]
+    "sha256:00ea295ef4c625aacb69081dbb72f80f40ab0c2cff08d011695405bc2331a3fc": ["v20230404-helm-chart-4.6.0-11-gc76179c04"]
 
 # httpbin image for e2e tests
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/httpbin
@@ -217,6 +219,7 @@
     "sha256:ccdb2382b53ed42fd76bfbff90a5b8a5815af0b3b8c6dfb9118a34770d9cac11": ["v20221219-controller-v1.5.1-49-ge3e0d9c1f"]
     "sha256:4d99688e557396f5baa150e019ff7d5b7334f9b9f9a8dab64038c5c2a006f6b5": ["v20221220-controller-v1.5.1-58-g787ea74b6"]
     "sha256:01d181618f270f2a96c04006f33b2699ad3ccb02da48d0f89b22abce084b292f": ["v20230312-helm-chart-4.5.2-28-g66a760794"]
+    "sha256:46a9364c2907dbde8a9fd01e75db44d4e0ba2ff9d7ab2ec9fe63e86a31cf8164": ["v20230404-helm-chart-4.6.0-11-gc76179c04"]
 
 # nginx-errors
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/custom-error-pages
@@ -229,6 +232,7 @@
     "sha256:09c421ac743bace19ab77979b82186941c5125c95e62cdb40bdf41293b5c275c": ["v20220916-gd32f8c343"]
     "sha256:0116499ff83f02360faee7b4f3842f63df7eea40be2db17cc41a467fdf991336": ["v20221219-controller-v1.5.1-49-ge3e0d9c1f"]
     "sha256:332be6ff8c4e93e8845963932f98839dfd52ae49829c29e06475368a3e4fbd9e": ["v20230312-helm-chart-4.5.2-28-g66a760794"]
+    "sha256:aabd7a001f6a0a07ed6ea8f6da87e928bfa8f971eba2bef708f3e8504fc5cc9b": ["v20230404-helm-chart-4.6.0-11-gc76179c04"]
 
 # opentelemetry
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/opentelemetry
@@ -245,3 +249,4 @@
     "sha256:fa3f47c289236b104a1f5195b020657a29a3a9b0a355f86f2d52d42d1fa6495e": ["v20221220-controller-v1.5.1-53-g81d40b70a"]
     "sha256:331b9bebd6acfcd2d3048abbdd86555f5be76b7e3d0b5af4300b04235c6056c9": ["v20230107-helm-chart-4.4.2-2-g96b3d2165"]
     "sha256:40f766ac4a9832f36f217bb0e98d44c8d38faeccbfe861fbc1a76af7e9ab257f": ["v20230312-helm-chart-4.5.2-28-g66a760794"]
+    "sha256:a6b8b6a562884dbfc38748c1560b71ded09ba18c14abc4a989f93e7c3136ed5b": ["v20230404-helm-chart-4.6.0-13-g91057c439"]


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX12Y4EVZXJ664XU8g7Xqy86ezb4N4pw7U%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=CuZLmGQ)
Referencing the issue : https://github.com/kubernetes/ingress-nginx/issues/9828

some of the 8 images use the base image and some don't. Apart from test-runner , echo-server 5 other remaining images rebuilt already are good for promotion.
promoted those images that are e2e-test-cfssl, e2e-test-fastcgi-helloserver, kube-webhook-certgen, nginx-errors and opentelemetry images in this PR.