### PR TITLE
eks-prow-build: increase vm.min_free_kbytes to 135168, finish public subnet and canary rollouts

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/bootstrap/node_bootstrap.sh
+++ b/infra/aws/terraform/prow-build-cluster/bootstrap/node_bootstrap.sh
@@ -27,6 +27,10 @@ set -o pipefail
 sysctl -w fs.inotify.max_user_watches=1048576
 sysctl -w fs.inotify.max_user_instances=8192
 
+## Increase vm.min_free_kbytes from 67584 to 135168 as a potential mitigation for
+## https://github.com/kubernetes/k8s.io/issues/5473
+echo 135168 > /proc/sys/vm/min_free_kbytes
+
 ## Set up ephemeral disks (SSDs) to be used by containerd and kubelet
 
 MNT_DIR="/mnt/k8s-disks"

--- a/infra/aws/terraform/prow-build-cluster/bootstrap/node_bootstrap_green.sh
+++ b/infra/aws/terraform/prow-build-cluster/bootstrap/node_bootstrap_green.sh
@@ -27,6 +27,10 @@ set -o pipefail
 sysctl -w fs.inotify.max_user_watches=1048576
 sysctl -w fs.inotify.max_user_instances=8192
 
+## Increase vm.min_free_kbytes from 67584 to 135168 as a potential mitigation for
+## https://github.com/kubernetes/k8s.io/issues/5473
+echo 135168 > /proc/sys/vm/min_free_kbytes
+
 ## Set up ephemeral disks (SSDs) to be used by containerd and kubelet
 
 MNT_DIR="/mnt/k8s-disks"

--- a/infra/aws/terraform/prow-build-cluster/node_group_green.tf
+++ b/infra/aws/terraform/prow-build-cluster/node_group_green.tf
@@ -23,7 +23,7 @@ locals {
     taints = var.node_taints_green
     labels = var.node_labels_green
 
-    subnet_ids = module.vpc.private_subnets
+    subnet_ids = module.vpc.public_subnets
 
     min_size     = var.node_min_size_green
     max_size     = var.node_max_size_green

--- a/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
@@ -36,16 +36,16 @@ cluster_autoscaler_version = "v1.25.0"
 node_ami_blue            = "ami-07e8e7dddc8b3bad9"
 node_instance_types_blue = ["r5d.xlarge"]
 
-node_min_size_blue     = 1
+node_min_size_blue     = 3
 node_max_size_blue     = 3
-node_desired_size_blue = 1
+node_desired_size_blue = 3
 
 node_ami_green            = "ami-07e8e7dddc8b3bad9"
 node_instance_types_green = ["r5d.xlarge"]
 
-node_min_size_green     = 1
-node_max_size_green     = 3
-node_desired_size_green = 1
+node_min_size_green     = 0
+node_max_size_green     = 1
+node_desired_size_green = 0
 
 node_taints_green = []
 

--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -38,16 +38,16 @@ cluster_autoscaler_version = "v1.25.0"
 node_ami_blue            = "ami-05da66fc7a4319aa8"
 node_instance_types_blue = ["r5ad.4xlarge"]
 
-node_min_size_blue     = 20
-node_max_size_blue     = 40
+node_min_size_blue     = 0
+node_max_size_blue     = 1
 node_desired_size_blue = 0
 
 node_ami_green            = "ami-05da66fc7a4319aa8"
 node_instance_types_green = ["r5d.4xlarge"]
 
-node_min_size_green     = 0
-node_max_size_green     = 1
-node_desired_size_green = 0
+node_min_size_green     = 20
+node_max_size_green     = 40
+node_desired_size_green = 20
 
 node_volume_size = 100
 


### PR DESCRIPTION
This PR includes several changes to the EKS Prow build cluster:

- `vm.min_free_kbytes` is increased from 67584 to 135168 as recommended by the AWS support in attempt to mitigate https://github.com/kubernetes/k8s.io/issues/5473
- green node group has been switched to the public subnet
- public subnet is fully rolled out on canary

The change is already rolled out on prod. I'm yet to rollout `vm.min_free_kbytes` change on canary, but I'll do that later today or tomorrow.

/assign @dims @ameukam 