### PR TITLE
Add k8s-io-packages app

### DIFF
--- a/apps/k8s-io-packages/.gitignore
+++ b/apps/k8s-io-packages/.gitignore
@@ -1,0 +1,3 @@
+tls.crt
+tls.key
+tls.csr

--- a/apps/k8s-io-packages/Dockerfile-test
+++ b/apps/k8s-io-packages/Dockerfile-test
@@ -1,0 +1,10 @@
+FROM python:3
+MAINTAINER Jeff Grafton <jgrafton@google.com>
+
+WORKDIR /workspace
+
+RUN pip install pyyaml
+
+COPY test.py configmap-*.yaml /workspace/
+
+ENTRYPOINT /workspace/test.py

--- a/apps/k8s-io-packages/Makefile
+++ b/apps/k8s-io-packages/Makefile
@@ -1,0 +1,24 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+all: test
+
+.PHONY: test
+test:
+	./test.py -q
+
+.PHONY: docker-test
+docker-test:
+	docker build -t k8s-io-test -f Dockerfile-test .
+	docker run -it --rm -e TARGET_IP=${TARGET_IP} k8s-io-test

--- a/apps/k8s-io-packages/OWNERS
+++ b/apps/k8s-io-packages/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- release-engineering-approvers
+
+labels:
+- sig/release
+- area/apps/k8s.io

--- a/apps/k8s-io-packages/README.md
+++ b/apps/k8s-io-packages/README.md
@@ -1,0 +1,28 @@
+Overview
+====
+This contains the Nginx configuration for apt.k8s.io and yum.k8s.io
+redirectors.
+
+Vanity URL(s)
+====
+
+|  | k8s.io | kubernetes.io |
+| --- | --- | --- |
+| APT downloads| https://apt.k8s.io | https://apt.kubernetes.io |
+| Kubernetes YouTube | https://yt.k8s.io | https://youtube.k8s.io | https://youtube.kubernetes.io | https://yt.kubernetes.io |
+
+How to deploy
+====
+
+1) Log into Google Cloud Shell.  Our clusters do not allow access from the
+   internet.
+
+2) Get the credentials for the cluster, if you don't already have them.  Run
+   `gcloud container clusters get-credentials aaa --region us-central1
+   --project kubernetes-public`.  When this is done, you should be able to list
+   namespaces with `kubectl --context gke_kubernetes-public_us-central1_aaa get
+   ns`.
+
+3) Run `./deploy.sh`.  This will effectively run `./deploy.sh canary` to push
+   and test configs in the canary namespace, followed by `./deploy.sh prod` to
+   do the same in prod if tests pass against canary.

--- a/apps/k8s-io-packages/configmap-nginx.yaml
+++ b/apps/k8s-io-packages/configmap-nginx.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-packages
+  labels:
+    app: k8s-io-packages
+data:
+  # Adding new entries here will make them appear as files in the deployment.
+  # Please update kubernetes/k8s.io/apps/k8s-io-packages/README.md when you update this file
+  nginx.conf: |
+    worker_processes 5;
+
+    events {
+    }
+
+    http {
+      # Disable to show the nginx version
+      server_tokens off;
+
+      # This is the main site.
+      server {
+        listen 80 default_server;
+
+        location = /_healthz {
+          add_header Content-Type text/plain;
+          return 200 'ok';
+        }
+      }
+
+      #
+      # Vanity redirect rules.
+      #
+
+      server {
+        server_name legacy.apt.kubernetes.io legacy.apt.k8s.io;
+        listen 80;
+
+        rewrite ^/(.*)?$    https://packages.cloud.google.com/apt/$1 redirect;
+      }
+
+      server {
+        server_name legacy.yum.kubernetes.io legacy.yum.k8s.io;
+        listen 80;
+
+        rewrite ^/(.*)?$    https://packages.cloud.google.com/yum/$1 redirect;
+      }
+    }

