### PR TITLE
eks-prow-build-cluster: set minimum back on active node group

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -38,7 +38,7 @@ cluster_autoscaler_version = "v1.25.0"
 node_ami_blue            = "ami-05da66fc7a4319aa8"
 node_instance_types_blue = ["r5ad.4xlarge"]
 
-node_min_size_blue     = 0
+node_min_size_blue     = 20
 node_max_size_blue     = 40
 node_desired_size_blue = 0
 


### PR DESCRIPTION
This has been accidentally omitted while migrating to new set of EKS nodes.

/assign @xmudrii