### PR TITLE
move registry.k8s.io to the new loadbalancer

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -276,9 +276,9 @@ _acme-challenge.registry-sandbox:
 # Reach to k8s-infra-oci-proxy-admins@kubernetes.io for major issues.
 registry:
   - type: A
-    value: 34.107.244.51
+    value: 34.96.108.209
   - type: AAAA
-    value: "2600:1901:0:1013::"
+    value: "2600:1901:0:bbc4::"
 # DNS challenge for prod redirector certs
 _acme-challenge.registry:
   - type: CNAME


### PR DESCRIPTION
New GCLB is from #5249.

Holding because I'm stepping away for a bit, but going ahead and filing this because we're ready whenever one of us is around to watch this and potentially revert. The LB is already live and has the cert ready to go etc. It should be no issue to rotate ... But we'll get some more test coverage first re: https://github.com/kubernetes/k8s.io/pull/5250#issuecomment-1541047200
/hold

cc @dims @ameukam 

```
$ curl --verbose --resolve registry.k8s.io:443:34.96.108.209 https://registry.k8s.io/v2/pause/manifest/3.1
* Added registry.k8s.io:443:34.96.108.209 to DNS cache
* Hostname registry.k8s.io was found in DNS cache
*   Trying 34.96.108.209:443...
* Connected to registry.k8s.io (34.96.108.209) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Client hello (1):
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Server hello (2):
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Unknown (8):
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Certificate (11):
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, CERT verify (15):
* [CONN-0-0][CF-SSL] (304) (IN), TLS handshake, Finished (20):
* [CONN-0-0][CF-SSL] (304) (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384
* ALPN: server accepted h2
* Server certificate:
*  subject: CN=registry.k8s.io
*  start date: May  9 06:25:11 2023 GMT
*  expire date: Aug  7 07:21:05 2023 GMT
*  subjectAltName: host "registry.k8s.io" matched cert's "registry.k8s.io"
*  issuer: C=US; O=Google Trust Services LLC; CN=GTS CA 1D4
*  SSL certificate verify ok.
* Using HTTP2, server supports multiplexing
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* h2h3 [:method: GET]
* h2h3 [:path: /v2/pause/manifest/3.1]
* h2h3 [:scheme: https]
* h2h3 [:authority: registry.k8s.io]
* h2h3 [user-agent: curl/7.87.0]
* h2h3 [accept: */*]
* Using Stream ID: 1 (easy handle 0x7f8727015a00)
> GET /v2/pause/manifest/3.1 HTTP/2
> Host: registry.k8s.io
> user-agent: curl/7.87.0
> accept: */*
> 
< HTTP/2 307 
< content-type: text/html; charset=utf-8
< location: https://us-west2-docker.pkg.dev/v2/k8s-artifacts-prod/images/pause/manifest/3.1
< x-cloud-trace-context: fd2257f22895e53c43f8e05af6905a02
< date: Wed, 10 May 2023 00:18:03 GMT
< server: Google Frontend
< content-length: 115
< via: 1.1 google
< alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
< 
<a href="https://us-west2-docker.pkg.dev/v2/k8s-artifacts-prod/images/pause/manifest/3.1">Temporary Redirect</a>.

* Connection #0 to host registry.k8s.io left intact
```