### PR TITLE
Add Terraform and CloudFormation configs for `cdn.packages.k8s.io`

### DIFF
--- a/infra/aws/cloudformation/iam/cdn.packages.k8s.io/OWNERS
+++ b/infra/aws/cloudformation/iam/cdn.packages.k8s.io/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - release-engineering-approvers
+reviewers:
+  - release-engineering-reviewers
+
+labels:
+  - sig/release
+  - area/release-eng

--- a/infra/aws/cloudformation/iam/cdn.packages.k8s.io/README.md
+++ b/infra/aws/cloudformation/iam/cdn.packages.k8s.io/README.md
@@ -1,0 +1,13 @@
+# IAM for OBS/`packages.k8s.io` account
+
+This directory contains CloudFormation templates needed to provision IAM
+resources to be used for managing AWS account backing OBS/`packages.k8s.io`
+infra.
+
+## Applying CloudFormation Stacks
+
+Stack is applied by logging in with the root user to obs-k8s-io-prod account
+and applying the appropriate stack (YAML file).
+See [the following document][using-cf] for more details.
+
+[using-cf]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-create-stack.html

--- a/infra/aws/cloudformation/iam/cdn.packages.k8s.io/README.md
+++ b/infra/aws/cloudformation/iam/cdn.packages.k8s.io/README.md
@@ -1,13 +1,20 @@
-# IAM for OBS/`packages.k8s.io` account
+# CloudFormation-Managed Resources For `cdn.packages.k8s.io`
 
-This directory contains CloudFormation templates needed to provision IAM
-resources to be used for managing AWS account backing OBS/`packages.k8s.io`
-infra.
+This directory contains CloudFormation template needed to provision:
 
-## Applying CloudFormation Stacks
+- S3 bucket used for Terraform state
+- IAM user, role, and policies used with Terraform to manage S3 bucket used for
+  packages and CloudFront distribution
+- IAM user and policy used by the OpenBuildService (OBS) platform to publish
+  packages
 
-Stack is applied by logging in with the root user to obs-k8s-io-prod account
-and applying the appropriate stack (YAML file).
-See [the following document][using-cf] for more details.
+## Applying/Updating CloudFormation Stacks
+
+Stack is applied and updated by logging in with the root account to
+`k8s-infra-obs-k8s-io-prod` AWS account and applying the appropriate stack
+(YAML file). See [the following document][using-cf] for more details.
+
+Credentials for the root account are located in 1Password where Release
+Managers have access.
 
 [using-cf]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-create-stack.html

--- a/infra/aws/cloudformation/iam/cdn.packages.k8s.io/cloudformation.yaml
+++ b/infra/aws/cloudformation/iam/cdn.packages.k8s.io/cloudformation.yaml
@@ -1,3 +1,16 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 Resources:
   #########################################
   # Terraform State                       #
@@ -12,13 +25,21 @@ Resources:
     DeletionPolicy: Retain
     Properties:
       BucketName: cdn-packages-k8s-io-tfstate
-      AccessControl: Private
+      VersioningConfiguration:
+        Status: Enabled
 
   #########################################
   # IAM user for Terraform                #
   #########################################
 
-  # ProvisionerUser (provisioner) is an IAM user used for running Terraform
+  # ProvisionerUser (provisioner) is an IAM user used for running Terraform.
+  # This is a shared user used by Kubernetes Release Managers to run Terraform
+  # and manage this AWS account.
+  # We need to use a shared IAM user because we can only run Terraform locally.
+  # In the future, we will intorduce some changes that will allow us to phase
+  # out this IAM user:
+  #   - GitOps workflow that's going to automatically apply Terraform changes
+  #   - Integration such as Okta so we have personalized AWS users
   ProvisionerUser:
     Type: 'AWS::IAM::User'
     Properties:
@@ -44,8 +65,27 @@ Resources:
           - Action: 'sts:AssumeRole'
             Effect: Allow
             Principal:
-              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:user/provisioner'
-    DependsOn: ProvisionerUser
+              AWS: !GetAtt ProvisionerUser.Arn
+
+  TerraformStateAccessPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      ManagedPolicyName: ProvisionerPlanAccess
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          # Permissions needed for S3 bucket used for Terraform state are documented here:
+          # https://developer.hashicorp.com/terraform/language/settings/backends/s3#s3-bucket-permissions
+          - Effect: 'Allow'
+            Action:
+              - 's3:ListBucket'
+            Resource: !GetAtt TFStateBucket.Arn
+          - Effect: 'Allow'
+            Action:
+              - 's3:GetObject'
+              - 's3:PutObject'
+              - 's3:DeleteObject'
+            Resource: !Sub '${TFStateBucket.Arn}/*'
 
   # ProvisionerPlanAccessPolicy is an IAM policy that grants permissions to run `terraform plan`
   ProvisionerPlanAccessPolicy:
@@ -55,6 +95,9 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
+          # CloudFront requires the ACM certificate objects to be located in
+          # the us-east-1 region. That's why we only give `acm:` permissions in
+          # that region.
           - Effect: 'Allow'
             Action:
               - 'acm:DescribeCertificate'
@@ -89,17 +132,9 @@ Resources:
               - 's3:GetReplicationConfiguration'
               - 's3:ListBucket'
             Resource: 'arn:aws:s3:::*-cdn-packages-k8s-io-*'
-          - Effect: 'Allow'
-            Action:
-              - 's3:GetObject'
-              - 's3:ListBucket'
-            Resource:
-              - !Sub 'arn:aws:s3:::${TFStateBucket}'
-              - !Sub 'arn:aws:s3:::${TFStateBucket}/*'
-      # Attach the policy to the provisioner IAM user
+      # Attach the policy to the Provisioner IAM role
       Roles:
         - Ref: ProvisionerRole
-    DependsOn: ProvisionerRole
 
   # ProvisionerApplyAccessPolicy is an IAM policy that grants permissions to run `terraform apply`
   ProvisionerApplyAccessPolicy:
@@ -131,14 +166,9 @@ Resources:
               - 's3:PutBucketPolicy'
               - 's3:PutBucketTagging'
             Resource: 'arn:aws:s3:::*-cdn-packages-k8s-io-*'
-          - Effect: 'Allow'
-            Action:
-              - 's3:PutObject'
-            Resource: !Sub 'arn:aws:s3:::${TFStateBucket}/*'
-      # Attach the policy to the provisioner IAM user
+      # Attach the policy to the Provisioner IAM role
       Roles:
         - Ref: ProvisionerRole
