### PR TITLE
cdn.dl.k8s.io: Enable inspectors

### DIFF
--- a/infra/fastly/terraform/dl.k8s.io/services.tf
+++ b/infra/fastly/terraform/dl.k8s.io/services.tf
@@ -173,6 +173,11 @@ resource "fastly_service_vcl" "files" {
     main    = true
   }
 
+  product_enablement {
+    origin_inspector = true
+    domain_inspector = true
+  }
+
   force_destroy = true
 }
 


### PR DESCRIPTION
[Origin](https://docs.fastly.com/en/guides/about-the-origin-inspector-stats) and [Domain](https://docs.fastly.com/en/guides/about-the-domain-inspector-stats) inspectors have been activated for Fastly account. This enable them for the current service.