### PR TITLE
Image promotion for etcd 3.5.8-0

### DIFF
--- a/registry.k8s.io/images/k8s-staging-etcd/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-etcd/images.yaml
@@ -15,6 +15,7 @@
     "sha256:4c4bb2ffc261dd79041c1fa8a7a979520b4c08d8e535583e8fbbf22690d13bb1": ["3.5.5-1"]
     "sha256:dd75ec974b0a2a6f6bb47001ba09207976e625db898d1b16735528c009cb171c": ["3.5.6-0"]
     "sha256:51eae8381dcb1078289fa7b4f3df2630cdc18d09fb56f8e56b41c40e191d6c83": ["3.5.7-0"]
+    "sha256:b3a0da984f9af598234c018faa4f28dd6a6461f5719163a61f10ebf26dbca1e9": ["3.5.8-0"]
     "sha256:87cd0c2afe02de8dca78b8027852a6e8a18752ad5036be71ff21dea8c175abb9": ["3.6.0-alpha.0-0"]
 - name: etcd-empty-dir-cleanup
   dmap:


### PR DESCRIPTION
Part of https://github.com/kubernetes/kubernetes/issues/117341


Based on: https://github.com/kubernetes/kubernetes/pull/117332

```
 docker inspect  gcr.io/k8s-staging-etcd/etcd:3.5.8-0
[
    {
        "Id": "sha256:291c432e82cb31038db567f89db79530419118472a134b55f540291ceb4cd882",
        "RepoTags": [
            "gcr.io/k8s-staging-etcd/etcd:3.5.8-0"
        ],
        "RepoDigests": [
            "gcr.io/k8s-staging-etcd/etcd@sha256:b3a0da984f9af598234c018faa4f28dd6a6461f5719163a61f10ebf26dbca1e9"
        ],
```

Required for: https://github.com/kubernetes/kubernetes/pull/117335