### PR TITLE
Add mailing list and group config for wg-lts

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -138,6 +138,10 @@ aliases:
     - cantbewong
     - cindyxing
     - dejanb
+  wg-lts-leads:
+    - micahhausler
+    - jeremyrickard
+    - liggitt
   wg-multitenancy-leads:
     - srampal
     - tashimi

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -254,4 +254,8 @@ restrictions:
     allowedGroups:
       - "^wg-batch@kubernetes.io$"
       - "^wg-batch-leads@kubernetes.io$"
+  - path: "wg-lts/groups.yaml"
+    allowedGroups:
+      - "^wg-lts@kubernetes.io$"
+      - "^wg-lts-leads@kubernetes.io$"
   - path: "**/*" # prevent any other file from containing anything

--- a/groups/wg-lts/OWNERS
+++ b/groups/wg-lts/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- wg-lts-leads
+reviewers:
+- wg-lts-leads
+
+labels:
+- wg/lts

--- a/groups/wg-lts/groups.yaml
+++ b/groups/wg-lts/groups.yaml
@@ -1,0 +1,36 @@
+groups:
+  #
+  # Mailing lists
+  #
+  # Each group here represents a mailing list for the WG or its subprojects,
+  # and is not intended to govern access to infrastructure
+  #
+  - email-id: wg-lts-leads@kubernetes.io
+    name: wg-lts-leads
+    description: |-
+      WG LTS Organizers
+    settings:
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      ReconcileMembers: "true"
+    owners:
+      - jeremy.r.rickard@gmail.com
+      - mhausler@amazon.com
+      - liggitt@google.com
+
+  - email-id: wg-lts@kubernetes.io
+    name: wg-lts
+    description: |-
+      Public mailing list for WG LTS
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      ReconcileMembers: "false"
+    owners:
+     - jeremy.r.rickard@gmail.com
+      - mhausler@amazon.com
+      - liggitt@google.com
+    members:
+      - wg-lts-leads@kubernetes.io

--- a/groups/wg-lts/groups.yaml
+++ b/groups/wg-lts/groups.yaml
@@ -29,8 +29,8 @@ groups:
       MessageModerationLevel: "MODERATE_NON_MEMBERS"
       ReconcileMembers: "false"
     owners:
-     - jeremy.r.rickard@gmail.com
-      - mhausler@amazon.com
+      - jeremy.r.rickard@gmail.com
       - liggitt@google.com
+      - mhausler@amazon.com
     members:
       - wg-lts-leads@kubernetes.io


### PR DESCRIPTION
Following up from the charter merge for [wg-lts](https://github.com/kubernetes/community/tree/master/wg-lts), this PR adds the wg-lts directory under `groups` and adds mailing lists, group config, and OWNER_ALIASES updates.

ref: https://github.com/kubernetes/community/issues/7259

/hold for review from @liggitt and @micahhausler as well

/area groups
/area access