-    DependsOn: ProvisionerRole
 
   # ProvisionerDestroyAccessPolicy is an IAM policy that grants permissions to run `terraform destroy`
   ProvisionerDestroyAccessPolicy:
@@ -165,13 +195,12 @@ Resources:
               - 's3:DeleteBucket'
               - 's3:DeleteBucketPolicy'
             Resource: 'arn:aws:s3:::*-cdn-packages-k8s-io-*'
-      # Attach the policy to the provisioner IAM user
+      # Attach the policy to the Provisioner IAM role
       Roles:
         - Ref: ProvisionerRole
-    DependsOn: ProvisionerRole
 
   #########################################
-  # IAM user for OBS                      #
+  # IAM user for OpenBuildService (OBS)   #
   #########################################
 
   # OBSAdminUser (obs-admin) is an IAM user used by the OBS platform to perform
@@ -198,7 +227,6 @@ Resources:
               - 's3:DeleteObject'
               - 's3:GetObject'
               - 's3:PutObject'
-              - 's3:PutObjectAcl'
             Resource:
               - 'arn:aws:s3:::prod-cdn-packages-k8s-io-*'
               - 'arn:aws:s3:::prod-cdn-packages-k8s-io-*/*'
@@ -207,4 +235,3 @@ Resources:
             Resource: 'arn:aws:s3:::prod-cdn-packages-k8s-io-*'
       Users:
         - Ref: OBSAdminUser
-    DependsOn: OBSAdminUser

--- a/infra/aws/cloudformation/iam/cdn.packages.k8s.io/cloudformation.yaml
+++ b/infra/aws/cloudformation/iam/cdn.packages.k8s.io/cloudformation.yaml
@@ -11,6 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+Parameters:
+  AllPackagesBucketsArn:
+    Type: String
+    Description: ARN that matches all buckets used for storing packages (prod and canary)
+    ConstraintDescription: ARN is required
+    AllowedPattern: ".+"
+    Default: "arn:aws:s3:::*-cdn-packages-k8s-io-*"
+  ProdPackagesBucketsArn:
+    Type: String
+    Description: ARN that matches buckets only used for production
+    ConstraintDescription: ARN is required
+    AllowedPattern: ".+"
+    Default: "arn:aws:s3:::prod-cdn-packages-k8s-io-*"
+
 Resources:
   #########################################
   # Terraform State                       #
@@ -70,7 +84,7 @@ Resources:
   TerraformStateAccessPolicy:
     Type: 'AWS::IAM::ManagedPolicy'
     Properties:
-      ManagedPolicyName: ProvisionerPlanAccess
+      ManagedPolicyName: TerraformStateAccess
       PolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -131,7 +145,7 @@ Resources:
               - 's3:GetLifecycleConfiguration'
               - 's3:GetReplicationConfiguration'
               - 's3:ListBucket'
-            Resource: 'arn:aws:s3:::*-cdn-packages-k8s-io-*'
+            Resource: !Ref AllPackagesBucketsArn
       # Attach the policy to the Provisioner IAM role
       Roles:
         - Ref: ProvisionerRole
@@ -165,7 +179,7 @@ Resources:
               - 's3:PutBucketOwnershipControls'
               - 's3:PutBucketPolicy'
               - 's3:PutBucketTagging'
-            Resource: 'arn:aws:s3:::*-cdn-packages-k8s-io-*'
+            Resource: !Ref AllPackagesBucketsArn
       # Attach the policy to the Provisioner IAM role
       Roles:
         - Ref: ProvisionerRole
@@ -194,7 +208,7 @@ Resources:
             Action:
               - 's3:DeleteBucket'
               - 's3:DeleteBucketPolicy'
-            Resource: 'arn:aws:s3:::*-cdn-packages-k8s-io-*'
+            Resource: !Ref AllPackagesBucketsArn
       # Attach the policy to the Provisioner IAM role
       Roles:
         - Ref: ProvisionerRole
@@ -228,10 +242,10 @@ Resources:
               - 's3:GetObject'
               - 's3:PutObject'
             Resource:
-              - 'arn:aws:s3:::prod-cdn-packages-k8s-io-*'
-              - 'arn:aws:s3:::prod-cdn-packages-k8s-io-*/*'
+              - !Ref ProdPackagesBucketsArn
+              - !Sub '${ProdPackagesBucketsArn}/*'
           - Effect: 'Allow'
             Action: 's3:ListAllMyBuckets'
-            Resource: 'arn:aws:s3:::prod-cdn-packages-k8s-io-*'
+            Resource: !Ref ProdPackagesBucketsArn
       Users:
         - Ref: OBSAdminUser

--- a/infra/aws/cloudformation/iam/cdn.packages.k8s.io/cloudformation.yaml
+++ b/infra/aws/cloudformation/iam/cdn.packages.k8s.io/cloudformation.yaml
@@ -54,6 +54,8 @@ Resources:
   # out this IAM user:
   #   - GitOps workflow that's going to automatically apply Terraform changes
   #   - Integration such as Okta so we have personalized AWS users
+  # Credentials for this IAM user are located in 1Password vault accessible
+  # by Kubernetes Release Managers.
   ProvisionerUser:
     Type: 'AWS::IAM::User'
     Properties:

