### PR TITLE
Add image-builder owners to OWNERS file

### DIFF
--- a/registry.k8s.io/images/k8s-staging-scl-image-builder/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-scl-image-builder/OWNERS
@@ -2,10 +2,9 @@
 
 # https://github.com/kubernetes/community/blob/master/OWNERS_ALIASES.
 approvers:
-- CecileRobertMichon
-- codenrhoden
-- detiber
-- moshloop
+- jsturtevant
+- mboersma
 
 reviewers:
-- justinsb
+- AverageMarcus
+- randomvariable


### PR DESCRIPTION
Adds current image-builder maintainers to the relevant OWNERS file.

cc: @jsturtevant @AverageMarcus @randomvariable