### PR TITLE
Manage ACM certificate for monitoring with Terraform

### DIFF
--- a/infra/aws/terraform/modules/eks-prow-iam/policy_apply.tf
+++ b/infra/aws/terraform/modules/eks-prow-iam/policy_apply.tf
@@ -32,6 +32,8 @@ data "aws_iam_policy_document" "eks_apply" {
     resources = ["*"]
 
     actions = [
+      "acm:AddTagsToCertificate",
+      "acm:RequestCertificate",
       "ec2:AllocateAddress",
       "ec2:AssociateRouteTable",
       "ec2:AssociateVpcCidrBlock",

--- a/infra/aws/terraform/modules/eks-prow-iam/policy_destroy.tf
+++ b/infra/aws/terraform/modules/eks-prow-iam/policy_destroy.tf
@@ -28,6 +28,7 @@ data "aws_iam_policy_document" "eks_destroy" {
     resources = ["*"]
 
     actions = [
+      "acm:DeleteCertificate",
       "ec2:DeleteEgressOnlyInternetGateway",
       "ec2:DeleteInternetGateway",
       "ec2:DeleteLaunchTemplate",

--- a/infra/aws/terraform/modules/eks-prow-iam/policy_plan.tf
+++ b/infra/aws/terraform/modules/eks-prow-iam/policy_plan.tf
@@ -28,6 +28,8 @@ data "aws_iam_policy_document" "eks_plan" {
     resources = ["*"]
 
     actions = [
+      "acm:DescribeCertificate",
+      "acm:ListTagsForCertificate",
       "ec2:DescribeAddresses",
       "ec2:DescribeAvailabilityZones",
       "ec2:DescribeEgressOnlyInternetGateways",

--- a/infra/aws/terraform/prow-build-cluster/.terraform.lock.hcl
+++ b/infra/aws/terraform/prow-build-cluster/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.61.0"
   constraints = ">= 3.72.0, >= 3.73.0, >= 4.0.0, >= 4.47.0"
   hashes = [
+    "h1:GrboLwI2hok/i8xfq87uS9kUKPqAE8b/1iJTEupRthY=",
     "h1:qyBawxoNN6EpiiX5h5ZG5P2dHsBeA5Z67xESl2c1HRk=",
     "zh:051e2588410b7448a5c4c30d668948dd6fdfa8037700bfc00fb228986ccbf3a5",
     "zh:082fbcf9706b48d0880ba552a11c29527e228dadd6d83668d0789abda24e5922",
@@ -28,6 +29,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   version     = "2.3.2"
   constraints = ">= 2.0.0"
   hashes = [
+    "h1:Ar/DAbZQ9Nsj0BrqX6camrEE6U+Yq4E87DCNVqxqx8k=",
     "h1:ocyv0lvfyvzW4krenxV5CL4Jq5DiA3EUfoy8DR6zFMw=",
     "zh:2487e498736ed90f53de8f66fe2b8c05665b9f8ff1506f751c5ee227c7f457d1",
     "zh:3d8627d142942336cf65eea6eb6403692f47e9072ff3fa11c3f774a3b93130b3",
@@ -48,6 +50,7 @@ provider "registry.terraform.io/hashicorp/helm" {
   version     = "2.9.0"
   constraints = "2.9.0"
   hashes = [
+    "h1:3M1gPJ2W3qtYr6do1HkH5l03kSEHIYMQ97W2tP59dYY=",
     "h1:fEDID5J/9ret/sLpOSNAu98F/ZBEZhOmL0Leut7m5JU=",
     "zh:1471cb45908b426104687c962007b2980cfde294fa3530fabc4798ce9fb6c20c",
     "zh:1572e9cec20591ec08ece797b3630802be816a5adde36ca91a93359f2430b130",
@@ -69,6 +72,7 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   constraints = ">= 2.10.0"
   hashes = [
     "h1:ID/u9YOv00w+Z8iG+592oyuV7HcqRmPiZpEC9hnyTMY=",
+    "h1:WXTbK59MHZVtikifTCvqpH/3TKMnj3MyQke4ymmUjlg=",
     "zh:028d346460de2d1d19b4c863dfc36be51c7bcd97d372b54a3a946bcb19f3f613",
     "zh:391d0b38c455437d0a2ab1beb6ce6e1230aa4160bbae11c58b2810b258b44280",
     "zh:40ea742f91b67f66e71d7091cfd40cc604528c4947651924bd6d8bd8d9793708",
@@ -88,6 +92,7 @@ provider "registry.terraform.io/hashicorp/time" {
   version     = "0.9.1"
   constraints = ">= 0.9.0"
   hashes = [
+    "h1:UHcDnIYFZ00uoou0TwPGMwOrE8gTkoRephIvdwDAK70=",
     "h1:VxyoYYOCaJGDmLz4TruZQTSfQhvwEcMxvcKclWdnpbs=",
     "zh:00a1476ecf18c735cc08e27bfa835c33f8ac8fa6fa746b01cd3bcbad8ca84f7f",
     "zh:3007f8fc4a4f8614c43e8ef1d4b0c773a5de1dcac50e701d8abc9fdc8fcb6bf5",
@@ -109,6 +114,7 @@ provider "registry.terraform.io/hashicorp/tls" {
   constraints = ">= 3.0.0"
   hashes = [
     "h1:GZcFizg5ZT2VrpwvxGBHQ/hO9r6g0vYdQqx3bFD3anY=",
+    "h1:Wd3RqmQW60k2QWPN4sK5CtjGuO1d+CRNXgC+D4rKtXc=",
     "zh:23671ed83e1fcf79745534841e10291bbf34046b27d6e68a5d0aab77206f4a55",
     "zh:45292421211ffd9e8e3eb3655677700e3c5047f71d8f7650d2ce30242335f848",
     "zh:59fedb519f4433c0fdb1d58b27c210b27415fddd0cd73c5312530b4309c088be",

--- a/infra/aws/terraform/prow-build-cluster/monitoring_acm.tf
+++ b/infra/aws/terraform/prow-build-cluster/monitoring_acm.tf
@@ -1,0 +1,28 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "aws_acm_certificate" "monitoring_cert" {
+  count = local.configure_prow ? 1 : 0
+
+  domain_name       = "monitoring-eks.prow.k8s.io"
+  validation_method = "DNS"
+
+  tags = local.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}


### PR DESCRIPTION
We already added AWS ACM certificate for monitoring in EKS Prow build cluster as part of #5320 

This PR adds a Terraform resource to manage this ACM certificate. This change has been already deployed.

/assign @pkprzekwas @wozniakjan 