### PR TITLE
Add sharedCredentialsFile to boskos-scale-001-kops secret

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/test-pods/externalsecrets.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/test-pods/externalsecrets.yaml
@@ -34,3 +34,7 @@ spec:
     remoteRef:
       key: prow-prod/k8s-infra-e2e-boskos-scale-001/kops
       property: secretAccessKey
+  - secretKey: sharedCredentialsFile
+    remoteRef:
+      key: prow-prod/k8s-infra-e2e-boskos-scale-001/kops
+      property: sharedCredentialsFile


### PR DESCRIPTION
Requested on Slack: https://kubernetes.slack.com/archives/CCK68P2Q2/p1690991082107399?thread_ts=1689009672.882279&cid=CCK68P2Q2

Add `sharedCredentialsFile` to be used as `AWS_SHARED_CREDENTIALS_FILE` to the `aws-credentials-boskos-scale-001-kops` Secret in EKS Prow build cluster.

/assign @pkprzekwas @dims @ameukam 