### PR TITLE
Add AlertManager to EKS Prow build cluster

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager-config.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager-config.yaml
@@ -1,0 +1,52 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: main
+  namespace: monitoring
+  labels:
+    alertmanager: main
+spec:
+  route:
+    receiver: 'kubermatic'
+
+    # How long to initially wait to send a notification for a group
+    # of alerts. Allows to wait for an inhibiting alert to arrive or collect
+    # more initial alerts for the same group.
+    groupWait: 30s
+
+    # How long to wait before sending a notification about new alerts that
+    # are added to a group of alerts for which an initial notification has
+    # already been sent.
+    groupInterval: 5m
+
+    # How long to wait before sending a notification again if it has already
+    # been sent successfully for an alert.
+    repeatInterval: 4h
+
+    # Default group criteria. This might need some refactor if we add more
+    # alerting rules.
+    groupBy: ['alertname', 'node']
+  receivers:
+  - name: 'kubermatic'
+    slackConfigs:
+    - apiURL:
+        name: alertmanager-k8c-slack-token
+        key: url
+      channel: '#alerting-cncf-prod'
+      sendResolved: true
+      title: ":warning: {{ .CommonLabels.alertname }}"
+      text: "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"

--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager-slack-token.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager-slack-token.yaml
@@ -1,0 +1,32 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: alertmanager-k8c-slack-token
+  namespace: monitoring
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secerts-manager
+    kind: ClusterSecretStore
+  target:
+    name: alertmanager-k8c-slack-token
+    creationPolicy: Owner
+  data:
+  - secretKey: url
+    remoteRef:
+      key: secrets/kubermatic
+      property: slack-alerting-cncf-prod

--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager.yaml
@@ -1,0 +1,23 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Alertmanager
+metadata:
+  name: main
+  namespace: monitoring
+spec:
+  replicas: 3
+  alertmanagerConfiguration:
+    name: main

--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/prometheus-rule-node-status.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/prometheus-rule-node-status.yaml
@@ -1,0 +1,41 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: node-status-rules
+  namespace: monitoring
+  labels:
+    prometheus: main
+spec:
+  groups:
+  - name: node:status
+    rules:
+    - alert: NodeStatusNotReady
+      # This expression might need some refinements in case we scale up
+      # kube-state-metrics to more than 1 replica.
+      expr: kube_node_status_condition{condition="Ready",status!="true"} == 1
+      # Only fire up alert if the alert condition has been firing to more than
+      # 5 minutes. This is to avoid false positives/flakes while a new node
+      # is joining the cluster.
+      for: 5m
+      # These annotations are used for building the Slack message.
+      annotations:
+        summary: "NodeStatusNotReady"
+        description: "Node {{ $labels.node }} is not ready"
+      # Additional labels used as metadata.
+      labels:
+        severity: critical
+        resource: "{{ $labels.node }}"


### PR DESCRIPTION
This PR adds initial alerting stack to the EKS Prow build cluster. Right now, it:

- has only one alert to notify us if there's a node that's NotReady (to help us triage #5473)
- sends notification to Kubermatic's internal Slack

Additional alerts might be added in the future. I'll also check if it's possible to route alerts to Kubernetes Slack.

This has been already tested in the canary cluster and it works well.

/assign @pkprzekwas 
cc @ameukam 