### PR TITLE
Increase vm.min_free_kbytes to 540672 on EKS Prow build cluster

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/bootstrap/node_bootstrap.sh
+++ b/infra/aws/terraform/prow-build-cluster/bootstrap/node_bootstrap.sh
@@ -27,9 +27,13 @@ set -o pipefail
 sysctl -w fs.inotify.max_user_watches=1048576
 sysctl -w fs.inotify.max_user_instances=8192
 
-## Increase vm.min_free_kbytes from 67584 to 135168 as a potential mitigation for
-## https://github.com/kubernetes/k8s.io/issues/5473
-echo 135168 > /proc/sys/vm/min_free_kbytes
+## Increase vm.min_free_kbytes from 67584 to 540672 as recommend by the AWS support
+## to try to mitigate https://github.com/kubernetes/k8s.io/issues/5473
+## The general guidance for the vm.min_free_kbytes parameter is to not have it exceed 5%
+## of the total system memory which in the case of an r5d.4xlarge would be about 6400MB.
+## For the sake of testing, let's increase this value from 67584 to 540672 (a 8x increase)
+## to bring this up to about 540MB.
+echo 540672 > /proc/sys/vm/min_free_kbytes
 
 ## Set up ephemeral disks (SSDs) to be used by containerd and kubelet
 

--- a/infra/aws/terraform/prow-build-cluster/bootstrap/node_bootstrap_green.sh
+++ b/infra/aws/terraform/prow-build-cluster/bootstrap/node_bootstrap_green.sh
@@ -27,9 +27,13 @@ set -o pipefail
 sysctl -w fs.inotify.max_user_watches=1048576
 sysctl -w fs.inotify.max_user_instances=8192
 
-## Increase vm.min_free_kbytes from 67584 to 135168 as a potential mitigation for
-## https://github.com/kubernetes/k8s.io/issues/5473
-echo 135168 > /proc/sys/vm/min_free_kbytes
+## Increase vm.min_free_kbytes from 67584 to 540672 as recommend by the AWS support
+## to try to mitigate https://github.com/kubernetes/k8s.io/issues/5473
+## The general guidance for the vm.min_free_kbytes parameter is to not have it exceed 5%
+## of the total system memory which in the case of an r5d.4xlarge would be about 6400MB.
+## For the sake of testing, let's increase this value from 67584 to 540672 (a 8x increase)
+## to bring this up to about 540MB.
+echo 540672 > /proc/sys/vm/min_free_kbytes
 
 ## Set up ephemeral disks (SSDs) to be used by containerd and kubelet
 

--- a/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
@@ -33,14 +33,14 @@ cluster_version            = "1.25"
 cluster_autoscaler_version = "v1.25.0"
 
 # Ubuntu EKS optimized AMI: https://cloud-images.ubuntu.com/aws-eks/
-node_ami_blue            = "ami-07e8e7dddc8b3bad9"
+node_ami_blue            = "ami-05da66fc7a4319aa8"
 node_instance_types_blue = ["r5d.xlarge"]
 
 node_min_size_blue     = 3
 node_max_size_blue     = 3
 node_desired_size_blue = 3
 
-node_ami_green            = "ami-07e8e7dddc8b3bad9"
+node_ami_green            = "ami-05da66fc7a4319aa8"
 node_instance_types_green = ["r5d.xlarge"]
 
 node_min_size_green     = 0
@@ -55,4 +55,4 @@ node_volume_size = 100
 
 node_max_unavailable_percentage = 100 # To ease testing
 
