### PR TITLE
Update OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -69,6 +69,7 @@ aliases:
     - jeremyot
     - pmorie
   sig-network-leads:
+    - aojea
     - danwinship
     - mikezappa87
     - shaneutt


### PR DESCRIPTION
add aojea to sig-net leads

Ref: https://github.com/kubernetes/community/issues/7650