### PR TITLE
cdn.dl.k8s.io: Fix BigQuery for Fastly logging

### DIFF
--- a/infra/fastly/terraform/dl.k8s.io/services.tf
+++ b/infra/fastly/terraform/dl.k8s.io/services.tf
@@ -63,7 +63,7 @@ resource "fastly_service_vcl" "files" {
     project_id = "k8s-infra-public-pii"
     name = "BigQuery logging"
     table = "fastly_bigquery_cdn_dl_k8s_io_logs"
-    account_name = "fastly-service-account"
+    account_name = "fastly-bigquery-logging-sa"
     email = "fastly-logging@datalog-bulleit-9e86.iam.gserviceaccount.com"
 
     format = "%%{strftime(\\{\"%Y-%m-%dT%H:%M:%S%z\"\\}, time.start)}V|%%{client.as.number}V|%%{if(fastly.ff.visits_this_service == 0, \"true\", \"false\")}V"


### PR DESCRIPTION
Follow-up of:
  - https://github.com/kubernetes/k8s.io/pull/5598

Ensure a service account to write log to the BigQuery dataset and impersonated by the Fastly service account.