### PR TITLE
promoting newbaseimage with openssl patch

### DIFF
--- a/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -122,6 +122,7 @@
     "sha256:3b650123c755392f8c0eb9a356b12716327106e624ab5f5b43bc25ab130978fb": ["91057c439cf07ffb62887b8a8bda66ce3cbe39ca"]
     "sha256:b05566e432d85a7681feb7ef93fda8385d53712478737b39e617c993c86c5e65": ["v20230526"]
     "sha256:cf77c71aa6e4284925ca2233ddf871b5823eaa3ee000347ae25096b07fb52c57": ["v20230527"]
+    "sha256:3c4f0c03df9b64511b4a47d0fc5dfec4245950dc7f7cece06049d9f4e9c81a5e": ["v20230601"]
 
 # image to run tests
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/test-runner


### PR DESCRIPTION
- A new baseimage was built by clicking rebuild in cloudbuild view of gcp console
- New baseimage was needed to patch openssl for CVEs

![image](https://github.com/kubernetes/k8s.io/assets/5085914/f7dce532-197e-4fb6-b6eb-51d54eb7f692)


- This PR promotes the new baseimage
- After this merges, the ingress-nginx project needs to be updated with this new SHA and TAG
- This is enroute to a v1.8.1 release of the ingress-nginx controller (that also requires uprade of go from v1.20.1 to v1.20.4 and 2 other package dependencies, to be done in different PR(s), not this one)

- @strongjz is looking to bump depedencies
```
- github.com/emicklei/go-restful/v3 version v3.9.0 has 1 vulnerability - Fixed in: v3.10.0
- github.com/sirupsen/logrus version v1.8.1 has 1 vulnerability - still open
```
- And there is a PR for bumping go https://github.com/kubernetes/ingress-nginx/pull/10016

cc @strongjz @tao12345666333 @rikatz seeking review/lgtm/approve

