### PR TITLE
Send alerts from EKS Prow cluster to #k8s-infra-alerts

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/flux-system/flux-slack-notifications.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/flux-system/flux-slack-notifications.yaml
@@ -22,6 +22,17 @@ spec:
   channel: alerting-cncf-prod
   secretRef:
     name: slack-url
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
+kind: Provider
+metadata:
+  name: slack-k8s-infra-alerts
+  namespace: flux-system
+spec:
+  type: slack
+  channel: k8s-infra-alerts
+  secretRef:
+    name: slack-k8s-infra-alerts-token
 
 ---
 apiVersion: notification.toolkit.fluxcd.io/v1beta2
@@ -33,6 +44,22 @@ spec:
   summary: "EKS Prow Build Cluster"
   providerRef:
     name: slack
+  eventSeverity: error
+  eventSources:
+    - kind: GitRepository
+      name: '*'
+    - kind: Kustomization
+      name: '*'
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta2
+kind: Alert
+metadata:
+  name: k8s-infra-alerts
+  namespace: flux-system
+spec:
+  summary: "EKS Prow Build Cluster"
+  providerRef:
+    name: slack-k8s-infra-alerts
   eventSeverity: error
   eventSources:
     - kind: GitRepository

--- a/infra/aws/terraform/prow-build-cluster/resources/flux-system/slack-alerting-external-secret.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/flux-system/slack-alerting-external-secret.yaml
@@ -30,3 +30,22 @@ spec:
     remoteRef:
       key: secrets/kubermatic
       property: slack-alerting-cncf-prod
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: slack-k8s-infra-alerts-token
+  namespace: flux-system
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secerts-manager
+    kind: ClusterSecretStore
+  target:
+    name: slack-k8s-infra-alerts-token
+    creationPolicy: Owner
+  data:
+  - secretKey: address
+    remoteRef:
+      key: prow-prod/slack-hooks/kubernetes
+      property: k8s-infra-alerts

--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager-config.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager-config.yaml
@@ -21,7 +21,7 @@ metadata:
     alertmanager: main
 spec:
   route:
-    receiver: 'kubermatic'
+    receiver: 'slack'
 
     # How long to initially wait to send a notification for a group
     # of alerts. Allows to wait for an inhibiting alert to arrive or collect
@@ -41,12 +41,19 @@ spec:
     # alerting rules.
     groupBy: ['alertname', 'node']
   receivers:
-  - name: 'kubermatic'
+  - name: 'slack'
     slackConfigs:
     - apiURL:
         name: alertmanager-k8c-slack-token
         key: url
       channel: '#alerting-cncf-prod'
+      sendResolved: true
+      title: ":warning: {{ .CommonLabels.alertname }}"
+      text: "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"
+    - apiURL:
+        name: slack-k8s-infra-alerts-token
+        key: url
+      channel: '#k8s-infra-alerts'
       sendResolved: true
       title: ":warning: {{ .CommonLabels.alertname }}"
       text: "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"

--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager-slack-token.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager-slack-token.yaml
@@ -30,3 +30,22 @@ spec:
     remoteRef:
       key: secrets/kubermatic
       property: slack-alerting-cncf-prod
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: slack-k8s-infra-alerts-token
+  namespace: monitoring
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: aws-secerts-manager
+    kind: ClusterSecretStore
+  target:
+    name: slack-k8s-infra-alerts-token
+    creationPolicy: Owner
+  data:
+  - secretKey: url
+    remoteRef:
+      key: prow-prod/slack-hooks/kubernetes
+      property: k8s-infra-alerts


### PR DESCRIPTION
This PR configures AlertManager and Flux to send alerts to [`#k8s-infra-alerts` channel](https://kubernetes.slack.com/archives/CUD6HL48N) on Kubernetes Slack. We're also still sending alerts to Kubermatic Slack as we're still debugging stability issues (#5473).

/assign @ameukam @pkprzekwas 