### PR TITLE
docs: add dan winship as signet tech lead

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -69,9 +69,10 @@ aliases:
     - jeremyot
     - pmorie
   sig-network-leads:
+    - thockin
+  sig-network-leads-emeritus:
     - caseydavenport
     - dcbw
-    - thockin
   sig-node-leads:
     - dchen1107
     - derekwaynecarr

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -69,6 +69,7 @@ aliases:
     - jeremyot
     - pmorie
   sig-network-leads:
+    - danwinship
     - mikezappa87
     - shaneutt
     - thockin

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -69,6 +69,8 @@ aliases:
     - jeremyot
     - pmorie
   sig-network-leads:
+    - mikezappa87
+    - shaneutt
     - thockin
   sig-network-leads-emeritus:
     - caseydavenport

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -40,7 +40,6 @@ groups:
       - bpratt@redhat.com # SIG Testing
       - bridget@kromhout.org # SIG Cloud Provider
       - caniszczyk@linuxfoundation.org
-      - shane@konghq.com
       - cbelu@cloudbasesolutions.com
       - cecilerobertm@gmail.com
       - chiachenk@google.com
@@ -119,6 +118,7 @@ groups:
       - saadali@google.com
       - saschagrunert@gmail.com # SIG Release
       - saveetha13@gmail.com
+      - shane@konghq.com # SIG Network
       - shu.mutow@gmail.com
       - siarkowicz@google.com
       - szostok.mateusz@gmail.com

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -46,6 +46,7 @@ groups:
       - cncf-speakers@linuxfoundation.org
       - community@kubernetes.io
       - ctadeu@gmail.com # SIG Release
+      - danwinship@redhat.com # SIG Network
       - davanum@gmail.com
       - dawnchen@google.com
       - dbosanac@redhat.com


### PR DESCRIPTION
Part of resolving https://github.com/kubernetes/community/issues/7572.

This also does some cleanup we missed in previous leadership changes: Dan and Casey are now emeritus leads, and @MikeZappa87 (one of my SIG Network co-chairs) and myself never got added here.