### PR TITLE
Add IP addresses for nginx hosting apt/yum.k8s.io and DNS records

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -91,6 +91,16 @@ _github-challenge-kubernetes-sigs:
 apt:
   type: CNAME
   value: redirect.k8s.io.
+legacy.apt:
+  - type: A
+    value: 34.107.249.95
+  # - type: AAAA
+  #   value: "2600:1901:0:a15f::"
+legacy.yum:
+  - type: A
+    value: 34.107.249.95
+  # - type: AAAA
+  #   value: "2600:1901:0:a15f::"
 yum:
   type: CNAME
   value: redirect.k8s.io.

--- a/infra/gcp/terraform/kubernetes-public/external-ips.tf
+++ b/infra/gcp/terraform/kubernetes-public/external-ips.tf
@@ -30,6 +30,13 @@ locals {
       name = "k8s-io-ingress-canary-v6",
       ipv6 = true
     },
+    canary-packages = {
+      name = "k8s-io-packages-ingress-canary",
+    },
+    canary-packages-v6 = {
+      name = "k8s-io-packages-ingress-canary-v6",
+      ipv6 = true
+    },
     cs = {
       name = "cs-k8s-io-ingress",
       description = "Used for cs-canary.k8s.io"
@@ -50,6 +57,13 @@ locals {
     },
     ingress-prod-v6 = {
       name = "k8s-io-ingress-prod-v6",
+      ipv6 = true
+    },
+    ingress-packages-prod = {
+      name = "k8s-io-packages-ingress-prod",
+    },
+    ingress-packages-prod-v6 = {
+      name = "k8s-io-packages-ingress-prod-v6",
       ipv6 = true
     },
     perf-dash = {


### PR DESCRIPTION
This PR adds IP addresses for a new nginx instance that's going to handle `apt.kubernetes.io` and `yum.kubernetes.io`. This PR is a prerequisite to deploying the said nginx instance.

xref https://github.com/kubernetes/k8s.io/issues/6157

/assign @upodroid @ameukam 