### PR TITLE
Add bug triage shadows to release-team-shadows email group

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -398,6 +398,10 @@ groups:
       - michael.levan@clouddev.engineering # 1.28 Docs Shadow
       - taniaduggal60@gmail.com # 1.28 Docs Shadow
       - vibhorchinda@gmail.com # 1.28 Docs Shadow
+      - a.zelyk@reply.de # 1.28 Bug Triage Shadow
+      - mofi@google.com # 1.28 Bug Triage Shadow
+      - parthvi.vala@gmail.com # 1.28 Bug Triage Shadow
+      - yigit.demirbas@gmail.com # 1.28 Bug Triage Shadow
 
   # RBAC groups:
   # - grant access to the `namespace-user` role for a single namespace on the `aaa` cluster

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -398,7 +398,7 @@ groups:
       - michael.levan@clouddev.engineering # 1.28 Docs Shadow
       - taniaduggal60@gmail.com # 1.28 Docs Shadow
       - vibhorchinda@gmail.com # 1.28 Docs Shadow
-      - a.zelyk@reply.de # 1.28 Bug Triage Shadow
+      - zelikangelina@gmail.com # 1.28 Bug Triage Shadow
       - mofi@google.com # 1.28 Bug Triage Shadow
       - parthvi.vala@gmail.com # 1.28 Bug Triage Shadow
       - yigit.demirbas@gmail.com # 1.28 Bug Triage Shadow


### PR DESCRIPTION
Adding bug triage team shadows' emails for release v1.28 to the `release-team-shadows` group. I noticed the emails were missing, meaning we shadows may have missed some communication in the mean time.

cc @furkatgofurov7 @leonardpahlke @gracenng 