### PR TITLE
release: adding image for capa v2.1.1

### DIFF
--- a/registry.k8s.io/images/k8s-staging-cluster-api-aws/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-cluster-api-aws/images.yaml
@@ -71,6 +71,7 @@
     "sha256:290985e74649f920c2b91dc56d11efe22e6ca6ecfde001f2d58395620b621477": ["v2.0.1"]
     "sha256:2ac290027403eebdbc5bc92e8c6d666eaf7d7ac04de07903fe9cef3d8945d6c0": ["v2.0.2"]
     "sha256:0d361f95fa484ba7ad48ba9bfa8ee790215ae870ab8dff28eec13d1266c762e8": ["v2.1.0"]
+    "sha256:15e40c3a084497a8f4ce5be53fdf4a22009fb5dec4ab540e9e9db21e010693d7": ["v2.1.1"]
 - name: eks-bootstrap-controller
   dmap:
     "sha256:0dda3f1be2c56b0ffee4668c67a9da2a5af33a5aa66c7db91c98534140265408": ["v0.6.0"]


### PR DESCRIPTION
Image: https://console.cloud.google.com/gcr/images/k8s-staging-cluster-api-aws/global/cluster-api-aws-controller@sha256:15e40c3a084497a8f4ce5be53fdf4a22009fb5dec4ab540e9e9db21e010693d7/details