### PR TITLE
SIG Autoscaling - New Mailing List for Karpenter Subproject leads

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -51,6 +51,7 @@ restrictions:
     allowedGroups:
       - "^k8s-infra-staging-autoscaling@kubernetes.io$"
       - "^sig-autoscaling-leads@kubernetes.io$"
+      - "^sig-autoscaling-karpenter-leads@kubernetes.io$"
   - path: "sig-cli/groups.yaml"
     allowedGroups:
       - "^sig-cli-leads@kubernetes.io$"

--- a/groups/sig-autoscaling/groups.yaml
+++ b/groups/sig-autoscaling/groups.yaml
@@ -20,6 +20,25 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
 
+  - email-id: sig-autoscaling-karpenter-leads@kubernetes.io
+    name: sig-autoscaling-karpenter-leads
+    description: |-
+      Karpenter Subproject leads
+    owners:
+      - ellistarn@gmail.com
+      - jonathan.innis.ji@gmail.com
+      - toddneal@protonmail.com
+      - bmwagner10@gmail.com
+      - ntranicholas@gmail.com
+      - alex.leites@gmail.com
+      - amanueng@gmail.com
+      - dealj@umich.edu
+    settings:
+      AllowWebPosting: "true"
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+
   #
   # k8s-staging write access for SIG-owned subprojects
   #


### PR DESCRIPTION
Creating a new mailing list for Karpenter subproject leads - currently setting this to all current [maintainers and reviewers](https://github.com/kubernetes-sigs/karpenter/blob/main/OWNERS_ALIASES#L8-L18) (missing @jackfrancis's email currently).


