### PR TITLE
Updating officer list for steering election 2023

### DIFF
--- a/groups/committee-steering/groups.yaml
+++ b/groups/committee-steering/groups.yaml
@@ -90,4 +90,4 @@ groups:
     owners:
       - kaslinfields@gmail.com
       - davanum@gmail.com
-      - noah@coderanger.net
+      - bridget@kromhout.org


### PR DESCRIPTION
Update of officers for the Steering Election of 2023 (to match the update in https://github.com/kubernetes/community/pull/7395).