--- a/infra/aws/cloudformation/iam/cdn.packages.k8s.io/cloudformation.yaml
+++ b/infra/aws/cloudformation/iam/cdn.packages.k8s.io/cloudformation.yaml
@@ -1,0 +1,210 @@
+Resources:
+  #########################################
+  # Terraform State                       #
+  #########################################
+
+  # TFStateBucket (packages-k8s-io-tfstate) is S3 bucket for storing Terraform
+  # state
+  TFStateBucket:
+    Type: AWS::S3::Bucket
+    # We retain the bucket to ensure that accidental deletion of the stack
+    # doesn't destroy Terraform state
+    DeletionPolicy: Retain
+    Properties:
+      BucketName: cdn-packages-k8s-io-tfstate
+      AccessControl: Private
+
+  #########################################
+  # IAM user for Terraform                #
+  #########################################
+
+  # ProvisionerUser (provisioner) is an IAM user used for running Terraform
+  ProvisionerUser:
+    Type: 'AWS::IAM::User'
+    Properties:
+      Path: /
+      UserName: provisioner
+      Policies:
+        - PolicyName: ProvisionerUserAccess
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Action: 'sts:AssumeRole'
+                Effect: Allow
+                Resource: !Sub 'arn:aws:iam::${AWS::AccountId}:role/Provisioner'
+
+  # ProvisionerRole is an IAM role assumed by provisioner IAM user to run Terraform
+  ProvisionerRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: Provisioner
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:user/provisioner'
+    DependsOn: ProvisionerUser
+
+  # ProvisionerPlanAccessPolicy is an IAM policy that grants permissions to run `terraform plan`
+  ProvisionerPlanAccessPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      ManagedPolicyName: ProvisionerPlanAccess
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: 'Allow'
+            Action:
+              - 'acm:DescribeCertificate'
+              - 'acm:ListTagsForCertificate'         
+            Resource: !Sub 'arn:aws:acm:us-east-1:${AWS::AccountId}:certificate/*'
+          - Effect: 'Allow'
+            Action:
+              - 'cloudfront:GetCachePolicy'
+              - 'cloudfront:GetDistribution'
+              - 'cloudfront:GetOriginAccessControl'
+              - 'cloudfront:ListCachePolicies'
+              - 'cloudfront:ListTagsForResource'
+            Resource:
+              - !Sub 'arn:aws:cloudfront::${AWS::AccountId}:distribution/*'
+              - !Sub 'arn:aws:cloudfront::${AWS::AccountId}:cache-policy/*'
+              - !Sub 'arn:aws:cloudfront::${AWS::AccountId}:origin-access-control/*'
+          - Effect: 'Allow'
+            Action:
+              - 's3:GetAccelerateConfiguration'
+              - 's3:GetBucketAcl'
+              - 's3:GetBucketCORS'
+              - 's3:GetBucketLogging'
+              - 's3:GetBucketObjectLockConfiguration'
+              - 's3:GetBucketOwnershipControls'
+              - 's3:GetBucketPolicy'
+              - 's3:GetBucketRequestPayment'
+              - 's3:GetBucketTagging'
+              - 's3:GetBucketVersioning'
+              - 's3:GetBucketWebsite'
+              - 's3:GetEncryptionConfiguration'
+              - 's3:GetLifecycleConfiguration'
+              - 's3:GetReplicationConfiguration'
+              - 's3:ListBucket'
+            Resource: 'arn:aws:s3:::*-cdn-packages-k8s-io-*'
+          - Effect: 'Allow'
+            Action:
+              - 's3:GetObject'
+              - 's3:ListBucket'
+            Resource:
+              - !Sub 'arn:aws:s3:::${TFStateBucket}'
+              - !Sub 'arn:aws:s3:::${TFStateBucket}/*'
+      # Attach the policy to the provisioner IAM user
+      Roles:
+        - Ref: ProvisionerRole
+    DependsOn: ProvisionerRole
+
+  # ProvisionerApplyAccessPolicy is an IAM policy that grants permissions to run `terraform apply`
+  ProvisionerApplyAccessPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      ManagedPolicyName: ProvisionerApplyAccess
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: 'Allow'
+            Action:
+              - 'acm:AddTagsToCertificate'
+              - 'acm:RequestCertificate'
+            Resource: !Sub 'arn:aws:acm:us-east-1:${AWS::AccountId}:certificate/*'
+          - Effect: 'Allow'
+            Action:
+              - 'cloudfront:CreateDistribution'
+              - 'cloudfront:CreateOriginAccessControl'
+              - 'cloudfront:UpdateDistribution'
+              - 'cloudfront:TagResource'
+            Resource:
+              - !Sub 'arn:aws:cloudfront::${AWS::AccountId}:distribution/*'
+              - !Sub 'arn:aws:cloudfront::${AWS::AccountId}:cache-policy/*'
+              - !Sub 'arn:aws:cloudfront::${AWS::AccountId}:origin-access-control/*'
+          - Effect: 'Allow'
+            Action:
+              - 's3:CreateBucket'
+              - 's3:PutBucketOwnershipControls'
+              - 's3:PutBucketPolicy'
+              - 's3:PutBucketTagging'
+            Resource: 'arn:aws:s3:::*-cdn-packages-k8s-io-*'
+          - Effect: 'Allow'
+            Action:
+              - 's3:PutObject'
+            Resource: !Sub 'arn:aws:s3:::${TFStateBucket}/*'
+      # Attach the policy to the provisioner IAM user
+      Roles:
+        - Ref: ProvisionerRole
+    DependsOn: ProvisionerRole
+
+  # ProvisionerDestroyAccessPolicy is an IAM policy that grants permissions to run `terraform destroy`
+  ProvisionerDestroyAccessPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      ManagedPolicyName: ProvisionerDestroyAccess
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: 'Allow'
+            Action:
+              - 'acm:DeleteCertificate'
+            Resource: !Sub 'arn:aws:acm:us-east-1:${AWS::AccountId}:certificate/*'
+          - Effect: 'Allow'
+            Action:
+              - 'cloudfront:DeleteDistribution'
+              - 'cloudfront:DeleteOriginAccessControl'
+            Resource:
+              - !Sub 'arn:aws:cloudfront::${AWS::AccountId}:distribution/*'
+              - !Sub 'arn:aws:cloudfront::${AWS::AccountId}:cache-policy/*'
+              - !Sub 'arn:aws:cloudfront::${AWS::AccountId}:origin-access-control/*'
+          - Effect: 'Allow'
+            Action:
+              - 's3:DeleteBucket'
+              - 's3:DeleteBucketPolicy'
+            Resource: 'arn:aws:s3:::*-cdn-packages-k8s-io-*'
+      # Attach the policy to the provisioner IAM user
+      Roles:
+        - Ref: ProvisionerRole
+    DependsOn: ProvisionerRole
+
+  #########################################
+  # IAM user for OBS                      #
+  #########################################
+
+  # OBSAdminUser (obs-admin) is an IAM user used by the OBS platform to perform
+  # needed operation on the S3 bucket (e.g. publish packages)
+  OBSAdminUser:
+    Type: 'AWS::IAM::User'
+    Properties:
+      Path: /
+      UserName: obs-admin
+
+  # OBSAdminAccessPolicy gives the permissions needed to run rclone on the S3 bucket.
+  # Permissions needed for rclone are documented here:
+  # https://rclone.org/s3/#s3-permissions
+  OBSAdminAccessPolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      ManagedPolicyName: OBSAdminAccess
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: 'Allow'
+            Action:
+              - 's3:ListBucket'
+              - 's3:DeleteObject'
+              - 's3:GetObject'
+              - 's3:PutObject'
+              - 's3:PutObjectAcl'
+            Resource:
+              - 'arn:aws:s3:::prod-cdn-packages-k8s-io-*'
+              - 'arn:aws:s3:::prod-cdn-packages-k8s-io-*/*'
+          - Effect: 'Allow'
+            Action: 's3:ListAllMyBuckets'
+            Resource: 'arn:aws:s3:::prod-cdn-packages-k8s-io-*'
+      Users:
+        - Ref: OBSAdminUser
+    DependsOn: OBSAdminUser

