### PR TITLE
kOps: Add a public hosted zone.

### DIFF
--- a/dns/zone-configs/k8s.io._2_aws.yaml
+++ b/dns/zone-configs/k8s.io._2_aws.yaml
@@ -6,3 +6,10 @@ test-cncf-aws:
   - ns-1825.awsdns-36.co.uk.
   - ns-265.awsdns-33.com.
   - ns-687.awsdns-21.net.
+tests-kops-aws:
+  type: NS
+  values:
+  - ns-319.awsdns-39.com.
+  - ns-557.awsdns-05.net.
+  - ns-1091.awsdns-08.org.
+  - ns-1922.awsdns-48.co.uk.

--- a/infra/aws/terraform/kops-infra-ci/vpc.tf
+++ b/infra/aws/terraform/kops-infra-ci/vpc.tf
@@ -88,6 +88,7 @@ module "vpc" {
   flow_log_cloudwatch_log_group_retention_in_days = 30
 
   enable_dns_hostnames = true
+  enable_dns_support   = true
 
   public_subnet_tags = {
     "kubernetes.io/role/elb" = 1
@@ -146,6 +147,15 @@ module "vpc_endpoints" {
         tags                = { Name = "${local.prefix}-${service}" }
       }
   })
+
+  tags = var.tags
+}
+
+// Required by kOps CI
+resource "aws_route53_zone" "hosted_zone" {
+  provider = aws.kops-local-ci
+
+  name = "tests-kops-aws.k8s.io"
 
   tags = var.tags
 }


### PR DESCRIPTION
Add a public hosted zone required for the E2E tests running inside AWS.