### PR TITLE
Grant access to gcr.io/k8s-staging-autoscaling to new people working …

### DIFF
--- a/groups/sig-autoscaling/groups.yaml
+++ b/groups/sig-autoscaling/groups.yaml
@@ -49,6 +49,9 @@ groups:
       - guyjtempleton@googlemail.com
       - kgolab@google.com
       - bwroblewski@google.com
+      - kwiesmueller@google.com
+      - luizaoj@google.com
+      - rgowman@google.com
 
   #
   # k8s-infra gcs write access

--- a/k8s.gcr.io/images/k8s-staging-autoscaling/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-autoscaling/OWNERS
@@ -12,4 +12,3 @@ approvers:
 - towca
 - gjtempleton
 - kgolab
-- kwiesmueller

--- a/k8s.gcr.io/images/k8s-staging-autoscaling/OWNERS
+++ b/k8s.gcr.io/images/k8s-staging-autoscaling/OWNERS
@@ -12,3 +12,4 @@ approvers:
 - towca
 - gjtempleton
 - kgolab
+- kwiesmueller

--- a/registry.k8s.io/images/k8s-staging-autoscaling/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-autoscaling/OWNERS
@@ -10,3 +10,4 @@ approvers:
 - gjtempleton
 - kgolab
 - bigdarkclown
+- kwiesmueller


### PR DESCRIPTION
…on workload autoscaling

As per https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/RELEASE.md#permissions

This is to enable us to release new versions of the addon-resizer.

kwiesmueller is a k8s org member; the others (incl me) are not. IIUC, this change should allow any of us to test, but only kwiesmueller to create new images.