### PR TITLE
Onboard new SRC member Craig Ingram

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -163,6 +163,7 @@ aliases:
     - salaxander
   committee-security-response:
     - cjcullen
+    - cji
     - enj
     - joelsmith
     - lukehinds

--- a/groups/committee-security-response/groups.yaml
+++ b/groups/committee-security-response/groups.yaml
@@ -21,6 +21,7 @@ groups:
       ReconcileMembers: "true"
     owners:
       - cjcullen@google.com
+      - cjingram@google.com
       - i@monis.app
       - joelsmith@redhat.com
       - lhinds@redhat.com
@@ -70,6 +71,7 @@ groups:
       ReconcileMembers: "true"
     owners:
       - cjcullen@google.com
+      - cjingram@google.com
       - i@monis.app
       - joelsmith@redhat.com
       - lhinds@redhat.com
@@ -89,6 +91,7 @@ groups:
       ReconcileMembers: "true"
     owners:
       - cjcullen@google.com
+      - cjingram@google.com
       - i@monis.app
       - joelsmith@redhat.com
       - lhinds@redhat.com


### PR DESCRIPTION
Craig Ingram (@cji) is joining the Security Response Committee