### PR TITLE
cdn.dl.k8s.io: Add Fastly endpoint for dualstack

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -127,9 +127,9 @@ artifacts-sandbox:
 # DNS configuration for Fastly service cdn.dl.k8s.io
 # Reach out to sig-k8s-infra-leads@kubernetes.io for any issue
 cdn.dl:
-  # Domain delegation of cdn.dl.l8s.io to Fastly.
-  - type: TXT
-    value: fastly-domain-delegation-yyD9G&IG34BM-2022-08-01
+  # CNAME record for Fastly endpoint
+  - type: CNAME
+    value: dualstack.m.sni.global.fastly.net.
 # Fastly ACME DNS challenge for cdn.dl.k8s.io
 _acme-challenge.cdn.dl:
   - type: CNAME


### PR DESCRIPTION
Ref: 
  - https://github.com/kubernetes/k8s.io/issues/4528

This endpoint ensure we serve traffic for IPv4 and IPv6 addresses and also support encrypted traffic with Fastly TLS certificates.

The DNS entry that ensures domain delegation to Fastly must be removed because OctoDNS does not let CNAME DNS records to coexist with other records per [RFC 1034](https://www.ietf.org/rfc/rfc1034.txt). See https://github.com/octodns/octodns/issues/414