### PR TITLE
hard code organization id to simplify permissions etc.

### DIFF
--- a/infra/gcp/terraform/modules/oci-proxy/main.tf
+++ b/infra/gcp/terraform/modules/oci-proxy/main.tf
@@ -381,14 +381,10 @@ locals {
   }
 }
 
-data "google_organization" "org" {
-  domain = "kubernetes.io"
-}
-
 resource "google_project" "project" {
   name            = var.project_id
   project_id      = var.project_id
-  org_id          = data.google_organization.org.org_id
+  org_id          = "758905017065"
   billing_account = "018801-93540E-22A20E"
 }
 


### PR DESCRIPTION
this isn't likely to change and it's already at https://github.com/kubernetes/k8s.io/blob/62f11d4eaee9885445a6bbe4fa947447add7e36e/audit/organizations/kubernetes.io/description.json#L5

this way we don't need to grant automation permission to query org info and require fewer API calls to `terraform apply` ...