### PR TITLE
add a cert DNS challenge to OCI-proxy so we can provision certs indep…

### DIFF
--- a/infra/gcp/terraform/modules/oci-proxy/network.tf
+++ b/infra/gcp/terraform/modules/oci-proxy/network.tf
@@ -14,6 +14,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+# Resources for new envoy-based loadbalancer / EXTERNAL_MANAGED mode.
+################################################################################
+
+# This challenge must be created first, then the DNS challenge must be added
+# To our DNS config under dns/
+#
+# Bootstrapping this for use with Certificate Manager will allow us to decouple
+# cert provisioning from LBs, to have a valid cert pre-provisioned before
+# we point traffic at an LB
+resource "google_certificate_manager_dns_authorization" "default" {
+  name        = replace("${var.domain}-dnsauth", ".", "-")
+  description = "The default dns auth"
+  domain      = var.domain
+}
+
+
+# old resources for use with lb-http
+################################################################################
+
 resource "google_compute_global_address" "default_ipv4" {
   project      = var.project_id
   name         = var.project_id


### PR DESCRIPTION
…endent of LB lifecycle

first step in phasing out lb-http module and pivoting to modern envoy based LB and certificate manager instead of managed ssl

plan is:
1. roll this out to staging and then prod
2. get the DNS challenge values from GCP and add then under dns/ (next PR)
3. PR adding provisioning a cert using the DNS challenge on a new envoy-based LB in https://github.com/kubernetes/k8s.io/pull/5230 (deploy to staging and prod)
4. confirm new LB is healthy and has the right cert, PR updating DNS for staging then prod to switch to the new LB
5. decomission lb-http resources

Migrating to these will:
- switch to best practices cert provisioning that is not coupled to loadbalancer serving traffic yet, for avoiding downtime on updating these
- allow us to adopt new LB features in the future.

porche is already using certificate manager / certificate maps and DNS challenge based certs, but not the envoy LB yet.