### PR TITLE
add envoy based loadbalancer using cert map

### DIFF
--- a/infra/gcp/terraform/modules/oci-proxy/network.tf
+++ b/infra/gcp/terraform/modules/oci-proxy/network.tf
@@ -58,6 +58,127 @@ resource "google_certificate_manager_certificate_map_entry" "default" {
   matcher      = "PRIMARY"
 }
 
+# IP Addresses for the loadbalancer
+resource "google_compute_global_address" "ipv4" {
+  project      = var.project_id
+  name         = "${var.project_id}-ipv4"
+  address_type = "EXTERNAL"
+  ip_version   = "IPV4"
+}
+
+resource "google_compute_global_address" "ipv6" {
+  project      = var.project_id
+  name         = "${var.project_id}-ipv6"
+  address_type = "EXTERNAL"
+  ip_version   = "IPV6"
+}
+
+
+# IPv4 and IPv6 forwarding rules (listeners)
+resource "google_compute_global_forwarding_rule" "http_ipv4" {
+  project               = var.project_id
+  name                  = "${var.project_id}-ipv4-http-managed"
+  target                = google_compute_target_http_proxy.default.self_link
+  ip_address            = google_compute_global_address.ipv4.address
+  port_range            = "80"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+resource "google_compute_global_forwarding_rule" "https_ipv4" {
+  project               = var.project_id
+  name                  = "${var.project_id}-ipv4-https-managed"
+  target                = google_compute_target_https_proxy.default.self_link
+  ip_address            = google_compute_global_address.ipv4.address
+  port_range            = "443"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+resource "google_compute_global_forwarding_rule" "http_ipv6" {
+  project               = var.project_id
+  name                  = "${var.project_id}-ipv6-http-managed"
+  target                = google_compute_target_http_proxy.default.self_link
+  ip_address            = google_compute_global_address.ipv6.address
+  port_range            = "80"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+resource "google_compute_global_forwarding_rule" "https_ipv6" {
+  project               = var.project_id
+  name                  = "${var.project_id}-ipv6-https-managed"
+  target                = google_compute_target_https_proxy.default.self_link
+  ip_address            = google_compute_global_address.ipv6.address
+  port_range            = "443"
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
+
+# Redirect HTTP to HTTPS
+resource "google_compute_target_http_proxy" "default" {
+  project = var.project_id
+  name    = "${var.project_id}-http-default"
+  url_map = google_compute_url_map.https_redirect.self_link
+}
+
+resource "google_compute_url_map" "https_redirect" {
+  project = var.project_id
+  name    = "${var.project_id}-http-to-https-redirect"
+  default_url_redirect {
+    https_redirect         = true
+    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+    strip_query            = false
+  }
+}
+
+# Serve HTTPS
+resource "google_compute_target_https_proxy" "default" {
+  project = var.project_id
+  name    = "${var.project_id}-default-https-proxy"
+  url_map = google_compute_url_map.default.self_link
+
+  certificate_map = "//certificatemanager.googleapis.com/${google_certificate_manager_certificate_map.default.id}"
+}
+
+resource "google_compute_region_network_endpoint_group" "default" {
+  for_each = google_cloud_run_service.oci-proxy
+
+  provider              = google-beta
+  project               = var.project_id
+  name                  = "${var.project_id}-${each.key}-neg"
+  network_endpoint_type = "SERVERLESS"
+  region                = google_cloud_run_service.oci-proxy[each.key].location
+  cloud_run {
+    service = google_cloud_run_service.oci-proxy[each.key].name
+  }
+}
+
+
+resource "google_compute_url_map" "default" {
+  project         = var.project_id
+  name            = "${var.project_id}-default-url-map"
+  default_service = google_compute_backend_service.default.self_link
+}
+
+resource "google_compute_backend_service" "default" {
+  project = var.project_id
+  name    = "${var.project_id}-default-bes"
+
+  enable_cdn      = false
+  security_policy = google_compute_security_policy.cloud-armor.self_link
+
+
+  dynamic "backend" {
+    for_each = google_compute_region_network_endpoint_group.default
+    content {
+      group = backend.value.id
+    }
+  }
+
+  log_config {
+    enable      = true
+    sample_rate = 1.0
+  }
+
+  load_balancing_scheme = "EXTERNAL_MANAGED"
+}
 
 # old resources for use with lb-http
 ################################################################################


### PR DESCRIPTION
Next step in #5241, after this is in staging and prod we can test the LB a bit and then PR rotating DNS to point at the new LBs. 

Then we can come back later and tear down the old ones when we're confident there's no more inbound traffic (from stale DNS client-side).

Tested in staging with `terraform apply -var digest=$(crane digest gcr.io/k8s-staging-infra-tools/archeio:$(crane ls gcr.io/k8s-staging-infra-tools/archeio | sort -V | tail -n1)` and then `curl --verbose --resolve registry-sandbox.k8s.io:443:107.178.255.82 https://registry-sandbox.k8s.io/v2/pause/manifest/3.1` (IP of new https LB)