-public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDTy+Rad9AtfTxTfmeNN6yvWSOwg3ytaJCWLwdOG/XAADJx5pRVIJ/OrYy/nO0sCMrjXf+Pv+JlERJA9pZIKahkiUNMG537Ubw9OjVhgtlhfO/PQNWa3aESpRPHYp/QOCHqj5ni75f/TpxVVO70tys4h75Et++tGdjEXfoTf03Sjk10ShYRzxf6LyZ8RkG2yJqN4hETe+YXP3ohBsv0dgt7bybSgRgLEpz9TLIpBjM5ZUdb2QQ4Grs/l+wne/tH6lu4p4ltEGSCByqzIw3XR1OWU+NrHFY2elsef1CQAvtIXv8QfFOUAur4VyXop/NC69+qG0uJcFQtrqPH3mma/NtJ7vnxZw1oJy2B5U1QdLuxpXu2VVLz3y0dPQ1PDKJWY4RxfyzY835Rv73XzwugvgZVehrgJ6gHeBBiwTDalz+DJuwlkUpHhfSjkk0xDxJyJdg4uncZld6NiJaOU/Fv901VyLuXQ/gQGIWRSm7ynTZda4uAfhhPbXab46+1yN6KERzo0sTQDnI2+dG/zZqIi9rwKsBG1mPvg8T1I78aN1w3ooPluYhFhMMfdUMHHzoItaXh+87Y1yPy0nrQZMk4oOK7g4+VXaN7PyqTLExecgTAHufnX9iEjsmBr2LT8nXMUvHjvrWeMJV0bgnTNc4qo3pOf+eatZVun+vSmDmFp4fYgw== kubernetes-sig-k8s-infra"
+public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDFJvXxqAJV+C84330Qp1Zx0Uq3TWbalOKlStfii2vnU9STalSOZ2oa4y2nG5Pu4Ah2G7ZSCVuaReagt2ESUNGdttT06llK8JjFce3n6nc7N6imPwR/e+csf0TV4ckLVugIJpHPgLBujpvml7c1SdlZZXKul6ZX0R6Z96JFpSrYOPyrTVl2yCqKqMEVEwOvvOxlO3vMTTyK/Z1d5jOyHFQ/88DdxWWeyugps4+++WtgcRvHe7vwcsOZYJWGL639jOcNpuXjyLXLL9CAGuDwFzDxomzSBcTaPmYtS3kJQPQOdmt2S0FoO/vHBEnvbGrEjlyzWluBLNPvn1rclCJghiv+ndF4AYSe/7FlWCEiZaDNJghF6PMyAPxIar9sAurFia9FMur4zy93ZA8iJeUKlzhImv/u1f2XjPef/Iu8Ni+eIVDYGVXZzWM7Qrw30mhLZhfrob8ZQ6MPQjMdQ+LZ3TAxZwk2QWG8qAMmUXvbbtS7aPGZL2R6+ZZ/Z3WA3T+pGUde9SRvhGlN1/Up85NGOGDAJICXKICTFJNEfp6yK65wAVC5URuoLw3Zacji+uodefWQovF3ke8rHLghqTR1l3jkWDddyejvt5Rf1mdV7xL0stRcoiXfM4MTSuQ3qbpBIsgCGzjjrseq5z3e85DgcXzdfuerDk0y0peH0pXAQCp8oQ=="

--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -38,16 +38,16 @@ cluster_autoscaler_version = "v1.25.0"
 node_ami_blue            = "ami-05da66fc7a4319aa8"
 node_instance_types_blue = ["r5ad.4xlarge"]
 
-node_min_size_blue     = 0
-node_max_size_blue     = 1
-node_desired_size_blue = 0
+node_min_size_blue     = 20
+node_max_size_blue     = 70
+node_desired_size_blue = 20
 
 node_ami_green            = "ami-05da66fc7a4319aa8"
 node_instance_types_green = ["r5d.4xlarge"]
 
-node_min_size_green     = 20
-node_max_size_green     = 40
-node_desired_size_green = 20
+node_min_size_green     = 0
+node_max_size_green     = 1
+node_desired_size_green = 0
 
 node_volume_size = 100
 


### PR DESCRIPTION
- Increase `vm.min_free_kbytes` to `540672` to try to mitigate #5473 
- Increase the node group size on canary to maximum 70 because we have many more jobs running
- Update Ubuntu AMI to the latest on canary
- Update SSH key on canary and put it in 1Password

This PR is already rolled out both to prod and canary. It didn't help much, but we'll leave `vm.min_free_kbytes` as it is hoping that it helps at least a little bit.

/assign @dims @ameukam 