### PR TITLE
eks-prow-build-cluster: Update Ubuntu AMI

### DIFF
--- a/infra/aws/terraform/modules/eks-prow-iam/policy_apply.tf
+++ b/infra/aws/terraform/modules/eks-prow-iam/policy_apply.tf
@@ -43,6 +43,8 @@ data "aws_iam_policy_document" "eks_apply" {
       "ec2:CreateEgressOnlyInternetGateway",
       "ec2:CreateInternetGateway",
       "ec2:CreateLaunchTemplate",
+      "ec2:CreateLaunchTemplateVersion",
+      "ec2:ModifyLaunchTemplate",
       "ec2:CreateNatGateway",
       "ec2:CreateRoute",
       "ec2:CreateRouteTable",

--- a/infra/aws/terraform/modules/eks-prow-iam/policy_destroy.tf
+++ b/infra/aws/terraform/modules/eks-prow-iam/policy_destroy.tf
@@ -32,6 +32,7 @@ data "aws_iam_policy_document" "eks_destroy" {
       "ec2:DeleteEgressOnlyInternetGateway",
       "ec2:DeleteInternetGateway",
       "ec2:DeleteLaunchTemplate",
+      "ec2:DeleteLaunchTemplateVersion",
       "ec2:DeleteNatGateway",
       "ec2:DeleteRoute",
       "ec2:DeleteRouteTable",

--- a/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
@@ -33,7 +33,7 @@ cluster_version            = "1.25"
 cluster_autoscaler_version = "v1.25.0"
 
 # Ubuntu EKS optimized AMI: https://cloud-images.ubuntu.com/aws-eks/
-node_ami            = "ami-03de35fda144b3672"
+node_ami            = "ami-07e8e7dddc8b3bad9"
 node_instance_types = ["r5d.xlarge"]
 node_volume_size    = 100
 

--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -33,7 +33,7 @@ cluster_version            = "1.25"
 cluster_autoscaler_version = "v1.25.0"
 
 # Ubuntu EKS optimized AMI: https://cloud-images.ubuntu.com/aws-eks/
-node_ami            = "ami-03de35fda144b3672"
+node_ami            = "ami-07e8e7dddc8b3bad9"
 node_instance_types = ["r5ad.4xlarge"]
 node_volume_size    = 100
 


### PR DESCRIPTION
This PR updates `ubuntu-eks/k8s_1.25/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230224`	 with `ubuntu-eks/k8s_1.25/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20230623`.

/assign @xmudrii @wozniakjan 