### PR TITLE
AWS: Add a OIDC provider for kOps CI.

### DIFF
--- a/infra/aws/terraform/kops-infra-ci/eks.tf
+++ b/infra/aws/terraform/kops-infra-ci/eks.tf
@@ -42,10 +42,10 @@ module "eks" {
   cluster_addons = {
     coredns = {
       most_recent       = true
-      resolve_conflicts        = "OVERWRITE"
+      resolve_conflicts = "OVERWRITE"
     }
     kube-proxy = {
-      most_recent       = true
+      most_recent = true
     }
     vpc-cni = {
       most_recent              = true

--- a/infra/aws/terraform/kops-infra-ci/main.tf
+++ b/infra/aws/terraform/kops-infra-ci/main.tf
@@ -1,0 +1,31 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This configures Google GKE cluster OIDC issuer as an Identity
+// Provider (IdP), and allows the list of audiences specified.
+resource "aws_iam_openid_connect_provider" "google_prow_idp" {
+  provider = aws.kops-infra-ci
+
+
+  url            = "https://container.googleapis.com/v1/projects/k8s-prow/locations/us-central1-f/clusters/prow"
+  client_id_list = ["sts.amazonaws.com"]
+
+  # AWS wants the thumbprint of the the top intermediate certificate authority.
+  thumbprint_list = [
+    # GlobalSign root certificate (Google Managed Certficates)
+    "08745487e891c19e3078c1f2a07e452950ef36f6"
+  ]
+}

--- a/infra/aws/terraform/kops-infra-ci/variables.tf
+++ b/infra/aws/terraform/kops-infra-ci/variables.tf
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 variable "eks_version" {
-  type = string
+  type    = string
   default = "1.26"
 }
 


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/k8s.io/issues/5127

Add an OIDC provider for Prow's Google GKE cluster.