### PR TITLE
Adjust alert mailing list for Cluster API Provider vSphere

### DIFF
--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -219,6 +219,7 @@ groups:
       List for test alerts for the Cluster API vSphere infrastructure provider.
     settings:
       ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
     members:
       - buringerst@vmware.com
       - christi.schlotter@gmail.com


### PR DESCRIPTION
/assign @sbueringer 
/assign @killianmuldoon 

After diffing: all `*-alerts` mailing lists do at least have this additional setting.

This should hopefully fix the alert mails to get sent out for CAPV.