### PR TITLE
eks-prow-build-cluster: Replace Terraform workspaces with dedicated backends

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/.gitignore
+++ b/infra/aws/terraform/prow-build-cluster/.gitignore
@@ -9,12 +9,6 @@
 # Crash log files
 crash.log
 
-# Exclude all .tfvars files, which are likely to contain sentitive data, such as
-# password, private keys, and other secrets. These should not be part of version
-# control as they are data points which are potentially sensitive and subject
-# to change depending on the environment.
-*.tfvars
-
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in
 override.tf

--- a/infra/aws/terraform/prow-build-cluster/Makefile
+++ b/infra/aws/terraform/prow-build-cluster/Makefile
@@ -22,7 +22,8 @@ PROW_ENV ?= canary
 
 .PHONY: init
 init:
-	$(TF) $@
+	$(TF) $@ \
+		-backend-config=./tfbackends/$(PROW_ENV).tfbackend
 
 .PHONY: plan
 plan:

--- a/infra/aws/terraform/prow-build-cluster/Makefile
+++ b/infra/aws/terraform/prow-build-cluster/Makefile
@@ -18,34 +18,33 @@ ASSUME_ROLE ?= true
 DEPLOY_K8S_RESOURCES ?= true
 
 # Valid values are: canary, prod
-WORKSPACE_NAME ?= canary
-
-.PHONY: workspace-select
-workspace-select:
-	$(TF) workspace select $(WORKSPACE_NAME)
+PROW_ENV ?= canary
 
 .PHONY: init
 init:
 	$(TF) $@
 
 .PHONY: plan
-plan: workspace-select
+plan:
 	$(TF) $@ $(TF_ARGS) \
-		-var-file=./terraform.$(WORKSPACE_NAME).tfvars \
+		-var-file=./terraform.tfvars \
+		-var-file=./terraform.$(PROW_ENV).tfvars \
 		-var="assume_role=$(ASSUME_ROLE)" \
 		-var="deploy_kubernetes_resources=$(DEPLOY_K8S_RESOURCES)"
 
 .PHONY: apply
-apply: workspace-select
+apply:
 	$(TF) $@ $(TF_ARGS) \
-		-var-file=./terraform.$(WORKSPACE_NAME).tfvars \
+		-var-file=./terraform.tfvars \
+		-var-file=./terraform.$(PROW_ENV).tfvars \
 		-var="assume_role=$(ASSUME_ROLE)" \
 		-var="deploy_kubernetes_resources=$(DEPLOY_K8S_RESOURCES)"
 
 .PHONY: destroy
-destroy: workspace-select
+destroy:
 	$(TF) $@ $(TF_ARGS) \
-		-var-file=./terraform.$(WORKSPACE_NAME).tfvars \
+		-var-file=./terraform.tfvars \
+		-var-file=./terraform.$(PROW_ENV).tfvars \
 		-var="assume_role=$(ASSUME_ROLE)" \
 		-var="deploy_kubernetes_resources=$(DEPLOY_K8S_RESOURCES)"
 
@@ -60,4 +59,3 @@ output:
 .PHONY: clean
 clean:
 	rm -rf ./.terraform
-

--- a/infra/aws/terraform/prow-build-cluster/README.md
+++ b/infra/aws/terraform/prow-build-cluster/README.md
@@ -15,18 +15,18 @@ There are two different environments, i.e. clusters:
 
 ### Choosing the environment
 
-Set the `WORKSPACE_NAME` environment variable to `prod` or `canary`.
+Set the `PROW_ENV` environment variable to `prod` or `canary`.
 
 Production:
 
 ```bash
-export WORKSPACE_NAME=prod
+export PROW_ENV=prod
 ```
 
 Canary:
 
 ```bash
-export WORKSPACE_NAME=canary
+export PROW_ENV=canary
 ```
 
 ### Differences between production and canary
@@ -97,7 +97,7 @@ We have a Makefile that can be used to execute Terraform targeting the
 appropriate/correct environment. This Makefile uses the following environment
 variables to control Terraform:
 
-* `WORKSPACE_NAME` (default: `canary`, can be `prod`)
+* `PROW_ENV` (default: `canary`, can be `prod`)
 * `ASSUME_ROLE` (default: `true`) - whether to authenticate to AWS using
   provided credentials or by assuming the ProwClusterAdmin role
 * `DEPLOY_K8S_RESOURCES` (default: `true`) - whether to deploy Kubernetes
