### PR TITLE
Add GCS bucket as remote state backend

### DIFF
--- a/infra/fastly/terraform/dl.k8s.io/provider.tf
+++ b/infra/fastly/terraform/dl.k8s.io/provider.tf
@@ -21,6 +21,11 @@ This file defines:
 */
 
 terraform {
+  backend "gcs" {
+    bucket = "k8s-infra-tf-fastly"
+    prefix = "cdn.dl.k8s.io"
+  }
+
   required_providers {
     fastly = {
       source  = "fastly/fastly"

--- a/infra/fastly/terraform/dl.k8s.io/services.tf
+++ b/infra/fastly/terraform/dl.k8s.io/services.tf
@@ -59,10 +59,6 @@ resource "fastly_service_vcl" "files" {
     window         = 4
   }
 
-  product_enablement {
-    origin_inspector = true
-  }
-
   snippet {
     content  = <<-EOT
       if (req.url.path ~ "^/release/") {


### PR DESCRIPTION
Follow-up of:
  - https://github.com/kubernetes/k8s.io/pull/5326

Also remove configuration for `Origin Inspector`

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>