--- a/infra/aws/cloudformation/iam/cdn.packages.k8s.io/cloudformation.yaml
+++ b/infra/aws/cloudformation/iam/cdn.packages.k8s.io/cloudformation.yaml
@@ -58,7 +58,7 @@ Resources:
           - Effect: 'Allow'
             Action:
               - 'acm:DescribeCertificate'
-              - 'acm:ListTagsForCertificate'         
+              - 'acm:ListTagsForCertificate'
             Resource: !Sub 'arn:aws:acm:us-east-1:${AWS::AccountId}:certificate/*'
           - Effect: 'Allow'
             Action:

--- a/infra/aws/cloudformation/iam/cdn.packages.k8s.io/cloudformation.yaml
+++ b/infra/aws/cloudformation/iam/cdn.packages.k8s.io/cloudformation.yaml
@@ -100,6 +100,9 @@ Resources:
               - 's3:PutObject'
               - 's3:DeleteObject'
             Resource: !Sub '${TFStateBucket.Arn}/*'
+      # Attach the policy to the Provisioner IAM role
+      Roles:
+        - Ref: ProvisionerRole
 
   # ProvisionerPlanAccessPolicy is an IAM policy that grants permissions to run `terraform plan`
   ProvisionerPlanAccessPolicy:

--- a/infra/aws/terraform/cdn.packages.k8s.io/.gitignore
+++ b/infra/aws/terraform/cdn.packages.k8s.io/.gitignore
@@ -1,0 +1,21 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+*.tfplan
+
+# Crash log files
+crash.log
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/infra/aws/terraform/cdn.packages.k8s.io/.gitignore
+++ b/infra/aws/terraform/cdn.packages.k8s.io/.gitignore
@@ -5,6 +5,7 @@
 *.tfstate
 *.tfstate.*
 *.tfplan
+plan.out
 
 # Crash log files
 crash.log

--- a/infra/aws/terraform/cdn.packages.k8s.io/.terraform.lock.hcl
+++ b/infra/aws/terraform/cdn.packages.k8s.io/.terraform.lock.hcl
@@ -1,0 +1,29 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.7.0"
+  constraints = "~> 5.7"
+  hashes = [
+    "h1:071SARqbKTnNUUKQVGYeVSKOb4jv/4m6jTy7Es4WCxg=",
+    "h1:A7p0npQ+UHlnapVuikOzhmgchAq8agtfZGkYiiEOnp0=",
+    "h1:JUI4Cqzc8/aQknRsbkSpOzC8k3yJ+wrY7i70L9XxwXg=",
+    "h1:aa0gGxD4NVirhzUUbEngnG2Ag6fAsPMjIsivd/f2QVM=",
+    "h1:gCmR7VjmH1RSMC6eaZRr37iGRDGBgzCPWomHHpeMEgA=",
+    "zh:03240d7fc041d5331db7fd5f2ca4fe031321d07d2a6ca27085c5020dae13f211",
+    "zh:0b5252b14c354636fe0348823195dd901b457de1a033015f4a7d11cfe998c766",
+    "zh:2bfb62325b0487be8d1850a964f09cca0d45148faec577459c2a24334ec9977b",
+    "zh:2f9e317ffc57d2b5117cfe8dc266f88aa139b760bc93d8adeed7ad533a78b5a3",
+    "zh:36512725c9d7c559927b98fead04be58494a3a997e5270b905a75a468e307427",
+    "zh:5483e696d3ea764f746d3fe439f7dcc49001c3c774122d7baa51ce01011f0075",
+    "zh:5967635cc14f969ea26622863a2e3f9d6a7ddd3e7d35a29a7275c5e10579ac8c",
+    "zh:7e63c94a64af5b7aeb36ea6e3719962f65a7c28074532c02549a67212d410bb8",
+    "zh:8a7d5f33b11a3f5c7281413b431fa85de149ed8493ec1eea73d50d2d80a475e6",
+    "zh:8e2ed2d986aaf590975a79a2f6b5e60e0dc7d804ab01a8c03ab181e41cfe9b0f",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c7b8ca1b17489f16a6d0f1fc2aa9c130978ea74c9c861d8435410567a0a888f",
+    "zh:a54385896a70524063f0c5420be26ff6f88909bd8e6902dd3e922577b21fd546",
+    "zh:aecd3a8fb70b938b58d93459bfb311540fd6aaf981924bf34abd48f953b4be0d",
+    "zh:f3de076fa3402768d27af0187c6a677777b47691d1f0f84c9b259ff66e65953e",
+  ]
+}

--- a/infra/aws/terraform/cdn.packages.k8s.io/Makefile
+++ b/infra/aws/terraform/cdn.packages.k8s.io/Makefile
@@ -59,6 +59,7 @@ apply: ## Create/Update Terraform resources.
 
 .PHONY: destroy
 destroy: ## Delete Terraform resources.
+	[ $(shell $(TF) workspace show) = "canary" ]
 	$(TF) $@ $(TF_ARGS) \
 		-var-file=./terraform.tfvars
 

--- a/infra/aws/terraform/cdn.packages.k8s.io/Makefile
+++ b/infra/aws/terraform/cdn.packages.k8s.io/Makefile
@@ -14,6 +14,7 @@
 
 TF ?= terraform
 TF_ARGS ?=
+TF_LOCK_TIMEOUT ?= 30s
 
 # Valid values are: canary, prod
 WORKSPACE_NAME ?= canary
@@ -50,17 +51,20 @@ init: ## Initialize Terraform's state and download necessary providers.
 .PHONY: plan
 plan: ## Present plan for creating/updating Terraform resources.
 	$(TF) $@ $(TF_ARGS) \
+		-lock-timeout=$(TF_LOCK_TIMEOUT) \
 		-var-file=./terraform.tfvars
 
 .PHONY: apply
 apply: ## Create/Update Terraform resources.
 	$(TF) $@ $(TF_ARGS) \
