### PR TITLE
prow-build-trusted: Add PVC for publishing-bot

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-pvcs.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-pvcs.yaml
@@ -1,0 +1,15 @@
+# Prow PVCs
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: publishing-bot-pvc
+  namespace: test-pods
+  labels:
+    app: publisher
+spec:
+  storageClassName: "premium-rwo"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/publishing-bot/issues/353

Add a PVC that will be used publishing-bot as a prowjob