### PR TITLE
eks-prow-build-cluster: Introduce node selector and taint for blue node group

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/eks.tf
+++ b/infra/aws/terraform/prow-build-cluster/eks.tf
@@ -103,11 +103,13 @@ module "eks" {
   }
 
   eks_managed_node_groups = {
-    # Build cluster node group.
     build-blue = {
       name            = "build-managed-blue"
       description     = "EKS managed node group called blue used to facilitate node rotations/rollouts"
       use_name_prefix = true
+
+      taints = var.node_taints_blue
+      labels = var.node_labels_blue
 
       subnet_ids = module.vpc.private_subnets
 
@@ -159,14 +161,19 @@ module "eks" {
         update = "180m"
       }
 
-      # Disabling autoscaling on that Node Group.
-      tags = local.tags # local.node_group_tags
+      tags = merge(
+        local.tags,
+        local.auto_scaling_tags,
+        var.additional_node_group_tags_blue
+      )
     }
-    # Build cluster node group.
     build-green = {
       name            = "build-managed-green"
       description     = "EKS managed node group called green used to facilitate node rotations/rollouts"
       use_name_prefix = true
+
+      taints = var.node_taints_green
+      labels = var.node_labels_green
 
       subnet_ids = module.vpc.private_subnets
 
@@ -218,7 +225,10 @@ module "eks" {
         update = "180m"
       }
 
-      tags = local.node_group_tags
+      tags = merge(
+        local.tags,
+        local.auto_scaling_tags,
+      )
     }
   }
 }

--- a/infra/aws/terraform/prow-build-cluster/locals.tf
+++ b/infra/aws/terraform/prow-build-cluster/locals.tf
@@ -39,8 +39,6 @@ locals {
     "k8s.io/cluster-autoscaler/enabled"             = true
   }
 
-  node_group_tags = merge(local.tags, local.auto_scaling_tags)
-
   azs = slice(data.aws_availability_zones.available.names, 0, 3)
 
   # Allow cluster admin access to the following IAM roles:

--- a/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
@@ -36,9 +36,26 @@ cluster_autoscaler_version = "v1.25.0"
 node_ami_blue            = "ami-07e8e7dddc8b3bad9"
 node_instance_types_blue = ["r5d.xlarge"]
 
-node_min_size_blue     = 0
+node_min_size_blue     = 1
 node_max_size_blue     = 3
-node_desired_size_blue = 0
+node_desired_size_blue = 1
+
+node_taints_blue = [
+  {
+    key    = "dedicated"
+    value  = "kind-tests"
+    effect = "NO_SCHEDULE"
+  }
+]
+
+node_labels_blue = {
+  kind-exclusive = "true"
+}
+
+additional_node_group_tags_blue = {
+  "k8s.io/cluster-autoscaler/node-template/label/kind-exclusive" = "true"
+  "k8s.io/cluster-autoscaler/node-template/taint/dedicated"      = "kind-tests:NoSchedule"
+}
 
 node_ami_green            = "ami-07e8e7dddc8b3bad9"
 node_instance_types_green = ["r5d.xlarge"]
@@ -46,6 +63,10 @@ node_instance_types_green = ["r5d.xlarge"]
 node_min_size_green     = 1
 node_max_size_green     = 3
 node_desired_size_green = 1
+
+node_taints_green = []
+
+node_labels_green = {}
 
 node_volume_size = 100
 

--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -40,6 +40,23 @@ node_min_size_blue     = 0
 node_max_size_blue     = 20
 node_desired_size_blue = 0
 
+node_taints_blue = [
+  {
+    key    = "dedicated"
+    value  = "kind-tests"
+    effect = "NO_SCHEDULE"
+  }
+]
+
+node_labels_blue = {
+  kind-exclusive = "true"
+}
+
+additional_node_group_tags_blue = {
+  "k8s.io/cluster-autoscaler/node-template/label/kind-exclusive" = "true"
+  "k8s.io/cluster-autoscaler/node-template/taint/dedicated"      = "kind-tests:NoSchedule"
+}
+
 node_ami_green            = "ami-07e8e7dddc8b3bad9"
 node_instance_types_green = ["r5d.4xlarge"]
 

--- a/infra/aws/terraform/prow-build-cluster/variables.tf
+++ b/infra/aws/terraform/prow-build-cluster/variables.tf
@@ -143,6 +143,36 @@ variable "node_max_unavailable_percentage" {
   description = "Maximum unavailable nodes in a node group"
 }
 
+variable "node_taints_blue" {
+  type    = list(map(string))
+  default = []
+}
+
+variable "node_taints_green" {
+  type    = list(map(string))
+  default = []
+}
+
+variable "node_labels_blue" {
+  type    = map(string)
+  default = {}
+}
+
+variable "node_labels_green" {
+  type    = map(string)
+  default = {}
+}
+
+variable "additional_node_group_tags_blue" {
+  type    = map(string)
+  default = {}
+}
+
+variable "additional_node_group_tags_green" {
+  type    = map(string)
+  default = {}
+}
+
 variable "cluster_autoscaler_version" {
   type        = string
   description = "Cluster Autoscaler version to use (must match the EKS version)"


### PR DESCRIPTION
As mentioned in https://github.com/kubernetes/k8s.io/issues/5641 we need this setup to test if the node rotation problem is caused by kind prow jobs. This PR decorates the blue node group with label and taint so that we can use it exclusively for kind prow jobs.

/assign @xmudrii 
/cc @ameukam @dims 