### PR TITLE
GCP: Enable KMS service for boskos

### DIFF
--- a/infra/gcp/bash/prow/ensure-e2e-projects.sh
+++ b/infra/gcp/bash/prow/ensure-e2e-projects.sh
@@ -63,6 +63,7 @@ function ensure_e2e_project() {
     color 6 "Ensuring only APIs necessary for kubernetes e2e jobs to use e2e project: ${prj}"
     ensure_only_services "${prj}" \
         compute.googleapis.com \
+        cloudkms.googleapis.com \
         container.googleapis.com \
         containerregistry.googleapis.com \
         logging.googleapis.com \


### PR DESCRIPTION
Enable the Cloud KMS service for each gcp project of the boskos pool. This is required by GCP PD driver e2e tests to validate KMS keys for GCE disks.