--- a/apps/k8s-io-packages/deploy.sh
+++ b/apps/k8s-io-packages/deploy.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)
+
+app=$(basename "${SCRIPT_ROOT}")
+
+# coordinates to locate the target cluster in gke
+cluster_name="aaa"
+cluster_project="kubernetes-public"
+cluster_region="us-central1"
+
+# well known name set by `gcloud container clusters get-credentials`
+gke_context="gke_${cluster_project}_${cluster_region}_${cluster_name}"
+context="${KUBECTL_CONTEXT:-${gke_context}}"
+
+# ensure we have a context to talk to the target cluster
+if ! kubectl config get-contexts "${context}" >/dev/null 2>&1; then
+    gcloud container clusters get-credentials "${cluster_name}" --project="${cluster_project}" --region="${cluster_region}"
+    context="${gke_context}"
+fi
+
+function deploy() {
+    local target="$1"
+    if [ "${target}" != "prod" ] && [ "${target}" != "canary" ]; then
+        echo >&2 "ERROR: unknown target: ${target}; valid targets are: prod, canary"
+        return 1
+    fi
+    local namespace="k8s-io-packages-$target"
+
+    local kubectl=(
+        kubectl
+        --context="${context}"
+        --namespace="${namespace}"
+    )
+
+    echo "running kubectl apply..."
+    "${kubectl[@]}" apply \
+        -f configmap-nginx.yaml \
+        -f deployment.yaml \
+        -f service.yaml
+
+    echo "restarting deployment..."
+    "${kubectl[@]}" rollout restart deployment k8s-io-packages
+
+    echo "waiting for all replicas to be up..."
+    while true; do
+      sleep 3
+      read -r spec ready unavail < <( \
+          "${kubectl[@]}" get deployment k8s-io-packages \
+              -o go-template='{{.spec.replicas}} {{.status.readyReplicas}} {{.status.unavailableReplicas}}{{"\n"}}'
+      )
+
+      if [ -z "${ready}" ] || [ "${ready}" == "<no value>" ]; then
+          ready=0
+      fi
+      if [ -z "${unavail}" ] || [ "${unavail}" == "<no value>" ]; then
+          unavail=0
+      fi
+      if [ -n "${spec}" ] && [ -n "${ready}" ] && [ "${spec}" == "${ready}" ] && [ "${unavail}" == 0 ]; then
+        break
+      fi
+      echo "  want ${spec}, found ${ready} ready and ${unavail} unavailable"
+    done
+
+    # We can only test IPv4 from within GCP.
+    all_ips=$("${kubectl[@]}" get ing k8s-io-packages -o go-template='{{range .status.loadBalancer.ingress}}{{.ip}}{{end}}')
+
+    for ip in $all_ips; do
+        echo "Testing TARGET_IP=$ip"
+        make test TARGET_IP="$ip"
+    done
+}
+
+function main() {
+  pushd "${SCRIPT_ROOT}" >/dev/null
+  if [ $# == 1 ]; then
+      echo "Deploying ${app} to '$1' target - ^C now to abort..."
+      sleep 5
+      deploy "$1"
+  elif [ $# == 0 ]; then
+      echo "Auto-deploying ${app} to canary then prod targets - ^C now to abort..."
+      sleep 5
+      deploy canary
+      deploy prod
+  else
+      echo >&2 "Usage: $0 [canary|prod]"
+  fi 
+}
+
+main "$@"

--- a/apps/k8s-io-packages/deployment.yaml
+++ b/apps/k8s-io-packages/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8s-io-packages
+  labels:
+    app: k8s-io-packages
+    version: v1
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: k8s-io-packages
+      version: v1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app: k8s-io-packages
+        version: v1
+    spec:
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: nginx
+        configMap:
+          name: nginx
+          # Map all keys to files.
+      containers:
+      - name: nginx
+        image: nginx:1.25-alpine
+        resources:
+          limits:
+            cpu: 1
+            memory: 512Mi
+        ports:
+        - name: http
+          containerPort: 80
+        - name: https
+          containerPort: 443
+        livenessProbe:
+          httpGet:
+            path: /_healthz
+            port: 80
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+          failureThreshold: 2
+        readinessProbe:
+          httpGet:
+            path: /_healthz
+            port: 80
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+          failureThreshold: 2
+        lifecycle:
+          preStop:
+            exec: # nginx likes to terminate ASAP
+              command:
+                - /usr/sbin/nginx
+                - -s
+                - quit
+        volumeMounts:
+        - name: nginx
+          mountPath: /etc/nginx
+          readOnly: true

--- a/apps/k8s-io-packages/ingress-canary-v6.yaml
+++ b/apps/k8s-io-packages/ingress-canary-v6.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: k8s-io-packages-v6
+  labels:
+    app: k8s-io-packages
+  namespace: k8s-io-packages-canary
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: k8s-io-packages-ingress-canary-v6
+spec:
+  defaultBackend:
+    service:
+      name: k8s-io-packages
+      port:
+        name: http
+  tls:
+  - secretName: k8s-io-tls

--- a/apps/k8s-io-packages/ingress-canary.yaml
+++ b/apps/k8s-io-packages/ingress-canary.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: k8s-io-packages
+  labels:
+    app: k8s-io-packages
+  namespace: k8s-io-packages-canary
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: k8s-io-packages-ingress-canary
+spec:
+  defaultBackend:
+    service:
+      name: k8s-io-packages
+      port:
+        name: http
+  tls:
+  - secretName: k8s-io-tls

--- a/apps/k8s-io-packages/ingress-prod-v6.yaml
+++ b/apps/k8s-io-packages/ingress-prod-v6.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: k8s-io-packages-v6
+  labels:
+    app: k8s-io-packages
+  namespace: k8s-io-packages-prod
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: k8s-io-packages-ingress-prod-v6
+    kubernetes.io/ingress.class: gce
+    networking.gke.io/managed-certificates: k8s-io-prod
+spec:
+  defaultBackend:
+    service:
+      name: k8s-io-packages
+      port:
+        name: http

--- a/apps/k8s-io-packages/ingress-prod.yaml
+++ b/apps/k8s-io-packages/ingress-prod.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: k8s-io-packages
+  labels:
+    app: k8s-io-packages
+  namespace: k8s-io-packages-prod
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: k8s-io-packages-ingress-prod
+    kubernetes.io/ingress.class: gce
+    networking.gke.io/managed-certificates: k8s-io-prod
+spec:
+  defaultBackend:
+    service:
+      name: k8s-io-packages
+      port:
+        name: http

--- a/apps/k8s-io-packages/service.yaml
+++ b/apps/k8s-io-packages/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8s-io-packages
+  labels:
+    app: k8s-io-packages
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
+spec:
+  selector:
+    app: k8s-io-packages
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80

--- a/apps/k8s-io-packages/test.py
+++ b/apps/k8s-io-packages/test.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    import HTMLParser
+    import httplib
+    import urlparse
+except ImportError:
+    import html.parser as HTMLParser
+    import http.client as httplib
+    import urllib.parse as urlparse
+import os
+import random
+import socket
+import ssl
+import subprocess
+import unittest
+import urllib.request
+
+import yaml
+
+SSL_VERIFY_DISABLE = False
+
+def rand_num():
+    return random.randint(1000, 10000)
+
+
+def do_get(url):
+    parsed = urlparse.urlparse(url)
+    path = parsed.path
+    if parsed.query:
+        path = '%s?%s' % (path, parsed.query)
+    if parsed.scheme == 'http':
+        conn = httplib.HTTPConnection(TARGET_IP)
+    elif parsed.scheme == 'https':
+        # We can't use plain old httplib.HTTPSConnection as we are connecting
+        # via IP address but need to verify the certificate chain based on the
+        # host name. HTTPSConnection isn't smart enough to pull out the host
+        # header. Instead we manually TLS wrap the socket for a HTTPConnection
+        # and override the hostname to verify.
+        conn = httplib.HTTPConnection(TARGET_IP, 443)
+        context = ssl.create_default_context()
+        if SSL_VERIFY_DISABLE:
+            context = ssl._create_unverified_context()
+        conn.connect()
+        conn.sock = context.wrap_socket(
+            conn.sock, server_hostname=parsed.netloc)
+    conn.request('GET', path, headers={'Host': parsed.netloc})
+    resp = conn.getresponse()
+    body = resp.read().decode('utf8')
+    resp.close()
+    conn.close()
+    return resp, body
+
+
+class HTTPTestCase(unittest.TestCase):
+    def do_get(self, url, expected_code):
+        resp, body = do_get(url)
+        self.assertEqual(resp.status, expected_code,
+                '\nGET "%s" got an unexpected status code:\n want: %d\n got:  %d'
+                % (url, expected_code, resp.status))
+        return resp, body
+
+    def assert_code(self, url, expected_code):
+        print('GET: %s => %s' % (url, expected_code))
+        return self.do_get(url, expected_code)
+
+class RedirTest(HTTPTestCase):
+    def assert_scheme_redirect(self, url, expected_loc, expected_code, **kwargs):
+        for k, v in kwargs.items():
+            k = '$%s' % k
+            v = '%s' % v
+            url = url.replace(k, v)
+            expected_loc = expected_loc.replace(k, v)
+        print('REDIR: %s => %s' % (url, expected_loc))
+        resp, body = self.do_get(url, expected_code)
+        self.assertEqual(resp.getheader('location'), expected_loc,
+                '\nGET "%s" got an unexpected redirect location:\n want: %s\n got:  %s'
+                % (url, expected_loc, resp.getheader('location')))
+
+    def assert_multischeme_redirect(self, partial_url, expected_loc, expected_code, **kwargs):
+        for scheme in ('http', 'https'):
+            self.assert_scheme_redirect(
+                    scheme + '://' + partial_url, expected_loc, expected_code, **kwargs)
+
+    def assert_temp_redirect(self, partial_url, expected_loc, **kwargs):
+        self.assert_multischeme_redirect(partial_url, expected_loc, 302, **kwargs)
+
+    def assert_permanent_redirect(self, partial_url, expected_loc, **kwargs):
+        self.assert_multischeme_redirect(partial_url, expected_loc, 301, **kwargs)
+
+    def test_yum(self):
+        for base in ('yum.k8s.io', 'yum.kubernetes.io'):
+            self.assert_temp_redirect(base, 'https://packages.cloud.google.com/yum/')
+            self.assert_temp_redirect(base + '/$id',
+                'https://packages.cloud.google.com/yum/$id', id=rand_num())
+
+    def test_apt(self):
+        for base in ('apt.k8s.io', 'apt.kubernetes.io'):
+            self.assert_temp_redirect(base, 'https://packages.cloud.google.com/apt/')
+            self.assert_temp_redirect(base + '/$id',
+                'https://packages.cloud.google.com/apt/$id', id=rand_num())
+
+class GoMetaParser(HTMLParser.HTMLParser, object):
+    def __init__(self):
+        super(GoMetaParser, self).__init__()
+        self.__go_meta_tags = dict()
+
+    def handle_starttag(self, tag, attrs):
+        if tag != "meta":
+            return
+
+        attrs = dict(attrs)
+        if attrs['name'] not in ('go-import', 'go-source'):
+            return
+
+        if 'content' not in attrs:
+            return
+
+        # remove extraneous whitespace from content value
+        content = ' '.join(attrs['content'].split())
+
+        self.__go_meta_tags[attrs['name']] = content
+
+    def go_meta_tag(self, name):
+        return self.__go_meta_tags.get(name)
+
+
+if __name__ == '__main__':
+    TARGET_IP = os.environ.get('TARGET_IP')
+    if not TARGET_IP:
+        print('Attempting to autodiscover service TARGET_IP, set env var to override...')
+        TARGET_IP = socket.gethostbyname('apt.k8s.io')
+        print('Testing against service at', TARGET_IP)
+    else:
+        print('TARGET_IP present in environment. Disabling SSL verification')
+        SSL_VERIFY_DISABLE = True
+    unittest.main()


### PR DESCRIPTION
This PR adds a new nginx instance under the `k8s-io-packages` app to handle requests for `apt.kubernetes.io` and `yum.kubernetes.io`. This app has been created as a clone of `k8s-io` app with `k8s-io` replaced with `k8s-io-packages`. Files unneeded for serving `apt.kubernetes.io` and `yum.kubernetes.io` redirects have been removed (e.g. `www-get` ConfigMap, tests for other endpoints).

The app is not yet deployed; I'll coordinated deploying the app with @upodroid. The deploy script has been modified to be compatible with this new app.

IP addresses have been created with https://github.com/kubernetes/k8s.io/pull/6156

There are three things that I'm unsure about:

- Do we want to move certificates for `apt.kubernetes.io` and `yum.kubernetes.io` to this app?
  - I left resources related to certificates in `apps/k8s-io` and I referenced the existing `k8s-io-tls` Secret. This is to make reverting/dropping this app easier
- I'm not sure if the default server configuration is correct, but we need it because of the `/_healthz` endpoint
- I made Release Managers as owners of this new app to make further approvals easier to handle

xref https://github.com/kubernetes/k8s.io/issues/6157

/assign @upodroid @ameukam 