### PR TITLE
Sync NPD owners with upstream and add myself as approver

### DIFF
--- a/registry.k8s.io/images/k8s-staging-npd/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-npd/OWNERS
@@ -1,5 +1,15 @@
-approvers:
+reviewers:
   - Random-Liu
-  - dchen1107
   - andyxning
   - wangzhen127
+  - xueweiz
+  - vteratipally
+  - mmiranda96
+  - hakman
+approvers:
+  - Random-Liu
+  - andyxning
+  - wangzhen127
+  - xueweiz
+  - vteratipally
+  - hakman


### PR DESCRIPTION
Someone needs to be able to promote images, like https://github.com/kubernetes/k8s.io/pull/6241.
Ref: https://github.com/kubernetes/node-problem-detector/blob/master/OWNERS

/cc @upodroid @ameukam 