### PR TITLE
infra/gcp: Ensure a purgatory GCP project

### DIFF
--- a/infra/gcp/bash/ensure-purgatory.sh
+++ b/infra/gcp/bash/ensure-purgatory.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script creates deprecated buckets on a dedicated GCP project
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR=$(dirname "${BASH_SOURCE[0]}")
+. "${SCRIPT_DIR}/lib.sh"
+
+function usage() {
+    echo "usage: $0 [project...]" > /dev/stderr
+    echo "example:" > /dev/stderr
+    echo "  $0 # do all projects" > /dev/stderr
+    echo "  $0 k8s-artifacts-prod # just do one" > /dev/stderr
+    echo > /dev/stderr
+}
+
+# This is a list of all purgatory projects
+mapfile -t PURGATORY_PROJECT < <(k8s_infra_projects "purgatory")
+readonly PURGATORY_PROJECT
+
+DEPRECATED_BUCKETS=(
+    "artifacts.k8s-release.appspot.com"
+    "k8s-release-asia"
+    "k8s-release-dev-asia"
+    "k8s-release-dev-eu"
+    "k8s-release-eu"
+)
+
+readonly PROD_PROJECT_SERVICES=(
+    # prod projects host unused GCS buckets
+    storage-component.googleapis.com
+)
+
+function ensure_deprecated_buckets() {
+    # Create deprecated GCS buckets.
+    for bkt in "${DEPRECATED_BUCKETS[@]}"; do
+        color 6 "Ensuring the GCS bucket: ${bkt}"
+        ensure_private_gcs_bucket \
+            "${PURGATORY_PROJECT}" \
+            "gs://${bkt}" \
+            | indent
+    done
+}
+
+function main() {
+
+    color 6 "Ensuring project exists: ${PURGATORY_PROJECT}"
+    ensure_project "${PURGATORY_PROJECT[@]}"
+
+    color 6 "Ensuring Services to host and analyze artifacts: ${PURGATORY_PROJECT}"
+    ensure_services "${PURGATORY_PROJECT}" "${PROD_PROJECT_SERVICES[@]}" 2>&1 | indent
+
+    color 6 "Ensuring deprecated buckets"
+    ensure_deprecated_buckets 2>&1 | indent
+
+    color 6 "Done"
+}
+
+main "${@}"

--- a/infra/gcp/bash/ensure-release-projects.sh
+++ b/infra/gcp/bash/ensure-release-projects.sh
@@ -196,11 +196,6 @@ function ensure_kubernetes_ci_gcs_bucket() {
 function special_case_kubernetes_ci_buckets() {
   # community-owned equivalents to gs://kubernetes-release-{dev,pull}
   ensure_kubernetes_ci_gcs_bucket "k8s-release" "gs://k8s-release-dev"
-  # TODO: we're squatting on these bucket names until we decide what to do:
-  # - these buckets aren't setup as regional buckets in ASIA and EU -> delete and recreate properly?
-  # - the google.com-owned -asia and -eu buckets are unpopulated -> forget the whole thing?
-  ensure_kubernetes_ci_gcs_bucket "k8s-release" "gs://k8s-release-dev-asia"
-  ensure_kubernetes_ci_gcs_bucket "k8s-release" "gs://k8s-release-dev-eu"
   # TODO(https://github.com/kubernetes/test-infra/issues/18789) remove this bucket when no longer needed
   ensure_kubernetes_ci_gcs_bucket "k8s-release" "gs://k8s-release-pull" 14
 }

--- a/infra/gcp/infra.yaml
+++ b/infra/gcp/infra.yaml
@@ -236,6 +236,10 @@ infra:
       kubernetes-public:
         managed_by: infra/gcp/bash/ensure-main-project.sh
 
+  purgatory:
+    projects:
+      k8s-infra-purgatory: infra/gcp/bash/ensure-purgatory.sh
+
   release:
     managed_by: infra/gcp/bash/ensure-release-projects.sh
     projects:


### PR DESCRIPTION
We have a few buckets created but currently unused. The intent of those buckets have been redefined over time and there is no need to keep them anymore.

Since some of them are public, delete them will a create bucket takeover vulnerability. We move them to a dedicated project and make them private.

Note that they are currently empty so there is no need to backup them.