### PR TITLE
eks-prow-build: add remaining boskos accounts

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/boskos/config.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/boskos/config.yaml
@@ -21,6 +21,15 @@ data:
   config: |
     resources:
     - names:
+        - eks-e2e-boskos-001
+        - eks-e2e-boskos-002
+        - eks-e2e-boskos-003
+        - eks-e2e-boskos-004
         - eks-e2e-boskos-005
+        - eks-e2e-boskos-006
+        - eks-e2e-boskos-007
+        - eks-e2e-boskos-008
+        - eks-e2e-boskos-009
+        - eks-e2e-boskos-010
       state: dirty
       type: aws-account


### PR DESCRIPTION
Now that we triaged the issue with failing CAPA tests (https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4272), let's add remaining boskos accounts.

xref #5048

/assign @pkprzekwas @dims 