### PR TITLE
Configure logs in httpRequest format - legacy

### DIFF
--- a/apps/k8s-io-packages/configmap-nginx.yaml
+++ b/apps/k8s-io-packages/configmap-nginx.yaml
@@ -31,6 +31,34 @@ data:
       # Vanity redirect rules.
       #
 
+      # https://geko.cloud/en/forward-real-ip-to-a-nginx-behind-a-gcp-load-balancer/
+      set_real_ip_from 2600:1901:0:95e7::; # LB IP
+      set_real_ip_from 34.128.166.11/32; # LB IP
+      set_real_ip_from 130.211.0.0/22; # IP SRC range for GCP Load Balancers
+      set_real_ip_from 35.191.0.0/16; # IP SRC range for GCP Load Balancers
+      real_ip_header X-Forwarded-For;
+      real_ip_recursive on;
+
+      log_format json_combined escape=json
+        '{'
+          '"time":"$msec",'
+          '"httpRequest":{'
+            '"requestMethod":"$request_method",'
+            '"requestUrl":"$scheme://$host$request_uri",'
+            '"requestSize":$request_length,'
+            '"status":"$status",'
+            '"responseSize":$bytes_sent,'
+            '"userAgent":"$http_user_agent",'
+            '"remoteIp":"$remote_addr",'
+            '"serverIp":"$server_addr",'
+            '"referer":"$http_referer",'
+            '"latency":"${request_time}s",'
+            '"protocol":"$server_protocol"'
+          '}'
+        '}';
+
+      access_log /dev/stdout json_combined;
+
       server {
         server_name legacy.apt.kubernetes.io legacy.apt.k8s.io;
         listen 80;

--- a/apps/k8s-io-packages/deploy.sh
+++ b/apps/k8s-io-packages/deploy.sh
@@ -81,7 +81,7 @@ function deploy() {
     done
 
     # We can only test IPv4 from within GCP.
-    all_ips=$("${kubectl[@]}" get ing k8s-io-packages -o go-template='{{range .status.loadBalancer.ingress}}{{.ip}}{{end}}')
+    all_ips=$("${kubectl[@]}" get ing k8s-io-packages --namespace="${namespace}" -o go-template='{{range .status.loadBalancer.ingress}}{{.ip}}{{end}}')
 
     for ip in $all_ips; do
         echo "Testing TARGET_IP=$ip"


### PR DESCRIPTION
I configured nginx to parse the logs into a [httpRequest](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#HttpRequest) for easy analysis.

We can apply the same to the production redirector as well.

/cc @BenTheElder @ameukam @xmudrii 