### PR TITLE
set oci-proxy memory limit explicitly

### DIFF
--- a/infra/gcp/terraform/modules/oci-proxy/oci-proxy.tf
+++ b/infra/gcp/terraform/modules/oci-proxy/oci-proxy.tf
@@ -478,6 +478,9 @@ resource "google_cloud_run_service" "oci-proxy" {
         resources {
           limits = {
             "cpu" = "1000m"
+            // default, also the minimum permitted for second generation
+            // https://cloud.google.com/run/docs/about-execution-environments
+            "memory" = "512Mi"
           }
         }
       }


### PR DESCRIPTION
prevents spurious terraform plan differences flapping on null vs 512mi

this change has **zero** `terraform plan` deltas and does not need to be applied.

prior to this change, `terraform plan` would flap on null vs 512mi (default).

TODO: evaluate switching to second generation execution environment