### PR TITLE
k8s.io: update redirect config for dl.k8s.io

### DIFF
--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -189,7 +189,7 @@ data:
           # CI (continuous integration) artifacts are hosted in a bucket owned by kubernetes.io (community-managed via sig-k8s-infra)
           rewrite ^/ci/?(.*)$              https://storage.googleapis.com/k8s-release-dev/ci/$1 redirect;
           # Release artifacts are hosted in a bucket owned by google.com (the google-containers project)
-          rewrite ^/(.*)$                  https://storage.googleapis.com/kubernetes-release/$1 redirect;
+          rewrite ^/(.*)$                  https://cdn.dl.k8s.io/$1 redirect;
         }
       }
       server {

--- a/apps/k8s-io/test.py
+++ b/apps/k8s-io/test.py
@@ -312,7 +312,7 @@ class RedirTest(HTTPTestCase):
             # Base case
             self.assert_temp_redirect(
                 base + '/$path',
-                'https://storage.googleapis.com/kubernetes-release/$path',
+                'https://cdn.dl.k8s.io/$path',
                 path=rand_num())
 
     def test_docs(self):


### PR DESCRIPTION
Ensure we can also redirect any request matching `dl.k8s.io/$1` to cdn.dl.k8s.io