### PR TITLE
cdn.dl.k8s.io: Add a BigQuery dataset for logging

### DIFF
--- a/infra/fastly/terraform/dl.k8s.io/services.tf
+++ b/infra/fastly/terraform/dl.k8s.io/services.tf
@@ -58,6 +58,17 @@ resource "fastly_service_vcl" "files" {
     window         = 4
   }
 
+  logging_bigquery {
+    dataset = "fastly_bigquery_cdn_dl_k8s_io"
+    project_id = "k8s-infra-public-pii"
+    name = "BigQuery logging"
+    table = "fastly_bigquery_cdn_dl_k8s_io_logs"
+    account_name = "fastly-service-account"
+    email = "fastly-logging@datalog-bulleit-9e86.iam.gserviceaccount.com"
+
+    format = "%%{strftime(\\{\"%Y-%m-%dT%H:%M:%S%z\"\\}, time.start)}V|%%{client.as.number}V|%%{if(fastly.ff.visits_this_service == 0, \"true\", \"false\")}V"
+  }
+
   snippet {
     content  = <<-EOT
       if (req.url.path ~ "^/release/") {

--- a/infra/gcp/terraform/k8s-infra-public-pii/fastly-cdn-dl-k8s-io.tf
+++ b/infra/gcp/terraform/k8s-infra-public-pii/fastly-cdn-dl-k8s-io.tf
@@ -1,0 +1,67 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This file contains
+- the BigQuery dataset and table for cdn.dl.k8s.io logging
+- The IAM configuration to allow Fastly SA write permissions on a dataset
+*/
+
+locals {
+  cdn_dl_k8s_io_logging_dataset_id = "fastly_bigquery_cdn_dl_k8s_io"
+  fastly_sa                        = "fastly-logging@datalog-bulleit-9e86.iam.gserviceaccount.com"
+}
+
+# https://docs.fastly.com/en/guides/configuring-google-iam-service-account-impersonation-for-fastly-logging
+resource "google_project_iam_member" "fastly_sa" {
+  project = google_project.project.project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = "serviceAccount:${local.fastly_sa}"
+}
+
+resource "google_bigquery_dataset" "fastly_cdn_dl_k8s_io_logging" {
+  project                     = google_project.project.project_id
+  dataset_id                  = local.cdn_dl_k8s_io_logging_dataset_id
+  friendly_name               = local.cdn_dl_k8s_io_logging_dataset_id
+  delete_contents_on_destroy  = true
+  default_table_expiration_ms = 400 * 24 * 60 * 60 * 1000 # 400 days
+  location                    = "US"
+}
+
+resource "google_bigquery_table" "fastly_cdn_dl_k8s_io_logs" {
+  project    = google_project.project.project_id
+  dataset_id = local.cdn_dl_k8s_io_logging_dataset_id
+  table_id   = "${local.cdn_dl_k8s_io_logging_dataset_id}_logs"
+
+  schema = file("${path.module}/files/fastly_cdn_dl_k8s_io_logs.json")
+
+  deletion_protection = false
+
+  depends_on = [
+    google_bigquery_dataset.fastly_cdn_dl_k8s_io_logging
+  ]
+}
+
+resource "google_bigquery_dataset_iam_member" "cdn_dl_k8s_io_logging" {
+  project    = google_project.project.project_id
+  dataset_id = google_bigquery_dataset.fastly_cdn_dl_k8s_io_logging.dataset_id
+  role       = "roles/bigquery.dataEditor"
+  member     = "serviceAccount:${local.fastly_sa}"
+
+  depends_on = [
+    google_bigquery_dataset.fastly_cdn_dl_k8s_io_logging
+  ]
+}

--- a/infra/gcp/terraform/k8s-infra-public-pii/files/fastly_cdn_dl_k8s_io_logs.json
+++ b/infra/gcp/terraform/k8s-infra-public-pii/files/fastly_cdn_dl_k8s_io_logs.json
@@ -1,0 +1,17 @@
+[
+    {
+        "mode": "NULLABLE",
+        "name": "timestamp",
+        "type": "TIMESTAMP"
+    },
+    {
+        "mode":"NULLABLE",
+        "name":"asn",
+        "type":"STRING"
+    },
+    {
+        "mode":"NULLABLE",
+        "name":"fastly_is_edge",
+        "type":"BOOLEAN"
+    }
+]

--- a/infra/gcp/terraform/k8s-infra-public-pii/main.tf
+++ b/infra/gcp/terraform/k8s-infra-public-pii/main.tf
@@ -15,9 +15,9 @@ limitations under the License.
 */
 
 locals {
-  project_id  = "k8s-infra-public-pii"
-  bucket_name = "k8s-infra-artifacts-gcslogs"
-  dataset-id  = replace(local.bucket_name, "-", "_")
+  project_id            = "k8s-infra-public-pii"
+  bucket_name           = "k8s-infra-artifacts-gcslogs"
+  dataset-id            = replace(local.bucket_name, "-", "_")
   registry-k8s-io-bq-id = "registry_k8s_io_logs"
 }
 
@@ -73,9 +73,9 @@ resource "google_bigquery_dataset" "registry_k8s_io_logs" {
 }
 
 resource "google_bigquery_dataset_iam_member" "registry_k8s_io_logs" {
-  project = google_project.project.project_id
+  project    = google_project.project.project_id
   dataset_id = google_bigquery_dataset.registry_k8s_io_logs.dataset_id
-  role = "roles/bigquery.dataEditor"
+  role       = "roles/bigquery.dataEditor"
   # Logs router Sink identity in k8s-infra-oci-proxy-prod
   # Not existing data resource to extract the writer identity
   member = "serviceAccount:p102333525888-824068@gcp-sa-logging.iam.gserviceaccount.com"


### PR DESCRIPTION
Ensure a BigQuery dataset exists if we want to use Fasty's Real-Time Log streaming. See: https://docs.fastly.com/en/guides/log-streaming-google-bigquery

A minimal configuration is defined to ensure logs are sent to BigQuery