### PR TITLE
Deploy and enable AWS WAF for prod-cdn.packages.k8s.io

### DIFF
--- a/infra/aws/cloudformation/iam/cdn.packages.k8s.io/cloudformation.yaml
+++ b/infra/aws/cloudformation/iam/cdn.packages.k8s.io/cloudformation.yaml
@@ -157,6 +157,14 @@ Resources:
               - 's3:GetReplicationConfiguration'
               - 's3:ListBucket'
             Resource: !Ref AllPackagesBucketsArn
+          # CloudFront requires the WAF Web ACL objects to be located in
+          # the us-east-1 region. That's why we only give `wafv2:` permissions in
+          # that region.
+          - Effect: 'Allow'
+            Action:
+              - 'wafv2:GetWebACL'
+              - 'wafv2:ListTagsForResource'
+            Resource: !Sub 'arn:aws:wafv2:us-east-1:${AWS::AccountId}:global/webacl/*-PackagesCloudFrontWebACL/*'
       # Attach the policy to the Provisioner IAM role
       Roles:
         - Ref: ProvisionerRole
@@ -191,6 +199,16 @@ Resources:
               - 's3:PutBucketPolicy'
               - 's3:PutBucketTagging'
             Resource: !Ref AllPackagesBucketsArn
+          - Effect: 'Allow'
+            Action:
+              - 'wafv2:CreateWebACL'
+            Resource:
+              - !Sub 'arn:aws:wafv2:us-east-1:${AWS::AccountId}:global/managedruleset/*/*'
+              - !Sub 'arn:aws:wafv2:us-east-1:${AWS::AccountId}:global/webacl/*-PackagesCloudFrontWebACL/*'
+          - Effect: 'Allow'
+            Action:
+              - 'wafv2:TagResource'
+            Resource: !Sub 'arn:aws:wafv2:us-east-1:${AWS::AccountId}:global/webacl/*-PackagesCloudFrontWebACL/*'
       # Attach the policy to the Provisioner IAM role
       Roles:
         - Ref: ProvisionerRole
@@ -220,6 +238,10 @@ Resources:
               - 's3:DeleteBucket'
               - 's3:DeleteBucketPolicy'
             Resource: !Ref AllPackagesBucketsArn
+          - Effect: 'Allow'
+            Action:
+              - 'wafv2:DeleteWebACL'
+            Resource: !Sub 'arn:aws:wafv2:us-east-1:${AWS::AccountId}:global/webacl/*-PackagesCloudFrontWebACL/*'
       # Attach the policy to the Provisioner IAM role
       Roles:
         - Ref: ProvisionerRole

--- a/infra/aws/terraform/cdn.packages.k8s.io/cloudfront.tf
+++ b/infra/aws/terraform/cdn.packages.k8s.io/cloudfront.tf
@@ -52,6 +52,8 @@ resource "aws_cloudfront_distribution" "cdn_packages_k8s_io" {
 
   aliases = ["${local.prefix}cdn.packages.k8s.io"]
 
+  web_acl_id = aws_wafv2_web_acl.cdn_packages_k8s_io.arn
+
   default_cache_behavior {
     target_origin_id = local.s3_origin_id
 
@@ -81,6 +83,7 @@ resource "aws_cloudfront_distribution" "cdn_packages_k8s_io" {
   depends_on = [
     aws_acm_certificate.cdn_packages_k8s_io,
     aws_cloudfront_origin_access_control.cdn_packages_k8s_io,
+    aws_wafv2_web_acl.cdn_packages_k8s_io,
     aws_s3_bucket.cdn_packages_k8s_io,
   ]
 

--- a/infra/aws/terraform/cdn.packages.k8s.io/waf.tf
+++ b/infra/aws/terraform/cdn.packages.k8s.io/waf.tf
@@ -1,0 +1,102 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "aws_wafv2_web_acl" "cdn_packages_k8s_io" {
+  # WAF Web ACLs for CloudFront distribution must be created in us-east-1 (required by AWS)
+  provider = aws.us-east-1
+
+  name        = "${local.prefix}PackagesCloudFrontWebACL"
+  description = "WAF Web ACL used by cdn.packages.k8s.io CloudFront."
+  scope       = "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesAmazonIpReputationList"
+    priority = 0
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesAmazonIpReputationList"
+        vendor_name = "AWS"
+      }
+    }
+
+    override_action {
+      none {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      sampled_requests_enabled   = true
+      metric_name                = "AWS-AWSManagedRulesAmazonIpReputationList"
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesCommonRuleSet"
+    priority = 1
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    override_action {
+      none {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      sampled_requests_enabled   = true
+      metric_name                = "AWS-AWSManagedRulesCommonRuleSet"
+    }
+  }
+
+  rule {
+    name     = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+    priority = 2
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesKnownBadInputsRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+
+    override_action {
+      none {}
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      sampled_requests_enabled   = true
+      metric_name                = "AWS-AWSManagedRulesKnownBadInputsRuleSet"
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    sampled_requests_enabled   = true
+    metric_name                = "${local.prefix}PackagesCloudFrontWebACL"
+  }
+
+  tags = local.tags
+}


### PR DESCRIPTION
As per recommendation that we received from AWS folks (https://kubernetes.slack.com/archives/CCK68P2Q2/p1688756337211689?thread_ts=1688752253.984129&cid=CCK68P2Q2), this PR enables WAF for our packages CloudFront distribution.

WAF is supposed to protect our distribution against DDoS attacks and malicious requests. Rules used are rules that AWS applies when you enable WAF from the AWS console.

Fixes #5617

/assign @saschagrunert @cpanato @ameukam 
cc @kubernetes/release-engineering 