### PR TITLE
Remove kayrus' broken email

### DIFF
--- a/groups/sig-architecture/groups.yaml
+++ b/groups/sig-architecture/groups.yaml
@@ -161,7 +161,6 @@ groups:
     members:
       - haka.jesse@gmail.com
       - jichenjc@cn.ibm.com
-      - kaydiam+k8s@gmail.com
       - mdulko@redhat.com
 
   - email-id: k8s-infra-conform-s390x-k8s@kubernetes.io

--- a/groups/sig-cloud-provider/groups.yaml
+++ b/groups/sig-cloud-provider/groups.yaml
@@ -39,7 +39,6 @@ groups:
     members:
       - haka.jesse@gmail.com
       - jichenjc@cn.ibm.com
-      - kaydiam+k8s@gmail.com
       - mdulko@redhat.com
 
   - email-id: k8s-infra-staging-provider-azure@kubernetes.io


### PR DESCRIPTION
xref #5717 


```
2023/10/31 21:19:42 [unable to add sig-api-machinery-leads@kubernetes.io to "sig-api-machinery@kubernetes.io" as OWNER: googleapi: Error 400: Invalid Input: memberKey, invalid, unable to add kaydiam+k8s@gmail.com to "k8s-infra-conform-provider-openstack@kubernetes.io" as MEMBER: googleapi: Error 404: Resource Not Found: kaydiam+k8s@gmail.com, notFound, unable to add kaydiam+k8s@gmail.com to "k8s-infra-staging-provider-os@kubernetes.io" as MEMBER: googleapi: Error 404: Resource Not Found: kaydiam+k8s@gmail.com, notFound]
```

/cc @BenTheElder 