### PR TITLE
oci-proxy: don't depend on project creation in tf

### DIFF
--- a/infra/gcp/terraform/modules/oci-proxy/cloud-armor.tf
+++ b/infra/gcp/terraform/modules/oci-proxy/cloud-armor.tf
@@ -18,7 +18,7 @@ limitations under the License.
 # This file contains the Cloud Armor policies
 
 resource "google_compute_security_policy" "cloud-armor" {
-  project = google_project.project.project_id
+  project = var.project_id
   name    = "security-policy-oci-proxy"
 
 

--- a/infra/gcp/terraform/modules/oci-proxy/monitoring.tf
+++ b/infra/gcp/terraform/modules/oci-proxy/monitoring.tf
@@ -16,7 +16,7 @@ limitations under the License.
 
 resource "google_monitoring_notification_channel" "emails" {
   display_name = "k8s-infra-alerts@kubernetes.io"
-  project      = google_project.project.project_id
+  project      = var.project_id
   type         = "email"
   labels = {
     email_address = "k8s-infra-alerts@kubernetes.io"
@@ -24,7 +24,7 @@ resource "google_monitoring_notification_channel" "emails" {
 }
 
 module "alerts" {
-  project_id         = google_project.project.project_id
+  project_id         = var.project_id
   source             = "../monitoring/uptime-alert"
   documentation_text = "${var.domain} is down"
   domain             = var.domain
@@ -32,7 +32,7 @@ module "alerts" {
   notification_channels = [
     # Manually created. Monitoring channels can't be created with Terraform.
     # See: https://github.com/hashicorp/terraform-provider-google/issues/1134
-    "${google_project.project.id}/notificationChannels/${var.notification_channel_id}",
+    "projects/${var.project_id}/notificationChannels/${var.notification_channel_id}",
     google_monitoring_notification_channel.emails.name,
   ]
 }

--- a/infra/gcp/terraform/modules/oci-proxy/network.tf
+++ b/infra/gcp/terraform/modules/oci-proxy/network.tf
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 resource "google_compute_global_address" "default_ipv4" {
-  project      = google_project.project.project_id
-  name         = google_project.project.project_id
+  project      = var.project_id
+  name         = var.project_id
   address_type = "EXTERNAL"
   ip_version   = "IPV4"
 
@@ -26,8 +26,8 @@ resource "google_compute_global_address" "default_ipv4" {
 }
 
 resource "google_compute_global_address" "default_ipv6" {
-  project      = google_project.project.project_id
-  name         = "${google_project.project.project_id}-v6"
+  project      = var.project_id
+  name         = "${var.project_id}-v6"
   address_type = "EXTERNAL"
   ip_version   = "IPV6"
 
@@ -37,20 +37,20 @@ resource "google_compute_global_address" "default_ipv6" {
 }
 
 data "google_compute_global_address" "default_ipv4" {
-  project = google_project.project.project_id
-  name    = google_project.project.project_id
+  project = var.project_id
+  name    = var.project_id
 }
 
 data "google_compute_global_address" "default_ipv6" {
-  project = google_project.project.project_id
-  name    = "${google_project.project.project_id}-v6"
+  project = var.project_id
+  name    = "${var.project_id}-v6"
 }
 
 resource "google_compute_region_network_endpoint_group" "oci-proxy" {
   for_each = google_cloud_run_service.oci-proxy
 
   provider              = google-beta
-  project               = google_project.project.project_id
+  project               = var.project_id
   name                  = "${var.project_id}--${each.key}--neg"
   network_endpoint_type = "SERVERLESS"
   region                = google_cloud_run_service.oci-proxy[each.key].location
@@ -63,7 +63,7 @@ module "lb-http" {
   source  = "GoogleCloudPlatform/lb-http/google//modules/serverless_negs"
   version = "~> 6.2.0"
 
-  project = google_project.project.project_id
+  project = var.project_id
   name    = var.project_id
 
   # ...


### PR DESCRIPTION
So we can auto apply infra config without over granting permissions

/hold

Requires `terraform state rm module.oci-proxy.google_project.project` from both staging and prod.

We could check in project creation somewhere else but ... it's just the project name / org as the inputs and we definitely don't want to delete the whole project so ...


other than `module.oci-proxy.google_project.project`, this has no plan diffs in prod or staging