### PR TITLE
Add sig-storage objectstorage containter images to registry

### DIFF
--- a/registry.k8s.io/images/k8s-staging-sig-storage/generate.sh
+++ b/registry.k8s.io/images/k8s-staging-sig-storage/generate.sh
@@ -39,6 +39,8 @@ readonly images=(
     nfs-provisioner
     nfs-subdir-external-provisioner
     nfsplugin
+    objectstorage-controller
+    objectstorage-sidecar
     smbplugin
     snapshot-controller
     snapshot-validation-webhook


### PR DESCRIPTION
Add both sig-storage Container Object Storage Interface (COSI) "objectstorage" images to k8s registry"
- objectstorage-controller
- objectstorage-sidecar