### PR TITLE
cdn.dl.k8s.io: Force TLS redirect

### DIFF
--- a/infra/fastly/terraform/dl.k8s.io/provider.tf
+++ b/infra/fastly/terraform/dl.k8s.io/provider.tf
@@ -29,7 +29,7 @@ terraform {
   required_providers {
     fastly = {
       source  = "fastly/fastly"
-      version = "~> 4.3.0"
+      version = "~> 5.2.0"
     }
   }
 }

--- a/infra/fastly/terraform/dl.k8s.io/services.tf
+++ b/infra/fastly/terraform/dl.k8s.io/services.tf
@@ -151,6 +151,12 @@ resource "fastly_service_vcl" "files" {
     stale_ttl       = 120
   }
 
+  request_setting {
+    name = "Force TLS"
+    force_ssl = true
+    xff = "leave"
+  }
+
   vcl {
     name    = "Main"
     content = file("${path.module}/vcl/binaries.vcl")


### PR DESCRIPTION
Force HTTP requests to be redirected to HTTPS.

Also bump required version of the terraform provider

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>