### PR TITLE
chore: add myself to k8s-infra-ii-coop

### DIFF
--- a/groups/sig-k8s-infra/groups.yaml
+++ b/groups/sig-k8s-infra/groups.yaml
@@ -134,6 +134,7 @@ groups:
       - hh@ii.coop
       - riaan@ii.coop
       - stephen@ii.coop
+      - caleb@ii.coop
 
   # Owners of the GCP projects:
   # - k8s-infra-oci-proxy


### PR DESCRIPTION
adds myself to the _k8s-infra-ii-coop_ group.

/cc @hh @dims 