### PR TITLE
Fastly: Add a GCS bucket for Terraform remote state

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -229,6 +229,7 @@ restrictions:
       - "^k8s-infra-cluster-admins@kubernetes.io$"
       - "^k8s-infra-dns-admins@kubernetes.io$"
       - "^k8s-infra-equinix-admins@kubernetes.io$"
+      - "^k8s-infra-fastly-admins@kubernetes.io$"
       - "^k8s-infra-gcs-access-logs@kubernetes.io$"
       - "^k8s-infra-gcp-accounting@kubernetes.io$"
       - "^k8s-infra-gcp-auditors@kubernetes.io$"

--- a/groups/sig-k8s-infra/groups.yaml
+++ b/groups/sig-k8s-infra/groups.yaml
@@ -320,6 +320,16 @@ groups:
     members:
       - sig-k8s-infra-leads@kubernetes.io
 
+  - email-id: k8s-infra-fastly-admins@kubernetes.io
+    name: k8s-infra-fastly-admins
+    description: |-
+      ACL for admins operating Fastly services
+    settings:
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+    members:
+      - sig-k8s-infra-leads@kubernetes.io
+
   - email-id: k8s-infra-okta-admins@kubernetes.io
     name: k8s-infra-okta-admins
     description: |-

--- a/infra/gcp/bash/ensure-main-project.sh
+++ b/infra/gcp/bash/ensure-main-project.sh
@@ -74,6 +74,7 @@ readonly DNS_GROUP="k8s-infra-dns-admins@kubernetes.io"
 readonly TERRAFORM_STATE_BUCKET_ENTRIES=(
     "${LEGACY_CLUSTER_TERRAFORM_BUCKET}:${CLUSTER_ADMINS_GROUP}"
     k8s-infra-tf-aws:k8s-infra-aws-admins@kubernetes.io
+    k8s-infra-tf-fastly:k8s-infra-fastly-admins@kubernetes.io
     k8s-infra-tf-gcp:k8s-infra-gcp-org-admins@kubernetes.io
     k8s-infra-tf-monitoring:"${CLUSTER_ADMINS_GROUP}"
     k8s-infra-tf-oci-proxy:"${CLUSTER_ADMINS_GROUP}"


### PR DESCRIPTION
Ref:
  - https://github.com/kubernetes/k8s.io/issues/4528

Ensure TF states for the fastly services are stored in a GCS bucket.