### PR TITLE
Add a daemonset for tuning fs.inotify.max_user_watches

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/kube-system/tune-sysctls_daemonset.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/kube-system/tune-sysctls_daemonset.yaml
@@ -1,0 +1,46 @@
+# a simple daemonset to tune sysctls
+# intended to be used in a prow build cluster
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: tune-sysctls
+  namespace: kube-system
+  labels:
+    app: tune-sysctls
+spec:
+  selector:
+    matchLabels:
+      name: tune-sysctls
+  template:
+    metadata:
+      labels:
+        name: tune-sysctls
+    spec:
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      containers:
+      - name: setsysctls
+        command:
+        - sh
+        - -c
+        - |
+          while true; do
+            sysctl -w fs.inotify.max_user_watches=524288
+            sleep 10
+          done
+        image: alpine:3.6
+        imagePullPolicy: IfNotPresent
+        resources: {}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: sys
+          mountPath: /sys
+      volumes:
+      - name: sys
+        hostPath:
+          path: /sys


### PR DESCRIPTION
Fix for flakiness in kinder/kubeadm based jobs as described here:
https://github.com/kubernetes/kubeadm/issues/2896#issuecomment-1595910088

We have this already in a couple of places:
- https://github.com/kubernetes/k8s.io/blob/master/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/kube-system/tune-sysctls_daemonset.yaml
- https://github.com/kubernetes/test-infra/blob/master/config/prow/cluster/build/tune-sysctls_daemonset.yaml