### PR TITLE
Add DNS records and redirects for OpenBuildService

### DIFF
--- a/apps/k8s-io/README.md
+++ b/apps/k8s-io/README.md
@@ -23,6 +23,7 @@ Vanity URL(s)
 | Redirections | https://go.k8s.io | https://go.kubernetes.io |
 | Issues | https://issue.k8s.io <br> https://issues.k8s.io | https://issue.kubernetes.io <br> https://issues.kubernetes.io |
 | Main site | https://k8s.io | https://kubernetes.io |
+| Packages (OpenBuildService) | https://packages.k8s.io <br> https://pkgs.k8s.io | https://packages.kubernetes.io <br> https://pkgs.kubernetes.io |
 | PR Dashboard | https://pr-test.k8s.io | https://pr-test.kubernetes.io |
 | Pull requests | https://pr.k8s.io <br> https://prs.k8s.io | https://pr.kubernetes.io <br> https://prs.kubernetes.io |
 | Downloads | https://releases.k8s.io <br> https://rel.k8s.io | https://releases.kubernetes.io <br> https://rel.kubernetes.io |

--- a/apps/k8s-io/certificate-canary.yaml
+++ b/apps/k8s-io/certificate-canary.yaml
@@ -47,6 +47,10 @@ spec:
   - issue.kubernetes.io
   - issues.k8s.io
   - issues.kubernetes.io
+  - packages.k8s.io
+  - packages.kubernetes.io
+  - pkgs.k8s.io
+  - pkgs.kubernetes.io
   - pr-test.k8s.io
   - pr-test.kubernetes.io
   - pr.k8s.io

--- a/apps/k8s-io/certificate-prod.yaml
+++ b/apps/k8s-io/certificate-prod.yaml
@@ -42,6 +42,10 @@ spec:
   - issues.kubernetes.io
   - kep.k8s.io
   - kep.kubernetes.io
+  - packages.k8s.io
+  - packages.kubernetes.io
+  - pkgs.k8s.io
+  - pkgs.kubernetes.io
   - pr-test.k8s.io
   - pr-test.kubernetes.io
   - pr.k8s.io

--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -135,6 +135,13 @@ data:
       }
 
       server {
+        server_name packages.kubernetes.io pkgs.kubernetes.io packages.k8s.io pkgs.k8s.io;
+        listen 80;
+
+        rewrite ^/(.*)?$    https://prod-cdn.packages.k8s.io/repositories/isv:/kubernetes:/$1 redirect;
+      }
+
+      server {
         server_name blog.kubernetes.io blog.k8s.io;
         listen 80;
 

--- a/apps/k8s-io/test.py
+++ b/apps/k8s-io/test.py
@@ -224,6 +224,12 @@ class RedirTest(HTTPTestCase):
             self.assert_temp_redirect(base, 'https://packages.cloud.google.com/apt/')
             self.assert_temp_redirect(base + '/$id',
                 'https://packages.cloud.google.com/apt/$id', id=rand_num())
+    
+    def test_packages(self):
+        for base in ('packages.k8s.io', 'packages.kubernetes.io', 'pkgs.k8s.io', 'pkgs.kubernetes.io'):
+            self.assert_temp_redirect(base, 'https://prod-cdn.packages.k8s.io/repositories/isv:/kubernetes:/')
+            self.assert_temp_redirect(base + '/$id',
+                'https://prod-cdn.packages.k8s.io/repositories/isv:/kubernetes:/$id', id=rand_num())
 
     def test_blog(self):
         for base in ('blog.k8s.io', 'blog.kubernetes.io'):

--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -105,11 +105,18 @@ releases:
   value: redirect.k8s.io.
 
 # Packages / OpenBuildService (OBS)
-# Record for AWS ACM DNS challenge for prod-cdn.packages.k8s.io
-# Should stay here all the time to support certificate renewal
+packages:
+  type: CNAME
+  value: redirect.k8s.io.
+pkgs:
+  type: CNAME
+  value: redirect.k8s.io.
+# CDN frontend for S3 bucket containing packages
 prod-cdn.packages:
   type: CNAME
   value: dkhzw6k7x6ord.cloudfront.net.
+# Record for AWS ACM DNS challenge for prod-cdn.packages.k8s.io
+# Should stay here all the time to support certificate renewal
 _952ed01ad08f0d53cf3b05e61bd7b6e6.prod-cdn.packages:
   type: CNAME
   value: _ed9dd4aee039559895c2c55de602691e.vrcmzfbvtx.acm-validations.aws.

--- a/dns/zone-configs/kubernetes.io._0_base.yaml
+++ b/dns/zone-configs/kubernetes.io._0_base.yaml
@@ -153,6 +153,13 @@ issues:
 kep:
   type: CNAME
   value: kep.k8s.io.
+# Packages / OpenBuildService (OBS)
+packages:
+  type: CNAME
+  value: packages.k8s.io.
+pkgs:
+  type: CNAME
+  value: pkgs.k8s.io.
 pr:
   type: CNAME
   value: pr.k8s.io.


### PR DESCRIPTION
The following DNS records are dedicated for packages hosted via OpenBuildService:

- `packages.k8s.io`
- `packages.kubernetes.io`
- `pkgs.k8s.io`
- `pkgs.kubernetes.io`

All four records are pointing to `redirect.k8s.io` which is then redirecting to `https://prod-cdn.packages.k8s.io/repositories/isv:/kubernetes:/`

Important note: after discussing with @bmwiedemann, we decided to serve packages from our CloudFront CDN instead of `download.opensuse.org` because registering our CDN as a mirror requires additional effort and development on the OBS side. We hope this will be sorted out in the future and once that happens, we'll switch domains to `download.o.o`

Fixes #5517 
xref #5386
xref https://kubernetes.slack.com/archives/C03U7N0VCGK/p1687769853801219

/assign @ameukam 
cc @kubernetes/sig-release-leads @kubernetes/release-engineering 