### PR TITLE
images: promote node-feature-discovery v0.13.6 and v0.14.3

### DIFF
--- a/registry.k8s.io/images/k8s-staging-nfd/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-nfd/images.yaml
@@ -47,12 +47,16 @@
     "sha256:02e6e597bf590f6bc732a13c4739ce34e4ce1e49c5bb3ec231738db3afd77c11": ["v0.13.4-full"]
     "sha256:efc2b84b8532cd1a5a40cffff0d1e6c0beb3bcd08195cb4e799eadab7426ad6e": ["v0.13.5","v0.13.5-minimal"]
     "sha256:9b4576f6c8146be23fdc2462fddd8b9e7a2799b4ebee84f0e5b2d9eaa67e387a": ["v0.13.5-full"]
+    "sha256:9f6516250e7ed3019ab4fc1545aed233f5d7f551cf4ca31fa5b0b2816d49208c": ["v0.13.6","v0.13.6-minimal"]
+    "sha256:f6629daede5008283054c8c2dfff7db1ddc2edf1028657ee60c28219184813b3": ["v0.13.6-full"]
     "sha256:5bfcae5ea107987520822b5d8bedd715b4a2951ab9ec975d387b40ef9e3a638f": ["v0.14.0","v0.14.0-minimal"]
     "sha256:fbc9f9b9cb177ae27710d79db2c6ab80ed7dd02e1ea123d2d9d95b7914484468": ["v0.14.0-full"]
     "sha256:a5e9f35119a1df99fba159002487e3b85fe439a43f166eb43fe67e1b99a19531": ["v0.14.1","v0.14.1-minimal"]
     "sha256:bf2a751750c83adaae99371fd40808208ef0cce605e4ae44d79787b1d8e012c2": ["v0.14.1-full"]
     "sha256:2a56d172c48b76531eb719780224ef278daa68b9088f592f16df2519bed08de4": ["v0.14.2","v0.14.2-minimal"]
     "sha256:478dcca20defd2f40966f0df76e5f951867eee9795cbb4f9402e78f2c6c6c849": ["v0.14.2-full"]
+    "sha256:91c10576980b4966952a3ed9500a13adec608c05d65b9ac06a6cc05da7960ec6": ["v0.14.3","v0.14.3-minimal"]
+    "sha256:0e459fa3b8159e355c15cde19160a319fac689554c35ab512609a4a59e707340": ["v0.14.3-full"]
 - name: node-feature-discovery-operator
   dmap:
     "sha256:36a9a2c9d40b08a72df2878fcb602a86c7cf5b71ee9a786bff67fb84b64dcd16": ["v0.2.0"]


### PR DESCRIPTION
```bash
$ skopeo inspect docker://gcr.io/k8s-staging-nfd/node-feature-discovery:v0.14.3 | jq .Digest
"sha256:91c10576980b4966952a3ed9500a13adec608c05d65b9ac06a6cc05da7960ec6"

$ skopeo inspect docker://gcr.io/k8s-staging-nfd/node-feature-discovery:v0.14.3-minimal | jq .Digest
"sha256:91c10576980b4966952a3ed9500a13adec608c05d65b9ac06a6cc05da7960ec6"

$ skopeo inspect docker://gcr.io/k8s-staging-nfd/node-feature-discovery:v0.14.3-full | jq .Digest
"sha256:0e459fa3b8159e355c15cde19160a319fac689554c35ab512609a4a59e707340"

$ skopeo inspect docker://gcr.io/k8s-staging-nfd/node-feature-discovery:v0.13.6 | jq .Digest
"sha256:9f6516250e7ed3019ab4fc1545aed233f5d7f551cf4ca31fa5b0b2816d49208c"

$ skopeo inspect docker://gcr.io/k8s-staging-nfd/node-feature-discovery:v0.13.6-minimal | jq .Digest
"sha256:9f6516250e7ed3019ab4fc1545aed233f5d7f551cf4ca31fa5b0b2816d49208c"

$ skopeo inspect docker://gcr.io/k8s-staging-nfd/node-feature-discovery:v0.13.6-full | jq .Digest
"sha256:f6629daede5008283054c8c2dfff7db1ddc2edf1028657ee60c28219184813b3"
```