### PR TITLE
Promote EBS CSI Driver v1.18.0

### DIFF
--- a/registry.k8s.io/images/k8s-staging-provider-aws/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-provider-aws/OWNERS
@@ -7,4 +7,5 @@ approvers:
 - justinsb
 - nckturner
 - olemarkus
+- torredil
 - wongma7

--- a/registry.k8s.io/images/k8s-staging-provider-aws/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-provider-aws/images.yaml
@@ -58,6 +58,7 @@
     "sha256:5bdde475ab94151118fa62771d539a4e9b46ee8843a97bf77f0ae9af4df11065": ["v1.16.0"]
     "sha256:e5a316e637ee3a11c2440f8b0ec76748db23abb60496a29b6ae84878cdebc2e1": ["v1.16.1"]
     "sha256:02c42645c7a672bbf313ed420e384507dbf0b04992624a3979b87aa4b3f9228e": ["v1.17.0"]
+    "sha256:ceba38e3cbfbae68f986c7484b56e02c6735f2ccc7d1013db0eda0ebd32620f9": ["v1.18.0"]
 - name: cloud-controller-manager
   dmap:
     "sha256:f900d8b4a358847cd311950c7802f938dad083f645eee784cd52b7aec0de8dfb": ["v1.18.0-alpha.0"]


### PR DESCRIPTION
```
crane manifest gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:v20230417-v1.18.0                                                                                                                                                                                                  
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1098,
         "digest": "sha256:52da3b95fee8afa39bc03a32ac52fe6d66f7bb2cf47b9dbf7942c8c0a0a06d4b",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1098,
         "digest": "sha256:e451e3bcc60553c6b94d177f368bd9ba0cae7d863f3c1aeaa937049081f43b2a",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 906,
         "digest": "sha256:6d60513078ac7fc6797ab3b1c85e1527b3db86e3cbee766193d2bacb69f9fb5a",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.19042.1889"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 905,
         "digest": "sha256:a392440e06c4434c6472f48fb833e3c2bac3df22e903b6f5d755cb52f65882d4",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.17763.4252"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 905,
         "digest": "sha256:6a1ab0eaa3ba0e4ca1d2ae08543cdc284804ecda11d22de237fa773e6ef22d39",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.20348.1668"
         }
      }
   ]
}%
```

```
docker run --rm gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:v20230417-v1.18.0 --version                                                                                                                                                                                        
Unable to find image 'gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:v20230417-v1.18.0' locally
v20230417-v1.18.0: Pulling from k8s-staging-provider-aws/aws-ebs-csi-driver
e86c7ac68836: Already exists
43caad45136d: Already exists
d50b0ba187c4: Already exists
3e838a70f98b: Pull complete
Digest: sha256:ceba38e3cbfbae68f986c7484b56e02c6735f2ccc7d1013db0eda0ebd32620f9
Status: Downloaded newer image for gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver:v20230417-v1.18.0
{
  "driverVersion": "v1.18.0",
  "gitCommit": "",
  "buildDate": "2023-04-17T16:42:03+00:00",
  "goVersion": "go1.20.3",
  "compiler": "gc",
  "platform": "linux/amd64"
}

```