### PR TITLE
infra/aws/tf/infrastructure-services: set up healthcheck for google-pacakges-apt

### DIFF
--- a/infra/aws/terraform/infrastructure-services/main.tf
+++ b/infra/aws/terraform/infrastructure-services/main.tf
@@ -1,0 +1,86 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  required_version = "~> 1.5.0"
+
+  backend "s3" {
+    bucket = "<NEW_BUCKET_NAME>"
+    key    = "infrastructure-services/terraform.tfstate"
+    region = "us-east-2"
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.7"
+    }
+  }
+}
+
+locals {
+  name = "external-dependency-health-checks"
+  external_dependency_health_checks_targets = {
+    google_cloud_pkgs_apt_gpg = {
+      name = "google-cloud-pkgs-apt-gpg"
+      fqdn = "packages.cloud.google.com"
+      resource_path = "/apt/doc/apt-key.gpg"
+    }
+  }
+  emails = [
+    "k8s-infra-alerts@kubernetes.io"
+  ]
+  sns_topic_delivery_policy = jsonencode({
+    "http" : {
+      "defaultHealthyRetryPolicy" : {
+        "minDelayTarget" : 20,
+        "maxDelayTarget" : 20,
+        "numRetries" : 3,
+        "numMaxDelayRetries" : 0,
+        "numNoDelayRetries" : 0,
+        "numMinDelayRetries" : 0,
+        "backoffFunction" : "linear"
+      },
+      "disableSubscriptionOverrides" : false,
+      "defaultThrottlePolicy" : {
+        "maxReceivesPerSecond" : 1
+      }
+    }
+  })
+}
+
+module "external_dependency_sns_topic" {
+  source = "../modules/sns/sns-topic"
+  name  =  local.name
+  delivery_policy = local.sns_topic_delivery_policy
+}
+
+module "external_dependency_sns_subscribe_emails" {
+  source = "../modules/sns/sns-subscribe-email"
+  name  =  local.name
+  emails = local.emails
+  sns_topic_arn = module.external_dependency_sns_topic.sns_topic_arn
+}
+
+module "external_dependency_health_checks" {
+  for_each = local.external_dependency_health_checks_targets
+  source = "../modules/external-resource-health-check/https-health-check"
+  name  = each.value["name"]
+  fqdn   = each.value["fqdn"]
+  resource_path   = each.value["resource_path"]
+  sns_arn = module.external_dependency_sns_topic.sns_topic_arn
+  disabled = each.value["disabled"]
+}

--- a/infra/aws/terraform/modules/external-resource-health-check/https-health-check/main.tf
+++ b/infra/aws/terraform/modules/external-resource-health-check/https-health-check/main.tf
@@ -1,0 +1,43 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+locals {
+  prefix = "external-https-dependency"
+}
+
+resource "aws_route53_health_check" "this" {
+  type = "HTTPS"
+  reference_name = "${local.prefix}-${var.name}"
+  failure_threshold = var.failure_threshold
+  request_interval = var.request_interval
+  fqdn = var.fqdn
+  port = var.port
+  resource_path = var.resource_path == "" ? null : var.resource_path
+  disabled = var.disabled
+}
+
+resource "aws_cloudwatch_metric_alarm" "this" {
+  alarm_name          = "${local.prefix}-${var.name}"
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = "1"
+  metric_name = "HealthCheckStatus"
+  namespace = "AWS/Route53"
+  period = var.alarm_period
+  statistic = "Average"
+  threshold = 1
+  alarm_description = "This Alarm monitors the healthcheck status of ${local.prefix}-${var.name}"
+  alarm_actions = [var.sns_arn]
+}