+		-lock-timeout=$(TF_LOCK_TIMEOUT) \
 		-var-file=./terraform.tfvars
 
 .PHONY: destroy
 destroy: ## Delete Terraform resources.
 	[ $(shell $(TF) workspace show) = "canary" ]
 	$(TF) $@ $(TF_ARGS) \
+		-lock-timeout=$(TF_LOCK_TIMEOUT) \
 		-var-file=./terraform.tfvars
 
 .PHONY: fmt

--- a/infra/aws/terraform/cdn.packages.k8s.io/Makefile
+++ b/infra/aws/terraform/cdn.packages.k8s.io/Makefile
@@ -61,14 +61,16 @@ platforms-lock:
 .PHONY: plan
 plan: init ## Present plan for creating/updating Terraform resources.
 	$(TF) $@ $(TF_ARGS) \
+		-out=plan.out \
 		-lock-timeout=$(TF_LOCK_TIMEOUT) \
 		-var-file=./terraform.tfvars
 
 .PHONY: apply
-apply: init ## Create/Update Terraform resources.
+apply: ## Create/Update Terraform resources.
 	$(TF) $@ $(TF_ARGS) \
 		-lock-timeout=$(TF_LOCK_TIMEOUT) \
-		-var-file=./terraform.tfvars
+		"plan.out"
+	rm -f plan.out
 
 .PHONY: destroy
 destroy: init ## Delete Terraform resources.

--- a/infra/aws/terraform/cdn.packages.k8s.io/Makefile
+++ b/infra/aws/terraform/cdn.packages.k8s.io/Makefile
@@ -1,0 +1,75 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+TF ?= terraform
+TF_ARGS ?=
+
+# Valid values are: canary, prod
+WORKSPACE_NAME ?= canary
+
+##@ Helpers:
+
+.PHONY: help
+help: ## Display this help.
+	@awk \
+		-v "col=${COLOR}" -v "nocol=${NOCOLOR}" \
+		' \
+			BEGIN { \
+				FS = ":.*##" ; \
+				printf "\nUsage:\n  make %s<target>%s\n", col, nocol \
+			} \
+			/^[a-zA-Z_-]+:.*?##/ { \
+				printf "  %s%-15s%s %s\n", col, $$1, nocol, $$2 \
+			} \
+			/^##@/ { \
+				printf "\n%s%s%s\n", col, substr($$0, 5), nocol \
+			} \
+		' $(MAKEFILE_LIST)
+
+##@ Terraform:
+
+.PHONY: select
+select: ## Select Terraform workspace.
+	$(TF) workspace select $(WORKSPACE_NAME)
+
+.PHONY: init
+init: ## Initialize Terraform's state and download necessary providers.
+	$(TF) $@
+
+.PHONY: plan
+plan: ## Present plan for creating/updating Terraform resources.
+	$(TF) $@ $(TF_ARGS) \
+		-var-file=./terraform.tfvars
+
+.PHONY: apply
+apply: ## Create/Update Terraform resources.
+	$(TF) $@ $(TF_ARGS) \
+		-var-file=./terraform.tfvars
+
+.PHONY: destroy
+destroy: ## Delete Terraform resources.
+	$(TF) $@ $(TF_ARGS) \
+		-var-file=./terraform.tfvars
+
+.PHONY: fmt
+fmt: ## Format Terraform files.
+	$(TF) $@
+
+.PHONY: output
+output: ## Print Terraform output.
+	@$(TF) $@ -json
+
+.PHONY: clean
+clean: ## Clean up Terraform cache and local state.
+	rm -rf ./.terraform

--- a/infra/aws/terraform/cdn.packages.k8s.io/Makefile
+++ b/infra/aws/terraform/cdn.packages.k8s.io/Makefile
@@ -48,20 +48,30 @@ select: ## Select Terraform workspace.
 init: ## Initialize Terraform's state and download necessary providers.
 	$(TF) $@
 
+.PHONY: platforms-lock
+platforms-lock:
+	$(TF) $(TF_ARGS) \
+		providers lock \
+		-platform=linux_arm64 \
+		-platform=linux_amd64 \
+		-platform=darwin_amd64 \
+		-platform=windows_amd64 \
+		-platform=darwin_arm64
+
 .PHONY: plan
-plan: ## Present plan for creating/updating Terraform resources.
+plan: init ## Present plan for creating/updating Terraform resources.
 	$(TF) $@ $(TF_ARGS) \
 		-lock-timeout=$(TF_LOCK_TIMEOUT) \
 		-var-file=./terraform.tfvars
 
 .PHONY: apply
-apply: ## Create/Update Terraform resources.
+apply: init ## Create/Update Terraform resources.
 	$(TF) $@ $(TF_ARGS) \
 		-lock-timeout=$(TF_LOCK_TIMEOUT) \
 		-var-file=./terraform.tfvars
 
 .PHONY: destroy
-destroy: ## Delete Terraform resources.
+destroy: init ## Delete Terraform resources.
 	[ $(shell $(TF) workspace show) = "canary" ]
 	$(TF) $@ $(TF_ARGS) \
 		-lock-timeout=$(TF_LOCK_TIMEOUT) \
@@ -72,7 +82,7 @@ fmt: ## Format Terraform files.
 	$(TF) $@
 
 .PHONY: output
-output: ## Print Terraform output.
+output: init ## Print Terraform output.
 	@$(TF) $@ -json
 
 .PHONY: clean

--- a/infra/aws/terraform/cdn.packages.k8s.io/OWNERS
+++ b/infra/aws/terraform/cdn.packages.k8s.io/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - release-engineering-approvers
+reviewers:
+  - release-engineering-reviewers
+
+labels:
+  - sig/release
+  - area/release-eng

