### PR TITLE
sbom.k8s.io: Allow file extensions

### DIFF
--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -329,8 +329,8 @@ data:
         server_name sbom.k8s.io sbom.kubernetes.io
         listen 80;
 
-        rewrite ^/(.*)?/release$ https://storage.googleapis.com/kubernetes-release/release/$1/kubernetes-release.spdx redirect;
-        rewrite ^/(.*)?/source$  https://storage.googleapis.com/kubernetes-release/release/$1/kubernetes-source.spdx redirect;
+        rewrite ^/(.*)?/release(\.cert|\.sig|\.sha256|\.sha512)?$ https://storage.googleapis.com/kubernetes-release/release/$1/kubernetes-release.spdx$2 redirect;
+        rewrite ^/(.*)?/source(\.cert|\.sig|\.sha256|\.sha512)?$  https://storage.googleapis.com/kubernetes-release/release/$1/kubernetes-source.spdx$2 redirect;
       }
 
       server {


### PR DESCRIPTION
We should allow to retrieve the `.sig`, `.cert`, `.sha256` or `.sha512` files of the SBOM's via sbom.k8s.io. This mean we now accept any suffix to the nginx rewrite and pass that down to the actual URL.

cc @kubernetes/release-engineering 

Refers to https://github.com/kubernetes/release/issues/3222#issuecomment-1695197942