### PR TITLE
Update Steering members following 2023 election cycle

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -183,12 +183,12 @@ aliases:
     - tabbysable
   committee-steering:
     - BenTheElder
-    - cblecker
-    - cpanato
     - justaugustus
     - mrbobbytables
+    - pacoxu
     - palnabarun
-    - tpepper
+    - pohly
+    - soltysh
 ## BEGIN CUSTOM CONTENT
   build-admins:
     - BenTheElder

--- a/groups/committee-steering/groups.yaml
+++ b/groups/committee-steering/groups.yaml
@@ -19,10 +19,13 @@ groups:
       - killen.bob@gmail.com
       - lachlan.evenson@microsoft.com
       - liggitt@google.com
+      - maszulik@redhat.com
       - michelle.noorali@gmail.com
       - nikhitaraghunath@gmail.com
+      - paco.xu@daocloud.io
       - pal.nabarun95@gmail.com
       - paris.pittman@gmail.com
+      - patrick.ohly@intel.com
       - phil.wittrock@gmail.com
       - quintonh@gmail.com
       - sarah.novotny@gmail.com
@@ -43,12 +46,12 @@ groups:
     owners:
       - augustus@cisco.com
       - bentheelder@google.com
-      - cblecker@gmail.com
-      - ctadeu@gmail.com
       - k8s@auggie.dev
       - killen.bob@gmail.com
+      - maszulik@redhat.com
+      - paco.xu@daocloud.io
       - pal.nabarun95@gmail.com
-      - tpepper@vmware.com
+      - patrick.ohly@intel.com
 
   - email-id: steering@kubernetes.io
     name: steering
@@ -68,12 +71,12 @@ groups:
     owners:
       - augustus@cisco.com
       - bentheelder@google.com
-      - cblecker@gmail.com
-      - ctadeu@gmail.com
       - k8s@auggie.dev
       - killen.bob@gmail.com
+      - maszulik@redhat.com
+      - paco.xu@daocloud.io
       - pal.nabarun95@gmail.com
-      - tpepper@vmware.com
+      - patrick.ohly@intel.com
     managers:
       - ihor.dvoretskyi@gmail.com
       - jdumars@gmail.com


### PR DESCRIPTION
(Part of https://github.com/kubernetes/steering/issues/273.)

Add:

- Maciej Szulik - @soltysh
- Paco Xu 徐俊杰 - @pacoxu
- Patrick Ohly - @pohly

Now Emeritus:

- Carlos Tadeu Panato Jr. - @cpanato
- Christoph Blecker - @cblecker
- Tim Pepper - @tpepper

Thanks to all of the Emeritus members for your service and welcome to the new Steering Committee members!

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @mrbobbytables @BenTheElder @palnabarun 
cc: @kubernetes/steering-committee 
/hold