### PR TITLE
Add an AWS account for OBS infra

### DIFF
--- a/infra/aws/terraform/management-account/organization-accounts-workloads-prod.tf
+++ b/infra/aws/terraform/management-account/organization-accounts-workloads-prod.tf
@@ -45,3 +45,17 @@ module "prow_prod" {
     "service"     = "eks"
   }
 }
+
+module "obs-k8s-io" {
+  source = "../modules/org-account"
+
+  account_name = "k8s-infra-obs-k8s-io-prod"
+  email        = "k8s-infra-aws-admins+obs-k8s-io-prod@kubernetes.io"
+  parent_id    = aws_organizations_organizational_unit.production.id
+  tags = {
+    "production"  = "true",
+    "environment" = "prod",
+    "group"       = "sig-release",
+    "service"     = "obs"
+  }
+}


### PR DESCRIPTION
Fixes #5462 

This PR adds a new AWS account called `k8s-infra-obs-k8s-io-prod` (following the same name pattern as other prod accounts).

This account is going to be used for hosting and serving system packages, as well as, infra needed for connecting with OBS to do so.

/assign @ameukam 