### PR TITLE
Create the k8s-kops-test SA on k8s-infra-prow-build cluster

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/test-pods/build-serviceaccounts.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/test-pods/build-serviceaccounts.yaml
@@ -14,3 +14,11 @@ metadata:
     iam.gke.io/gcp-service-account: gcb-builder-releng-test@k8s-staging-releng-test.iam.gserviceaccount.com
   name: gcb-builder-releng-test
   namespace: test-pods
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: prow-build@k8s-infra-prow-build.iam.gserviceaccount.com
+  name: k8s-kops-test
+  namespace: test-pods

--- a/infra/gcp/terraform/k8s-infra-prow-build/serviceaccounts.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/serviceaccounts.tf
@@ -18,6 +18,9 @@ locals {
   workload_identity_service_accounts = {
     prow-build = {
       description = "default service account for pods in ${local.cluster_name}"
+      additional_workload_identity_principals = [
+        "serviceAccount:${module.project.project_id}.svc.id.goog[test-pods/k8s-kops-test]"
+      ]
     }
     boskos-janitor = {
       description = "used by boskos-janitor in ${local.cluster_name}"


### PR DESCRIPTION
Part of https://github.com/kubernetes/test-infra/issues/29722

/cc @ameukam @hakman 

The new test I created in https://github.com/kubernetes/test-infra/pull/30719 is failing to start because the k8s-infra-prow-build cluster is missing the k8s-kops-test service account.

https://prow.k8s.io/?job=*cos-105*&state=error

If you look at https://github.com/kubernetes/test-infra/blob/506a5f2d067db7231a96d3773028d0f7186fa1c5/config/prow/cluster/build/build_serviceaccounts.yaml#L47 it is configured to use the service account that is used for running tests in the boskos pools.

