### PR TITLE
kops-ci: bump cluster version

### DIFF
--- a/infra/aws/terraform/kops-infra-ci/variables.tf
+++ b/infra/aws/terraform/kops-infra-ci/variables.tf
@@ -16,7 +16,7 @@ limitations under the License.
 
 variable "eks_version" {
   type    = string
-  default = "1.26"
+  default = "1.27"
 }
 
 variable "tags" {


### PR DESCRIPTION
Bump cluster version to meet EKS Pod identity requirement.

See: https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html