### PR TITLE
AWS: Enable EKS Pod Identity

### DIFF
--- a/infra/aws/terraform/kops-infra-ci/eks.tf
+++ b/infra/aws/terraform/kops-infra-ci/eks.tf
@@ -142,6 +142,24 @@ module "eks" {
   })
 }
 
+resource "aws_eks_addon" "eks_pod_identity" {
+  provider = aws.kops-local-ci
+
+  cluster_name                = module.eks.cluster_name
+  addon_name                  = "eks-pod-identity-agent"
+  addon_version               = "v1.0.0-eksbuild.1"
+  resolve_conflicts_on_update = "OVERWRITE"
+}
+
+resource "aws_eks_pod_identity_association" "kops_prow_build" {
+  provider = aws.kops-local-ci
+
+  cluster_name    = module.eks.cluster_name
+  namespace       = "test-pods"
+  service_account = "prowjob-default-sa"
+  role_arn        = aws_iam_role.eks_pod_identity_role.arn
+}
+
 
 module "vpc_cni_irsa" {
   providers = { aws = aws.kops-infra-ci }

--- a/infra/aws/terraform/kops-infra-ci/eks.tf
+++ b/infra/aws/terraform/kops-infra-ci/eks.tf
@@ -73,7 +73,7 @@ module "eks" {
 
   eks_managed_node_group_defaults = {
     ami_type       = "AL2_x86_64"
-    instance_types = ["m6i.large", "m5.large", "m5n.large", "m5zn.large"]
+    instance_types = ["m7i.large", "m5.large", "m5n.large", "m5zn.large"]
 
     iam_role_attach_cni_policy = true
   }
@@ -99,7 +99,7 @@ module "eks" {
       }
 
       capacity_type  = "ON_DEMAND"
-      instance_types = ["r6i.2xlarge"]
+      instance_types = ["r7i.2xlarge"]
       ami_type       = "BOTTLEROCKET_x86_64"
       platform       = "bottlerocket"
 

--- a/infra/aws/terraform/kops-infra-ci/providers.tf
+++ b/infra/aws/terraform/kops-infra-ci/providers.tf
@@ -23,6 +23,12 @@ provider "aws" {
   }
 }
 
+provider "aws" {
+  region  = "us-east-2"
+  alias   = "kops-local-ci"
+  profile = "kops-ci"
+}
+
 provider "kubernetes" {
   host                   = module.eks.cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)

--- a/infra/aws/terraform/kops-infra-ci/resources/00-namespaces.yaml
+++ b/infra/aws/terraform/kops-infra-ci/resources/00-namespaces.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-pods

--- a/infra/aws/terraform/kops-infra-ci/resources/sa.yaml
+++ b/infra/aws/terraform/kops-infra-ci/resources/sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "prowjob-default-sa"
+  namespace: "test-pods"

--- a/infra/aws/terraform/kops-infra-ci/terraform.tf
+++ b/infra/aws/terraform/kops-infra-ci/terraform.tf
@@ -27,7 +27,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.11.0"
+      version = "~> 5.29.0"
     }
   }
 }


### PR DESCRIPTION
Enable EKS Pod Identity for EKS cluster `k8s-infra-kops-prow-build`.

See: https://aws.amazon.com/blogs/aws/amazon-eks-pod-identity-simplifies-iam-permissions-for-applications-on-amazon-eks-clusters/

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>