### PR TITLE
AWS: Add a replication role for registry.k8s.io

### DIFF
--- a/infra/aws/terraform/registry-k8s-io-prod/iam.tf
+++ b/infra/aws/terraform/registry-k8s-io-prod/iam.tf
@@ -1,0 +1,71 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+###
+# Replication
+###
+
+data "aws_iam_policy_document" "s3_assume_role" {
+  statement {
+    effect = "Allow"
+    principals {
+      type = "Service"
+      identifiers = [
+        "s3.amazonaws.com",
+        "batchoperations.s3.amazonaws.com",
+      ]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+data "aws_iam_policy_document" "replication" {
+
+  policy_id = "CrossRegionReplicationPolicy"
+  statement {
+    actions = [
+      "s3:GetReplicationConfiguration",
+      "s3:GetObjectVersionForReplication",
+      "s3:GetObjectVersionAcl",
+      "s3:GetObjectVersionTagging",
+      "s3:ListBucket",
+    ]
+
+    resources = ["*"]
+  }
+
+  statement {
+    actions = [
+      "s3:ReplicateObject",
+      "s3:ReplicateDelete",
+      "s3:ReplicateTags",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "replication" {
+  provider = aws.registry-k8s-io-prod
+
+  name_prefix        = "registry-k8s-io-s3-replication"
+  path               = "/"
+  assume_role_policy = data.aws_iam_policy_document.s3_assume_role.json
+  inline_policy {
+    name   = "S3Replication"
+    policy = data.aws_iam_policy_document.replication.json
+  }
+}


### PR DESCRIPTION
Related to:
 - https://github.com/kubernetes/registry.k8s.io/issues/172

Define permissions needed to use S3 replication in the same account.