### PR TITLE
Create GCP secret for EKS cluster kubeconfig

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/secrets.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/secrets.tf
@@ -36,6 +36,10 @@ locals {
       group  = "sig-release"
       owners = "k8s-infra-release-admins@kubernetes.io"
     }
+    k8s-infra-kops-prow-build-kubeconfig = {
+      group = "sig-cluster-lifecycle"
+      owners = "k8s-infra-kops-maintainers@kubernetes.io"
+    }
     k8s-release-enhancements-triage-github-token = {
       group  = "sig-release"
       owners = "k8s-infra-release-editors@kubernetes.io"


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/k8s.io/issues/5127

Add a GCP secret that will be used to stored the kubeconfig of the EKS cluster `k8s-infra-kops-prow-build`.