### PR TITLE
Add a service account for provider-aws-test-role

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/test-pods/build-serviceaccounts.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/test-pods/build-serviceaccounts.yaml
@@ -11,3 +11,11 @@ metadata:
     eks.amazonaws.com/role-arn: arn:aws:iam::855606814420:role/node-e2e-tests
   name: node-e2e-tests
   namespace: test-pods
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::855606814420:role/kubetest2/provider-aws-test-role
+  name: provider-aws-test-role
+  namespace: test-pods


### PR DESCRIPTION
we have one for `node-e2e-tests` role, but not for `provider-aws-test-role` so adding it here