### PR TITLE
AWS: Add a DNS zone for kops tests

### DIFF
--- a/infra/aws/terraform/workloads/kops/infra-services/main.tf
+++ b/infra/aws/terraform/workloads/kops/infra-services/main.tf
@@ -1,0 +1,27 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/* This file contains services used by kOps */
+
+
+resource "aws_route53_zone" "kops_tests" {
+  name = "tests-kops-aws.k8s.io"
+
+  tags = {
+    environment = "staging"
+    group = "sig-cluster-lifecycle"
+  }
+}

--- a/infra/aws/terraform/workloads/kops/infra-services/provider.tf
+++ b/infra/aws/terraform/workloads/kops/infra-services/provider.tf
@@ -1,0 +1,23 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  required_providers {
+    aws = {
+      version = "4.61.0"
+    }
+  }
+}

--- a/infra/aws/terraform/workloads/kops/infra-services/versions.tf
+++ b/infra/aws/terraform/workloads/kops/infra-services/versions.tf
@@ -1,0 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  required_version = "~> 1.3.0"
+}


### PR DESCRIPTION
Ref: https://github.com/kubernetes/k8s.io/issues/5127

Add a Route53 public zone used by kops tests.