### PR TITLE
chore: Promote aws-ebs-csi-driver v1.25.0 images

### DIFF
--- a/registry.k8s.io/images/k8s-staging-provider-aws/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-provider-aws/images.yaml
@@ -71,6 +71,8 @@
     "sha256:775f72d668be4402f9c5ba689edbc19389e1e5ef6acafa5419ad08fdc2a68c2b": ["v1.7.0"]
     "sha256:2727c4ba96b420f6280107daaf4a40a5de5f7241a1b70052056a5016dff05b2f": ["v1.8.0"]
     "sha256:40603af23c56fe78141b219208f72df025844b2fa35f906fb89f5f58b77ade85": ["v1.9.0"]
+    "sha256:b09b785943922346f0ccd98146fe574ec661ceb49c6c3e4b7f54c4a12372a3eb": ["v1.25.0"]
+    "sha256:ce14f7cee63bb5a38a4628b3eca27e7d3eb644abed6cd3ffa18623991976cbfd": ["v1.25.0-a1compat"]
 - name: cloud-controller-manager
   dmap:
     "sha256:f900d8b4a358847cd311950c7802f938dad083f645eee784cd52b7aec0de8dfb": ["v1.18.0-alpha.0"]


### PR DESCRIPTION
Promote aws-ebs-csi-driver v1.25.0 manifest list and v1.25.0-a1compat image. 

/cc @ConnorJC3 
/cc @torredil 

manifest-list: [gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver@sha256:b09b785943922346f0ccd98146fe574ec661ceb49c6c3e4b7f54c4a12372a3eb](http://gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver@sha256:b09b785943922346f0ccd98146fe574ec661ceb49c6c3e4b7f54c4a12372a3eb)
a1-compat: [gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver@sha256:ce14f7cee63bb5a38a4628b3eca27e7d3eb644abed6cd3ffa18623991976cbfd](http://gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver@sha256:ce14f7cee63bb5a38a4628b3eca27e7d3eb644abed6cd3ffa18623991976cbfd)

Version + Multi-arch sanity
```
❯ docker run --rm gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver@sha256:b09b785943922346f0ccd98146fe574ec661ceb49c6c3e4b7f54c4a12372a3eb --version
{
  "driverVersion": "v1.25.0",
  "gitCommit": "",
  "buildDate": "2023-11-10T19:13:22+00:00",
  "goVersion": "go1.21.4",
  "compiler": "gc",
  "platform": "linux/arm64"
}
❯ docker run --rm gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver@sha256:ce14f7cee63bb5a38a4628b3eca27e7d3eb644abed6cd3ffa18623991976cbfd --version
Unable to find image 'gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver@sha256:ce14f7cee63bb5a38a4628b3eca27e7d3eb644abed6cd3ffa18623991976cbfd' locally
gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver@sha256:ce14f7cee63bb5a38a4628b3eca27e7d3eb644abed6cd3ffa18623991976cbfd: Pulling from k8s-staging-provider-aws/aws-ebs-csi-driver
4af0cb493592: Already exists
f267f1ed2c74: Already exists
b3c3177a08d4: Pull complete
9c01ff450ed9: Pull complete
Digest: sha256:ce14f7cee63bb5a38a4628b3eca27e7d3eb644abed6cd3ffa18623991976cbfd
Status: Downloaded newer image for gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver@sha256:ce14f7cee63bb5a38a4628b3eca27e7d3eb644abed6cd3ffa18623991976cbfd
{
  "driverVersion": "v1.25.0",
  "gitCommit": "",
  "buildDate": "2023-11-10T19:06:27+00:00",
  "goVersion": "go1.21.4",
  "compiler": "gc",
  "platform": "linux/arm64"
}

❯ crane manifest  gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver@sha256:b09b785943922346f0ccd98146fe574ec661ceb49c6c3e4b7f54c4a12372a3eb
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1098,
         "digest": "sha256:286169dc7f94b84d7b56c317f065809e68d462769aebb06be8d14f989c84c61f",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 1098,
         "digest": "sha256:b6b313fe0c3141e0e5512902e107f2afb786c6f405ed797e68d57d645a265ca0",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 900,
         "digest": "sha256:1b18d00ecd42889160111c549f62a595621eb1773ac82625629a34bc5b6872b7",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.17763.4974"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 900,
         "digest": "sha256:5813cdec6449eaa1c6f1e7db9ce45d3a4720166b7ec06ff307c66fac0f4a1cec",
         "platform": {
            "architecture": "amd64",
            "os": "windows",
            "os.version": "10.0.20348.2031"
         }
      }
   ]
}⏎
❯ crane manifest gcr.io/k8s-staging-provider-aws/aws-ebs-csi-driver@sha256:ce14f7cee63bb5a38a4628b3eca27e7d3eb644abed6cd3ffa18623991976cbfd
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
  "config": {
    "mediaType": "application/vnd.docker.container.image.v1+json",
    "digest": "sha256:84114ca2eba4855fcd9078eeb55c066a4c625241284431430168a3c4ed2be819",
    "size": 1637
  },
  "layers": [
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
      "digest": "sha256:4af0cb493592ba7d70891174853893649886e7c55e6951be8feaf6e85a5bee0c",
      "size": 1693754
    },
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
      "digest": "sha256:f267f1ed2c74560b51e3c69103a0065eb6ad21b050ae37039d3376929d6b6bf9",
      "size": 9388849
    },
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
      "digest": "sha256:b3c3177a08d4be657c204761f1728d939b6f43802f2e03058cad6e01b19e8898",
      "size": 4715201
    },
    {
      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
      "digest": "sha256:9c01ff450ed9b97c931bed7ee49892c2ebbd1981a87e1bb82e64e5dca4457d76",
      "size": 14498402
    }
  ]
}⏎
```