### PR TITLE
eks-prow-build: introduce stable node group

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/eks.tf
+++ b/infra/aws/terraform/prow-build-cluster/eks.tf
@@ -106,5 +106,6 @@ module "eks" {
   eks_managed_node_groups = {
     build-blue  = local.node_group_build_blue
     build-green = local.node_group_build_green
+    stable      = local.node_group_stable
   }
 }

--- a/infra/aws/terraform/prow-build-cluster/node_group_green.tf
+++ b/infra/aws/terraform/prow-build-cluster/node_group_green.tf
@@ -33,10 +33,6 @@ locals {
 
     iam_role_permissions_boundary = data.aws_iam_policy.eks_resources_permission_boundary.arn
 
-    # TODO(xmudrii-ubuntu): Temporarily disabled because it's not supported by Bottlerocket Linux
-    # ami_id                     = var.node_ami_blue
-    # enable_bootstrap_user_data = true
-
     ami_type             = "BOTTLEROCKET_x86_64"
     platform             = "bottlerocket"
     bootstrap_extra_args = <<-EOT

--- a/infra/aws/terraform/prow-build-cluster/node_group_stable.tf
+++ b/infra/aws/terraform/prow-build-cluster/node_group_stable.tf
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors.
+Copyright 2024 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/infra/aws/terraform/prow-build-cluster/node_group_stable.tf
+++ b/infra/aws/terraform/prow-build-cluster/node_group_stable.tf
@@ -15,21 +15,21 @@ limitations under the License.
 */
 
 locals {
-  node_group_build_blue = {
-    name            = "build-managed-blue"
-    description     = "EKS managed node group called blue used to facilitate node rotations/rollouts"
+  node_group_stable = {
+    name            = "managed-stable"
+    description     = "EKS managed node group called stable used for stateful components"
     use_name_prefix = true
 
-    cluster_version = var.node_group_version_blue
+    cluster_version = var.node_group_version_stable
 
-    taints = var.node_taints_blue
-    labels = var.node_labels_blue
+    taints = var.node_taints_stable
+    labels = var.node_labels_stable
 
     subnet_ids = module.vpc.public_subnets
 
-    min_size     = var.node_min_size_blue
-    max_size     = var.node_max_size_blue
-    desired_size = var.node_desired_size_blue
+    min_size     = var.node_desired_size_stable
+    max_size     = var.node_desired_size_stable
+    desired_size = var.node_desired_size_stable
 
     iam_role_permissions_boundary = data.aws_iam_policy.eks_resources_permission_boundary.arn
 
@@ -62,7 +62,7 @@ locals {
     pre_bootstrap_user_data = file("${path.module}/bootstrap/node_bootstrap.sh")
 
     capacity_type  = "ON_DEMAND"
-    instance_types = var.node_instance_types_blue
+    instance_types = var.node_instance_types_stable
 
     ebs_optimized     = true
     enable_monitoring = true
@@ -95,8 +95,7 @@ locals {
 
     tags = merge(
       local.tags,
-      local.auto_scaling_tags,
-      var.additional_node_group_tags_blue
+      var.additional_node_group_tags_stable
     )
   }
 }

--- a/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
@@ -34,28 +34,33 @@ cluster_name               = "prow-canary-cluster"
 cluster_version            = "1.28"
 node_group_version_blue    = "1.28"
 node_group_version_green   = "1.28"
+node_group_version_stable  = "1.28"
 cluster_autoscaler_version = "v1.28.0"
 
-# Ubuntu EKS optimized AMI: https://cloud-images.ubuntu.com/aws-eks/
-node_ami_blue = "ami-0d9ec2930add3de7d"
-# TODO(xmudrii-ubuntu): Temporarily bumped instance size from r5d.xlarge to r5ad.2xlarge to be able to run more jobs
-node_instance_types_blue = ["r5ad.2xlarge"]
+node_instance_types_blue   = ["r5ad.2xlarge"]
+node_instance_types_green  = ["r5ad.2xlarge"]
+node_instance_types_stable = ["r5ad.2xlarge"]
 
 node_min_size_blue     = 0
 node_max_size_blue     = 1
 node_desired_size_blue = 0
 
-node_ami_green = "ami-0d9ec2930add3de7d"
-# TODO(xmudrii-ubuntu): Temporarily bumped instance size from r5d.xlarge to r5ad.2xlarge to be able to run more jobs
-node_instance_types_green = ["r5ad.2xlarge"]
+node_min_size_green     = 1
+node_max_size_green     = 1
+node_desired_size_green = 1
 
-node_min_size_green     = 3
-node_max_size_green     = 3
-node_desired_size_green = 3
+node_desired_size_stable = 2
 
-node_taints_green = []
-
-node_labels_green = {}
+node_taints_stable = [
+  {
+    key    = "node-group"
+    value  = "stable"
+    effect = "NO_SCHEDULE"
+  }
+]
+node_labels_stable = {
+  "node-group" = "stable"
+}
 
 node_volume_size = 100
 

--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -36,22 +36,33 @@ cluster_name               = "prow-build-cluster"
 cluster_version            = "1.28"
 node_group_version_blue    = "1.28"
 node_group_version_green   = "1.28"
+node_group_version_stable  = "1.28"
 cluster_autoscaler_version = "v1.28.0"
 
-# Ubuntu EKS optimized AMI: https://cloud-images.ubuntu.com/aws-eks/
-node_ami_blue            = "ami-0d9ec2930add3de7d"
-node_instance_types_blue = ["r5ad.4xlarge"]
+node_instance_types_blue   = ["r5ad.4xlarge"]
+node_instance_types_green  = ["r5ad.4xlarge"]
+node_instance_types_stable = ["r5ad.2xlarge"]
 
 node_min_size_blue     = 20
 node_max_size_blue     = 70
 node_desired_size_blue = 20
 
-node_ami_green            = "ami-0d9ec2930add3de7d"
-node_instance_types_green = ["r5ad.4xlarge"]
-
 node_min_size_green     = 0
 node_max_size_green     = 1
 node_desired_size_green = 0
+
+node_desired_size_stable = 3
+
+node_taints_stable = [
+  {
+    key    = "node-group"
+    value  = "stable"
+    effect = "NO_SCHEDULE"
+  }
+]
+node_labels_stable = {
+  "node-group" = "stable"
+}
 
 node_volume_size = 100
 

--- a/infra/aws/terraform/prow-build-cluster/variables.tf
+++ b/infra/aws/terraform/prow-build-cluster/variables.tf
@@ -93,14 +93,9 @@ variable "node_group_version_green" {
   description = "Kubernetes version of the EKS-managed node group (green)"
 }
 
-variable "node_ami_blue" {
+variable "node_group_version_stable" {
   type        = string
-  description = "EKS optimized AMI to be used for blue Node groups"
-}
-
-variable "node_ami_green" {
-  type        = string
-  description = "EKS optimized AMI to be used for green node group"
+  description = "Kubernetes version of the EKS-managed node group (stable)"
 }
 
 variable "node_instance_types_blue" {
@@ -111,6 +106,11 @@ variable "node_instance_types_blue" {
 variable "node_instance_types_green" {
   type        = list(string)
   description = "Instance sizes to use for green EKS node group"
+}
+
+variable "node_instance_types_stable" {
+  type        = list(string)
+  description = "Instance sizes to use for stable EKS node group"
 }
 
 variable "node_volume_size" {
@@ -148,6 +148,11 @@ variable "node_desired_size_green" {
   description = "Desired number of nodes in the green EKS node group"
 }
 
+variable "node_desired_size_stable" {
+  type        = number
+  description = "Desired number of nodes in the stable EKS node group"
+}
+
 variable "node_max_unavailable_percentage" {
   type        = number
   description = "Maximum unavailable nodes in a node group"
@@ -163,6 +168,11 @@ variable "node_taints_green" {
   default = []
 }
 
+variable "node_taints_stable" {
+  type    = list(map(string))
+  default = []
+}
+
 variable "node_labels_blue" {
   type    = map(string)
   default = {}
@@ -173,12 +183,22 @@ variable "node_labels_green" {
   default = {}
 }
 
+variable "node_labels_stable" {
+  type    = map(string)
+  default = {}
+}
+
 variable "additional_node_group_tags_blue" {
   type    = map(string)
   default = {}
 }
 
 variable "additional_node_group_tags_green" {
+  type    = map(string)
+  default = {}
+}
+
+variable "additional_node_group_tags_stable" {
   type    = map(string)
   default = {}
 }


### PR DESCRIPTION
Some components are not taking often node rotations well:

- Flux: a lot of alerts coming into `#k8s-infra-alerts` upon evicting/rescheduling Flux pods
- KubeCost: it's watching pods and their resource usage all the time, as well as, has integrated Prometheus
- Our monitoring stack: same as KubeCost

To mitigate this issue, I created a stable node group, that's not autoscaled, with three nodes. This node group is tainted and it's only going to run these components (and potentially some other components that might benefit from this).

This PR is the first part, there'll be another PR to change manifests for these components. Terraform changes are already applied and the node group has been successfully created.