### PR TITLE
promote testrunner alpine318

### DIFF
--- a/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -162,6 +162,7 @@
     "sha256:e52a2f86818f8c7970e5caabc1ffa50ed92c41083e4b7ba822641f670ce80506": ["v20230312-helm-chart-4.5.2-28-g66a760794"]
     "sha256:754c62f9a5efd1ee515ee908ecc16c0c4d1dda96a8cc8019667182a55f3a9035": ["v20230314-helm-chart-4.5.2-32-g520384b11"]
     "sha256:a3deb0444d53b3f3b2d73acec8be2c3330d28d2df1ef09d0b9d7dbecdee706fb": ["v20230522"]
+    "sha256:a98ce8ab90f16bdd8539b168a4d000f366afa4eec23a220b3ce39698c5769bfd": ["v20230527"]
 
 # custom cfssl image for e2e tests
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/cfssl


### PR DESCRIPTION
- A new e2e-test-runner got built(based on alpine v3.18) because of https://github.com/kubernetes/ingress-nginx/pull/10000
- This PR promotes the above mentioned new e2e-test-runner to prod registry
- Once this merges, the ingress-nginx project needs to be updated to use this tag+sha

cc @tao12345666333 @strongjz @rikatz 