### PR TITLE
move registry-sandbox.k8s.io to the new loadbalancer

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -265,9 +265,9 @@ prs:
 # Sandbox OCI redirector service. (@ameukam,@BenTheElder,@thockin,@dims)
 registry-sandbox:
   - type: A
-    value: 34.149.65.206
+    value: 107.178.255.82
   - type: AAAA
-    value: "2600:1901:0:4e2f::"
+    value: "2600:1901:0:8513::"
 # DNS challenge for redirector sandbox certs
 _acme-challenge.registry-sandbox:
   - type: CNAME


### PR DESCRIPTION
New GCLB is from https://github.com/kubernetes/k8s.io/pull/5249

The old LB still exists, but the new one should be ready to go already.

We're *only* doing this on the staging deployment, will circle back and do production later after confirming staging is working fine.