### PR TITLE
AWS: setup config for kOps CI

### DIFF
--- a/infra/aws/terraform/kops-infra-ci/data.tf
+++ b/infra/aws/terraform/kops-infra-ci/data.tf
@@ -1,0 +1,30 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+data "aws_availability_zones" "available" {
+  provider = aws.kops-infra-ci
+  state    = "available"
+}
+
+data "aws_caller_identity" "current" {
+  provider = aws.kops-infra-ci
+}
+
+data "aws_region" "current" {
+  provider = aws.kops-infra-ci
+}
+
+data "aws_organizations_organization" "current" {}

--- a/infra/aws/terraform/kops-infra-ci/locals.tf
+++ b/infra/aws/terraform/kops-infra-ci/locals.tf
@@ -1,0 +1,22 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+locals {
+  kops-infra-ci-name       = "kops-infra-ci"
+  kops-infra-ci-index      = index(data.aws_organizations_organization.current.accounts.*.name, local.kops-infra-ci-name)
+  kops-infra-ci-account-id = data.aws_organizations_organization.current.accounts[local.kops-infra-ci-index].id
+}

--- a/infra/aws/terraform/kops-infra-ci/provider.tf
+++ b/infra/aws/terraform/kops-infra-ci/provider.tf
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+provider "aws" {
+  region = "us-east-2"
+  alias  = "kops-infra-ci"
+
+  assume_role {
+    role_arn = "arn:aws:iam::${local.kops-infra-ci-account-id}:role/OrganizationAccountAccessRole"
+  }
+}

--- a/infra/aws/terraform/kops-infra-ci/terraform.tf
+++ b/infra/aws/terraform/kops-infra-ci/terraform.tf
@@ -1,0 +1,33 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  backend "s3" {
+    bucket = "k8s-infra-kops-ci-tf-state"
+    region = "us-east-2"
+    key    = "kops-infra-ci/terraform.tfstate"
+    // TODO(ameukam): stop used hardcoded account id. Preferably use SSO user
+    role_arn     = "arn:aws:iam::808842816990:role/OrganizationAccountAccessRole"
+    session_name = "kops-infra-ci"
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.11.0"
+    }
+  }
+}

--- a/infra/aws/terraform/kops-infra-ci/versions.tf
+++ b/infra/aws/terraform/kops-infra-ci/versions.tf
@@ -1,0 +1,20 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+terraform {
+  required_version = "~> 1.5.1"
+}


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/k8s.io/issues/5127

Setup the terraform config needed to build the kOps CI infrastructure in the community infrastructure