### PR TITLE
promoting go1205 & alpine3182 images

### DIFF
--- a/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -168,6 +168,7 @@
     "sha256:a98ce8ab90f16bdd8539b168a4d000f366afa4eec23a220b3ce39698c5769bfd": ["v20230527"]
     "sha256:75e167024ab116d01aab8199b0c8250ad4df38d2ea46d5ad696a73046c67ffdf": ["v20230622"]
     "sha256:e5c68dc56934c273850bfb75c0348a2819756669baf59fcdce9e16771537b247": ["v20230623-d50c7193b"]
+    "sha256:2cc681d0d20911946e6b9c2048397f5c9e9b17e8f5c2007f6a3814bfb22f1816": ["v20230627-1ddecfc09"]
 
 # custom cfssl image for e2e tests
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/cfssl
@@ -202,6 +203,7 @@
     "sha256:4938d1d91a2b7d19454460a8c1b010b89f6ff92d2987fd889ac3e8fc3b70d91a": ["v20230318-helm-chart-4.5.2-44-gfec1dbe3a"]
     "sha256:0027567308893767ffe64b2388d3ee3be11e984812a3f943bf521a6c1989a252": ["v20230407"]
     "sha256:6fc5aa2994c86575975bb20a5203651207029a0d28e3f491d8a127d08baadab4": ["v20230527"]
+    "sha256:d9c4240efb797beeaa7d4a28314a6c982469da1de0a62645c4c72d4f3fa338ee": ["v20230627"]
 
 # fastcgi HTTP server image for e2e tests
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/fastcgi-helloserver
@@ -212,6 +214,7 @@
     "sha256:0e08c836cc58f1ea862578de99b13bc4264fe071e816f96dc1d79857bfba7473": ["v20230312-helm-chart-4.5.2-28-g66a760794"]
     "sha256:00ea295ef4c625aacb69081dbb72f80f40ab0c2cff08d011695405bc2331a3fc": ["v20230404-helm-chart-4.6.0-11-gc76179c04"]
     "sha256:ad48881259c03149c39a348ad1662ee2a2e056465b9c08b5ec317eea46a4fdde": ["v20230407"]
+    "sha256:5470f0ddcfdaadcb7ccaf3db1b9fd7ac692e86eae2d59d272cd09d20a6a45c53": ["v20230626"]
 
 # httpbin image for e2e tests
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/httpbin
@@ -228,6 +231,7 @@
 - name: e2e-test-httpbun
   dmap:
     "sha256:cffe47cb15334c17dae63ed6bdfc2b287c43c130ee554735661c0aeb20b84933": ["v20230505-v0.0.1"]
+    "sha256:bd6728b770de8425dbbd7937bcadf27373a1ad3c103e4b00801f60d48059e39f": ["v20230626"]
 
 # kube-webhook-certgen
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/kube-webhook-certgen
@@ -244,6 +248,7 @@
     "sha256:01d181618f270f2a96c04006f33b2699ad3ccb02da48d0f89b22abce084b292f": ["v20230312-helm-chart-4.5.2-28-g66a760794"]
     "sha256:46a9364c2907dbde8a9fd01e75db44d4e0ba2ff9d7ab2ec9fe63e86a31cf8164": ["v20230404-helm-chart-4.6.0-11-gc76179c04"]
     "sha256:543c40fd093964bc9ab509d3e791f9989963021f1e9e4c9c7b6700b02bfb227b": ["v20230407"]
+    "sha256:1b6b18750eab3b5ebc00f1a6d96a34bf21138c875f3be6122103669a024fe63f": ["v20230626"]
 
 # nginx-errors
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/custom-error-pages
@@ -258,6 +263,7 @@
     "sha256:332be6ff8c4e93e8845963932f98839dfd52ae49829c29e06475368a3e4fbd9e": ["v20230312-helm-chart-4.5.2-28-g66a760794"]
     "sha256:aabd7a001f6a0a07ed6ea8f6da87e928bfa8f971eba2bef708f3e8504fc5cc9b": ["v20230404-helm-chart-4.6.0-11-gc76179c04"]
     "sha256:3600dcd1bbd0d05959bb01af4b272714e94d22d24a64e91838e7183c80e53f7f": ["v20230505"]
+    "sha256:59bd93fede2559c2b61d3baa5e9066e5b3ba71fa4faa06e368629ed287469b1d": ["v20230626"]
 
 # opentelemetry
 # https://github.com/kubernetes/ingress-nginx/tree/main/images/opentelemetry
@@ -277,3 +283,4 @@
     "sha256:a6b8b6a562884dbfc38748c1560b71ded09ba18c14abc4a989f93e7c3136ed5b": ["v20230404-helm-chart-4.6.0-13-g91057c439"]
     "sha256:fc366b7a2bc908794be614a7ff6384b14273ec5f12734ce7bc10886b3f19c59d": ["v20230407"]
     "sha256:fd7ec835f31b7b37187238eb4fdad4438806e69f413a203796263131f4f02ed0": ["v20230527"]
+    "sha256:1c8fa555f66d016b27e230f0b9b8c2fd7c8fe86fef342bdf5be609b392bf121f": ["v20230612"]


### PR DESCRIPTION
- New images got built after bumping go to v1.20.5 and alpine to v3.18.2
- These bumps fix CVEs
- Baseimae was promoted earlier this week and triggered rebuild of 3 images
- So this PR promotes 7 new image sha+tag to production registry
- This PR will need a follow up PR to change the ingress-nginx project to use all these 7 new image sha+tag

cc @strongjz @tao12345666333 @rikatz @cpanato 