### PR TITLE
[prod] eks-prow-build-cluster: Upgrade to Kubernetes 1.28

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -31,7 +31,7 @@ eks_cluster_viewers = [
 ]
 
 cluster_name               = "prow-build-cluster"
-cluster_version            = "1.25"
+cluster_version            = "1.26"
 node_group_version_blue    = "1.25"
 node_group_version_green   = "1.25"
 cluster_autoscaler_version = "v1.25.0"

--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -34,7 +34,7 @@ cluster_name               = "prow-build-cluster"
 cluster_version            = "1.28"
 node_group_version_blue    = "1.25"
 node_group_version_green   = "1.25"
-cluster_autoscaler_version = "v1.25.0"
+cluster_autoscaler_version = "v1.28.0"
 
 # Ubuntu EKS optimized AMI: https://cloud-images.ubuntu.com/aws-eks/
 node_ami_blue            = "ami-05da66fc7a4319aa8"

--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -40,9 +40,9 @@ cluster_autoscaler_version = "v1.28.0"
 node_ami_blue            = "ami-05da66fc7a4319aa8"
 node_instance_types_blue = ["r5ad.4xlarge"]
 
-node_min_size_blue     = 20
-node_max_size_blue     = 70
-node_desired_size_blue = 20
+node_min_size_blue     = 0
+node_max_size_blue     = 1
+node_desired_size_blue = 0
 
 node_ami_green            = "ami-0d9ec2930add3de7d"
 node_instance_types_green = ["r5ad.4xlarge"]

--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -32,12 +32,12 @@ eks_cluster_viewers = [
 
 cluster_name               = "prow-build-cluster"
 cluster_version            = "1.28"
-node_group_version_blue    = "1.25"
+node_group_version_blue    = "1.28"
 node_group_version_green   = "1.28"
 cluster_autoscaler_version = "v1.28.0"
 
 # Ubuntu EKS optimized AMI: https://cloud-images.ubuntu.com/aws-eks/
-node_ami_blue            = "ami-05da66fc7a4319aa8"
+node_ami_blue            = "ami-0d9ec2930add3de7d"
 node_instance_types_blue = ["r5ad.4xlarge"]
 
 node_min_size_blue     = 0

--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -31,7 +31,7 @@ eks_cluster_viewers = [
 ]
 
 cluster_name               = "prow-build-cluster"
-cluster_version            = "1.27"
+cluster_version            = "1.28"
 node_group_version_blue    = "1.25"
 node_group_version_green   = "1.25"
 cluster_autoscaler_version = "v1.25.0"

--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -47,9 +47,9 @@ node_desired_size_blue = 20
 node_ami_green            = "ami-0d9ec2930add3de7d"
 node_instance_types_green = ["r5ad.4xlarge"]
 
-node_min_size_green     = 0
-node_max_size_green     = 1
-node_desired_size_green = 0
+node_min_size_green     = 20
+node_max_size_green     = 70
+node_desired_size_green = 20
 
 node_volume_size = 100
 

--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -33,7 +33,7 @@ eks_cluster_viewers = [
 cluster_name               = "prow-build-cluster"
 cluster_version            = "1.28"
 node_group_version_blue    = "1.25"
-node_group_version_green   = "1.25"
+node_group_version_green   = "1.28"
 cluster_autoscaler_version = "v1.28.0"
 
 # Ubuntu EKS optimized AMI: https://cloud-images.ubuntu.com/aws-eks/
@@ -44,7 +44,7 @@ node_min_size_blue     = 20
 node_max_size_blue     = 70
 node_desired_size_blue = 20
 
-node_ami_green            = "ami-05da66fc7a4319aa8"
+node_ami_green            = "ami-0d9ec2930add3de7d"
 node_instance_types_green = ["r5ad.4xlarge"]
 
 node_min_size_green     = 0

--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -31,7 +31,7 @@ eks_cluster_viewers = [
 ]
 
 cluster_name               = "prow-build-cluster"
-cluster_version            = "1.26"
+cluster_version            = "1.27"
 node_group_version_blue    = "1.25"
 node_group_version_green   = "1.25"
 cluster_autoscaler_version = "v1.25.0"


### PR DESCRIPTION
Second part of #5931 targeting the production environment.

The EKS Prod cluster has been upgraded to Kubernetes 1.28. This PR commits all changes relevant to that. The upgrade process has been done in several steps, see list of commits for more details. The workflow was:

- Upgrade control plane from 1.25 to 1.26
- Upgrade control plane from 1.26 to 1.27
- Upgrade control plane from 1.27 to 1.28
- Upgrade cluster-autoscaler from 1.25.0 to 1.28.0
- Upgrade node groups from 1.25 to 1.28

That way, we satisfy:

- [the version skew policy](https://kubernetes.io/releases/version-skew-policy/)
- requirement to upgrade only to n+1 minor version

/assign @pkprzekwas @ameukam @dims 
/hold
the upgrade is scheduled for October 6 (https://groups.google.com/a/kubernetes.io/g/dev/c/YJLJtpJz_Ek/m/Cvl71fBKAwAJ)