### PR TITLE
adding marosset's gmail to release-editors

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -47,7 +47,7 @@ groups:
       - jameswangel@gmail.com
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
-      - marosset@microsoft.com
+      - markrossetti@gmail.com
       - mudrinic.mare@gmail.com
       - nng.grace@gmail.com
       - pal.nabarun95@gmail.com
@@ -71,6 +71,7 @@ groups:
       - nng.grace@gmial.com # 1.28 Release Team Lead
       - hebaelayoty@gmail.com # 1.28 Lead Shadow
       - leonard.pahlke@googlemail.com # 1.28 Emeritus Advisor
+      - markrossetti@gmail.com # 1.28 Lead Shadow
       - marosset@microsoft.com # 1.28 Lead Shadow
       - m.r.boxell@gmail.com # 1.28 Lead Shadow
       - neoaggelos@gmail.com # 1.28 Lead Shadow


### PR DESCRIPTION
Part of https://github.com/kubernetes/sig-release/issues/2303

@jeremyrickard thinks I might need to use a at-gmail address