### PR TITLE
Add aws-credentials-boskos-scale-001-kops Secret to EKS Prow cluster

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/test-pods/externalsecrets.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/test-pods/externalsecrets.yaml
@@ -1,81 +1,36 @@
-# This is a place holder for adding kubernetes external secrets, please add the
-# ExternalSecret CR here, separated by `---`.
-
-# NOTE !!!
-# THIS CLUSTER USES EXTERNAL SECRETS OPERATOR INSTEAD OF KUBERNETES EXTERNAL SECRETS.
-# The CRDs are different from other prow clusters. Sample guide that explains the diff https://wiki.cac.washington.edu/display/MCI/Transition+from+KES+to+ESO
-# ---
-# apiVersion: kubernetes-client.io/v1
-# kind: ExternalSecret
-# metadata:
-#   name: service-account             # The name of the Kubernetes Secret
-#   namespace: test-pods
-# spec:
-#   backendType: gcpSecretsManager
-#   projectId: k8s-infra-prow-build
-#   data:
-#   - key: prow-build-service-account # The name of the GSM Secret
-#     name: service-account.json      # The key to write to in the Kubernetes Secret
-#     version: latest                 # The version of the GSM Secret
-# ---
-# apiVersion: kubernetes-client.io/v1
-# kind: ExternalSecret
-# metadata:
-#   name: ssh-key-secret                          # The name of the Kubernetes Secret
-#   namespace: test-pods
-# spec:
-#   backendType: gcpSecretsManager
-#   projectId: k8s-infra-prow-build
-#   data:
-#   - key: prow-build-ssh-key-secret-ssh-public   # The name of the GSM Secret
-#     name: ssh-public                            # The key to write to in the Kubernetes Secret
-#     version: latest                             # The version of the GSM Secret
-#   - key: prow-build-ssh-key-secret-ssh-private  # The name of the GSM Secret
-#     name: ssh-private                           # The key to write to in the Kubernetes Secret
-#     version: latest                             # The version of the GSM Secret
-# ---
-# apiVersion: kubernetes-client.io/v1
-# kind: ExternalSecret
-# metadata:
-#   name: aws-credentials-768319786644           # The name of the Kubernetes Secret
-#   namespace: test-pods
-# spec:
-#   backendType: gcpSecretsManager
-#   projectId: k8s-infra-prow-build
-#   data:
-#   - key: gke_k8s-prow-builds_us-central1-f_prow__test-pods__aws-credentials-768319786644   # The name of the GSM Secret
-#     name: credentials                                                                      # The key to write to in the Kubernetes Secret
-#     version: latest                                                                        # The version of the GSM Secret
-#     property: credentials
-# ---
-# apiVersion: kubernetes-client.io/v1
-# kind: ExternalSecret
-# metadata:
-#   name: aws-credentials-607362164682           # The name of the Kubernetes Secret
-#   namespace: test-pods
-# spec:
-#   backendType: gcpSecretsManager
-#   projectId: k8s-infra-prow-build
-#   data:
-#   - key: gke_k8s-prow-builds_us-central1-f_prow__test-pods__aws-credentials-607362164682   # The name of the GSM Secret
-#     name: credentials                                                                      # The key to write to in the Kubernetes Secret
-#     version: latest                                                                        # The version of the GSM Secret
-#     property: credentials
-# ---
-# apiVersion: kubernetes-client.io/v1
-# kind: ExternalSecret
-# metadata:
-#   name: aws-ssh-key-secret           # The name of the Kubernetes Secret
-#   namespace: test-pods
-# spec:
-#   backendType: gcpSecretsManager
-#   projectId: k8s-infra-prow-build
-#   data:
-#   - key: gke_k8s-prow-builds_us-central1-f_prow__test-pods__aws-ssh-key-secret   # The name of the GSM Secret
-#     name: aws-ssh-private                                                        # The key to write to in the Kubernetes Secret
-#     version: latest                                                              # The version of the GSM Secret
-#     property: aws-ssh-private
-#   - key: gke_k8s-prow-builds_us-central1-f_prow__test-pods__aws-ssh-key-secret   # The name of the GSM Secret
-#     name: aws-ssh-public                                                         # The key to write to in the Kubernetes Secret
-#     version: latest                                                              # The version of the GSM Secret
-#     property: aws-ssh-public
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: aws-credentials-boskos-scale-001-kops
+  namespace: test-pods
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secerts-manager
+    kind: ClusterSecretStore
+  target:
+    name: aws-credentials-boskos-scale-001-kops
+    creationPolicy: Owner
+  data:
+  - secretKey: accessKeyId
+    remoteRef:
+      key: prow-prod/k8s-infra-e2e-boskos-scale-001/kops
+      property: accessKeyId
+  - secretKey: secretAccessKey
+    remoteRef:
+      key: prow-prod/k8s-infra-e2e-boskos-scale-001/kops
+      property: secretAccessKey

