### PR TITLE
cdn.dl.k8s.io: Reduce the first byte timeout

### DIFF
--- a/infra/fastly/terraform/dl.k8s.io/services.tf
+++ b/infra/fastly/terraform/dl.k8s.io/services.tf
@@ -41,7 +41,6 @@ resource "fastly_service_vcl" "files" {
     override_host = "${var.bucket}.storage.googleapis.com"
 
     connect_timeout       = 5000  # milliseconds
-    first_byte_timeout    = 60000 # milliseconds
     between_bytes_timeout = 15000 # milliseconds
     error_threshold       = 5
   }


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/k8s.io/issues/4528

Following guidance from https://developer.fastly.com/learning/concepts/cache-freshness/#best-practices and remove the value set in the terraform, the first byte timeout is reduce to 15000 milliseconds.