### PR TITLE
Drop iam:CreateServiceLinkedRole from EKS permission boundary

### DIFF
--- a/infra/aws/terraform/modules/eks-prow-iam/boundary_eks_resources.tf
+++ b/infra/aws/terraform/modules/eks-prow-iam/boundary_eks_resources.tf
@@ -79,7 +79,6 @@ data "aws_iam_policy_document" "eks_resources_permission_boundary_doc" {
 
     actions = [
       "iam:AttachRolePolicy",
-      "iam:CreateServiceLinkedRole",
       "iam:DeleteRolePolicy",
       "iam:PutRolePolicy",
       "iam:PutRolePermissionsBoundary",


### PR DESCRIPTION
We're facing the following error when trying to create a LoadBalancer Service on canary EKS Prow cluster:

```
Warning  SyncLoadBalancerFailed  16s   service-controller               Error syncing load balancer: failed to ensure load balancer: AccessDenied: User: arn:aws:sts::<redacted>:assumed-role/prow-canary-cluster-cluster-<readacted>/<redacted> is not authorized to perform: iam:CreateServiceLinkedRole on resource: arn:aws:iam::<redacted>:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing with an explicit deny in a permissions boundary
```

As per [AWS docs](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html), Service Linked Roles are not allowed to have permission boundaries (emphasis mine):

> **Permissions boundary**
An advanced feature in which you use policies to limit the maximum permissions that an identity-based policy can grant to a role. **You cannot apply a permissions boundary to a service-linked role.** For more information, see [Permissions boundaries for IAM entities](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html).

That said, we shouldn't enforce permission boundaries on Service Linked Roles.

Note: the reason why we don't face this error on prod cluster is that the Service Linked Role got created before introducing permission boundaries.

/assign @pkprzekwas 