### PR TITLE
promote the simulator image v0.1.1

### DIFF
--- a/registry.k8s.io/images/k8s-staging-sched-simulator/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-sched-simulator/images.yaml
@@ -1,6 +1,8 @@
 - name: simulator-backend
   dmap:
     "sha256:2ab7173ee2e1ca094e5c31a7bb66f0df64d8ff016ca9cce94611f9fce3ca7724": ["v0.1.0"]
+    "sha256:f7b2f96f3667b8e89e04fa2d3af51e2fd00f250610a16fa3bfe46615fd77479c": ["v0.1.1"]
 - name: simulator-frontend
   dmap:
     "sha256:eba8ef95caf780c82cbc5c882590b5d97fc2b574ff2a2bcd7253d4fee6357e6e": ["v0.1.0"]
+    "sha256:92905ccf6678c2a864656cb8498808f6792c30fa3f4839ae424447900bbc445a": ["v0.1.1"]


### PR DESCRIPTION
We released a new version: https://github.com/kubernetes-sigs/kube-scheduler-simulator/releases/tag/simulator%2Fv0.1.1