--- a/infra/aws/terraform/cdn.packages.k8s.io/README.md
+++ b/infra/aws/terraform/cdn.packages.k8s.io/README.md
@@ -1,0 +1,64 @@
+# `cdn.packages.k8s.io`
+
+This directory contains Terraform configs used to manage the following
+resources:
+
+- S3 buckets used for storing and serving packages
+- Configuration and bucket policies for said S3 buckets
+- CloudFront distribution used a CDN for these S3 buckets to reduce costs
+- ACM certificate for domain used with CloudFront
+
+## AWS Access
+
+We currently use the `provisioner` IAM user to apply these Terraform configs.
+Credentials for that user are located in 1Password.
+
+The given IAM user is managed with CloudFormation Stack located in
+[`infra/aws/cloudformation/iam/cdn.packages.k8s.io`][cloudformation].
+
+[cloudformation]: https://github.com/kubernetes/k8s.io/tree/main/infra/aws/cloudformation/iam/cdn.packages.k8s.io
+
+## Applying Terraform Configs
+
+These Terraform configs support two different environments implemented as
+[Terrraform workspaces][tf-worksapces]: `prod` (production) and `canary`.
+
+Before getting started, it's mandatory to choose the correct Terraform
+workspace:
+
+```shell
+export WORKSPACE_NAME=canary # or prod
+make select
+```
+
+After that, you can plan your changes using the following Make target:
+
+```shell
+make plan
+```
+
+Similar, you can apply your changes using the following Make target:
+
+```shell
+make apply
+```
+
+You can list available Make targets and their description in the following
+way:
+
+```shell
+make help
+```
+
+## Destroying Resources
+
+If you ever need to destroy resources, you can use the following Make target:
+
+```shell
+make destroy
+```
+
+This is very dangerous and discouraged. This can eventually be used only
+on canary in some special cases.
+
+[tf-workspaces]: https://developer.hashicorp.com/terraform/language/state/workspaces

--- a/infra/aws/terraform/cdn.packages.k8s.io/README.md
+++ b/infra/aws/terraform/cdn.packages.k8s.io/README.md
@@ -49,6 +49,17 @@ way:
 make help
 ```
 
+## Updating `.lock` File
+
+The `.lock` file can be easily updated using the following Make target:
+
+```shell
+make platforms-lock
+```
+
+That way, the `.lock` file will include all used providers and their hashes
+for the most common platforms.
+
 ## Destroying Resources
 
 If you ever need to destroy resources, you can use the following Make target:

--- a/infra/aws/terraform/cdn.packages.k8s.io/README.md
+++ b/infra/aws/terraform/cdn.packages.k8s.io/README.md
@@ -27,8 +27,7 @@ Before getting started, it's mandatory to choose the correct Terraform
 workspace:
 
 ```shell