--- a/infra/aws/terraform/prow-build-cluster/resources/test-pods/externalsecrets_legacy.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/test-pods/externalsecrets_legacy.yaml
@@ -1,0 +1,81 @@
+# This is a place holder for adding kubernetes external secrets, please add the
+# ExternalSecret CR here, separated by `---`.
+
+# NOTE !!!
+# THIS CLUSTER USES EXTERNAL SECRETS OPERATOR INSTEAD OF KUBERNETES EXTERNAL SECRETS.
+# The CRDs are different from other prow clusters. Sample guide that explains the diff https://wiki.cac.washington.edu/display/MCI/Transition+from+KES+to+ESO
+# ---
+# apiVersion: kubernetes-client.io/v1
+# kind: ExternalSecret
+# metadata:
+#   name: service-account             # The name of the Kubernetes Secret
+#   namespace: test-pods
+# spec:
+#   backendType: gcpSecretsManager
+#   projectId: k8s-infra-prow-build
+#   data:
+#   - key: prow-build-service-account # The name of the GSM Secret
+#     name: service-account.json      # The key to write to in the Kubernetes Secret
+#     version: latest                 # The version of the GSM Secret
+# ---
+# apiVersion: kubernetes-client.io/v1
+# kind: ExternalSecret
+# metadata:
+#   name: ssh-key-secret                          # The name of the Kubernetes Secret
+#   namespace: test-pods
+# spec:
+#   backendType: gcpSecretsManager
+#   projectId: k8s-infra-prow-build
+#   data:
+#   - key: prow-build-ssh-key-secret-ssh-public   # The name of the GSM Secret
+#     name: ssh-public                            # The key to write to in the Kubernetes Secret
+#     version: latest                             # The version of the GSM Secret
+#   - key: prow-build-ssh-key-secret-ssh-private  # The name of the GSM Secret
+#     name: ssh-private                           # The key to write to in the Kubernetes Secret
+#     version: latest                             # The version of the GSM Secret
+# ---
+# apiVersion: kubernetes-client.io/v1
+# kind: ExternalSecret
+# metadata:
+#   name: aws-credentials-768319786644           # The name of the Kubernetes Secret
+#   namespace: test-pods
+# spec:
+#   backendType: gcpSecretsManager
+#   projectId: k8s-infra-prow-build
+#   data:
+#   - key: gke_k8s-prow-builds_us-central1-f_prow__test-pods__aws-credentials-768319786644   # The name of the GSM Secret
+#     name: credentials                                                                      # The key to write to in the Kubernetes Secret
+#     version: latest                                                                        # The version of the GSM Secret
+#     property: credentials
+# ---
+# apiVersion: kubernetes-client.io/v1
+# kind: ExternalSecret
+# metadata:
+#   name: aws-credentials-607362164682           # The name of the Kubernetes Secret
+#   namespace: test-pods
+# spec:
+#   backendType: gcpSecretsManager
+#   projectId: k8s-infra-prow-build
+#   data:
+#   - key: gke_k8s-prow-builds_us-central1-f_prow__test-pods__aws-credentials-607362164682   # The name of the GSM Secret
+#     name: credentials                                                                      # The key to write to in the Kubernetes Secret
+#     version: latest                                                                        # The version of the GSM Secret
+#     property: credentials
+# ---
+# apiVersion: kubernetes-client.io/v1
+# kind: ExternalSecret
+# metadata:
+#   name: aws-ssh-key-secret           # The name of the Kubernetes Secret
+#   namespace: test-pods
+# spec:
+#   backendType: gcpSecretsManager
+#   projectId: k8s-infra-prow-build
+#   data:
+#   - key: gke_k8s-prow-builds_us-central1-f_prow__test-pods__aws-ssh-key-secret   # The name of the GSM Secret
+#     name: aws-ssh-private                                                        # The key to write to in the Kubernetes Secret
+#     version: latest                                                              # The version of the GSM Secret
+#     property: aws-ssh-private
+#   - key: gke_k8s-prow-builds_us-central1-f_prow__test-pods__aws-ssh-key-secret   # The name of the GSM Secret
+#     name: aws-ssh-public                                                         # The key to write to in the Kubernetes Secret
+#     version: latest                                                              # The version of the GSM Secret
+#     property: aws-ssh-public


### PR DESCRIPTION
Add `aws-credentials-boskos-scale-001-kops` ExternalSecret/Secret to the EKS Prow build cluster. This secret contains access key ID (`accessKeyId`) and secret access key (`secretAccessKey`) for `kops` IAM user in `k8s-infra-e2e-scale-boskos-001` AWS account with the following permissions:

```
AmazonEC2FullAccess
AmazonRoute53FullAccess
AmazonS3FullAccess
IAMFullAccess
AmazonVPCFullAccess
AmazonSQSFullAccess
AmazonEventBridgeFullAccess
```

(from https://kops.sigs.k8s.io/getting_started/aws/#setup-iam-user)

The ExternalSecret uses AWS Secret Manager as a source.

xref https://kubernetes.slack.com/archives/CCK68P2Q2/p1689009672882279

/assign @ameukam @dims @pkprzekwas 
cc @kubernetes/release-engineering 