### PR TITLE
promote kube-scheduler-simulator v0.1.0

### DIFF
--- a/registry.k8s.io/images/k8s-staging-sched-simulator/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-sched-simulator/OWNERS
@@ -1,0 +1,15 @@
+# See the OWNERS file documentation:
+#  https://github.com/kubernetes/community/blob/master/contributors/devel/owners.md
+
+approvers:
+- alculquicondor
+- Huang-Wei
+- sanposhiho
+reviewers:
+- alculquicondor
+- Huang-Wei
+- sanposhiho
+- 196Ikuchil
+
+labels:
+- sig/scheduling

--- a/registry.k8s.io/images/k8s-staging-sched-simulator/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-sched-simulator/images.yaml
@@ -1,0 +1,6 @@
+- name: simulator-backend
+  dmap:
+    "sha256:2ab7173ee2e1ca094e5c31a7bb66f0df64d8ff016ca9cce94611f9fce3ca7724": ["v0.1.0"]
+- name: simulator-frontend
+  dmap:
+    "sha256:eba8ef95caf780c82cbc5c882590b5d97fc2b574ff2a2bcd7253d4fee6357e6e": ["v0.1.0"]


### PR DESCRIPTION
This PR promotes kube-scheduler-simulator v0.1.0 images.
(I created k8s-staging-sched-simulator dir in [the past](https://github.com/kubernetes/k8s.io/pull/2681), but it's somehow deleted now. 🤔  )