### PR TITLE
fix the other affected dl.k8s.io test case

### DIFF
--- a/apps/k8s-io/test.py
+++ b/apps/k8s-io/test.py
@@ -293,7 +293,7 @@ class RedirTest(HTTPTestCase):
             # Not a valid release version (gamma)
             self.assert_temp_redirect(
                 base + '/v1.2.3-gamma.4/kubernetes.tar.gz',
-                'https://storage.googleapis.com/kubernetes-release/v1.2.3-gamma.4/kubernetes.tar.gz')
+                'https://cdn.dl.k8s.io/v1.2.3-gamma.4/kubernetes.tar.gz')
             # A few /ci/ tests
             self.assert_temp_redirect(
                 base + '/ci/v$ver/$path',


### PR DESCRIPTION
cdn.dl.k8s.io is also used even for invalid versions in the current config, and this is expected

follow up to #5614 