### PR TITLE
Add image-builder approvers to OWNERS file

### DIFF
--- a/registry.k8s.io/images/k8s-staging-scl-image-builder/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-scl-image-builder/OWNERS
@@ -2,9 +2,10 @@
 
 # https://github.com/kubernetes/community/blob/master/OWNERS_ALIASES.
 approvers:
+- AverageMarcus
 - jsturtevant
+- kkeshavamurthy
 - mboersma
 
 reviewers:
-- AverageMarcus
 - randomvariable


### PR DESCRIPTION
Syncs current image-builder maintainers with the relevant OWNERS file.

cc: @AverageMarcus @kkeshavamurthy 