### PR TITLE
fastly: don't cache text files for cdn.dl.k8s.io

### DIFF
--- a/infra/fastly/terraform/dl.k8s.io/vcl/binaries.vcl
+++ b/infra/fastly/terraform/dl.k8s.io/vcl/binaries.vcl
@@ -44,6 +44,13 @@ sub vcl_fetch {
     set beresp.stale_while_revalidate = 60s; // 1 minute
   }
 
+  //Ensure version markers are not cached
+  if (req.url.ext == "txt") {
+    set beresp.cacheable = false;
+    set beresp.ttl = 0s;
+    return (pass);
+  }
+
   # TODO: Drop this when the origin(GCS bucket) is owned by the community
   # See: https://github.com/kubernetes/k8s.io/issues/2396
   if (req.url.path ~ "^/release/") {


### PR DESCRIPTION
Related to:
   - https://github.com/kubernetes/k8s.io/issues/5900
 
The version makers for the project are currently served under the path `/release`. we recently applied a TTL of 30 days for any object served under this path. For any backend response, any `txt` file will not be cached.