### PR TITLE
Recreate the `k8s-authenticated-test` GCP project as `k8s-staging-authenticated-test` on kubernetes.io GCP Org

### DIFF
--- a/infra/gcp/bash/ensure-main-project.sh
+++ b/infra/gcp/bash/ensure-main-project.sh
@@ -73,6 +73,7 @@ readonly DNS_GROUP="k8s-infra-dns-admins@kubernetes.io"
 # - entry syntax is "bucket_name:owners_group" (: is invalid bucket name char)
 readonly TERRAFORM_STATE_BUCKET_ENTRIES=(
     "${LEGACY_CLUSTER_TERRAFORM_BUCKET}:${CLUSTER_ADMINS_GROUP}"
+    k8s-staging-authenticated-test-tf:"${CLUSTER_ADMINS_GROUP}"
     k8s-infra-tf-aws:k8s-infra-aws-admins@kubernetes.io
     k8s-infra-tf-fastly:k8s-infra-fastly-admins@kubernetes.io
     k8s-infra-tf-gcp:k8s-infra-gcp-org-admins@kubernetes.io

--- a/infra/gcp/infra.yaml
+++ b/infra/gcp/infra.yaml
@@ -345,3 +345,5 @@ infra:
       k8s-staging-win-op-rdnss:
       k8s-staging-gcb-untrusted:
         managed_by: infra/gcp/bash/ensure-staging-gcb-untrusted.sh
+      k8s-staging-authenticated-test:
+        managed_by: infra/gcp/terraform/k8s-staging-authenticated-test/main.tf

--- a/infra/gcp/terraform/k8s-staging-authenticated-test/README.md
+++ b/infra/gcp/terraform/k8s-staging-authenticated-test/README.md
@@ -1,0 +1,3 @@
+# k8s-staging-authenticated-test
+
+This projects holds docker images that are used to test private image pulls.

--- a/infra/gcp/terraform/k8s-staging-authenticated-test/images.tf
+++ b/infra/gcp/terraform/k8s-staging-authenticated-test/images.tf
@@ -1,0 +1,43 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Enable services needed for the project
+resource "google_project_service" "project" {
+  project = google_project.project.id
+
+  for_each = toset([
+    "artifactregistry.googleapis.com",
+  ])
+
+  service = each.key
+}
+
+// Create the docker registry
+resource "google_artifact_registry_repository" "images" {
+  location      = "us-central1"
+  project       = google_project_service.project
+  repository_id = "images"
+  description   = "e2e private pulls testing"
+  format        = "DOCKER"
+}
+
+resource "google_artifact_registry_repository_iam_member" "member" {
+  project    = google_artifact_registry_repository.images.project
+  location   = google_artifact_registry_repository.images.location
+  repository = google_artifact_registry_repository.images.name
+  role       = "roles/artifactregistry.reader"
+  member     = "allAuthenticatedUsers"
+}

--- a/infra/gcp/terraform/k8s-staging-authenticated-test/provider.tf
+++ b/infra/gcp/terraform/k8s-staging-authenticated-test/provider.tf
@@ -1,0 +1,32 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  backend "gcs" {
+    bucket = "k8s-staging-authenticated-test-tf"
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.38.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 4.38.0"
+    }
+  }
+}

--- a/infra/gcp/terraform/k8s-staging-authenticated-test/terraform.tfvars
+++ b/infra/gcp/terraform/k8s-staging-authenticated-test/terraform.tfvars
@@ -1,0 +1,17 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+project_id = "k8s-staging-authenticated-test"

--- a/infra/gcp/terraform/k8s-staging-authenticated-test/variables.tf
+++ b/infra/gcp/terraform/k8s-staging-authenticated-test/variables.tf
@@ -1,0 +1,19 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+variable "project_id" {
+  type = string
+}

--- a/infra/gcp/terraform/k8s-staging-authenticated-test/versions.tf
+++ b/infra/gcp/terraform/k8s-staging-authenticated-test/versions.tf
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This file defines:
+- Required Terraform version
+*/
+
+terraform {
+  required_version = "~> 1.2.0"
+}


### PR DESCRIPTION
Fixes: https://github.com/kubernetes/kubernetes/issues/97026
Part of https://github.com/kubernetes/k8s.io/issues/1458

The following tests in k/k are failing quite frequently on kops clusters and for anyone who doesn't run e2e tests on specific projects.

```
[sig-apps] ReplicaSet should serve a basic image on each replica with a private image
[sig-apps] ReplicationController should serve a basic image on each replica with a private image
```

Sample failure:
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/e2e-kops-gce-cni-cilium-k8s-ci/1702296867670331392

This particular image `gcr.io/k8s-authenticated-test/agnhost:2.6` is pulled for testing and runs in a google.com GCP org.

We can't get rid of these tests till the in-tree Kubelet auth providers are gone.

I'm proposing the images live in a new location that is owned by the community and the images can be pulled by any google service account.

The new pull location for the image will be `us-central1.docker.pkg.dev/k8s-staging-authenticated-test/images/agnhost:2.6`

/cc @dims @ameukam @bentheelder

