### PR TITLE
Update leads and conduct email lists, plus OWNERS_ALIASES for CoCC 2023 Election

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -164,7 +164,7 @@ aliases:
     - mylesagray
     - phenixblue
   committee-code-of-conduct:
-    - detiber
+    - AnaMMedina21
     - endocrimes
     - hlipsig
     - jeremyrickard

--- a/groups/committee-code-of-conduct/groups.yaml
+++ b/groups/committee-code-of-conduct/groups.yaml
@@ -11,7 +11,7 @@ groups:
       - jeremy.r.rickard@gmail.com
       - lancashiredanielle@gmail.com
       - xandergrzyw@gmail.com
-      - detiber@gmail.com
+      - AnaMMedina21@gmail.com
   - email-id: conduct-emeritus@kubernetes.io
     name: conduct-emeritus
     description: |-
@@ -23,6 +23,7 @@ groups:
       - jeremy.r.rickard@gmail.com
       - lancashiredanielle@gmail.com
       - xandergrzyw@gmail.com
-      - detiber@gmail.com
+      - AnaMMedina21@gmail.com
     members:
       - tpepper@vmware.com
+      - detiber@gmail.com

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -43,9 +43,7 @@ groups:
       - shane@konghq.com
       - cbelu@cloudbasesolutions.com
       - cecilerobertm@gmail.com
-      - celeste.e.horgan@gmail.com #CoCC
       - chiachenk@google.com
-      - chu.karen.h@gmail.com #CoCC
       - cncf-speakers@linuxfoundation.org
       - community@kubernetes.io
       - ctadeu@gmail.com # SIG Release
@@ -146,3 +144,6 @@ groups:
       - rficcaglia@gmail.com
       - strong.james.e@gmail.com # Sig Network Sub Project Ingress-nginx
       - ricardo.katz@gmail.com # Sig Network Sub Project Ingress-nginx
+      - xandergrzyw@gmail.com # CoCC
+      - hilliary.lipsig@gmail.com # CoCC
+      - AnaMMedina21@gmail.com # CoCC


### PR DESCRIPTION
This PR updates a few things for onboarding/offboarding following the 2023 Code of Conduct Election: 
  - OWNER_ALIASES
  - leads@ email list
  - conduct@ email list
  - conduct-emeritus@ list

Part of https://github.com/kubernetes/community/issues/7482

/committee code-of-conduct