### PR TITLE
aaa: Drop workloads monitoring

### DIFF
--- a/infra/gcp/terraform/kubernetes-public/10-cluster-configuration.tf
+++ b/infra/gcp/terraform/kubernetes-public/10-cluster-configuration.tf
@@ -135,9 +135,12 @@ resource "google_container_cluster" "cluster" {
   // Enable GKE workloads monitoring
   monitoring_config {
     enable_components = [
-      "SYSTEM_COMPONENTS",
-      "WORKLOADS"
+      "SYSTEM_COMPONENTS"
     ]
+
+    managed_prometheus {
+      enabled = true
+    }
   }
 
   // Enable GKE Usage Metering


### PR DESCRIPTION
aaa cluster is upgraded to 1.25. "WORKLOADS" option has been removed since 1.24. Enable managed prometheus to a replacement