### PR TITLE
remove adtac from the simulator group

### DIFF
--- a/groups/sig-scheduling/groups.yaml
+++ b/groups/sig-scheduling/groups.yaml
@@ -78,7 +78,6 @@ groups:
     members:
       - hweicdl@gmail.com
       - acondor@google.com
-      - adtac@google.com
       - handbomusic@gmail.com
 
   - email-id: k8s-infra-staging-kwok@kubernetes.io


### PR DESCRIPTION
- remove @adtac from the simulator group

ref: https://github.com/kubernetes-sigs/kube-scheduler-simulator/pull/297