### PR TITLE
GKE: Enable GKE CSI driver

### DIFF
--- a/infra/gcp/terraform/kubernetes-public/10-cluster-configuration.tf
+++ b/infra/gcp/terraform/kubernetes-public/10-cluster-configuration.tf
@@ -159,6 +159,9 @@ resource "google_container_cluster" "cluster" {
 
   // Configure cluster addons
   addons_config {
+    gce_persistent_disk_csi_driver_config {
+      enabled = true
+    }
     horizontal_pod_autoscaling {
       disabled = false
     }

--- a/infra/gcp/terraform/modules/gke-cluster/main.tf
+++ b/infra/gcp/terraform/modules/gke-cluster/main.tf
@@ -161,6 +161,9 @@ resource "google_container_cluster" "prod_cluster" {
 
   // Configure cluster addons
   addons_config {
+    gce_persistent_disk_csi_driver_config {
+      enabled = true
+    }
     horizontal_pod_autoscaling {
       disabled = false
     }


### PR DESCRIPTION
Starting with GKE 1.25, GKE CSI driver is enabled by default. Reconciciling the terraform code to reflect the change introduced. See: https://cloud.google.com/kubernetes-engine/docs/release-notes#June_08_2023