### PR TITLE
infra/aws: Add cost allocation option to tag-policy Terraform module

### DIFF
--- a/infra/aws/terraform/management-account/organization-tag-policies.tf
+++ b/infra/aws/terraform/management-account/organization-tag-policies.tf
@@ -61,6 +61,9 @@ module "organization_tag_policy_group" {
     "ecr",
     "s3"
   ]
+
+  enable_cost_allocation = true
+
 }
 
 module "organization_tag_policy_environment" {
@@ -78,4 +81,7 @@ module "organization_tag_policy_environment" {
     "ecr",
     "s3"
   ]
+
+  enable_cost_allocation = true
+
 }

--- a/infra/aws/terraform/modules/tag-policy/main.tf
+++ b/infra/aws/terraform/modules/tag-policy/main.tf
@@ -227,3 +227,13 @@ resource "aws_organizations_policy" "deny_tag_deletion" {
   description = "Deny tag deletion ${var.tag_name} Service Control Policy"
   content     = data.aws_iam_policy_document.deny_tag_deletion.json
 }
+
+# --------------------------------------- #
+# Enable Cost Allocation
+# --------------------------------------- #
+
+resource "aws_ce_cost_allocation_tag" "this" {
+  count   = var.enable_cost_allocation ? 1 : 0
+  tag_key = var.tag_name
+  status  = "Active"
+}

--- a/infra/aws/terraform/modules/tag-policy/variables.tf
+++ b/infra/aws/terraform/modules/tag-policy/variables.tf
@@ -30,3 +30,8 @@ variable "enforce_services" {
   default     = []
 }
 
+variable "enable_cost_allocation" {
+  description = "Enable cost allocation for tag"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Ref: [#4684](https://github.com/kubernetes/k8s.io/issues/4684)

This PR adds the option to enable tag cost allocation in the tag-policy Terraform module.
It also enables tag cost allocation for "group" and "environment" tags.
 

