### PR TITLE
Rename releases prod bucket

### DIFF
--- a/infra/gcp/terraform/k8s-infra-releases-prod/main.tf
+++ b/infra/gcp/terraform/k8s-infra-releases-prod/main.tf
@@ -35,11 +35,10 @@ resource "google_project" "project" {
 module "k8s_releases_prod" {
   source                   = "../modules/k8s-releases"
   project_id               = google_project.project.project_id
-  bucket_name              = "k8s-releases"
-  public_access_prevention = "enforced"
+  bucket_name              = "767373bbdcb8270361b96548387bf2a9ad0d48758c35"
 }
 
-resource "google_storage_bucket_iam_member" "s3-backup-bucket" {
+resource "google_storage_bucket_iam_member" "gcs-backup-bucket" {
   bucket     = module.k8s_releases_prod.bucket_name
   role       = "roles/storage.admin"
   member     = "serviceAccount:${data.google_storage_transfer_project_service_account.default.email}"

--- a/infra/gcp/terraform/modules/k8s-releases/k8s-releases.tf
+++ b/infra/gcp/terraform/modules/k8s-releases/k8s-releases.tf
@@ -43,7 +43,7 @@ resource "google_storage_bucket" "k8s_releases" {
     enabled = true
   }
 
-  public_access_prevention = true
+  public_access_prevention = var.public_access_prevention
 
   lifecycle {
     prevent_destroy = true


### PR DESCRIPTION
Rename the release bucket to avoid possible bucket takeover attack and ensure it's private.