### PR TITLE
📖 Update Bug Triage Shadow email address

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -338,7 +338,7 @@ groups:
       - msha.harshadithya@gmail.com # 1.28 Release Notes Shadow
       - smith.rashan@gmail.com # 1.28 Release Notes Shadow
       - furkat.gofurov@suse.com # 1.28 Bug Triage Lead
-      - a.zelyk@reply.de # 1.28 Bug Triage Shadow
+      - zelikangelina@gmail.com # 1.28 Bug Triage Shadow
       - mofi@google.com # 1.28 Bug Triage Shadow
       - parthvi.vala@gmail.com # 1.28 Bug Triage Shadow
       - yigit.demirbas@gmail.com # 1.28 Bug Triage Shadow


### PR DESCRIPTION
Updates email address used for v1.28 Bug Triage Shadow @zelenushechka to grant the access rights for https://groups.google.com/a/kubernetes.io/g/release-team?pli=1

cc @gracenng @leonardpahlke 