### PR TITLE
Configure IRSA for node e2e tests in dev account

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/test-pods/build-serviceaccounts.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/test-pods/build-serviceaccounts.yaml
@@ -3,3 +3,11 @@ kind: ServiceAccount
 metadata:
   name: prow-build
   namespace: test-pods
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::855606814420:role/node-e2e-tests
+  name: node-e2e-tests
+  namespace: test-pods


### PR DESCRIPTION
/cc @dims

I'm using the playground account created in #4884 to run the e2e tests for now. These jobs will need to run in their own dedicated accounts later.


I manually created the role on the 855606814420 account with reasonable permisisons.

```
[cloudshell-user@ip-10-6-84-235 ~]$ aws iam get-role --role-name node-e2e-tests 
{
    "Role": {
        "Path": "/",
        "RoleName": "node-e2e-tests",
        "RoleId": "AROA4ONRD43KG4Y7CFLIJ",
        "Arn": "arn:aws:iam::855606814420:role/node-e2e-tests",
        "CreateDate": "2023-06-13T17:22:21+00:00",
        "AssumeRolePolicyDocument": {
            "Version": "2012-10-17",
            "Statement": [
                {
                    "Effect": "Allow",
                    "Principal": {
                        "Federated": "arn:aws:iam::855606814420:oidc-provider/oidc.eks.us-east-2.amazonaws.com/id/F8B73554FE6FBAF9B19569183FB39762"
                    },
                    "Action": "sts:AssumeRoleWithWebIdentity",
                    "Condition": {
                        "StringEquals": {
                            "oidc.eks.us-east-2.amazonaws.com/id/F8B73554FE6FBAF9B19569183FB39762:aud": "sts.amazonaws.com"
                        }
                    }
                }
            ]
        },
        "Description": "",
        "MaxSessionDuration": 3600,
        "RoleLastUsed": {}
    }
}
[cloudshell-user@ip-10-6-84-235 ~]$ aws iam list-attached-role-policies --role-name node-e2e-tests 
{
    "AttachedPolicies": [
        {
            "PolicyName": "AmazonEC2FullAccess",
            "PolicyArn": "arn:aws:iam::aws:policy/AmazonEC2FullAccess"
        },
        {
            "PolicyName": "EC2InstanceConnect",
            "PolicyArn": "arn:aws:iam::aws:policy/EC2InstanceConnect"
        }
    ]
}
```

