### PR TITLE
kops-ci: Use container image for boostrap

### DIFF
--- a/infra/aws/terraform/kops-infra-ci/ecr.tf
+++ b/infra/aws/terraform/kops-infra-ci/ecr.tf
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+resource "aws_ecr_repository" "repo" {
+  provider             = aws.kops-local-ci
+  name                 = "eks-bootstrap"
+  image_tag_mutability = "IMMUTABLE"
+
+  tags = var.tags
+}

--- a/infra/aws/terraform/kops-infra-ci/eks.tf
+++ b/infra/aws/terraform/kops-infra-ci/eks.tf
@@ -119,20 +119,13 @@ module "eks" {
         }
       }
 
-      # NVMe instance store volumes are automatically enumerated and assigned a device
-      pre_bootstrap_user_data = <<-EOT
-        cat <<-EOF > /etc/profile.d/bootstrap.sh
-        #!/bin/sh
-
-        # Configure NVMe volumes in RAID0 configuration
-        # https://github.com/awslabs/amazon-eks-ami/blob/056e31f8c7477e893424abce468cb32bbcd1f079/files/bootstrap.sh#L35C121-L35C126
-        # Mount will be: /mnt/k8s-disks
-        export LOCAL_DISKS='raid0'
-        EOF
-
-        # Source extra environment variables in bootstrap script
-        sed -i '/^set -o errexit/a\\nsource /etc/profile.d/bootstrap.sh' /etc/eks/bootstrap.sh
-      EOT
+      bootstrap_extra_args = <<-EOT
+      # Bootstrap the instance using our bootstrap script embeded in a Docker image
+      [settings.bootstrap-containers.bootstrap]
+      source = "${aws_ecr_repository.repo.repository_url}:v0.0.1"
+      mode = "always"
+      essential = true
+    EOT
 
       metadata_options = {
         http_endpoint               = "enabled"

--- a/infra/aws/terraform/kops-infra-ci/resources/bootstrap/Dockerfile
+++ b/infra/aws/terraform/kops-infra-ci/resources/bootstrap/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# https://hub.docker.com/_/alpine
+# 3.18 as of 12/07/2023
+FROM alpine@sha256:34871e7290500828b39e22294660bee86d966bc0017544e848dd9a255cdf59e0
+
+RUN apk update \
+    && apk add --no-cache \
+        bash \
+        findutils \
+        util-linux \
+        xfsprogs
+
+ADD https://raw.githubusercontent.com/kubernetes/k8s.io/a8be6bcc88c61dc55ce0f6b888e7f4e6c0a5293d/infra/aws/terraform/prow-build-cluster/bootstrap_bottlerocket/node_bootstrap.sh /bootstrap.sh
+
+RUN chmod +x /bootstrap.sh
+
+ENTRYPOINT ["bash", "/bootstrap.sh"]

--- a/infra/aws/terraform/kops-infra-ci/resources/bootstrap/Makefile
+++ b/infra/aws/terraform/kops-infra-ci/resources/bootstrap/Makefile
@@ -1,0 +1,30 @@
+# Copyright 2023 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+AWS_ECR_ACCOUNT_ID ?= 808842816990
+AWS_ECR_REGION ?= us-east-2
+ # Keep that in sync with the terraform resource aws_ecr_repository.repo
+AWS_ECR_REPO ?= eks-bootstrap
+AWS_ECR_URI ?= $(AWS_ECR_ACCOUNT_ID).dkr.ecr.$(AWS_ECR_REGION).amazonaws.com
+TAG ?= v0.0.1
+
+ecr-login:
+	aws ecr get-login-password --region $(AWS_ECR_REGION) --profile kops-ci | docker login --username AWS --password-stdin $(AWS_ECR_URI)
+
+docker-build:
+	docker build --platform linux/amd64 -t $(AWS_ECR_REPO):$(TAG) -f Dockerfile .
+
+push: docker-build ecr-login
+	docker tag $(AWS_ECR_REPO):$(TAG) $(AWS_ECR_URI)/$(AWS_ECR_REPO):$(TAG)
+	docker push $(AWS_ECR_URI)/$(AWS_ECR_REPO):$(TAG)


### PR DESCRIPTION
Follow-up of:
  - https://github.com/kubernetes/k8s.io/pull/6148

Use a custom image for bootstrap since Bottlerocket only TOML format for bootstrap