### PR TITLE
Adding k8s-infra-kops-scale-tests bucket with public read

### DIFF
--- a/infra/aws/terraform/s3/k8s-infra-e2e-boskos-scale-001/.gitignore
+++ b/infra/aws/terraform/s3/k8s-infra-e2e-boskos-scale-001/.gitignore
@@ -1,0 +1,21 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+*.tfplan
+
+# Crash log files
+crash.log
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/infra/aws/terraform/s3/k8s-infra-e2e-boskos-scale-001/.terraform.lock.hcl
+++ b/infra/aws/terraform/s3/k8s-infra-e2e-boskos-scale-001/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.67.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:5Zfo3GfRSWBaXs4TGQNOflr1XaYj6pRnVJLX5VAjFX4=",
+    "zh:0843017ecc24385f2b45f2c5fce79dc25b258e50d516877b3affee3bef34f060",
+    "zh:19876066cfa60de91834ec569a6448dab8c2518b8a71b5ca870b2444febddac6",
+    "zh:24995686b2ad88c1ffaa242e36eee791fc6070e6144f418048c4ce24d0ba5183",
+    "zh:4a002990b9f4d6d225d82cb2fb8805789ffef791999ee5d9cb1fef579aeff8f1",
+    "zh:559a2b5ace06b878c6de3ecf19b94fbae3512562f7a51e930674b16c2f606e29",
+    "zh:6a07da13b86b9753b95d4d8218f6dae874cf34699bca1470d6effbb4dee7f4b7",
+    "zh:768b3bfd126c3b77dc975c7c0e5db3207e4f9997cf41aa3385c63206242ba043",
+    "zh:7be5177e698d4b547083cc738b977742d70ed68487ce6f49ecd0c94dbf9d1362",
+    "zh:8b562a818915fb0d85959257095251a05c76f3467caa3ba95c583ba5fe043f9b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c385d03a958b54e2afd5279cd8c7cbdd2d6ca5c7d6a333e61092331f38af7cf",
+    "zh:b3ca45f2821a89af417787df8289cb4314b273d29555ad3b2a5ab98bb4816b3b",
+    "zh:da3c317f1db2469615ab40aa6baba63b5643bae7110ff855277a1fb9d8eb4f2c",
+    "zh:dc6430622a8dc5cdab359a8704aec81d3825ea1d305bbb3bbd032b1c6adfae0c",
+    "zh:fac0d2ddeadf9ec53da87922f666e1e73a603a611c57bcbc4b86ac2821619b1d",
+  ]
+}

--- a/infra/aws/terraform/s3/k8s-infra-e2e-boskos-scale-001/bucket.tf
+++ b/infra/aws/terraform/s3/k8s-infra-e2e-boskos-scale-001/bucket.tf
@@ -1,0 +1,65 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "aws_s3_bucket" "k8s_infra_kops_scale_tests" {
+  bucket = "k8s-infra-kops-scale-tests"
+}
+
+resource "aws_s3_bucket_public_access_block" "k8s_infra_kops_scale_tests" {
+  bucket = aws_s3_bucket.k8s_infra_kops_scale_tests.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_policy" "k8s_infra_kops_scale_tests" {
+  bucket = aws_s3_bucket.k8s_infra_kops_scale_tests.id
+
+  depends_on = [aws_s3_bucket_public_access_block.k8s_infra_kops_scale_tests]
+
+  policy = jsonencode({
+    "Id" : "Public-Access",
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Action" : "s3:ListBucket",
+        "Effect" : "Allow",
+        "Resource" : "${aws_s3_bucket.k8s_infra_kops_scale_tests.arn}",
+        "Principal" : "*"
+      },
+      {
+        "Action" : "s3:GetObject",
+        "Effect" : "Allow",
+        "Resource" : "${aws_s3_bucket.k8s_infra_kops_scale_tests.arn}/*",
+        "Principal" : "*"
+      },
+      {
+        "Sid" : "RequireTLSForObjectAccess",
+        "Action" : "s3:*",
+        "Effect" : "Deny",
+        "Resource" : "${aws_s3_bucket.k8s_infra_kops_scale_tests.arn}/*",
+        "Condition" : {
+          "Bool" : {
+            "aws:SecureTransport" : "false"
+          }
+        },
+        "Principal" : "*"
+      }
+    ]
+  })
+}

--- a/infra/aws/terraform/s3/k8s-infra-e2e-boskos-scale-001/providers.tf
+++ b/infra/aws/terraform/s3/k8s-infra-e2e-boskos-scale-001/providers.tf
@@ -1,0 +1,28 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-east-2"
+}

--- a/infra/aws/terraform/s3/k8s-infra-e2e-boskos-scale-001/providers.tf
+++ b/infra/aws/terraform/s3/k8s-infra-e2e-boskos-scale-001/providers.tf
@@ -15,6 +15,11 @@ limitations under the License.
 */
 
 terraform {
+  backend "s3" {
+    bucket = "k8s-infra-kops-scale-tests-tf-state"
+    region = "us-east-2"
+    key    = "s3/k8s-infra-kops-scale-tests/terraform.tfstate"
+  }
   required_providers {
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
Creating dedicated bucket with public read access for kops scale tests (as discussed [here](https://kubernetes.slack.com/archives/CCK68P2Q2/p1691083904395479?thread_ts=1689009672.882279&cid=CCK68P2Q2))

/assign @ameukam @dims 
/cc @prateekgogia