### PR TITLE
Add a github token for publishing-bot

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-externalsecrets.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-externalsecrets.yaml
@@ -95,6 +95,19 @@ spec:
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
+  name: k8s-release-publishing-bot-github-token
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-public
+  data:
+  - key: publishing-bot-github-token
+    name: token
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
   name: k8s-cip-test-prod-service-account
   namespace: test-pods
 spec:


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/publishing-bot/issues/353

Sync existing Github token to trusted GKE cluster `prow-build-trusted`. The token will be consumed by a prowjob