### PR TITLE
Add CNAME record for prod-cdn.packages.k8s.io

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -107,6 +107,9 @@ releases:
 # Packages / OpenBuildService (OBS)
 # Record for AWS ACM DNS challenge for prod-cdn.packages.k8s.io
 # Should stay here all the time to support certificate renewal
+prod-cdn.packages:
+  type: CNAME
+  value: dkhzw6k7x6ord.cloudfront.net.
 _952ed01ad08f0d53cf3b05e61bd7b6e6.prod-cdn.packages:
   type: CNAME
   value: _ed9dd4aee039559895c2c55de602691e.vrcmzfbvtx.acm-validations.aws.


### PR DESCRIPTION
This PR adds a CNAME record for `prod-cdn.packages.k8s.io` as per [AWS docs for alternate domain names](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/CNAMEs.html#CreatingCNAME).

![image](https://github.com/kubernetes/k8s.io/assets/18719127/f7dde078-16ee-403d-a18b-a01510e85078)

/assign @ameukam @dims @cblecker 
cc @kubernetes/release-engineering 