### PR TITLE
chore: add aws-ebs-csi-driver v1.24.0 digest

### DIFF
--- a/registry.k8s.io/images/k8s-staging-provider-aws/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-provider-aws/images.yaml
@@ -66,6 +66,7 @@
     "sha256:d9e91f03babf5a89a3bed4b6f4b9ad47658e713784b431f25813b3c1938716c6": ["v1.22.1"]
     "sha256:1669262267c5b89e94c67ab400d5b8fde95faa60066a1c04082e85e3e76710a9": ["v1.23.0"]
     "sha256:fe9d99c75151a656abbc1dd44312e774bea7ec3da5084dfc7ab824e9f72291cf": ["v1.23.1"]
+    "sha256:3dba81d0c3c8ce51abeda40ec0dbad7e4930a89c8c6a1984a64bf67caa46a3ae": ["v1.24.0"]
 - name: cloud-controller-manager
   dmap:
     "sha256:f900d8b4a358847cd311950c7802f938dad083f645eee784cd52b7aec0de8dfb": ["v1.18.0-alpha.0"]


### PR DESCRIPTION
/cc @ConnorJC3 
/cc @torredil 

[GCR Manifest](https://console.cloud.google.com/gcr/images/k8s-staging-provider-aws/global/aws-ebs-csi-driver@sha256:3dba81d0c3c8ce51abeda40ec0dbad7e4930a89c8c6a1984a64bf67caa46a3ae/details?project=k8s-staging-provider-aws)


Multi-arch and version sanity checks
```
❯ docker run -t --rm "$URI" --version
Unable to find image 'gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver@sha256:3dba81d0c3c8ce51abeda40ec0dbad7e4930a89c8c6a1984a64bf67caa46a3ae' locally
gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver@sha256:3dba81d0c3c8ce51abeda40ec0dbad7e4930a89c8c6a1984a64bf67caa46a3ae: Pulling from k8s-staging-provider-aws/aws-ebs-csi-driver
a77bd5479ef4: Already exists
f75dd4fda1a8: Already exists
7a2ce72b8145: Already exists
36848388bfc8: Pull complete
Digest: sha256:3dba81d0c3c8ce51abeda40ec0dbad7e4930a89c8c6a1984a64bf67caa46a3ae
Status: Downloaded newer image for gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver@sha256:3dba81d0c3c8ce51abeda40ec0dbad7e4930a89c8c6a1984a64bf67caa46a3ae
{
  "driverVersion": "v1.24.0",
  "gitCommit": "",
  "buildDate": "2023-10-13T17:06:37+00:00",
  "goVersion": "go1.20.10",
  "compiler": "gc",
  "platform": "linux/amd64"
}

❯ crane manifest gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver@sha256:3dba81d0c3c8ce51abeda40ec0dbad7e4930a89c8c6a1984a64bf67caa46a3ae

{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1098,
         "digest": "sha256:4db105dd58bc8fde6ccf79e628bdea099b181961ac12f957d2713c4cecd3b2b0",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1098,
         "digest": "sha256:36ba022032983eb7228327178c4f03e18bdd2644fe39cbe1baced47c81dcd06f",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 900,
         "digest": "sha256:ef59b28bb6c5b29ed8958af3b1ffa340d38b19d25d8fe25e1b71e6441f473a6d",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.17763.4974"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 900,
         "digest": "sha256:e8c0e16f21f414315a22084818634671d245603d6bebc94f8c156470f14388d1",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.20348.2031"
         }
      }
   ]
}
```