@@ -156,7 +156,7 @@ That said, the cluster creation is done in four phases:
 - Phase 3: deploy the Kubernetes resources managed by Terraform
 - Phase 4: deploy the Kubernetes resources not managed by Terraform
 
-**WARNING: Before getting started, make sure the `WORKSPACE_NAME` environment
+**WARNING: Before getting started, make sure the `PROW_ENV` environment
 variable is set to the correct value!!!**
 
 ### Phase 0: preparing the environment
@@ -164,7 +164,7 @@ variable is set to the correct value!!!**
 Before getting started, make sure to set the needed environment variables:
 
 ```bash
-export WORKSPACE_NAME=canary # or prod
+export PROW_ENV=canary # or prod
 export ASSUME_ROLE=false # the role to be assumed will be created in phase 1
 export DEPLOY_K8S_RESOURCES=false
 ```
@@ -248,7 +248,7 @@ streamlining this, but until then, you have to deploy those resources manually.
 The cluster can be removed by running the following command:
 
 ```bash
-export WORKSPACE_NAME= # choose between canary/prod
+export PROW_ENV= # choose between canary/prod
 
 # First destroy as much you can with assuming the role
 export ASSUME_ROLE=true

--- a/infra/aws/terraform/prow-build-cluster/README.md
+++ b/infra/aws/terraform/prow-build-cluster/README.md
@@ -85,7 +85,7 @@ appropriate cluster:
       - --cluster-name
       - prow-build-canary-cluster
       - --role-arn
-      - arn:aws:iam::468814281478:role/canary-Prow-Cluster-Admin
+      - arn:aws:iam::054318140392:role/Prow-Cluster-Admin
     ```
 
 ## Running Terraform
