### PR TITLE
promote image gcr.io/k8s-staging-cloud-pv-labeler/cloud-pv-admission-labeler:v0.3.0

### DIFF
--- a/registry.k8s.io/images/k8s-staging-cloud-pv-labeler/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-cloud-pv-labeler/images.yaml
@@ -1,1 +1,3 @@
-# No images yet
+- name: cloud-pv-admission-labeler
+  dmap:
+    "sha256:72f2393188f3a2b43415f3dd5508d95e7d233b7f767dcd462962bdeff7fdd353": ["v0.3.0"]


### PR DESCRIPTION
```
$ docker pull gcr.io/k8s-staging-cloud-pv-labeler/cloud-pv-admission-labeler:v0.3.0
v0.3.0: Pulling from k8s-staging-cloud-pv-labeler/cloud-pv-admission-labeler
Digest: sha256:72f2393188f3a2b43415f3dd5508d95e7d233b7f767dcd462962bdeff7fdd353
Status: Image is up to date for gcr.io/k8s-staging-cloud-pv-labeler/cloud-pv-admission-labeler:v0.3.0
gcr.io/k8s-staging-cloud-pv-labeler/cloud-pv-admission-labeler:v0.3.0
```