### PR TITLE
Add forgotten FluxCD PodMonitor and fix memory usage

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/flux-system/pod-monitor.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/flux-system/pod-monitor.yaml
@@ -1,0 +1,45 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: flux-system
+  namespace: flux-system
+  labels:
+    app.kubernetes.io/part-of: flux
+    app.kubernetes.io/component: monitoring
+    prometheus: main
+spec:
+  namespaceSelector:
+    matchNames:
+      - flux-system
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - helm-controller
+          - source-controller
+          - kustomize-controller
+          - notification-controller
+          - image-automation-controller
+          - image-reflector-controller
+  podMetricsEndpoints:
+    - port: http-prom
+      relabelings:
+        # https://github.com/prometheus-operator/prometheus-operator/issues/4816
+        - sourceLabels: [__meta_kubernetes_pod_phase]
+          action: keep
+          regex: Running

--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/grafana/dashboards/flux-control-plane.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/grafana/dashboards/flux-control-plane.yaml
@@ -555,7 +555,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(container_memory_working_set_bytes{container_label_io_kubernetes_pod_namespace=\"$namespace\",container_label_app!=\"POD\",container_label_app!=\"\",container_label_io_kubernetes_pod_name=~\".*-controller-.*\"}) by (container_label_io_kubernetes_pod_name)",
+              "expr": "sum(container_memory_working_set_bytes{namespace=\"$namespace\",container!=\"POD\",container!=\"\",pod=~\".*-controller-.*\"}) by (pod)",
               "hide": false,
               "interval": "",
               "legendFormat": "{{pod}}",


### PR DESCRIPTION
Add forgotten PodMonitor for FluxCD and fix grafana dashboard [after removing cadvisor](https://github.com/kubernetes/k8s.io/pull/5356) https://monitoring-eks.prow.k8s.io/d/flux-control-plane/flux-control-plane

/assign @wozniakjan