### PR TITLE
capz: update maintainers and reviewers

### DIFF
--- a/registry.k8s.io/images/k8s-staging-cluster-api-azure/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-cluster-api-azure/OWNERS
@@ -2,16 +2,17 @@
 # Should always mirror the maintainers/reviewers in https://sigs.k8s.io/cluster-api-provider-azure/OWNERS_ALIASES
 
 approvers:
-- alexeldeib
 - CecileRobertMichon
-- devigned
 - jackfrancis
 - mboersma
+- nojnhuh
+- sonasingh46
 reviewers:
 - Jont828
 - jsturtevant
+- marosset
 - nawazkh
-- nojnhuh
+- willie-yao
 
 labels:
 - sig/cluster-lifecycle


### PR DESCRIPTION
Updates maintainers and reviewers of the cluster-api-provider-azure (CAPZ) project to match its current [`OWNERS_ALIASES`](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES).

~~(One change is still pending but soon to merge, so I opened this clerical PR now because they're not strictly linked.)~~