### PR TITLE
eks-prow-build-cluster: Fix instance size for green node group

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -45,7 +45,7 @@ node_max_size_blue     = 70
 node_desired_size_blue = 20
 
 node_ami_green            = "ami-05da66fc7a4319aa8"
-node_instance_types_green = ["r5d.4xlarge"]
+node_instance_types_green = ["r5ad.4xlarge"]
 
 node_min_size_green     = 0
 node_max_size_green     = 1


### PR DESCRIPTION
The green node group has been using a wrong instance type (Intel instances instead of AMD instances). This PR fixes this by switching green node group to AMD instances.

/assign @pkprzekwas @ameukam @dims 