### PR TITLE
A group may not be the owner or manager of another group

### DIFF
--- a/groups/sig-api-machinery/groups.yaml
+++ b/groups/sig-api-machinery/groups.yaml
@@ -27,7 +27,10 @@ groups:
   description: |-
     SIG api-machinery general discussion group, for future migration from old googlegroups
   owners:
-    - sig-api-machinery-leads@kubernetes.io
+    - jpbetz@google.com
+    - deads@redhat.com
+    - fbongiovanni@google.com
+    - stefan.schimanski@gmail.com
   settings:
     WhoCanJoin: "ANYONE_CAN_JOIN"
     WhoCanViewGroup: "ANYONE_CAN_VIEW"


### PR DESCRIPTION
Fixing the following error

```
2023/10/31 22:08:18 unable to add sig-api-machinery-leads@kubernetes.io to "sig-api-machinery@kubernetes.io" as OWNER: googleapi: Error 400: Invalid Input: memberKey, invalid
2023/10/31 22:08:59 unable to add sig-api-machinery-leads@kubernetes.io to "sig-api-machinery@kubernetes.io" as OWNER: googleapi: Error 400: Invalid Input: memberKey, invalid
```

/cc @BenTheElder 