### PR TITLE
images: promote node-feature-discovery v0.14.1 and v0.13.5

### DIFF
--- a/registry.k8s.io/images/k8s-staging-nfd/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-nfd/images.yaml
@@ -45,8 +45,12 @@
     "sha256:d496d18261c37821eb9c771c0894bc6e3b1f880821d4d7cd8fdc0c5c5a6a7238": ["v0.13.3-full"]
     "sha256:0d61797f917e34b4bfa731581e3ccd07a0f078129dd1d0c4aa6525c7d87a8d26": ["v0.13.4","v0.13.4-minimal"]
     "sha256:02e6e597bf590f6bc732a13c4739ce34e4ce1e49c5bb3ec231738db3afd77c11": ["v0.13.4-full"]
+    "sha256:efc2b84b8532cd1a5a40cffff0d1e6c0beb3bcd08195cb4e799eadab7426ad6e": ["v0.13.5","v0.13.5-minimal"]
+    "sha256:9b4576f6c8146be23fdc2462fddd8b9e7a2799b4ebee84f0e5b2d9eaa67e387a": ["v0.13.5-full"]
     "sha256:5bfcae5ea107987520822b5d8bedd715b4a2951ab9ec975d387b40ef9e3a638f": ["v0.14.0","v0.14.0-minimal"]
     "sha256:fbc9f9b9cb177ae27710d79db2c6ab80ed7dd02e1ea123d2d9d95b7914484468": ["v0.14.0-full"]
+    "sha256:a5e9f35119a1df99fba159002487e3b85fe439a43f166eb43fe67e1b99a19531": ["v0.14.1","v0.14.1-minimal"]
+    "sha256:bf2a751750c83adaae99371fd40808208ef0cce605e4ae44d79787b1d8e012c2": ["v0.14.1-full"]
 - name: node-feature-discovery-operator
   dmap:
     "sha256:36a9a2c9d40b08a72df2878fcb602a86c7cf5b71ee9a786bff67fb84b64dcd16": ["v0.2.0"]


### PR DESCRIPTION
```bash
$ skopeo inspect docker://gcr.io/k8s-staging-nfd/node-feature-discovery:v0.13.5 | jq .Digest
"sha256:efc2b84b8532cd1a5a40cffff0d1e6c0beb3bcd08195cb4e799eadab7426ad6e"

$ skopeo inspect docker://gcr.io/k8s-staging-nfd/node-feature-discovery:v0.13.5-minimal | jq .Digest
"sha256:efc2b84b8532cd1a5a40cffff0d1e6c0beb3bcd08195cb4e799eadab7426ad6e"

$ skopeo inspect docker://gcr.io/k8s-staging-nfd/node-feature-discovery:v0.13.5-full | jq .Digest
"sha256:9b4576f6c8146be23fdc2462fddd8b9e7a2799b4ebee84f0e5b2d9eaa67e387a"

$ skopeo inspect docker://gcr.io/k8s-staging-nfd/node-feature-discovery:v0.14.1 | jq .Digest
"sha256:a5e9f35119a1df99fba159002487e3b85fe439a43f166eb43fe67e1b99a19531"

$ skopeo inspect docker://gcr.io/k8s-staging-nfd/node-feature-discovery:v0.14.1-minimal | jq .Digest
"sha256:a5e9f35119a1df99fba159002487e3b85fe439a43f166eb43fe67e1b99a19531"

$ skopeo inspect docker://gcr.io/k8s-staging-nfd/node-feature-discovery:v0.14.1-full | jq .Digest
"sha256:bf2a751750c83adaae99371fd40808208ef0cce605e4ae44d79787b1d8e012c2"
```