### PR TITLE
Point testgrid.k8s.io to a load balancer.

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -329,22 +329,14 @@ slack-infra:
 submit-queue:
   type: CNAME
   value: redirect.k8s.io.
-# Running on Google App Engine (@michelle192837)
+# Running on Google App Engine using a load balancer (@michelle192837)
 testgrid:
   - type: A
     values:
-      - 216.239.32.21
-      - 216.239.34.21
-      - 216.239.36.21
-      - 216.239.38.21
-    # - 34.120.51.46 // TODO(michelle192837): Use this once certificate is active.
+      - 34.120.51.46
   - type: AAAA
     values:
-      - "2001:4860:4802:32::15"
-      - "2001:4860:4802:34::15"
-      - "2001:4860:4802:36::15"
-      - "2001:4860:4802:38::15"
-    # - "2600:1901:0:dc01::" // TODO(michelle192837): Use this once certificate is active.
+      - "2600:1901:0:dc01::"
 # DNS challenge for issuing (transition) TLS certificate
 _acme-challenge.k8s-testgrid:
   type: CNAME


### PR DESCRIPTION
Ref #5392. The load balancer should be set up to switch without downtime now, so theoretically this should work well!

/hold

Will remove hold when I can watch this, in case of rollback.