### PR TITLE
infra/aws: Infra tests in policy-staging-account for tag policies

### DIFF
--- a/infra/aws/terraform/policy-staging-account-1/data.tf
+++ b/infra/aws/terraform/policy-staging-account-1/data.tf
@@ -1,0 +1,39 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+locals {
+  name = "tag-policy-test"
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+data "aws_iam_session_context" "whoami" {
+  arn = data.aws_caller_identity.current.arn
+}
+
+data "aws_ami" "amazon_linux" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-hvm-*-x86_64-gp2"]
+  }
+}
+
+data "aws_availability_zones" "available" {}

--- a/infra/aws/terraform/policy-staging-account-1/ec2.tf
+++ b/infra/aws/terraform/policy-staging-account-1/ec2.tf
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module "ec2" {
+  source  = "terraform-aws-modules/ec2-instance/aws"
+  version = "4.3.0"
+
+  name              = local.name
+  ami               = data.aws_ami.amazon_linux.id
+  instance_type     = "t3.micro"
+  availability_zone = element(module.vpc.azs, 0)
+  subnet_id         = element(module.vpc.private_subnets, 0)
+
+  root_block_device = [
+    {
+      encrypted   = true
+      volume_type = "gp3"
+      volume_size = 8
+    },
+  ]
+
+  ebs_block_device = [
+    {
+      device_name = "/dev/sdf"
+      volume_type = "gp3"
+      volume_size = 5
+    }
+  ]
+
+  volume_tags = {
+    group       = "sig-k8s-infra" # Enforced tag
+    environment = "staging"       # Enforced tag
+  }
+
+  tags = {
+    group       = "sig-k8s-infra" # Enforced tag
+    environment = "staging"       # Enforced tag
+  }
+}
+
+

--- a/infra/aws/terraform/policy-staging-account-1/ecr.tf
+++ b/infra/aws/terraform/policy-staging-account-1/ecr.tf
@@ -1,0 +1,28 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module "ecr" {
+  source  = "terraform-aws-modules/ecr/aws"
+  version = "1.6.0"
+
+  repository_name         = local.name
+  create_lifecycle_policy = false
+
+  tags = {
+    group       = "sig-k8s-infra" # Enforced tag
+    environment = "staging"       # Enforced tag
+  }
+}

--- a/infra/aws/terraform/policy-staging-account-1/eks.tf
+++ b/infra/aws/terraform/policy-staging-account-1/eks.tf
@@ -1,0 +1,57 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "19.11.0"
+
+  cluster_name                   = local.name
+  cluster_endpoint_public_access = false
+  vpc_id                         = module.vpc.vpc_id
+  subnet_ids                     = module.vpc.private_subnets
+  control_plane_subnet_ids       = module.vpc.intra_subnets
+
+  # EKS Managed Node Group(s)
+  eks_managed_node_group_defaults = {
+    ami_type                              = "AL2_x86_64"
+    instance_types                        = ["t3.large", "t3a.large", "t2.large"]
+    attach_cluster_primary_security_group = true
+  }
+
+  eks_managed_node_groups = {
+    blue = {
+      min_size     = 1
+      max_size     = 1
+      desired_size = 1
+
+      instance_types = ["t3.large"]
+    }
+    green = {
+      min_size     = 1
+      max_size     = 1
+      desired_size = 1
+
+      instance_types = ["t3.large"]
+      capacity_type  = "SPOT"
+    }
+  }
+
+  tags = {
+    group       = "sig-k8s-infra" # Enforced tag
+    environment = "staging"       # Enforced tag
+  }
+}
+

--- a/infra/aws/terraform/policy-staging-account-1/providers.tf
+++ b/infra/aws/terraform/policy-staging-account-1/providers.tf
@@ -1,0 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+provider "aws" {
+  region = "us-east-2"
+}

--- a/infra/aws/terraform/policy-staging-account-1/terraform.tf
+++ b/infra/aws/terraform/policy-staging-account-1/terraform.tf
@@ -1,0 +1,30 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  backend "s3" {
+    bucket = "k8s-infra-policy-staging-terraform-state"
+    region = "us-east-2"
+    key    = "account-1/terraform.state"
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.61"
+    }
+  }
+}

--- a/infra/aws/terraform/policy-staging-account-1/variables.tf
+++ b/infra/aws/terraform/policy-staging-account-1/variables.tf
@@ -1,0 +1,23 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags for AWS resources"
+  default = {
+    "managed-by" = "Terraform"
+  }
+}

--- a/infra/aws/terraform/policy-staging-account-1/versions.tf
+++ b/infra/aws/terraform/policy-staging-account-1/versions.tf
@@ -1,0 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  required_version = "~> 1.3.0"
+}

--- a/infra/aws/terraform/policy-staging-account-1/vpc.tf
+++ b/infra/aws/terraform/policy-staging-account-1/vpc.tf
@@ -1,0 +1,51 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+locals {
+  vpc_cidr = "10.0.0.0/16"
+  azs      = slice(data.aws_availability_zones.available.names, 0, 3)
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 3.0"
+
+  name = local.name
+  cidr = local.vpc_cidr
+
+  azs             = local.azs
+  private_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 4, k)]
+  public_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 48)]
+  intra_subnets   = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 52)]
+
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = 1
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb" = 1
+  }
+
+  tags = {
+    group       = "sig-k8s-infra" # Enforced tag
+    environment = "staging"       # Enforced tag
+  }
+}


### PR DESCRIPTION
Ref: [#4684](https://github.com/kubernetes/k8s.io/issues/4684)

@ameukam 

This pull request includes Terraform code designed to test the efficacy of [AWS Tag Policies and Service Control Policies](https://github.com/kubernetes/k8s.io/pull/5065) which have been attached to our policy staging organizational unit (OU). As per inheritance, any policies enforced at this level should impact all child accounts nested within the OU.

Any tags that are removed or possess an invalid value from the code and are subjected to enforcement will result in an unauthorized error at creation time.