### PR TITLE
sig-release: cleanup triageparty references

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Kubernetes project infrastructure, managed by the kubernetes community via [sig-
     - `publishing-bot`: instance of [publishing-bot] - owned by [sig-release]
     - `slack-infra`: instance of [slack-infra] including https://slack.k8s.io - owned by [sig-contributor-experience]
     - `triageparty-cli`: instance of [triage-party] - owned by [sig-cli]
-    - `triageparty-release`: instance of [triage-party] - owned by [sig-release]
 - `artifacts`: non-image artifacts published to `artifacts.k8s.io`
 - `audit`: scripts to export all relevant gcp resources, and the most recently-reviewed export
 - `dns`: DNS for kubernetes.io and k8s.io

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -143,7 +143,6 @@ restrictions:
   - path: "sig-release/groups.yaml"
     allowedGroups:
       - "^k8s-infra-rbac-publishing-bot@kubernetes.io$"
-      - "^k8s-infra-rbac-triageparty-release@kubernetes.io$"
       - "^k8s-infra-google-build-admins@kubernetes.io$"
       - "^k8s-infra-release-admins@kubernetes.io$"
       - "^k8s-infra-release-editors@kubernetes.io$"

--- a/groups/sig-k8s-infra/groups.yaml
+++ b/groups/sig-k8s-infra/groups.yaml
@@ -116,7 +116,6 @@ groups:
       - k8s-infra-rbac-prow@kubernetes.io
       - k8s-infra-rbac-publishing-bot@kubernetes.io
       - k8s-infra-rbac-triageparty-cli@kubernetes.io
-      - k8s-infra-rbac-triageparty-release@kubernetes.io
       - k8s-infra-rbac-triageparty-scalability@kubernetes.io
       - k8s-infra-rbac-slack-infra@kubernetes.io
 

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -431,22 +431,6 @@ groups:
       - stefan.schimanski@gmail.com
       - thockin@google.com
 
-  - email-id: k8s-infra-rbac-triageparty-release@kubernetes.io
-    name: k8s-infra-rbac-triageparty-release
-    description: |-
-      ACL for Bug Triage Release Team
-    settings:
-      ReconcileMembers: "true"
-      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW"
-    members:
-      - bartek@smykla.com
-      - bradmccoydev@gmail.com # 1.29 Bug Triage Shadow
-      - k8s-infra-release-viewers@kubernetes.io
-      - maryam_tavakkoli@hotmail.com # 1.29 Bug Triage Shadow
-      - mofi@google.com # 1.29 Bug Triage Shadow
-      - yigit.demirbas@gmail.com # 1.29 Bug Triage Lead
-      - zelikangelina@gmail.com # 1.29 Bug Triage Shadow
-
   - email-id: k8s-infra-staging-bom@kubernetes.io
     name: k8s-infra-staging-bom
     description: |-

--- a/infra/gcp/bash/namespaces/ensure-namespaces.sh
+++ b/infra/gcp/bash/namespaces/ensure-namespaces.sh
@@ -155,7 +155,6 @@ ALL_APPS=(
     publishing-bot
     slack-infra
     triageparty-cli
-    triageparty-release
     triageparty-scalability
 )
 

--- a/infra/gcp/terraform/kubernetes-public/secrets.tf
+++ b/infra/gcp/terraform/kubernetes-public/secrets.tf
@@ -60,12 +60,6 @@ locals {
         "slackin-token",
       ]
     },
-    triageparty-release = {
-      group = "sig-release"
-      secrets = [
-        "triage-party-github-token",
-      ]
-    },
   }
   // Even though we could just use the list, we're going to keep parity with
   // the map structure used in k8s-infra-prow-build, so resource definitions


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/sig-release/issues/2345

 - Drop secret for the Github token
 - remove google groups for GKE authentification
 - remove kubernetes namespace