### PR TITLE
Fix affected redirection tests for pkgs.k8s.io

### DIFF
--- a/apps/k8s-io/test.py
+++ b/apps/k8s-io/test.py
@@ -227,8 +227,8 @@ class RedirTest(HTTPTestCase):
 
     def test_packages(self):
         for base in ('packages.k8s.io', 'packages.kubernetes.io', 'pkgs.k8s.io', 'pkgs.kubernetes.io'):
-            self.assert_permanent_redirect(base, 'https://prod-cdn.packages.k8s.io/repositories/isv:/kubernetes:/')
-            self.assert_permanent_redirect(base + '/$id',
+            self.assert_temp_redirect(base, 'https://prod-cdn.packages.k8s.io/repositories/isv:/kubernetes:/')
+            self.assert_temp_redirect(base + '/$id',
                 'https://prod-cdn.packages.k8s.io/repositories/isv:/kubernetes:/$id', id=rand_num())
 
     def test_blog(self):


### PR DESCRIPTION
`pkgs.k8s.io` is using temporary redirection same as old endpoints (`apt.kubernetes.io` and `yum.kubernetes.io`). This requires adjusting redirection tests as done in this PR.

/assign @dims @BenTheElder @cblecker 