### PR TITLE
promote ccm gcp v27.1.6

### DIFF
--- a/registry.k8s.io/images/k8s-staging-cloud-provider-gcp/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-cloud-provider-gcp/images.yaml
@@ -103,3 +103,4 @@
 - name: cloud-controller-manager
   dmap:
     "sha256:e70becd7b8cc50a3ac80f36ad0db8781742a225563e759897f846ac728da87db": ["v26.2.4"]
+    "sha256:f057f6c934d6afa73a38f94b71d7da2f99033e9a6e689d59b4ee1e689031ef00": ["v27.1.6"]


### PR DESCRIPTION
```
docker run --rm gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v27.1.6
Unable to find image 'gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v27.1.6' locally
v27.1.6: Pulling from k8s-staging-cloud-provider-gcp/cloud-controller-manager
fc251a6e7981: Already exists
1a8af71790f3: Already exists
f847b2b43fa5: Pull complete
Digest: sha256:f057f6c934d6afa73a38f94b71d7da2f99033e9a6e689d59b4ee1e689031ef00
Status: Downloaded newer image for gcr.io/k8s-staging-cloud-provider-gcp/cloud-controller-manager:v27.1.6

```