### PR TITLE
descheduler codeowners: add knelasevero and a7i to approvers

### DIFF
--- a/registry.k8s.io/images/k8s-staging-descheduler/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-descheduler/OWNERS
@@ -3,6 +3,8 @@
 approvers:
   - damemi
   - ingvagabund
+  - knelasevero
+  - a7i
 
 emeritus_approvers:
   - ravisantoshgudimetla


### PR DESCRIPTION
@knelasevero are working on Descheduler 0.28.1 release and need to be able to approve
(Mike is out until mid December)