### PR TITLE
GCP/prow-build: Enabled Cloud Resource Manager service

### DIFF
--- a/infra/gcp/terraform/modules/gke-project/main.tf
+++ b/infra/gcp/terraform/modules/gke-project/main.tf
@@ -23,6 +23,7 @@ locals {
   project_services = [
     "bigquery.googleapis.com",
     "cloudbuild.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
     "compute.googleapis.com",
     "container.googleapis.com",
     "logging.googleapis.com",


### PR DESCRIPTION
Follow of:
 - https://github.com/kubernetes/test-infra/pull/30757

Some E2E tests requires the service to be enabled. Failure on https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/sigs.k8s.io_gcp-compute-persistent-disk-csi-driver/1375/pull-gcp-compute-persistent-disk-csi-driver-e2e/1704443546796298240/