### PR TITLE
Enable GKE API on `k8s-infra-e2e-boskos-*` GCP projects

### DIFF
--- a/infra/gcp/bash/prow/ensure-e2e-projects.sh
+++ b/infra/gcp/bash/prow/ensure-e2e-projects.sh
@@ -63,6 +63,7 @@ function ensure_e2e_project() {
     color 6 "Ensuring only APIs necessary for kubernetes e2e jobs to use e2e project: ${prj}"
     ensure_only_services "${prj}" \
         compute.googleapis.com \
+        container.googleapis.com \
         containerregistry.googleapis.com \
         logging.googleapis.com \
         monitoring.googleapis.com \


### PR DESCRIPTION
/cc @ameukam @dims

I migrated some jobs to the community cluster and they rely on the GKE API to run.

Can we get them enabled please?

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_kubetest2/232/pull-kubetest2-gke-up-down-singlecluster/1683891062487126016

https://github.com/kubernetes/test-infra/pull/30195