@@ -234,6 +234,10 @@ streamlining this, but until then, you have to deploy those resources manually.
     ```bash
     kubectl apply -f ./resources/kube-system
     kubectl apply -f ./resources/test-pods
+    ```
+- Deploy Boskos
+    ```bash
+    kubectl apply -f ./resources/boskos
     ```
 - [ONLY FOR PRODUCTION] Deploy the External Secrets Operator (ESO)
     ```bash

--- a/infra/aws/terraform/prow-build-cluster/eks.tf
+++ b/infra/aws/terraform/prow-build-cluster/eks.tf
@@ -20,7 +20,7 @@ limitations under the License.
 
 locals {
   aws_auth_roles = concat(
-    terraform.workspace == "prod" ? [
+    var.prow_build_cluster ? [
       # Allow access to the Prow-EKS-Admin IAM role (used by Prow directly).
       {
         "rolearn"  = aws_iam_role.eks_admin[0].arn

--- a/infra/aws/terraform/prow-build-cluster/iam.tf
+++ b/infra/aws/terraform/prow-build-cluster/iam.tf
@@ -17,6 +17,5 @@ limitations under the License.
 module "iam" {
   source = "./modules/iam"
 
-  eks_admins    = var.eks_admins
-  canary_prefix = local.canary_prefix
+  eks_admins = var.eks_admins
 }

--- a/infra/aws/terraform/prow-build-cluster/main.tf
+++ b/infra/aws/terraform/prow-build-cluster/main.tf
@@ -22,8 +22,6 @@ data "aws_caller_identity" "current" {}
 data "aws_availability_zones" "available" {}
 
 locals {
-  canary_prefix = terraform.workspace != "prod" ? "canary-" : ""
-
   root_account_arn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
   aws_cli_base_args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
   aws_cli_args = var.assume_role != true ? local.aws_cli_base_args : concat(
@@ -51,7 +49,7 @@ provider "aws" {
     for_each = var.assume_role ? [null] : []
 
     content {
-      role_arn     = "arn:aws:iam::468814281478:role/${local.canary_prefix}Prow-Cluster-Admin"
+      role_arn     = "arn:aws:iam::468814281478:role/Prow-Cluster-Admin"
       session_name = "prow-build-cluster-terraform"
     }
   }

--- a/infra/aws/terraform/prow-build-cluster/main.tf
+++ b/infra/aws/terraform/prow-build-cluster/main.tf
@@ -49,7 +49,7 @@ provider "aws" {
     for_each = var.assume_role ? [null] : []
 
     content {
-      role_arn     = "arn:aws:iam::468814281478:role/Prow-Cluster-Admin"
+      role_arn     = "arn:aws:iam::${var.aws_account_id}:role/Prow-Cluster-Admin"
       session_name = "prow-build-cluster-terraform"
     }
   }

--- a/infra/aws/terraform/prow-build-cluster/modules/iam/policies.tf
+++ b/infra/aws/terraform/prow-build-cluster/modules/iam/policies.tf
@@ -214,19 +214,19 @@ data "aws_iam_policy_document" "prow_cluster_destroy" {
 }
 
 resource "aws_iam_policy" "prow_cluster_viewer" {
-  name   = "${var.canary_prefix}ProwClusterViewer"
+  name   = "ProwClusterViewer"
   path   = "/"
   policy = data.aws_iam_policy_document.prow_cluster_viewer.json
 }
 
 resource "aws_iam_policy" "prow_cluster_maintainer" {
-  name   = "${var.canary_prefix}ProwClusterMaintainer"
+  name   = "ProwClusterMaintainer"
   path   = "/"
   policy = data.aws_iam_policy_document.prow_cluster_maintainer.json
 }
 
 resource "aws_iam_policy" "prow_cluster_destroy" {
-  name   = "${var.canary_prefix}ProwClusterDestroy"
+  name   = "ProwClusterDestroy"
   path   = "/"
   policy = data.aws_iam_policy_document.prow_cluster_destroy.json
 }

--- a/infra/aws/terraform/prow-build-cluster/modules/iam/roles.tf
+++ b/infra/aws/terraform/prow-build-cluster/modules/iam/roles.tf
@@ -19,8 +19,8 @@ limitations under the License.
 ###############################################
 
 resource "aws_iam_role" "iam_cluster_admin" {
-  name        = "${var.canary_prefix}Prow-Cluster-Admin"
-  description = "IAM role used to delegate access to ${var.canary_prefix}prow-build-cluster"
+  name        = "Prow-Cluster-Admin"
+  description = "IAM role used to delegate access to prow-build-cluster"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/infra/aws/terraform/prow-build-cluster/modules/iam/variables.tf
+++ b/infra/aws/terraform/prow-build-cluster/modules/iam/variables.tf
@@ -19,9 +19,3 @@ variable "eks_admins" {
   description = "List of maintainers that have administrator access to the account and cluster"
   default     = []
 }
-
-variable "canary_prefix" {
-  type        = string
-  description = "Prefix to use for canary resources"
-  default     = ""
-}

--- a/infra/aws/terraform/prow-build-cluster/prow.tf
+++ b/infra/aws/terraform/prow-build-cluster/prow.tf
@@ -19,7 +19,7 @@ limitations under the License.
 
 # Recognize federated identities from the prow trusted cluster
 resource "aws_iam_openid_connect_provider" "k8s_prow" {
-  count = terraform.workspace == "prod" ? 1 : 0
+  count = var.prow_build_cluster ? 1 : 0
 
   url             = "https://container.googleapis.com/v1/projects/k8s-prow/locations/us-central1-f/clusters/prow"
   client_id_list  = ["sts.amazonaws.com"]
@@ -28,7 +28,7 @@ resource "aws_iam_openid_connect_provider" "k8s_prow" {
 
 # We allow Prow Pods with specific service acccounts on the a particular cluster to assume this role
 resource "aws_iam_role" "eks_admin" {
-  count = terraform.workspace == "prod" ? 1 : 0
+  count = var.prow_build_cluster ? 1 : 0
 
   name = "Prow-EKS-Admin"
 

--- a/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+aws_account_id = "054318140392"
 eks_admins = [
   "pkprzekwas",
   "xmudrii"

--- a/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
@@ -21,6 +21,7 @@ eks_admins = [
 
 prow_build_cluster = false
 
+cluster_name               = "prow-build-canary-cluster"
 cluster_version            = "1.25"
 cluster_autoscaler_version = "v1.25.0"
 

--- a/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
@@ -21,8 +21,6 @@ eks_admins = [
 
 prow_build_cluster = false
 
-cluster_name               = "prow-build-canary-cluster"
-cluster_region             = "us-east-2"
 cluster_version            = "1.25"
 cluster_autoscaler_version = "v1.25.0"
 

--- a/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 eks_admins = [
-  "pprzekwa",
+  "pkprzekwas",
   "xmudrii"
 ]
 

--- a/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
@@ -19,18 +19,12 @@ eks_admins = [
   "xmudrii"
 ]
 
-assume_role                 = true
-deploy_kubernetes_resources = true
+prow_build_cluster = false
 
-cluster_name    = "prow-build-canary-cluster"
-cluster_region  = "us-east-2"
-cluster_version = "1.25"
-
-vpc_cidr                  = "10.3.0.0/16"
-vpc_secondary_cidr_blocks = ["10.4.0.0/16", "10.5.0.0/16"]
-vpc_public_subnet         = ["10.3.0.0/18", "10.3.64.0/18", "10.3.128.0/18"]
-vpc_private_subnet        = ["10.4.0.0/18", "10.4.64.0/18", "10.4.128.0/18"]
-vpc_intra_subnet          = ["10.5.0.0/18", "10.5.64.0/18", "10.5.128.0/18"]
+cluster_name               = "prow-build-canary-cluster"
+cluster_region             = "us-east-2"
+cluster_version            = "1.25"
+cluster_autoscaler_version = "v1.25.0"
 
 # Ubuntu EKS optimized AMI: https://cloud-images.ubuntu.com/aws-eks/
 node_ami            = "ami-03de35fda144b3672"
@@ -38,9 +32,6 @@ node_instance_types = ["r5d.xlarge"]
 node_volume_size    = 100
 
 node_min_size                   = 1
-node_max_size                   = 10
+node_max_size                   = 1
 node_desired_size               = 1
 node_max_unavailable_percentage = 100 # To ease testing
-
-cluster_autoscaler_version = "v1.25.0"
-

--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -19,29 +19,19 @@ eks_admins = [
   "xmudrii"
 ]
 
-assume_role                 = true
-deploy_kubernetes_resources = true
+prow_build_cluster = true
 
-cluster_name    = "prow-build-cluster"
-cluster_region  = "us-east-2"
-cluster_version = "1.25"
-
-vpc_cidr                  = "10.0.0.0/16"
-vpc_secondary_cidr_blocks = ["10.1.0.0/16", "10.2.0.0/16"]
-vpc_public_subnet         = ["10.0.0.0/18", "10.0.64.0/18", "10.0.128.0/18"]
-vpc_private_subnet        = ["10.1.0.0/18", "10.1.64.0/18", "10.1.128.0/18"]
-vpc_intra_subnet          = ["10.2.0.0/18", "10.2.64.0/18", "10.2.128.0/18"]
+cluster_name               = "prow-build-cluster"
+cluster_region             = "us-east-2"
+cluster_version            = "1.25"
+cluster_autoscaler_version = "v1.25.0"
 
 # Ubuntu EKS optimized AMI: https://cloud-images.ubuntu.com/aws-eks/
 node_ami            = "ami-03de35fda144b3672"
 node_instance_types = ["r5ad.4xlarge"]
 node_volume_size    = 100
 
-# TODO(xmudrii): Increase this later.
 node_min_size                   = 20
 node_max_size                   = 40
 node_desired_size               = 20
 node_max_unavailable_percentage = 100 # To ease testing
-
-cluster_autoscaler_version = "v1.25.0"
-

--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -21,6 +21,7 @@ eks_admins = [
 
 prow_build_cluster = true
 
+cluster_name               = "prow-build-cluster"
 cluster_version            = "1.25"
 cluster_autoscaler_version = "v1.25.0"
 

--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -21,8 +21,6 @@ eks_admins = [
 
 prow_build_cluster = true
 
-cluster_name               = "prow-build-cluster"
-cluster_region             = "us-east-2"
 cluster_version            = "1.25"
 cluster_autoscaler_version = "v1.25.0"
 

--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+aws_account_id = "468814281478"
 eks_admins = [
   "pprzekwa",
   "xmudrii"

--- a/infra/aws/terraform/prow-build-cluster/terraform.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.tfvars
@@ -17,6 +17,9 @@ limitations under the License.
 assume_role                 = true
 deploy_kubernetes_resources = true
 
+cluster_name   = "prow-build-cluster"
+cluster_region = "us-east-2"
+
 vpc_cidr                  = "10.0.0.0/16"
 vpc_secondary_cidr_blocks = ["10.1.0.0/16", "10.2.0.0/16"]
 vpc_public_subnet         = ["10.0.0.0/18", "10.0.64.0/18", "10.0.128.0/18"]

--- a/infra/aws/terraform/prow-build-cluster/terraform.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.tfvars
@@ -14,21 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-data "aws_iam_policy_document" "secretsmanager_read" {
-  statement {
-    sid       = ""
-    effect    = "Allow"
-    resources = ["*"]
+assume_role                 = true
+deploy_kubernetes_resources = true
 
-    actions = [
-      "secretsmanager:GetSecretValue",
-      "secretsmanager:DescribeSecret",
-    ]
-  }
-}
-
-resource "aws_iam_policy" "secretsmanager_read" {
-  name   = "secretsmanager_read"
-  path   = "/"
-  policy = data.aws_iam_policy_document.secretsmanager_read.json
-}
+vpc_cidr                  = "10.0.0.0/16"
+vpc_secondary_cidr_blocks = ["10.1.0.0/16", "10.2.0.0/16"]
+vpc_public_subnet         = ["10.0.0.0/18", "10.0.64.0/18", "10.0.128.0/18"]
+vpc_private_subnet        = ["10.1.0.0/18", "10.1.64.0/18", "10.1.128.0/18"]
+vpc_intra_subnet          = ["10.2.0.0/18", "10.2.64.0/18", "10.2.128.0/18"]

--- a/infra/aws/terraform/prow-build-cluster/terraform.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.tfvars
@@ -17,7 +17,6 @@ limitations under the License.
 assume_role                 = true
 deploy_kubernetes_resources = true
 
-cluster_name   = "prow-build-cluster"
 cluster_region = "us-east-2"
 
 vpc_cidr                  = "10.0.0.0/16"

--- a/infra/aws/terraform/prow-build-cluster/tfbackends/canary.tfbackend
+++ b/infra/aws/terraform/prow-build-cluster/tfbackends/canary.tfbackend
@@ -1,0 +1,3 @@
+bucket = "prow-build-canary-cluster-tfstate"
+key    = "terraform.tfstate"
+region = "us-east-2"

--- a/infra/aws/terraform/prow-build-cluster/tfbackends/prod.tfbackend
+++ b/infra/aws/terraform/prow-build-cluster/tfbackends/prod.tfbackend
@@ -1,0 +1,3 @@
+bucket = "prow-build-cluster-tfstate"
+key    = "terraform.tfstate"
+region = "us-east-2"

--- a/infra/aws/terraform/prow-build-cluster/variables.tf
+++ b/infra/aws/terraform/prow-build-cluster/variables.tf
@@ -37,6 +37,14 @@ variable "deploy_kubernetes_resources" {
   nullable    = false
 }
 
+# This variable defines if this cluster is used as a Prow build cluster.
+variable "prow_build_cluster" {
+  type        = bool
+  description = "Provision this cluster as a Prow build cluster."
+  default     = true
+  nullable    = false
+}
+
 variable "vpc_cidr" {
   type        = string
   description = "CIDR of the VPC"

--- a/infra/aws/terraform/prow-build-cluster/variables.tf
+++ b/infra/aws/terraform/prow-build-cluster/variables.tf
@@ -37,6 +37,7 @@ variable "deploy_kubernetes_resources" {
   nullable    = false
 }
 
+# TODO(xmudrii): This is a temporary variable. To be deleted after making canary cluster a build cluster.
 # This variable defines if this cluster is used as a Prow build cluster.
 variable "prow_build_cluster" {
   type        = bool

--- a/infra/aws/terraform/prow-build-cluster/variables.tf
+++ b/infra/aws/terraform/prow-build-cluster/variables.tf
@@ -46,6 +46,14 @@ variable "prow_build_cluster" {
   nullable    = false
 }
 
+# We need this information to be able to assume the role. We can't automatically determine it with caller_identity
+# because that would cause a dependency cycle.
+variable "aws_account_id" {
+  type        = string
+  description = "AWS account ID"
+  default     = ""
+}
+
 variable "vpc_cidr" {
   type        = string
   description = "CIDR of the VPC"


### PR DESCRIPTION
We want to use two different AWS accounts for production and canary setups. The accounts are already created and configured, but we need to move canary cluster to the new account.

Our Terraform scripts are using [the workspaces concept](https://developer.hashicorp.com/terraform/cli/workspaces) right now. This worked well so far, however, workspaces are not suitable (as per the Terraform docs) when:

* there are multiple backends
    > Workspaces let you quickly switch between multiple instances of a single configuration within its single backend.
* multiple accounts are used
    > We recommend using [alternative approaches](https://developer.hashicorp.com/terraform/cli/workspaces#alternatives-to-workspaces) for complex deployments requiring separate credentials and access controls.

That said, we should replace workspaces with something else. This PR replaces workspaces with dedicated backends. We already had this before, but we decided to use workspaces because we had a single account for both clusters at that time. Now that we have different accounts, let's give dedicated backends another try.

/assign @pkprzekwas @ameukam @dims 