### PR TITLE
Promote provider-aws 1.27.4, 1.28.3 artifacts

### DIFF
--- a/artifacts/manifests/k8s-staging-provider-aws/v1.27.4.yaml
+++ b/artifacts/manifests/k8s-staging-provider-aws/v1.27.4.yaml
@@ -1,0 +1,13 @@
+files:
+- name: v1.27.4/linux/amd64/ecr-credential-provider-linux-amd64
+  sha256: d07ed6b7e7f639e18fbe8f08f818964c8cb7d2325d341dd738c3bb3aa1db438b
+- name: v1.27.4/linux/amd64/ecr-credential-provider-linux-amd64.sha256
+  sha256: f359fff1c083cd826e6599bc9970aedd467bad1655c41af1f2c102d5cea424d5
+- name: v1.27.4/linux/arm64/ecr-credential-provider-linux-arm64
+  sha256: e047daf51db28a9ca1e5ad30f6ca75a69aa1a30404cbcb629aa8b42f41cbe123
+- name: v1.27.4/linux/arm64/ecr-credential-provider-linux-arm64.sha256
+  sha256: 1d4f93587454387c369a235463f8ab6110b15cf6412f890c23ae2d3b826e9333
+- name: v1.27.4/windows/amd64/ecr-credential-provider-windows-amd64
+  sha256: 48b25cf7f275f4f6bda38f7a137931a54a059d81153e15f684682011aa12eb5c
+- name: v1.27.4/windows/amd64/ecr-credential-provider-windows-amd64.sha256
+  sha256: 3613966c03dcf7cde86aa5411775d2f30d5b5a01351660354bf41ad09d1aa798

--- a/artifacts/manifests/k8s-staging-provider-aws/v1.28.3.yaml
+++ b/artifacts/manifests/k8s-staging-provider-aws/v1.28.3.yaml
@@ -1,0 +1,13 @@
+files:
+- name: v1.28.3/linux/amd64/ecr-credential-provider-linux-amd64
+  sha256: 5479806685290a89537122b00ee93b602c0bbf29f27f6730999feb719924a14d
+- name: v1.28.3/linux/amd64/ecr-credential-provider-linux-amd64.sha256
+  sha256: 32935023d9f9dc951f0410158aef3b702f9ca8569d4bf5e411f8d1dac3037bfd
+- name: v1.28.3/linux/arm64/ecr-credential-provider-linux-arm64
+  sha256: cf831eae34949a4e981d27a3435be47cb03be5fcb8a3c18377c2c747b11f89f3
+- name: v1.28.3/linux/arm64/ecr-credential-provider-linux-arm64.sha256
+  sha256: 9d6254a5dcac0ef7b3abbf00dc68f0e5283d9189fb58f777a664119d88a87c7e
+- name: v1.28.3/windows/amd64/ecr-credential-provider-windows-amd64
+  sha256: 278d59b7d586968aeffb331991e55451ead3a68f1b1247cc2bbbc6f9b59f7df5
+- name: v1.28.3/windows/amd64/ecr-credential-provider-windows-amd64.sha256
+  sha256: ec9a3346dbda32ea17c363407e733a6c3803dc2a4011dca4a440d14453d370ad


### PR DESCRIPTION
Generated by following these steps: https://github.com/kubernetes-sigs/promo-tools/blob/main/docs/file-promotion.md#generating-a-file-promotion-manifest