### PR TITLE
release: Promote CAPA v2.2.0 image

### DIFF
--- a/registry.k8s.io/images/k8s-staging-cluster-api-aws/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-cluster-api-aws/images.yaml
@@ -75,6 +75,7 @@
     "sha256:96bdbd1af8709b292411570f287ddfc2fdacc64f9d8fb665928872a64f1ae721": ["v2.1.2"]
     "sha256:6465e145fab91f9b3b72a52c43adc825c57a673ea9ee0fedd25526254cf400ea": ["v2.1.3"]
     "sha256:8049ea6406e4a9ed17ffa885b29a8fe833a5c1010fde561a034a341b25836cb3": ["v2.1.4"]
+    "sha256:a12edb41b98f2bd075b2581b591acbfcd0ff3b4d89bb31f568252d280ddb8fce": ["v2.2.0"]
 - name: eks-bootstrap-controller
   dmap:
     "sha256:0dda3f1be2c56b0ffee4668c67a9da2a5af33a5aa66c7db91c98534140265408": ["v0.6.0"]


### PR DESCRIPTION
Adds the v2.2.0 images for CAPA.