### PR TITLE
promoting testrunner with ginkgo295

### DIFF
--- a/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -159,6 +159,7 @@
     "sha256:38220a0b0cdc9dab9c8704f02fb17541831a67dd2d668a1e5926272e21c55d0d": ["v20221224-controller-v1.5.1-70-gc50a9e99b"]
     "sha256:e52a2f86818f8c7970e5caabc1ffa50ed92c41083e4b7ba822641f670ce80506": ["v20230312-helm-chart-4.5.2-28-g66a760794"]
     "sha256:754c62f9a5efd1ee515ee908ecc16c0c4d1dda96a8cc8019667182a55f3a9035": ["v20230314-helm-chart-4.5.2-32-g520384b11"]
+    "sha256:a3deb0444d53b3f3b2d73acec8be2c3330d28d2df1ef09d0b9d7dbecdee706fb": ["v20230522"]
 
 # custom cfssl image for e2e tests
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/cfssl


### PR DESCRIPTION
- This PR https://github.com/kubernetes/ingress-nginx/pull/9985 caused new test-runner image to be built
- So now promoting the new test-runner image

cc @rikatz @strongjz @tao12345666333 @cpanato 