### PR TITLE
AWS: add an account for a canary build cluster

### DIFF
--- a/infra/aws/terraform/management-account/organization-accounts-workloads-non-prod.tf
+++ b/infra/aws/terraform/management-account/organization-accounts-workloads-non-prod.tf
@@ -23,6 +23,23 @@ module "aws-playground-01" {
   parent_id    = aws_organizations_organizational_unit.non_production.id
   tags = {
     "production" = "false",
-    "owners"     = "upodroid"
+    "owners"     = "upodroid",
+    "group"      = "sig-k8s-infra"
+  }
+}
+
+#  account used to create and main a canary cluster as build cluster for prow
+module "prow_canary" {
+  source = "../modules/org-account"
+
+  account_name = "k8s-infra-prow-canary"
+  email        = "k8s-infra-aws-admins+prow_canary@kubernetes.io"
+  parent_id    = aws_organizations_organizational_unit.non_production.id
+  tags = {
+    "production"  = "false",
+    "environment" = "canary",
+    "owners"      = "xmudrii",
+    "group"       = "sig-k8s-infra",
+    "service"     = "eks"
   }
 }

--- a/infra/aws/terraform/management-account/organization-accounts-workloads-prod.tf
+++ b/infra/aws/terraform/management-account/organization-accounts-workloads-prod.tf
@@ -17,9 +17,9 @@ limitations under the License.
 module "artifacts-k8s-io" {
   source = "../modules/org-account"
 
-  account_name               = "k8s-infra-artifacts-k8s-io-prod"
-  email                      = "k8s-infra-aws-admins+artifacts-k8s-io-prod@kubernetes.io"
-  parent_id                  = aws_organizations_organizational_unit.production.id
+  account_name = "k8s-infra-artifacts-k8s-io-prod"
+  email        = "k8s-infra-aws-admins+artifacts-k8s-io-prod@kubernetes.io"
+  parent_id    = aws_organizations_organizational_unit.production.id
 }
 
 module "registry-k8s-io" {
@@ -29,4 +29,19 @@ module "registry-k8s-io" {
   email                      = "k8s-infra-aws-admins+registry-k8s-io-prod@kubernetes.io"
   iam_user_access_to_billing = "ALLOW"
   parent_id                  = aws_organizations_organizational_unit.production.id
+}
+
+
+module "prow_prod" {
+  source = "../modules/org-account"
+
+  account_name = "k8s-infra-prow"
+  email        = "k8s-infra-aws-admins+prow@kubernetes.io"
+  parent_id    = aws_organizations_organizational_unit.production.id
+  tags = {
+    "production"  = "true",
+    "environment" = "prod",
+    "group"       = "sig-k8s-infra",
+    "service"     = "eks"
+  }
 }

--- a/infra/aws/terraform/management-account/organization-tag-policies.tf
+++ b/infra/aws/terraform/management-account/organization-tag-policies.tf
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 module "organization_tag_policy_group" {
-  source   = "../modules/tag-policy"
+  source = "../modules/tag-policy"
 
   tag_name = "group"
   # Values from https://github.com/kubernetes/community/blob/master/sig-list.md
@@ -64,7 +64,7 @@ module "organization_tag_policy_group" {
 }
 
 module "organization_tag_policy_environment" {
-  source   = "../modules/tag-policy"
+  source = "../modules/tag-policy"
 
   tag_name = "environment"
   tag_values = [


### PR DESCRIPTION
- Add an account that will host a EKS cluster as canary build cluster
- Declare existing account for prod build cluster in HCL


Also ran `terraform fmt .`