### PR TITLE
eks-prow-build-cluster: add missing namespace to grafana dashboard test-infra CM

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/grafana/dashboards/test-infra-dashboard.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/grafana/dashboards/test-infra-dashboard.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: test-infra-dashboard
+  namespace: monitoring
 data:
   boskos-http.json: |
     {


### PR DESCRIPTION
followup to https://github.com/kubernetes/k8s.io/pull/5324