### PR TITLE
Enable Filestore API for boskos

### DIFF
--- a/infra/gcp/bash/prow/ensure-e2e-projects.sh
+++ b/infra/gcp/bash/prow/ensure-e2e-projects.sh
@@ -64,6 +64,7 @@ function ensure_e2e_project() {
     ensure_only_services "${prj}" \
         compute.googleapis.com \
         cloudkms.googleapis.com \
+        file.googleapis.com \
         container.googleapis.com \
         containerregistry.googleapis.com \
         logging.googleapis.com \


### PR DESCRIPTION
Enable the Filestore service for each gcp project of the boskos pool. This is required by GCP Filestore CSI driver e2e tests to make filestore API calls