### PR TITLE
dns challenge: add required project field

### DIFF
--- a/infra/gcp/terraform/modules/oci-proxy/network.tf
+++ b/infra/gcp/terraform/modules/oci-proxy/network.tf
@@ -27,6 +27,7 @@ resource "google_certificate_manager_dns_authorization" "default" {
   name        = replace("${var.domain}-dnsauth", ".", "-")
   description = "The default dns auth"
   domain      = var.domain
+  project     = var.project_id
 }
 
 


### PR DESCRIPTION
This is what we get when we only run in postsubmit. This time I've tested locally with:
`terraform apply -auto-approve -var digest=$(crane digest gcr.io/k8s-staging-infra-tools/archeio:$(crane ls gcr.io/k8s-staging-infra-tools/archeio | sort -V | tail -n1))`