-export WORKSPACE_NAME=canary # or prod
-make select
+WORKSPACE_NAME=canary make select # can also specify "prod"
 ```
 
 After that, you can plan your changes using the following Make target:

--- a/infra/aws/terraform/cdn.packages.k8s.io/acm_certificate.tf
+++ b/infra/aws/terraform/cdn.packages.k8s.io/acm_certificate.tf
@@ -1,0 +1,29 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "aws_acm_certificate" "cdn_packages_k8s_io" {
+  # ACM certificate for CloudFront distribution must be created in us-east-1 (required by AWS)
+  provider = aws.us-east-1
+
+  domain_name       = "${var.prefix}cdn.packages.k8s.io"
+  validation_method = "DNS"
+
+  tags = local.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/infra/aws/terraform/cdn.packages.k8s.io/acm_certificate.tf
+++ b/infra/aws/terraform/cdn.packages.k8s.io/acm_certificate.tf
@@ -18,7 +18,7 @@ resource "aws_acm_certificate" "cdn_packages_k8s_io" {
   # ACM certificate for CloudFront distribution must be created in us-east-1 (required by AWS)
   provider = aws.us-east-1
 
-  domain_name       = "${var.prefix}cdn.packages.k8s.io"
+  domain_name       = "${local.prefix}cdn.packages.k8s.io"
   validation_method = "DNS"
 
   tags = local.tags

--- a/infra/aws/terraform/cdn.packages.k8s.io/cloudfront.tf
+++ b/infra/aws/terraform/cdn.packages.k8s.io/cloudfront.tf
@@ -1,0 +1,88 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+locals {
+  s3_origin_id = "${var.prefix}cdn.packages.k8s.io-s3-origin"
+}
+
+data "aws_cloudfront_cache_policy" "caching_optimized" {
+  # CachingOptmizied is recommended for S3
+  name = "Managed-CachingOptimized"
+}
+
+resource "aws_cloudfront_origin_access_control" "cdn_packages_k8s_io" {
+  name                              = "${var.prefix}cdn.packages.k8s.io"
+  description                       = "Control policy for cdn.packages.k8s.io"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "cdn_packages_k8s_io" {
+  origin {
+    origin_id = local.s3_origin_id
+
+    domain_name              = aws_s3_bucket.cdn_packages_k8s_io.bucket_regional_domain_name
+    origin_access_control_id = aws_cloudfront_origin_access_control.cdn_packages_k8s_io.id
+
+    origin_path = ""
+
+    connection_attempts = 3
+    connection_timeout  = 10
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  http_version        = "http2"
+  default_root_object = ""
+  comment             = "CloudFront used by OpenBuildService (OBS) as a mirror"
+
+  aliases = ["${var.prefix}cdn.packages.k8s.io"]
+
+  default_cache_behavior {
+    target_origin_id = local.s3_origin_id
+
+    cache_policy_id = data.aws_cloudfront_cache_policy.caching_optimized.id
+
+    compress               = true
+    viewer_protocol_policy = "allow-all"
+
+    allowed_methods = ["GET", "HEAD", "OPTIONS"]
+    cached_methods  = ["GET", "HEAD"]
+  }
+
+  price_class = "PriceClass_All"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+      locations        = []
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn = aws_acm_certificate.cdn_packages_k8s_io.arn
+    ssl_support_method  = "sni-only"
+  }
+
+  depends_on = [
+    aws_acm_certificate.cdn_packages_k8s_io,
+    aws_cloudfront_origin_access_control.cdn_packages_k8s_io,
+    aws_s3_bucket.cdn_packages_k8s_io
+  ]
+
+  tags = local.tags
+}

--- a/infra/aws/terraform/cdn.packages.k8s.io/cloudfront.tf
+++ b/infra/aws/terraform/cdn.packages.k8s.io/cloudfront.tf
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 locals {
-  s3_origin_id = "${var.prefix}cdn.packages.k8s.io-s3-origin"
+  s3_origin_id = "${local.prefix}cdn.packages.k8s.io-s3-origin"
 }
 
 data "aws_cloudfront_cache_policy" "caching_optimized" {
@@ -24,7 +24,7 @@ data "aws_cloudfront_cache_policy" "caching_optimized" {
 }
 
 resource "aws_cloudfront_origin_access_control" "cdn_packages_k8s_io" {
-  name                              = "${var.prefix}cdn.packages.k8s.io"
+  name                              = "${local.prefix}cdn.packages.k8s.io"
   description                       = "Control policy for cdn.packages.k8s.io"
   origin_access_control_origin_type = "s3"
   signing_behavior                  = "always"
@@ -50,7 +50,7 @@ resource "aws_cloudfront_distribution" "cdn_packages_k8s_io" {
   default_root_object = ""
   comment             = "CloudFront used by OpenBuildService (OBS) as a mirror"
 
-  aliases = ["${var.prefix}cdn.packages.k8s.io"]
+  aliases = ["${local.prefix}cdn.packages.k8s.io"]
 
   default_cache_behavior {
     target_origin_id = local.s3_origin_id

--- a/infra/aws/terraform/cdn.packages.k8s.io/cloudfront.tf
+++ b/infra/aws/terraform/cdn.packages.k8s.io/cloudfront.tf
@@ -81,7 +81,7 @@ resource "aws_cloudfront_distribution" "cdn_packages_k8s_io" {
   depends_on = [
     aws_acm_certificate.cdn_packages_k8s_io,
     aws_cloudfront_origin_access_control.cdn_packages_k8s_io,
-    aws_s3_bucket.cdn_packages_k8s_io
+    aws_s3_bucket.cdn_packages_k8s_io,
   ]
 
   tags = local.tags

--- a/infra/aws/terraform/cdn.packages.k8s.io/providers.tf
+++ b/infra/aws/terraform/cdn.packages.k8s.io/providers.tf
@@ -16,9 +16,11 @@ limitations under the License.
 
 terraform {
   backend "s3" {
-    bucket = "cdn-packages-k8s-io-tfstate"
-    key    = "terraform.tfstate"
-    region = "eu-central-1"
+    bucket       = "cdn-packages-k8s-io-tfstate"
+    key          = "terraform.tfstate"
+    region       = "eu-central-1"
+    role_arn     = "arn:aws:iam::309501585971:role/Provisioner"
+    session_name = "cdn-packages-k8s-io-terraform"
   }
 
   required_version = "~> 1.5.0"
@@ -33,12 +35,22 @@ terraform {
 
 provider "aws" {
   region = var.region
+
+  assume_role {
+    role_arn     = "arn:aws:iam::309501585971:role/Provisioner"
+    session_name = "cdn-packages-k8s-io-terraform"
+  }
 }
 
 # ACM certificate for CloudFront distribution must be created in us-east-1 (required by AWS)
 provider "aws" {
   region = "us-east-1"
   alias  = "us-east-1"
+
+  assume_role {
+    role_arn     = "arn:aws:iam::309501585971:role/Provisioner"
+    session_name = "cdn-packages-k8s-io-terraform"
+  }
 }
 
 data "aws_caller_identity" "current" {}

--- a/infra/aws/terraform/cdn.packages.k8s.io/providers.tf
+++ b/infra/aws/terraform/cdn.packages.k8s.io/providers.tf
@@ -60,6 +60,8 @@ data "aws_region" "current" {}
 locals {
   account_id = data.aws_caller_identity.current.account_id
 
+  prefix = "${terraform.workspace}-"
+
   tags = {
     project = "cdn.packages.k8s.io"
   }

--- a/infra/aws/terraform/cdn.packages.k8s.io/providers.tf
+++ b/infra/aws/terraform/cdn.packages.k8s.io/providers.tf
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  backend "s3" {
+    bucket = "cdn-packages-k8s-io-tfstate"
+    key    = "terraform.tfstate"
+    region = "eu-central-1"
+  }
+
+  required_version = "~> 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.7"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+# ACM certificate for CloudFront distribution must be created in us-east-1 (required by AWS)
+provider "aws" {
+  region = "us-east-1"
+  alias  = "us-east-1"
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+
+  tags = {
+    project = "cdn.packages.k8s.io"
+  }
+}

--- a/infra/aws/terraform/cdn.packages.k8s.io/s3_bucket.tf
+++ b/infra/aws/terraform/cdn.packages.k8s.io/s3_bucket.tf
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 resource "aws_s3_bucket" "cdn_packages_k8s_io" {
-  bucket = "${var.prefix}cdn-packages-k8s-io-${data.aws_region.current.name}"
+  bucket = "${local.prefix}cdn-packages-k8s-io-${data.aws_region.current.name}"
 
   tags = local.tags
 }

--- a/infra/aws/terraform/cdn.packages.k8s.io/s3_bucket.tf
+++ b/infra/aws/terraform/cdn.packages.k8s.io/s3_bucket.tf
@@ -20,6 +20,7 @@ resource "aws_s3_bucket" "cdn_packages_k8s_io" {
   tags = local.tags
 }
 
+# This object ownership control ensures that ACLs are disabled for the bucket.
 resource "aws_s3_bucket_ownership_controls" "cdn_packages_k8s_io" {
   bucket = aws_s3_bucket.cdn_packages_k8s_io.id
 
@@ -28,7 +29,7 @@ resource "aws_s3_bucket_ownership_controls" "cdn_packages_k8s_io" {
   }
 
   depends_on = [
-    aws_s3_bucket.cdn_packages_k8s_io
+    aws_s3_bucket.cdn_packages_k8s_io,
   ]
 }
 
@@ -40,7 +41,7 @@ resource "aws_s3_bucket_versioning" "cdn_packages_k8s_io" {
   }
 
   depends_on = [
-    aws_s3_bucket.cdn_packages_k8s_io
+    aws_s3_bucket.cdn_packages_k8s_io,
   ]
 }
 
@@ -68,6 +69,6 @@ resource "aws_s3_bucket_policy" "cdn_packages_k8s_io_cloudfront_read" {
 
   depends_on = [
     aws_s3_bucket.cdn_packages_k8s_io,
-    aws_cloudfront_distribution.cdn_packages_k8s_io
+    aws_cloudfront_distribution.cdn_packages_k8s_io,
   ]
 }

--- a/infra/aws/terraform/cdn.packages.k8s.io/s3_bucket.tf
+++ b/infra/aws/terraform/cdn.packages.k8s.io/s3_bucket.tf
@@ -1,0 +1,73 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "aws_s3_bucket" "cdn_packages_k8s_io" {
+  bucket = "${var.prefix}cdn-packages-k8s-io-${data.aws_region.current.name}"
+
+  tags = local.tags
+}
+
+resource "aws_s3_bucket_ownership_controls" "cdn_packages_k8s_io" {
+  bucket = aws_s3_bucket.cdn_packages_k8s_io.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+
+  depends_on = [
+    aws_s3_bucket.cdn_packages_k8s_io
+  ]
+}
+
+resource "aws_s3_bucket_versioning" "cdn_packages_k8s_io" {
+  bucket = aws_s3_bucket.cdn_packages_k8s_io.id
+
+  versioning_configuration {
+    status = "Disabled"
+  }
+
+  depends_on = [
+    aws_s3_bucket.cdn_packages_k8s_io
+  ]
+}
+
+resource "aws_s3_bucket_policy" "cdn_packages_k8s_io_cloudfront_read" {
+  bucket = aws_s3_bucket.cdn_packages_k8s_io.bucket
+
+  # Source: https://docs.aws.amazon.com/whitepapers/latest/secure-content-delivery-amazon-cloudfront/s3-origin-with-cloudfront.html
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : {
+      "Sid" : "AllowCloudFrontServicePrincipalReadOnly",
+      "Effect" : "Allow",
+      "Principal" : {
+        "Service" : "cloudfront.amazonaws.com"
+      },
+      "Action" : "s3:GetObject",
+      "Resource" : "arn:aws:s3:::${aws_s3_bucket.cdn_packages_k8s_io.bucket}/*",
+      "Condition" : {
+        "StringEquals" : {
+          "AWS:SourceArn" : "arn:aws:cloudfront::${local.account_id}:distribution/${aws_cloudfront_distribution.cdn_packages_k8s_io.id}"
+        }
+      }
+    }
+  })
+
+  depends_on = [
+    aws_s3_bucket.cdn_packages_k8s_io,
+    aws_cloudfront_distribution.cdn_packages_k8s_io
+  ]
+}

--- a/infra/aws/terraform/cdn.packages.k8s.io/terraform.tfvars
+++ b/infra/aws/terraform/cdn.packages.k8s.io/terraform.tfvars
@@ -1,0 +1,17 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+region = "eu-central-1"

--- a/infra/aws/terraform/cdn.packages.k8s.io/variables.tf
+++ b/infra/aws/terraform/cdn.packages.k8s.io/variables.tf
@@ -30,6 +30,7 @@ variable "prefix" {
 }
 
 variable "region" {
-  type     = string
-  nullable = false
+  type        = string
+  nullable    = false
+  description = "Region where to deploy non-global resources (e.g. S3 bucket)"
 }

--- a/infra/aws/terraform/cdn.packages.k8s.io/variables.tf
+++ b/infra/aws/terraform/cdn.packages.k8s.io/variables.tf
@@ -14,21 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// prefix prefixes every resource so that the resources
-// can be created without using the same names. Useful
-// for testing and staging
-
-variable "prefix" {
-  type        = string
-  default     = "test-"
-  description = "The prefix for all resources"
-
-  validation {
-    condition     = can(regex(".*-$|^$", var.prefix))
-    error_message = "The string must end with a hyphen or be empty."
-  }
-}
-
 variable "region" {
   type        = string
   nullable    = false

--- a/infra/aws/terraform/cdn.packages.k8s.io/variables.tf
+++ b/infra/aws/terraform/cdn.packages.k8s.io/variables.tf
@@ -1,0 +1,35 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// prefix prefixes every resource so that the resources
+// can be created without using the same names. Useful
+// for testing and staging
+
+variable "prefix" {
+  type        = string
+  default     = "test-"
+  description = "The prefix for all resources"
+
+  validation {
+    condition     = can(regex(".*-$|^$", var.prefix))
+    error_message = "The string must end with a hyphen or be empty."
+  }
+}
+
+variable "region" {
+  type     = string
+  nullable = false
+}


### PR DESCRIPTION
This PR adds Terraform and CloudFormation configs for `cdn.packages.k8s.io` (`k8s-infra-obs-k8s-io-prod` account).

CloudFormation is used to manage:

- S3 bucket used for Terraform state (`cdn-packages-k8s-io-tfstate`)
- IAM user, role, and policies for `provisioner` (user that's used to run `terraform {plan,apply,destroy}`)
- IAM user and policy for `obs-admin` (user which credentials are given to the OBS team, used with [`rclone`](https://rclone.org) to sync packages)

All policies are scoped down as much as possible. The initial policies were generated using [`iamlive`](https://github.com/iann0036/iamlive) and then manually edited to limit them as much as possible.

There are several reasons for using CloudFormation over Terraform for the state bucket and IAM:

- We avoid giving any of `iam:*` permissions to the `provisioner` user as Terraform doesn't need to do anything with IAM
  - This avoids potential security risks that can be caused giving `iam:*` permissions
  - This avoids need to use permission boundaries to limit what the `provisioner` user can do `iam:*` permissions
- It's very easy to apply the CloudFormation stack as long as you have access to the AWS dashboard

Terraform is used to manage:

- S3 bucket for storing packages (`prod-cdn-packages-k8s-io-eu-central-1`)
  - This is a bucket where OBS is going to push packages and where a CDN is going to point at
  - It's a private bucket with only CDN allowed to read from it and `obs-admin` user to upload to it
- AWS ACM certificate for `cdn.packages.k8s.io`
- CloudFront as a CDN solution in front of the S3 bucket
  - We received recommendation from the OBS team to use a CDN as it's usually cheaper to serve via CDN rather than S3 directly: https://kubernetes.slack.com/archives/C03U7N0VCGK/p1688642374759019?thread_ts=1686913539.737289&cid=C03U7N0VCGK
  - It's still unsure if CloudFront is a temporary or a permanent solution. We might switch to Fastly if we get enough bandwidth from them. Switching should as easy as changing the DNS record (`cdn.packages.k8s.io`) though

Terraform configs are written in a way to support production and canary environments, although, we only have the production environment at this time. All resources (aside from the AWS ACM certificate which must be in `us-east-1`) are located in `eu-central-1` (Frankfurt) region to be close to the OBS/SUSE datacenter (which is in Nuremberg, Germany, to be moved to Prague, Czech Republic soon).

These configs are owned by Kubernetes Release Managers. This is different than for Prow and Registry configs which are owned by SIG K8s Infra mainly. SIG K8s Infra members in the root OWNERS file still have rights to approve PRs (i.e. we don't use `no_parent_owners: true` option).

/assign @ameukam @pkprzekwas @sftim @saschagrunert @cpanato @jeremyrickard 
cc @kubernetes/release-engineering 
/hold
for reviews and discussion