### PR TITLE
Double resources for EKS Prow build cluster Prometheus

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/prometheus-main/prometheus.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/prometheus-main/prometheus.yaml
@@ -24,11 +24,11 @@ spec:
       prometheus: main
   resources:
     requests:
-      cpu: 2
-      memory: 16Gi
+      cpu: 4
+      memory: 32Gi
     limits:
-      cpu: 2
-      memory: 16Gi
+      cpu: 4
+      memory: 32Gi
   replicas: 1
   logLevel: info
   logFormat: logfmt


### PR DESCRIPTION
Prometheus in the EKS Prow build cluster started CrashLooping as of recently:

```
prometheus-main-0                      1/2     CrashLoopBackOff   20 (2m29s ago)   135m
```

The reason is `OOMKilled`:

```
    Last State:  Terminated
      Reason:    OOMKilled
      Message:   <redacted for brevity>
      Exit Code:    137
      Started:      Fri, 08 Dec 2023 14:05:11 +0100
      Finished:     Fri, 08 Dec 2023 14:07:59 +0100
```

/assign @ameukam @rjsadow 