### PR TITLE
Allow requests without User-Agent header to pkgs.k8s.io

### DIFF
--- a/infra/aws/terraform/cdn.packages.k8s.io/waf.tf
+++ b/infra/aws/terraform/cdn.packages.k8s.io/waf.tf
@@ -66,6 +66,16 @@ resource "aws_wafv2_web_acl" "cdn_packages_k8s_io" {
             count {}
           }
         }
+
+        // tdnf used on Photon OS doesn't send a user agent header so
+        // this rule is being triggered which makes tdnf fail with 403 Forbidden.
+        rule_action_override {
+          name = "NoUserAgent_HEADER"
+
+          action_to_use {
+            count {}
+          }
+        }
       }
     }
 


### PR DESCRIPTION
The `tdnf` package manager used on Photon OS doesn't send a valid User-Agent header which results in 403 Forbidden when trying to reach `pkgs.k8s.io`. This is breaking all `tdnf` users, but also the image-builder project which uses `tdnf` for their work.

More details about this can be found in this Slack thread: https://kubernetes.slack.com/archives/C03U7N0VCGK/p1694194051373989

The change has been already deployed to production and we have a confirmation from `tdnf` users that it works now. 🎉 

Fixes https://github.com/kubernetes/release/issues/3261

/assign @saschagrunert @cpanato 
cc @kubernetes/release-engineering 