### PR TITLE
AWS: Allow AWS IAM role for cluster authentication

### DIFF
--- a/infra/aws/terraform/kops-infra-ci/eks.tf
+++ b/infra/aws/terraform/kops-infra-ci/eks.tf
@@ -37,6 +37,18 @@ module "eks" {
     "scheduler"
   ]
 
+  manage_aws_auth_configmap = true
+
+  aws_auth_roles = [
+    {
+      # AWS role used by prow to authenticate to build clusters
+      # Please, keep it in sync with prow deployment (AWS_ROLE_ARN)
+      rolearn = "arn:aws:iam::468814281478:role/Prow-EKS-Admin"
+      username = "arn:aws:iam::468814281478:role/Prow-EKS-Admin"
+      groups   = ["system:masters"]
+    }
+  ]
+
   cloudwatch_log_group_retention_in_days = 30
 
   cluster_addons = {

--- a/infra/aws/terraform/kops-infra-ci/providers.tf
+++ b/infra/aws/terraform/kops-infra-ci/providers.tf
@@ -22,3 +22,16 @@ provider "aws" {
     role_arn = "arn:aws:iam::${local.kops-infra-ci-account-id}:role/OrganizationAccountAccessRole"
   }
 }
+
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+
+  # This requires the awscli to be installed locally where Terraform is executed.
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    # This requires the awscli to be installed locally where Terraform is executed
+    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+  }
+}


### PR DESCRIPTION
Allow role Prow-EKS-Admin from account k8s-infra-prow to authenticate to k8s-infra-kops-prow-build