### PR TITLE
enable segmented caching for archive files

### DIFF
--- a/infra/fastly/terraform/dl.k8s.io/services.tf
+++ b/infra/fastly/terraform/dl.k8s.io/services.tf
@@ -71,7 +71,7 @@ resource "fastly_service_vcl" "files" {
 
   snippet {
     content  = <<-EOT
-      if (req.url.path ~ "^/release/") {
+      if (req.url.path ~ "^/release/" || req.url.path ~ "(tar|tgz|tar\.gz|zip)$") {
         set req.enable_segmented_caching = true;
       }
     EOT


### PR DESCRIPTION
Without segmented caching this there is a 20MB limit for files. Turn it on for common archives that can exceed this size.