### PR TITLE
[canary] eks-prow-build-cluster: Upgrade to Kubernetes 1.28

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/node_group_blue.tf
+++ b/infra/aws/terraform/prow-build-cluster/node_group_blue.tf
@@ -20,6 +20,8 @@ locals {
     description     = "EKS managed node group called blue used to facilitate node rotations/rollouts"
     use_name_prefix = true
 
+    cluster_version = var.node_group_version_blue
+
     taints = var.node_taints_blue
     labels = var.node_labels_blue
 

--- a/infra/aws/terraform/prow-build-cluster/node_group_green.tf
+++ b/infra/aws/terraform/prow-build-cluster/node_group_green.tf
@@ -20,6 +20,8 @@ locals {
     description     = "EKS managed node group called green used to facilitate node rotations/rollouts"
     use_name_prefix = true
 
+    cluster_version = var.node_group_version_green
+
     taints = var.node_taints_green
     labels = var.node_labels_green
 

--- a/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
@@ -29,7 +29,7 @@ eks_cluster_admins = [
 ]
 
 cluster_name               = "prow-canary-cluster"
-cluster_version            = "1.26"
+cluster_version            = "1.27"
 node_group_version_blue    = "1.25"
 node_group_version_green   = "1.25"
 cluster_autoscaler_version = "v1.25.0"

--- a/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
@@ -30,6 +30,8 @@ eks_cluster_admins = [
 
 cluster_name               = "prow-canary-cluster"
 cluster_version            = "1.25"
+node_group_version_blue    = "1.25"
+node_group_version_green   = "1.25"
 cluster_autoscaler_version = "v1.25.0"
 
 # Ubuntu EKS optimized AMI: https://cloud-images.ubuntu.com/aws-eks/

--- a/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
@@ -30,24 +30,24 @@ eks_cluster_admins = [
 
 cluster_name               = "prow-canary-cluster"
 cluster_version            = "1.28"
-node_group_version_blue    = "1.25"
-node_group_version_green   = "1.25"
+node_group_version_blue    = "1.28"
+node_group_version_green   = "1.28"
 cluster_autoscaler_version = "v1.28.0"
 
 # Ubuntu EKS optimized AMI: https://cloud-images.ubuntu.com/aws-eks/
-node_ami_blue            = "ami-05da66fc7a4319aa8"
+node_ami_blue            = "ami-0d9ec2930add3de7d"
 node_instance_types_blue = ["r5d.xlarge"]
 
-node_min_size_blue     = 3
-node_max_size_blue     = 3
-node_desired_size_blue = 3
+node_min_size_blue     = 0
+node_max_size_blue     = 1
+node_desired_size_blue = 0
 
-node_ami_green            = "ami-05da66fc7a4319aa8"
+node_ami_green            = "ami-0d9ec2930add3de7d"
 node_instance_types_green = ["r5d.xlarge"]
 
-node_min_size_green     = 0
-node_max_size_green     = 1
-node_desired_size_green = 0
+node_min_size_green     = 3
+node_max_size_green     = 3
+node_desired_size_green = 3
 
 node_taints_green = []
 

--- a/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
@@ -32,7 +32,7 @@ cluster_name               = "prow-canary-cluster"
 cluster_version            = "1.28"
 node_group_version_blue    = "1.25"
 node_group_version_green   = "1.25"
-cluster_autoscaler_version = "v1.25.0"
+cluster_autoscaler_version = "v1.28.0"
 
 # Ubuntu EKS optimized AMI: https://cloud-images.ubuntu.com/aws-eks/
 node_ami_blue            = "ami-05da66fc7a4319aa8"

--- a/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
@@ -29,7 +29,7 @@ eks_cluster_admins = [
 ]
 
 cluster_name               = "prow-canary-cluster"
-cluster_version            = "1.25"
+cluster_version            = "1.26"
 node_group_version_blue    = "1.25"
 node_group_version_green   = "1.25"
 cluster_autoscaler_version = "v1.25.0"

--- a/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
@@ -29,7 +29,7 @@ eks_cluster_admins = [
 ]
 
 cluster_name               = "prow-canary-cluster"
-cluster_version            = "1.27"
+cluster_version            = "1.28"
 node_group_version_blue    = "1.25"
 node_group_version_green   = "1.25"
 cluster_autoscaler_version = "v1.25.0"

--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -32,6 +32,8 @@ eks_cluster_viewers = [
 
 cluster_name               = "prow-build-cluster"
 cluster_version            = "1.25"
+node_group_version_blue    = "1.25"
+node_group_version_green   = "1.25"
 cluster_autoscaler_version = "v1.25.0"
 
 # Ubuntu EKS optimized AMI: https://cloud-images.ubuntu.com/aws-eks/

--- a/infra/aws/terraform/prow-build-cluster/variables.tf
+++ b/infra/aws/terraform/prow-build-cluster/variables.tf
@@ -80,7 +80,17 @@ variable "cluster_region" {
 
 variable "cluster_version" {
   type        = string
-  description = "Kubernetes version of the EKS cluster"
+  description = "Kubernetes version of the EKS control plane"
+}
+
+variable "node_group_version_blue" {
+  type        = string
+  description = "Kubernetes version of the EKS-managed node group (blue)"
+}
+
+variable "node_group_version_green" {
+  type        = string
+  description = "Kubernetes version of the EKS-managed node group (green)"
 }
 
 variable "node_ami_blue" {


### PR DESCRIPTION
The EKS Canary cluster has been upgraded to Kubernetes 1.28. This PR commits all changes relevant to that. The upgrade process has been done in several steps, see list of commits for more details. The workflow was:

- Upgrade control plane from 1.25 to 1.26
- Upgrade control plane from 1.26 to 1.27
- Upgrade control plane from 1.27 to 1.28
- Upgrade cluster-autoscaler from 1.25.0 to 1.28.0
- Upgrade node groups from 1.25 to 1.28

That way, we satisfy:

- [the version skew policy](https://kubernetes.io/releases/version-skew-policy/)
- requirement to upgrade only to n+1 minor version

/assign @pkprzekwas @ameukam @dims 