### PR TITLE
eks-prow-build-cluster: FluxCD Logs Grafana Dashboard

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/grafana/dashboards/flux-logs.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/grafana/dashboards/flux-logs.yaml
@@ -1,0 +1,333 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: monitoring
+  name: flux-logs
+data:
+  flux-logs.json: |-
+    {
+      "__inputs": [
+        {
+          "name": "DS_LOKI",
+          "label": "Loki",
+          "description": "",
+          "type": "datasource",
+          "pluginId": "loki",
+          "pluginName": "Loki"
+        }
+      ],
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          },
+          {
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
+            "enable": true,
+            "iconColor": "red",
+            "name": "flux events",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [
+                "flux"
+              ],
+              "type": "tags"
+            }
+          }
+        ]
+      },
+      "description": "Flux logs collected from Kubernetes, stored in Loki",
+      "editable": true,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "id": 29,
+      "iteration": 1653748775696,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "datasource": "${DS_LOKI}",
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "bars",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 4,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "hidden",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": "${DS_LOKI}",
+              "expr": "sum(count_over_time({namespace=~\"flux-system\", stream=~\"$stream\", app =~\"$controller\"} | json | __error__!=\"JSONParserErr\" | level=~\"$level\" |= \"$query\" [$__interval]))",
+              "instant": false,
+              "legendFormat": "Log count",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": "${DS_LOKI}",
+          "description": "Logs from services running in Kubernetes",
+          "gridPos": {
+            "h": 25,
+            "w": 24,
+            "x": 0,
+            "y": 4
+          },
+          "id": 2,
+          "options": {
+            "dedupStrategy": "numbers",
+            "enableLogDetails": false,
+            "prettifyLogMessage": true,
+            "showCommonLabels": false,
+            "showLabels": false,
+            "showTime": false,
+            "sortOrder": "Descending",
+            "wrapLogMessage": false
+          },
+          "targets": [
+            {
+              "datasource": "${DS_LOKI}",
+              "expr": "{namespace=~\"flux-system\", stream=~\"$stream\", app =~\"$controller\"} | json | __error__!=\"JSONParserErr\" | level=~\"$level\" |= \"$query\"",
+              "refId": "A"
+            }
+          ],
+          "type": "logs"
+        }
+      ],
+      "refresh": "10s",
+      "schemaVersion": 36,
+      "style": "light",
+      "tags": [
+        "flux"
+      ],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": false,
+              "text": "",
+              "value": ""
+            },
+            "description": "String to search for",
+            "hide": 0,
+            "label": "Search Query",
+            "name": "query",
+            "options": [
+              {
+                "selected": true,
+                "text": "",
+                "value": ""
+              }
+            ],
+            "query": "",
+            "skipUrlSync": false,
+            "type": "textbox"
+          },
+          {
+            "allValue": "info|error",
+            "current": {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            "hide": 0,
+            "includeAll": true,
+            "multi": false,
+            "name": "level",
+            "options": [
+              {
+                "selected": true,
+                "text": "All",
+                "value": "$__all"
+              },
+              {
+                "selected": false,
+                "text": "info",
+                "value": "info"
+              },
+              {
+                "selected": false,
+                "text": "error",
+                "value": "error"
+              }
+            ],
+            "query": "info,error",
+            "queryValue": "",
+            "skipUrlSync": false,
+            "type": "custom"
+          },
+          {
+            "allValue": ".+",
+            "current": {
+              "selected": true,
+              "text": [
+                "All"
+              ],
+              "value": [
+                "$__all"
+              ]
+            },
+            "datasource": "${DS_LOKI}",
+            "definition": "label_values(app)",
+            "hide": 0,
+            "includeAll": true,
+            "multi": true,
+            "name": "controller",
+            "options": [],
+            "query": {
+              "label": "app",
+              "refId": "A",
+              "stream": "{namespace=\"flux-system\"}",
+              "type": 1
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          },
+          {
+            "allValue": ".+",
+            "current": {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": "${DS_LOKI}",
+            "definition": "label_values(stream)",
+            "hide": 0,
+            "includeAll": true,
+            "multi": true,
+            "name": "stream",
+            "options": [],
+            "query": "label_values(stream)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "type": "query"
+          },
+          {
+            "current": {
+              "selected": false,
+              "text": "Loki",
+              "value": "Loki"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": "Datasource",
+            "multi": false,
+            "name": "DS_LOKI",
+            "options": [],
+            "query": "loki",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Flux Logs",
+      "uid": "flux-logs",
+      "version": 2
+    }

--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/grafana/deployment.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/grafana/deployment.yaml
@@ -1,3 +1,17 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -39,6 +53,9 @@ spec:
             - name: flux-control-plane
               mountPath: "/var/lib/grafana/dashboards/kubernetes/flux-control-plane.json"
               subPath: flux-control-plane.json
+            - name: flux-logs
+              mountPath: "/var/lib/grafana/dashboards/kubernetes/flux-logs.json"
+              subPath: flux-logs.json
             - name: prow
               mountPath: "/var/lib/grafana/dashboards/kubernetes/prow-builds.json"
               subPath: builds.json
@@ -111,6 +128,9 @@ spec:
         - name: flux-control-plane
           configMap:
             name: flux-control-plane
+        - name: flux-logs
+          configMap:
+            name: flux-logs
         - name: prow
           configMap:
             name: prow-dashboards

--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/loki-stack/flux-hr-loki.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/loki-stack/flux-hr-loki.yaml
@@ -1,0 +1,52 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: loki-stack
+spec:
+  interval: 5m
+  chart:
+    spec:
+      version: "2.x"
+      chart: loki-stack
+      sourceRef:
+        kind: HelmRepository
+        name: grafana-charts
+      interval: 60m
+  # https://github.com/grafana/helm-charts/blob/main/charts/loki-stack/values.yaml
+  # https://github.com/grafana/loki/blob/main/production/helm/loki/values.yaml
+  values:
+    grafana:
+      enabled: false
+      sidecar:
+        datasources:
+          enabled: true
+          maxLines: 1000
+    promtail:
+      enabled: true
+    loki:
+      enabled: true
+      isDefault: false
+      serviceMonitor:
+        enabled: true
+        additionalLabels:
+          prometheus: main
+      config:
+        chunk_store_config:
+          max_look_back_period: 0s
+        table_manager:
+          retention_deletes_enabled: true
+          retention_period: 12h

--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/loki-stack/flux-source-helm-grafana-charts.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/loki-stack/flux-source-helm-grafana-charts.yaml
@@ -1,0 +1,21 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: grafana-charts
+spec:
+  interval: 120m0s
+  url: https://grafana.github.io/helm-charts

--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/loki-stack/kustomization.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/loki-stack/kustomization.yaml
@@ -1,0 +1,21 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - flux-source-helm-grafana-charts.yaml
+  - flux-hr-loki.yaml
+


### PR DESCRIPTION
This pull request introduces a new Grafana Dashboard that displays logs of all Flux controllers. The primary motivation behind this update is to empower developers by providing them with the ability to check for sync errors without requiring assistance from EKS administrators.

The deployment process for EKS clusters has been enhanced, and the updated flow now follows these steps:
* Create a pull request with your resources.
* Wait for approval and merge.
* Check the status of the sync process on the [Grafana Dashboard](https://monitoring-eks.prow.k8s.io/d/flux-cluster/flux-cluster-stats?viewPanel=33).
* If an error occurs during the sync process, navigate to the Flux-Logs dashboard and check the message from the controller (example below):
<img width="1028" alt="Screenshot 2023-06-15 at 17 41 36" src="https://github.com/kubernetes/k8s.io/assets/9121459/2e77d995-fd24-4997-8a56-5757d7889d68">

I'll create a separate PR with documentation update.

/assign @hh @ameukam @wozniakjan 
/cc @dims @xmudrii 
