### PR TITLE
Bump terraform version and required provider - part1

### DIFF
--- a/infra/gcp/terraform/k8s-infra-ii-sandbox/provider.tf
+++ b/infra/gcp/terraform/k8s-infra-ii-sandbox/provider.tf
@@ -33,11 +33,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90.1"
+      version = "~> 4.73.2"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.90.1"
+      version = "~> 4.73.2"
     }
   }
 }

--- a/infra/gcp/terraform/k8s-infra-ii-sandbox/versions.tf
+++ b/infra/gcp/terraform/k8s-infra-ii-sandbox/versions.tf
@@ -20,5 +20,5 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 1.0.0"
+  required_version = "~> 1.3.0"
 }

--- a/infra/gcp/terraform/k8s-infra-kubernetes-io/provider.tf
+++ b/infra/gcp/terraform/k8s-infra-kubernetes-io/provider.tf
@@ -30,11 +30,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.90.1"
+      version = "~> 4.73.2"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.90.1"
+      version = "~> 4.73.2"
     }
   }
 }

--- a/infra/gcp/terraform/k8s-infra-kubernetes-io/versions.tf
+++ b/infra/gcp/terraform/k8s-infra-kubernetes-io/versions.tf
@@ -20,5 +20,5 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 1.0.0"
+  required_version = "~> 1.3.0"
 }

--- a/infra/gcp/terraform/k8s-infra-monitoring/provider.tf
+++ b/infra/gcp/terraform/k8s-infra-monitoring/provider.tf
@@ -25,11 +25,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.16.0"
+      version = "~> 4.73.2"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = " 4.16.0"
+      version = "~> 4.73.2"
     }
   }
 }

--- a/infra/gcp/terraform/k8s-infra-monitoring/versions.tf
+++ b/infra/gcp/terraform/k8s-infra-monitoring/versions.tf
@@ -20,5 +20,5 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 1.1.0"
+  required_version = "~> 1.3.0"
 }

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/00-provider.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/00-provider.tf
@@ -30,11 +30,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.16.0"
+      version = "~> 4.73.2"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.16.0"
+      version = "~> 4.73.2"
     }
   }
 }

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/versions.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/versions.tf
@@ -20,5 +20,5 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 1.1.0"
+  required_version = "~> 1.3.0"
 }

--- a/infra/gcp/terraform/k8s-infra-prow-build/00-provider.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/00-provider.tf
@@ -30,11 +30,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.57.0"
+      version = "~> 4.73.2"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.57.0"
+      version = "~> 4.73.2"
     }
   }
 }

--- a/infra/gcp/terraform/k8s-infra-prow-build/versions.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/versions.tf
@@ -20,5 +20,5 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 1.1.0"
+  required_version = "~> 1.3.0"
 }

--- a/infra/gcp/terraform/k8s-infra-public-pii/provider.tf
+++ b/infra/gcp/terraform/k8s-infra-public-pii/provider.tf
@@ -31,11 +31,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.32.0"
+      version = "~> 4.73.2"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.32.0"
+      version = "~> 4.73.2"
     }
   }
 }

--- a/infra/gcp/terraform/k8s-infra-public-pii/versions.tf
+++ b/infra/gcp/terraform/k8s-infra-public-pii/versions.tf
@@ -20,5 +20,5 @@ This file defines:
 */
 
 terraform {
-  required_version = "~> 1.1.0"
+  required_version = "~> 1.3.0"
 }

--- a/infra/gcp/terraform/kubernetes-public/00-inputs.tf
+++ b/infra/gcp/terraform/kubernetes-public/00-inputs.tf
@@ -27,7 +27,7 @@ locals {
 }
 
 terraform {
-  required_version = "~> 1.1.0"
+  required_version = "~> 1.3.0"
 
   backend "gcs" {
     bucket = "k8s-infra-tf-public-clusters"
@@ -36,10 +36,10 @@ terraform {
 
   required_providers {
     google = {
-      version = "~> 4.16.0"
+      version = "~> 4.73.2"
     }
     google-beta = {
-      version = "~> 4.16.0"
+      version = "~> 4.73.2"
     }
   }
 }

--- a/infra/gcp/terraform/modules/gke-cluster/versions.tf
+++ b/infra/gcp/terraform/modules/gke-cluster/versions.tf
@@ -17,15 +17,16 @@
  */
 
 terraform {
-  required_version = "~> 1.1.0"
+  required_version = "~> 1.3.0"
+
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.57.0"
+      version = "~> 4.73.2"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.57.0"
+      version = "~> 4.73.2"
     }
   }
 }

--- a/infra/gcp/terraform/modules/gke-nodepool/versions.tf
+++ b/infra/gcp/terraform/modules/gke-nodepool/versions.tf
@@ -17,15 +17,16 @@
  */
 
 terraform {
-  required_version = "~> 1.1.0"
+  required_version = "~> 1.3.0"
+
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.57.0"
+      version = "~> 4.73.2"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.57.0"
+      version = "~> 4.73.2"
     }
   }
 }

--- a/infra/gcp/terraform/modules/gke-project/versions.tf
+++ b/infra/gcp/terraform/modules/gke-project/versions.tf
@@ -17,15 +17,16 @@
  */
 
 terraform {
-  required_version = "~> 1.1.0"
+  required_version = "~> 1.3.0"
+
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.57.0"
+      version = "~> 4.73.2"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.57.0"
+      version = "~> 4.73.2"
     }
   }
 }

--- a/infra/gcp/terraform/modules/workload-identity-service-account/versions.tf
+++ b/infra/gcp/terraform/modules/workload-identity-service-account/versions.tf
@@ -14,15 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 terraform {
-  required_version = "~> 1.1.0"
+  required_version = "~> 1.3.0"
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.57.0"
+      version = "~> 4.73.2"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.57.0"
+      version = "~> 4.73.2"
     }
   }
 }


### PR DESCRIPTION
Bump the terraform provider to the latest (as of 07/17/2023): https://github.com/hashicorp/terraform-provider-google/releases/tag/v4.73.0

and the required version of terraform: https://github.com/hashicorp/terraform/releases/tag/v1.3.0

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>