### PR TITLE
redirect to rendered OWNERS docs on kubernetes.dev instead of github …

### DIFF
--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -269,7 +269,7 @@ data:
           rewrite ^/needs-ok-to-test$ https://github.com/pulls?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Apr+label%3Aneeds-ok-to-test+label%3A%22cncf-cla%3A+yes%22+-label%3Aneeds-rebase redirect;
           rewrite ^/oncall$          https://storage.googleapis.com/test-infra-oncall/oncall.html redirect;
           rewrite ^/oncall-hotlist$  https://github.com/kubernetes/test-infra/search?q=label%3Akind%2Foncall-hotlist+is%3Aopen&type=Issues redirect;
-          rewrite ^/owners$          https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md redirect;
+          rewrite ^/owners$          https://www.kubernetes.dev/docs/guide/owners/ redirect;
           rewrite ^/owners/([^/]*)/?$ https://cs.k8s.io/?q=$1&i=fosho&files=OWNERS&excludeFiles=vendor%2F&repos= redirect;
           rewrite ^/partner-request$ https://docs.google.com/forms/d/e/1FAIpQLSdN1KtSKX2VAOPGABFlShkSd6CajQynoL4QCVtY0dj76MNDKg/viewform redirect;
           rewrite ^/pr-dashboard$    https://gubernator.k8s.io/pr redirect;

--- a/apps/k8s-io/test.py
+++ b/apps/k8s-io/test.py
@@ -183,7 +183,7 @@ class RedirTest(HTTPTestCase):
                 base + 'oncall',
                 'https://storage.googleapis.com/test-infra-oncall/oncall.html')
             self.assert_temp_redirect(base + 'owners',
-                'https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md')
+                'https://www.kubernetes.dev/docs/guide/owners/')
             self.assert_temp_redirect(base + 'owners/$ghuser',
                 'https://cs.k8s.io/?q=$ghuser&i=fosho&files=OWNERS&excludeFiles=vendor%2F&repos=',
                  ghuser=rand_num())


### PR DESCRIPTION
…source

discussed here https://kubernetes.slack.com/archives/C1TU9EB9S/p1692728318487289