### PR TITLE
Update distributors-announce group settings

### DIFF
--- a/groups/committee-security-response/groups.yaml
+++ b/groups/committee-security-response/groups.yaml
@@ -19,6 +19,10 @@ groups:
       https://git.k8s.io/committee-security-response/private-distributors-list.md
     settings:
       ReconcileMembers: "true"
+      AllowWebPosting: "true"
+      MessageModerationLevel: "MODERATE_ALL_MESSAGES"
+      WhoCanViewGroup: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanDiscoverGroup: "ALL_MEMBERS_CAN_DISCOVER"
     owners:
       - cjcullen@google.com
       - cjingram@google.com


### PR DESCRIPTION
Defaults for config from https://github.com/kubernetes/k8s.io/blob/85e692779d056ec2c890b69c90d7d63db2469731/groups/service.go#L456-L491 (only non-default values are manually set).