### PR TITLE
eks-prow-build-cluster: expose grafana as lb svc

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/grafana/lb.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/grafana/lb.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: monitoring
+  name: grafana-lb
+  labels:
+    app: grafana
+spec:
+  type: LoadBalancer
+  ports:
+    - name: service
+      port: 3000
+      protocol: TCP
+  selector:
+    app: grafana

--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/grafana/lb.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/grafana/lb.yaml
@@ -3,13 +3,22 @@ kind: Service
 metadata:
   namespace: monitoring
   name: grafana-lb
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "https"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "arn:aws:acm:us-east-2:468814281478:certificate/a7969b50-8477-47eb-a623-8ef90688d16f"
   labels:
     app: grafana
 spec:
   type: LoadBalancer
   ports:
-    - name: service
-      port: 3000
+    - name: https
+      port: 443
       protocol: TCP
+      targetPort: 3000
+    - name: http
+      port: 80
+      protocol: TCP
+      targetPort: 3000
   selector:
     app: grafana


### PR DESCRIPTION
exposed over http at:
http://a9c199484557245839f927864e289c04-1058206500.us-east-2.elb.amazonaws.com/

exposed over https (thanks https://github.com/kubernetes/k8s.io/pull/5320) at:
https://monitoring-eks.prow.k8s.io/

see also: https://github.com/kubernetes/k8s.io/issues/5165