### PR TITLE
Add DNS for monitoring in EKS Prow build cluster

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -253,6 +253,13 @@ prow:
 monitoring.prow:
   type: A
   value: 130.211.20.136
+monitoring-eks.prow:
+  type: CNAME
+  value: a9c199484557245839f927864e289c04-1058206500.us-east-2.elb.amazonaws.com.
+# Record for AWS ACM DNS challenge
+_bec7190baed957d2b71b4fc33bdec856.monitoring-eks.prow:
+  type: CNAME
+  value: _0ecdcf0799a37fa4bd5ba9bbe5877d56.dnzkjbsjxj.acm-validations.aws.
 prow-canary:
   type: A
   value: 35.244.182.122


### PR DESCRIPTION
This PR adds records for monitoring stack in the EKS Prow build cluster. Two records are added:

- `monitoring-eks.prow.k8s.io` that points to Grafana's Load Balancer
- `_bec7190baed957d2b71b4fc33bdec856.monitoring-eks.prow.k8s.io` that's used for AWS ACM DNS challenge

/assign @BenTheElder 
cc @dims @wozniakjan 