### PR TITLE
Promote provider-aws 1.27.3, 1.28.3 artifacts

### DIFF
--- a/artifacts/manifests/k8s-staging-provider-aws/v1.27.3.yaml
+++ b/artifacts/manifests/k8s-staging-provider-aws/v1.27.3.yaml
@@ -1,0 +1,13 @@
+files:
+- name: v1.27.3/linux/amd64/ecr-credential-provider-linux-amd64
+  sha256: 27a4730e1f4f4986320bf54d8e0e3f30384e3df819225a280d979285933732d5
+- name: v1.27.3/linux/amd64/ecr-credential-provider-linux-amd64.sha256
+  sha256: bd2da6a5f35c740e396e7ee12ed756110f759f786828ed4764c0d6e3d42af2bc
+- name: v1.27.3/linux/arm64/ecr-credential-provider-linux-arm64
+  sha256: f0e92da41d17c33780a659f89fb2aec15ab76680358e6383250b7a5d4898a47c
+- name: v1.27.3/linux/arm64/ecr-credential-provider-linux-arm64.sha256
+  sha256: 6660d37f5ec11f556dcc9d334fbf7d21f7d53499bd6f6b7e7df82ac18ef68ea3
+- name: v1.27.3/windows/amd64/ecr-credential-provider-windows-amd64
+  sha256: 7cc88083f61431cb1fa2f4b53800b79bbf1907e8dbe00d14e7beed36eee39662
+- name: v1.27.3/windows/amd64/ecr-credential-provider-windows-amd64.sha256
+  sha256: e1f1fc974eb0440f6953fd35c7ce296875dbf376fb401c1aa0221c703c70f644

--- a/artifacts/manifests/k8s-staging-provider-aws/v1.28.2.yaml
+++ b/artifacts/manifests/k8s-staging-provider-aws/v1.28.2.yaml
@@ -1,0 +1,13 @@
+files:
+- name: v1.28.2/linux/amd64/ecr-credential-provider-linux-amd64
+  sha256: 54a2cfe702168d07e35b5ad4071377b5bb8d82a8eb6909805690ea046bcb2cb7
+- name: v1.28.2/linux/amd64/ecr-credential-provider-linux-amd64.sha256
+  sha256: c076910f4dfaeb25a1ea1deb864c601ce66452a0d446e6d18e3ad4257bae7adc
+- name: v1.28.2/linux/arm64/ecr-credential-provider-linux-arm64
+  sha256: fee2cbc975dee8f92554a590ea6a30f23d331b21de4946a773b889f6b8a121cc
+- name: v1.28.2/linux/arm64/ecr-credential-provider-linux-arm64.sha256
+  sha256: 039976206d1e2523067d1ddd688750e96c16dc39ef65b147a2b20f9442160a44
+- name: v1.28.2/windows/amd64/ecr-credential-provider-windows-amd64
+  sha256: 85d896ddea6bfd2c26199129a9a9756866d25b83d7cd8c60309e6edb75b2e08b
+- name: v1.28.2/windows/amd64/ecr-credential-provider-windows-amd64.sha256
+  sha256: 9b0c544315cc6f90e5b2d6f1457621938feaab9c6ae73a656ed81e786d67c0f4


### PR DESCRIPTION
Generated by following these steps: https://github.com/kubernetes-sigs/promo-tools/blob/main/docs/file-promotion.md#generating-a-file-promotion-manifest

/assign @olemarkus