### PR TITLE
Add DNS challenge for TestGrid cert.

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -326,16 +326,22 @@ submit-queue:
 testgrid:
   - type: A
     values:
-    - 216.239.32.21
-    - 216.239.34.21
-    - 216.239.36.21
-    - 216.239.38.21
+      - 216.239.32.21
+      - 216.239.34.21
+      - 216.239.36.21
+      - 216.239.38.21
+    # - 34.120.51.46 // TODO(michelle192837): Use this once certificate is active.
   - type: AAAA
     values:
-    - 2001:4860:4802:32::15
-    - 2001:4860:4802:34::15
-    - 2001:4860:4802:36::15
-    - 2001:4860:4802:38::15
+      - "2001:4860:4802:32::15"
+      - "2001:4860:4802:34::15"
+      - "2001:4860:4802:36::15"
+      - "2001:4860:4802:38::15"
+    # - "2600:1901:0:dc01::" // TODO(michelle192837): Use this once certificate is active.
+# DNS challenge for issuing (transition) TLS certificate
+_acme-challenge.k8s-testgrid:
+  type: CNAME
+  value: 2da25d3f-2ee8-4cfb-bbca-08a9fce4d3a4.1.authorize.certificatemanager.goog.
 # Running on GKE (@chases2)
 testgrid-data:
   - type: A


### PR DESCRIPTION
This _should_ let us transition to the load balancer later with zero downtime, hopefully?

Ref #5392