### PR TITLE
aaa: Ensure image type for NAP

### DIFF
--- a/infra/gcp/terraform/kubernetes-public/10-cluster-configuration.tf
+++ b/infra/gcp/terraform/kubernetes-public/10-cluster-configuration.tf
@@ -182,6 +182,9 @@ resource "google_container_cluster" "cluster" {
       resource_type = "memory"
       maximum       = 256
     }
+    auto_provisioning_defaults {
+      image_type = "COS_CONTAINERD"
+    }
   }
 
   // Enable VPA


### PR DESCRIPTION
Currently, the NAP profile use `COS_DOCKER` and prevents upgrade to 1.23.
Enforcing the image type for any instance created by NAP to allow upgrade to 1.24.