### PR TITLE
Add dims, cartermckinnon to provider-aws OWNERS

### DIFF
--- a/registry.k8s.io/images/k8s-staging-provider-aws/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-provider-aws/OWNERS
@@ -9,3 +9,5 @@ approvers:
 - olemarkus
 - torredil
 - wongma7
+- cartermckinnon
+- dims


### PR DESCRIPTION
Adding @dims, @cartermckinnon to provider-aws OWNERS to unblock image promotions.