### PR TITLE
Updating to current sig cloud provider chairs

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -27,7 +27,10 @@ aliases:
     - soltysh
   sig-cloud-provider-leads:
     - andrewsykim
+    - bridgetkromhout
     - cheftako
+    - elmiko
+    - nckturner
   sig-cluster-lifecycle-leads:
     - CecileRobertMichon
     - fabriziopandini


### PR DESCRIPTION
Update to match https://github.com/kubernetes/community/blob/master/OWNERS_ALIASES#L28-L33.