### PR TITLE
Add SIG Release binary artifact bucket

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -142,6 +142,7 @@ restrictions:
       - "^k8s-infra-staging-sp-operator@kubernetes.io$"
   - path: "sig-release/groups.yaml"
     allowedGroups:
+      - "^k8s-infra-push-sig-release@kubernetes.io$"
       - "^k8s-infra-rbac-publishing-bot@kubernetes.io$"
       - "^k8s-infra-google-build-admins@kubernetes.io$"
       - "^k8s-infra-release-admins@kubernetes.io$"

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -506,3 +506,12 @@ groups:
       ReconcileMembers: "true"
     members:
       - k8s-infra-release-editors@kubernetes.io
+
+  - email-id: k8s-infra-push-sig-release@kubernetes.io
+    name: k8s-infra-push-sig-release
+    description: |-
+      ACL for pushing release engineering binary artifacts
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - k8s-infra-release-editors@kubernetes.io

--- a/infra/gcp/bash/ensure-prod-storage.sh
+++ b/infra/gcp/bash/ensure-prod-storage.sh
@@ -70,6 +70,7 @@ ALL_PROD_BUCKETS=(
     "cni"
     "cri-tools"
     "kind"
+    "sig-release"
 )
 
 readonly PROD_PROJECT_SERVICES=(


### PR DESCRIPTION
The bucket will be used to publish binary artifacts for our maintained repositories, for example k/release.

Refers to https://github.com/kubernetes/release/pull/3297

PTAL @kubernetes/k8s-infra-gcp-org-admins @kubernetes/release-engineering 