### PR TITLE
rate limit registry

### DIFF
--- a/infra/gcp/terraform/modules/oci-proxy/cloud-armor.tf
+++ b/infra/gcp/terraform/modules/oci-proxy/cloud-armor.tf
@@ -151,7 +151,7 @@ resource "google_compute_security_policy" "cloud-armor" {
     preview = false
   }
 
-  # Reject all traffic that hasn't been whitelisted.
+  # Permit all other traffic
   rule {
     action      = "allow"
     description = "Default rule, higher priority overrides it"

--- a/infra/gcp/terraform/modules/oci-proxy/cloud-armor.tf
+++ b/infra/gcp/terraform/modules/oci-proxy/cloud-armor.tf
@@ -151,10 +151,10 @@ resource "google_compute_security_policy" "cloud-armor" {
     preview = false
   }
 
-  # Permit all other traffic
+  # Permit all other traffic, with rate limits
   rule {
-    action      = "allow"
-    description = "Default rule, higher priority overrides it"
+    action      = "throttle"
+    description = "Default rule, throttle traffic"
     priority    = "2147483647"
 
     match {
@@ -162,6 +162,18 @@ resource "google_compute_security_policy" "cloud-armor" {
         src_ip_ranges = ["*"]
       }
       versioned_expr = "SRC_IPS_V1"
+    }
+
+    rate_limit_options {
+      conform_action = "allow"
+      exceed_action  = "deny(429)"
+
+      enforce_on_key = "IP"
+      # This is comparable to the GCR limits from k8s.gcr.io
+      rate_limit_threshold {
+        count        = 5000
+        interval_sec = 60
+      }
     }
 
     preview = false


### PR DESCRIPTION
This will deploy to registry-sandbox.k8s.io after merge.

It will not deploy to registry.k8s.io until we've confirmed we're happy with the behavior and opt to roll it out to production

I've selected roughly the same rate limit as the backing AR instances, 5000 requests / minute per IP, however this applies to *all* calls coming through registry.k8s.io and helps shield us from excessive traffic even on S3 etc. 

(excluding users that bypass registry.k8s.io and call through to backing storage directly, hopefully most users will be nice and not do that...)

Part of: https://github.com/kubernetes/registry.k8s.io/issues/195