### PR TITLE
Override UserAgent_BadBots_HEADER rule in WAF for cdn.packages.k8s.io

### DIFF
--- a/infra/aws/cloudformation/iam/cdn.packages.k8s.io/cloudformation.yaml
+++ b/infra/aws/cloudformation/iam/cdn.packages.k8s.io/cloudformation.yaml
@@ -202,6 +202,7 @@ Resources:
           - Effect: 'Allow'
             Action:
               - 'wafv2:CreateWebACL'
+              - 'wafv2:UpdateWebACL'
             Resource:
               - !Sub 'arn:aws:wafv2:us-east-1:${AWS::AccountId}:global/managedruleset/*/*'
               - !Sub 'arn:aws:wafv2:us-east-1:${AWS::AccountId}:global/webacl/*-PackagesCloudFrontWebACL/*'

--- a/infra/aws/terraform/cdn.packages.k8s.io/waf.tf
+++ b/infra/aws/terraform/cdn.packages.k8s.io/waf.tf
@@ -56,6 +56,16 @@ resource "aws_wafv2_web_acl" "cdn_packages_k8s_io" {
       managed_rule_group_statement {
         name        = "AWSManagedRulesCommonRuleSet"
         vendor_name = "AWS"
+
+        // Older yum versions (e.g. 3.4.3 used on CentOS 7) are triggering
+        // this rule which makes yum fail with 403 Forbidden.
+        rule_action_override {
+          name = "UserAgent_BadBots_HEADER"
+
+          action_to_use {
+            count {}
+          }
+        }
       }
     }
 


### PR DESCRIPTION
Older `yum` versions (e.g. 3.4.3 used on CentOS 7) are triggering the `UserAgent_BadBots_HEADER` rule in WAF which results in all `yum` commands failing with the following error:

```
https://prod-cdn.packages.k8s.io/repositories/isv%3A/kubernetes%3A/core%3A/prerelease%3A/v1.28/rpm/repodata/repomd.xml: [Errno 14] HTTPS Error 403 - Forbidden
Trying other mirror.
To address this issue please refer to the below wiki article
```

To avoid this issue, we're going to override this rule using the `count` action. This action is going to allow those user agents and count how many times this rule is triggered.

The change is already applied and tested on prod.

/assign @saschagrunert @cpanato @pkprzekwas 
cc @kubernetes/release-engineering 