### PR TITLE
Fastly: fix cache config for cdn.dl.k8s.io

### DIFF
--- a/infra/fastly/terraform/dl.k8s.io/vcl/binaries.vcl
+++ b/infra/fastly/terraform/dl.k8s.io/vcl/binaries.vcl
@@ -53,7 +53,7 @@ sub vcl_fetch {
 
   # TODO: Drop this when the origin(GCS bucket) is owned by the community
   # See: https://github.com/kubernetes/k8s.io/issues/2396
-  if (req.url.path ~ "^/release/") {
+  if (beresp.status == 200 && req.url.path ~ "^/release/") {
     set beresp.http.Cache-Control = "private, no-store"; # Don't cache in the browser
     set beresp.ttl = 30d;
     set beresp.ttl -= std.atoi(beresp.http.Age);


### PR DESCRIPTION
Potential fix to ensure objects are cached at edge for only requests responding 200 from the origin. We have a short ttl(2 min) for 404 responses from the origin but this is defined after the object is cached at edge.