### PR TITLE
AWS: Add a VPC for kOps CI

### DIFF
--- a/infra/aws/terraform/kops-infra-ci/locals.tf
+++ b/infra/aws/terraform/kops-infra-ci/locals.tf
@@ -21,4 +21,9 @@ locals {
   kops-infra-ci-account-id = data.aws_organizations_organization.current.accounts[local.kops-infra-ci-index].id
 
   prefix = "k8s-infra-kops"
+
+  partition       = cidrsubnets(aws_vpc_ipam_preview_next_cidr.main.cidr, 2, 2, 2)
+  azs             = slice(data.aws_availability_zones.available.names, 0, 3)
+  private_subnets = cidrsubnets(local.partition[0], 2, 2, 2)
+  public_subnets  = cidrsubnets(local.partition[1], 2, 2, 2)
 }

--- a/infra/aws/terraform/kops-infra-ci/variables.tf
+++ b/infra/aws/terraform/kops-infra-ci/variables.tf
@@ -27,3 +27,9 @@ variable "region" {
   type = string
   default = "us-east-2"
 }
+
+variable "vpc_cidr" {
+  type        = string
+  description = "CIDR of the VPC"
+  default     = "10.128.0.0/16"
+}

--- a/infra/aws/terraform/kops-infra-ci/vpc.tf
+++ b/infra/aws/terraform/kops-infra-ci/vpc.tf
@@ -45,3 +45,59 @@ resource "aws_vpc_ipam_pool" "main" {
     "region" = "${data.aws_region.current.name}"
   })
 }
+
+
+resource "aws_vpc_ipam_pool_cidr" "main" {
+  provider       = aws.kops-infra-ci
+  ipam_pool_id = aws_vpc_ipam_pool.main.id
+  cidr         = var.vpc_cidr
+}
+
+resource "aws_vpc_ipam_preview_next_cidr" "main" {
+  provider       = aws.kops-infra-ci
+  ipam_pool_id   = aws_vpc_ipam_pool.main.id
+
+  netmask_length = 20 // a 18 netmask length is considered as too big for the CIDR pool
+}
+
+module "vpc" {
+  providers = {
+    aws = aws.kops-infra-ci
+  }
+
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  name = "${local.prefix}-vpc"
+  cidr = aws_vpc_ipam_preview_next_cidr.main.cidr
+
+  ipv4_ipam_pool_id = aws_vpc_ipam_pool.main.id
+
+  azs             = local.azs
+  private_subnets = local.private_subnets
+  public_subnets  = local.public_subnets
+
+  enable_nat_gateway     = true
+  single_nat_gateway     = false
+  one_nat_gateway_per_az = true
+
+  // TODO(ameukam): Remove this after https://github.com/kubernetes/k8s.io/issues/5127 is closed
+  enable_flow_log                                 = true
+  create_flow_log_cloudwatch_iam_role             = true
+  create_flow_log_cloudwatch_log_group            = true
+  flow_log_cloudwatch_log_group_retention_in_days = 30
+
+  enable_dns_hostnames = true
+
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = 1
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb" = 1
+  }
+
+  tags = merge(var.tags, {
+    "region" = "${data.aws_region.current.name}"
+  })
+}


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/k8s.io/issues/5127

Create a VPC that will be used to create the EKS cluster for kOps CI. The CIDR 10.128.0.0/16 is used and splitted different the different azs of us-east-2 region.