### PR TITLE
Allow akhilerm to access publishing-bot instance

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -178,6 +178,7 @@ groups:
       ReconcileMembers: "true"
     members:
       - k8s-infra-release-editors@kubernetes.io
+      - akhilerm@gmail.com
       - davanum@gmail.com
       - nikitaraghunath@gmail.com
       - stefan.schimanski@gmail.com
@@ -418,6 +419,7 @@ groups:
       WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # required
     members:
       - k8s-infra-release-editors@kubernetes.io
+      - akhilerm@gmail.com
       - ameukam@gmail.com
       - cblecker@gmail.com
       - davanum@gmail.com


### PR DESCRIPTION
Akhil is a publishing-bot reviewer and has created multiple non-trivial and complicated PRs to the bot. His PRs demonstrate that he understands how the bot works and I'm confident that he can help with fixing any bot failures.

Ref: https://github.com/kubernetes/publishing-bot/pulls?q=+is%3Apr+involves%3Aakhilerm+


/assign @dims 
cc @akhilerm 