### PR TITLE
Fix ConfigMap name for nginx deployment in k8s-io-packages

### DIFF
--- a/apps/k8s-io-packages/deployment.yaml
+++ b/apps/k8s-io-packages/deployment.yaml
@@ -26,7 +26,7 @@ spec:
       volumes:
       - name: nginx
         configMap:
-          name: nginx
+          name: nginx-packages
           # Map all keys to files.
       containers:
       - name: nginx


### PR DESCRIPTION
I forgot to update a reference to the nginx ConfigMap for the `k8s-io-packages` app, so this PR takes care of that.

/assign @upodroid 