### PR TITLE
eks-prow-build-cluster: Update missing Loki datasource

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/grafana/datasources.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/grafana/datasources.yaml
@@ -12,3 +12,8 @@ data:
       name: Prometheus Main
       type: prometheus
       url: http://prometheus-operated.monitoring:9090
+    - access: proxy
+      isDefault: false
+      name: Loki
+      type: loki
+      url: http://loki-stack.monitoring:3100


### PR DESCRIPTION
Follow up of https://github.com/kubernetes/k8s.io/pull/5428. The PR adds missing grafana datasource required for https://monitoring-eks.prow.k8s.io/d/flux-logs/flux-logs dashboard.

/assign @wozniakjan @ameukam 