### PR TITLE
extend permission to replicasets/scale subresource

### DIFF
--- a/infra/gcp/bash/namespaces/namespace-user-role.yml
+++ b/infra/gcp/bash/namespaces/namespace-user-role.yml
@@ -12,7 +12,7 @@ rules:
     resources: ["horizontalpodautoscalers"]
     verbs: ["*"]
   - apiGroups: ["apps"]
-    resources: ["deployments", "replicasets", "statefulsets"]
+    resources: ["deployments", "replicasets", "replicasets/scale", "statefulsets"]
     verbs: ["*"]
   - apiGroups: ["batch"]
     resources: ["cronjobs", "jobs"]


### PR DESCRIPTION
as part of cleanup procedure of the publishing-bot PVC, users should have permission to scale up/down the replicaset

Ref: https://github.com/kubernetes/publishing-bot/issues/364