### PR TITLE
Promote cluster-proportional-autoscaler:v1.8.8-rc.1.

### DIFF
--- a/registry.k8s.io/images/k8s-staging-cpa/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-cpa/images.yaml
@@ -6,6 +6,7 @@
     "sha256:aa60f453d64dfb3c3fd9e7306f988c36c6352c4f2d956aa90467f2808091effa": ["1.8.5"]
     "sha256:68d396900aeaa072c1f27289485fdac29834045a6f3ffe369bf389d830ef572d": ["1.8.6"]
     "sha256:69bf675e356770c651864305f2ce17ec25623ac0ff77a040f9396e72daba2d5f": ["v1.8.8"]
+    "sha256:7a155604bfa165e1c8a0959d0134ecf4e6151c859355e9256a1d11973faf4ea5": ["v1.8.8-rc.1"]
 - name: cluster-proportional-autoscaler-amd64
   dmap:
     "sha256:e310b7e60ed5dabcf9945fb86ee049bafde69b01ac0b9eb647c2b96c273e18d8": ["1.8.2"]


### PR DESCRIPTION
This is a re-build of v1.8.8 to pick up CVE fixes (Go version bumped to 1.20.5).

Ref https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/issues/148.

/assign @thockin 