### PR TITLE
releng: temp RM access for Mark Rossetti (marosset)

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -47,6 +47,7 @@ groups:
       - jameswangel@gmail.com
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
+      - marosset@microsoft.com
       - mudrinic.mare@gmail.com
       - nng.grace@gmail.com
       - pal.nabarun95@gmail.com


### PR DESCRIPTION
Adding myself as a Release Manager Associate with temporary elevated access to cut the v1.28.0-rc.1 release

/assign @jeremyrickard 
/sig release

Part of https://github.com/kubernetes/sig-release/issues/2303