### PR TITLE
Update cloud-provider-openstack google group membership

### DIFF
--- a/groups/sig-architecture/groups.yaml
+++ b/groups/sig-architecture/groups.yaml
@@ -176,9 +176,10 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
-      - anusha.iiitm@gmail.com
-      - anlin.kong@gmail.com
-      - glaubich@gmail.com
+      - haka.jesse@gmail.com
+      - jichenjc@cn.ibm.com
+      - kaydiam+k8s@gmail.com
+      - mdulko@redhat.com
 
   - email-id: k8s-infra-conform-s390x-k8s@kubernetes.io
     name: k8s-infra-conform-s390x-k8s

--- a/groups/sig-cloud-provider/groups.yaml
+++ b/groups/sig-cloud-provider/groups.yaml
@@ -38,8 +38,9 @@ groups:
       ReconcileMembers: "true"
     members:
       - haka.jesse@gmail.com
-      - glaubich@gmail.com
-      - lemonjchjch@gmail.com
+      - jichenjc@cn.ibm.com
+      - kaydiam+k8s@gmail.com
+      - mdulko@redhat.com
 
   - email-id: k8s-infra-staging-provider-azure@kubernetes.io
     name: k8s-infra-staging-provider-azure


### PR DESCRIPTION
Update to reflect https://github.com/kubernetes/cloud-provider-openstack/pull/2318

Distinct from https://github.com/kubernetes/k8s.io/pull/5716 as that deals with GitHub permissions.

- [x] Confirm email of @jichenjc 
- [x] Obtain email of @kayrus 

/hold