### PR TITLE
eks-prow-build: increase repeatInterval for alertmanager

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager-config.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager-config.yaml
@@ -35,7 +35,7 @@ spec:
 
     # How long to wait before sending a notification again if it has already
     # been sent successfully for an alert.
-    repeatInterval: 4h
+    repeatInterval: 24h
 
     # Default group criteria. This might need some refactor if we add more
     # alerting rules.


### PR DESCRIPTION
To reduce noise while we're debugging issues, let's increase the `repeatInterval` for alerts from 4 to 24 hours.

/assign @pkprzekwas @ameukam 