--- a/infra/aws/terraform/modules/external-resource-health-check/https-health-check/variables.tf
+++ b/infra/aws/terraform/modules/external-resource-health-check/https-health-check/variables.tf
@@ -1,0 +1,81 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+variable "name" {
+  type = string
+  description = "Name for health-check and associated alarm"
+}
+
+variable "fqdn" {
+  type = string
+  description = "Destination domain to check"
+}
+
+variable "resource_path" {
+  type = string
+  description = "Health check resource path"
+  default = ""
+}
+
+variable "port" {
+  type =  number
+  description = "HTTP port to check"
+  default = 443
+}
+
+variable "request_interval" {
+  type = string
+  description = "Health check request interval"
+  default = "30"
+}
+
+variable "regions" {
+  type = list(string)
+  description = "AWS regions - us-east-1 | us-west-1 | us-west-2 | eu-west-1 | ap-southeast-1 | ap-southeast-2 | ap-northeast-1 | sa-east-1"
+  default = [
+    "us-east-1",
+    "us-west-1",
+    "us-west-2",
+    "eu-west-1",
+    "ap-southeast-1",
+    "ap-southeast-2",
+    "ap-northeast-1",
+    "sa-east-1"
+  ]
+}
+
+variable "disabled" {
+  type = bool
+  description = "Enable or Disable the healthcheck - disabled set target as always healthy"
+  default = false
+}
+
+variable "failure_threshold" {
+  type = string
+  description = "The number of consecutive health checks that an endpoint must pass or fail."
+  default = "5"
+}
+
+variable "alarm_period" {
+  type = string
+  description = "The period in seconds over which the specified statistic is applied. Valid values are 10, 30, or any multiple of 60"
+  default = "60"
+}
+
+variable "sns_arn" {
+  type = string
+  description = "AWS SNS Arn to alert the relevant group"
+}

--- a/infra/aws/terraform/modules/sns/sns-subscribe-email/main.tf
+++ b/infra/aws/terraform/modules/sns/sns-subscribe-email/main.tf
@@ -1,0 +1,23 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "aws_sns_topic_subscription" "this" {
+  name = "${var.name}-email-${var.emails[count.index]}"
+  count     = length(var.emails)
+  endpoint = var.emails[count.index]
+  protocol = "email"
+  topic_arn = var.sns_topic_arn
+}

--- a/infra/aws/terraform/modules/sns/sns-subscribe-email/variables.tf
+++ b/infra/aws/terraform/modules/sns/sns-subscribe-email/variables.tf
@@ -1,0 +1,30 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+variable "name" {
+  type = string
+  description = "Name for sns topic and and associated subscription"
+}
+
+variable "sns_topic_arn" {
+  type = string
+  description = "SNS Topic ARN"
+}
+
+variable "emails" {
+  type = list(string)
+  description = "Emails addresses to subscribe"
+}

--- a/infra/aws/terraform/modules/sns/sns-topic/main.tf
+++ b/infra/aws/terraform/modules/sns/sns-topic/main.tf
@@ -1,0 +1,20 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "aws_sns_topic" "this" {
+  name = var.name
+  delivery_policy = var.delivery_policy
+}

--- a/infra/aws/terraform/modules/sns/sns-topic/outputs.tf
+++ b/infra/aws/terraform/modules/sns/sns-topic/outputs.tf
@@ -1,0 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+output "sns_topic_arn" {
+  value = aws_sns_topic.this.arn
+}

--- a/infra/aws/terraform/modules/sns/sns-topic/variables.tf
+++ b/infra/aws/terraform/modules/sns/sns-topic/variables.tf
@@ -1,0 +1,25 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+variable "name" {
+  type = string
+  description = "Name for sns topic and and associated subscription"
+}
+
+variable "delivery_policy" {
+  type = string
+  description = "SNS delivery policy"
+}


### PR DESCRIPTION
- introduce two new modules: 
  -  sns-via-email: setup sns topic and associated email subscription 
  - external-resource-health-check/https-health-check: setup HTTPS health checks per provided config

Requires a new backend s3 bucket per discussion with @ameukam 

ref: #4841 
/cc @xmudrii
/assign @ameukam
