### PR TITLE
k8s-infra: bump github client

### DIFF
--- a/images/k8s-infra/Dockerfile
+++ b/images/k8s-infra/Dockerfile
@@ -28,7 +28,7 @@ FROM debian:bookworm
 
 ARG CONFTEST_VERSION=0.43.1
 ARG GCLOUD_VERSION=437.0.0
-ARG GH_VERSION=2.31.0
+ARG GH_VERSION=2.32.0
 ARG GO_VERSION=1.20.5
 ARG JQ_VERSION=1.6
 # K8S_VERSION should be within +/- 1 minor version of our clusters


### PR DESCRIPTION
Follow-up of:
  - https://github.com/kubernetes/k8s.io/pull/5528

Failure in the build process related the GitHub client. https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-k8sio-push-image-k8s-infra/1679191710799761408