### PR TITLE
[1.30] Updates google groups for v1.30 release

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -47,7 +47,7 @@ groups:
       - jameswangel@gmail.com
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
-      - markrossetti@gmail.com # 1.29 Release Manager associate
+      - markrossetti@gmail.com # 1.30 Release Manager
       - mudrinic.mare@gmail.com
       - nng.grace@gmail.com
       - pal.nabarun95@gmail.com
@@ -65,17 +65,18 @@ groups:
       - k8s-infra-google-build-admins@kubernetes.io
       - ameukam@gmail.com
       - cicih@google.com
+      - fsmunoz@gmail.com # 1.30 RT Lead Shadow
       - jameswangel@gmail.com
       - joseph.r.sandoval@gmail.com
+      - kat.cosgrove@gmail.com # 1.30 RT Lead
       - pal.nabarun95@gmail.com
-      - markrossetti@gmail.com # 1.29 Release Manager associate
-      - marosset@microsoft.com # 1.29 Release Manager associate
-      - mehabhalodiya@gmail.com # 1.29 Lead Shadow
-      - m.r.boxell@gmail.com # 1.29 Lead Shadow
-      - neoaggelos@gmail.com # 1.29 Lead Shadow
-      - priyankasaggu11929@gmail.com # 1.29 Lead
-      - ramses.green.2@gmail.com # 1.29 Lead Shadow
-      - xandergrzyw@gmail.com # 1.29 Emeritus Advisor
+      - markrossetti@gmail.com # 1.30 Release Manager
+      - marosset@microsoft.com # 1.30 Release Manager
+      - neoaggelos@gmail.com # 1.30 RT Lead Shadow
+      - nng.grace@gmail.com # 1.30 RT EA
+      - ramses.green.2@gmail.com # 1.30 RT Lead Shadow
+      - rodomar@outlook.com # 1.30 RT Lead Shadow
+      - sanchita.mishra1718@gmail.com # 1.30 RT Lead Shadow
 
   - email-id: k8s-infra-staging-artifact-promoter@kubernetes.io
     name: k8s-infra-staging-artifact-promoter
@@ -205,17 +206,16 @@ groups:
       - k8s@auggie.dev
       - saschagrunert@gmail.com
     members:
-      - abigailkmccarthy@gmail.com # 1.29 Comms Shadow
-      - hkamel.msft@gmail.com # 1.29 Comms Shadow
-      - james@quigley.us # 1.29 Comms Shadow
-      - kcmartin2@mac.com # 1.29 Comms Shadow
-      - mehabhalodiya@gmail.com # 1.29 Lead Shadow
-      - m.r.boxell@gmail.com # 1.29 Lead Shadow
-      - neoaggelos@gmail.com # 1.29 Lead Shadow
-      - priyankasaggu11929@gmail.com # 1.29 Lead
-      - ramses.green.2@gmail.com # 1.29 Lead Shadow
-      - xandergrzyw@gmail.com # 1.29 Emeritus Advisor
-      - valencia0.carol@gmail.com # 1.29 Comms Lead
+      - abigailkmccarthy@gmail.com # 1.30 Comms Shadow
+      - amit@odysseycloud.io # 1.30 Comms Shadow
+      - frederick@kautz.dev # 1.30 Comms Shadow
+      - fsmunoz@gmail.com # 1.30 RT Lead Shadow
+      - kat.cosgrove@gmail.com # 1.30 RT Lead
+      - kcmartin2@mac.com # 1.30 Comms Lead
+      - natalivlatko@gmail.com # 1.30 Comms Shadow
+      - neoaggelos@gmail.com # 1.30 RT Lead Shadow
+      - ramses.green.2@gmail.com # 1.30 RT Lead Shadow
+      - sanchita.mishra1718@gmail.com # 1.30 RT Lead Shadow
 
   - email-id: release-managers-private@kubernetes.io
     name: release-managers-private
@@ -260,17 +260,18 @@ groups:
       - antheabjung@gmail.com
       - augustus@cisco.com
       - bentheelder@google.com
+      - fsmunoz@gmail.com # 1.30 RT Lead Shadow
       - gmccloskey@google.com
       - jameswangel@gmail.com
       - joseph.r.sandoval@gmail.com
+      - kat.cosgrove@gmail.com # 1.30 RT Lead
+      - markrossetti@gmail.com # 1.30 Release Manager
+      - marosset@microsoft.com # 1.30 Release Manager
       - mudrinic.mare@gmail.com
       - spiffxp@google.com
-      - mehabhalodiya@gmail.com # 1.29 Lead Shadow
-      - m.r.boxell@gmail.com # 1.29 Lead Shadow
-      - neoaggelos@gmail.com # 1.29 Lead Shadow
-      - priyankasaggu11929@gmail.com # 1.29 Lead
-      - ramses.green.2@gmail.com # 1.29 Lead Shadow
-      - xandergrzyw@gmail.com # 1.29 Emeritus Advisor
+      - neoaggelos@gmail.com # 1.30 Lead Shadow
+      - ramses.green.2@gmail.com # 1.30 Lead Shadow
+      - sanchita.mishra1718@gmail.com # 1.30 RT Lead Shadow
 
   - email-id: security-release-team@kubernetes.io
     name: security-release-team
@@ -317,47 +318,43 @@ groups:
       - k8s@auggie.dev
       - saschagrunert@gmail.com
     managers:
-      - mehabhalodiya@gmail.com # 1.29 Lead Shadow
-      - m.r.boxell@gmail.com # 1.29 Lead Shadow
-      - neoaggelos@gmail.com # 1.29 Lead Shadow
-      - priyankasaggu11929@gmail.com # 1.29 Lead
-      - ramses.green.2@gmail.com # 1.29 Lead Shadow
-      - xandergrzyw@gmail.com # 1.29 Emeritus Advisor
+      - fsmunoz@gmail.com # 1.30 RT Lead Shadow
+      - nng.grace@gmail.com # 1.30 RT EA
+      - kat.cosgrove@gmail.com # 1.30 RT Lead
+      - neoaggelos@gmail.com # 1.30 Lead Shadow
+      - ramses.green.2@gmail.com # 1.30 Lead Shadow
+      - sanchita.mishra1718@gmail.com # 1.30 RT Lead Shadow
     members:
-      - abigailkmccarthy@gmail.com # 1.29 Communications Shadow
-      - AnaMMedina21@gmail.com # 1.29 Enhancements Shadow
-      - bradmccoydev@gmail.com # 1.29 Bug Triage Shadow
-      - drewhagendev@gmail.com # 1.29 Docs Shadow
-      - egbunaoluebube@gmail.com # 1.29 Docs Shadow
-      - faeka6@gmail.com # 1.29 Release Notes Shadow
-      - fsmunoz@gmail.com # 1.29 Release Notes Lead
-      - harshitasao@gmail.com # 1.29 Docs Shadow
-      - hkamel.msft@gmail.com # 1.29 Communications Shadow
-      - jackhammervyom@gmail.com # 1.29 CI Signal Lead
-      - james@quigley.us # 1.29 Communications Shadow
-      - kat.cosgrove@gmail.com # 1.29 Docs Lead
-      - kcmartin2@mac.com # 1.29 Communications Shadow
-      - mankulka@redhat.com # 1.29 CI Signal Shadow
-      - markrossetti@gmail.com # 1.29 Release Manager associate
-      - marosset@microsoft.com # 1.29 Release Manager associate
-      - maryam_tavakkoli@hotmail.com # 1.29 Bug Triage Shadow
-      - mengjiao.liu@daocloud.io # 1.29 Release Notes Shadow
-      - mofi@google.com # 1.29 Bug Triage Shadow
-      - mr.salehsedghpour@yahoo.com # 1.29 Enhancements Shadow
-      - msha.harshadithya@gmail.com # 1.29 Release Notes Shadow
-      - ninapolshakova@gmail.com # 1.29 Enhancements Lead
-      - paco.xu@daocloud.io # 1.29 CI Signal Shadow
-      - rayandas91@gmail.com # 1.29 Enhancements Shadow
-      - richard.j.sadowski@gmail.com # 1.29 CI Signal Shadow
-      - sanchita.mishra1718@gmail.com # 1.29 Enhancements Shadow
-      - singh.reeta66@gmail.com # 1.29 CI Signal Shadow
-      - smith.rashan@gmail.com # 1.29 Release Notes Shadow
-      - sontek@gmail.com # 1.29 CI Signal Shadow
-      - sreeram.venkitesh@bigbinary.com # 1.29 Enhancements Shadow
-      - taniaduggal60@gmail.com # 1.29 Docs Shadow
-      - valencia0.carol@gmail.com # 1.29 Comms Lead
-      - yigit.demirbas@gmail.com # 1.29 Bug Triage Lead
-      - zelikangelina@gmail.com # 1.29 Bug Triage Shadow
+      - abigailkmccarthy@gmail.com # 1.30 Communications Shadow
+      - amit@odysseycloud.io # 1.30 Communications Shadow
+      - AnaMMedina21@gmail.com # 1.30 Enhancements Shadow
+      - celeste.e.horgan@gmail.com # 1.30 Docs Shadow
+      - danieljoshuachan@gmail.com # 1.30 Docs Shadow
+      - drewhagendev@gmail.com # 1.30 Docs Lead
+      - egbunaoluebube@gmail.com # 1.30 Docs Shadow
+      - faeka6@gmail.com # 1.30 Release Notes Shadow
+      - frederick@kautz.dev # 1.30 Communications Shadow
+      - jackhammervyom@gmail.com # 1.30 Docs Shadow
+      - kcmartin2@mac.com # 1.30 Communications Lead
+      - orlin@orlix.org # 1.30 Release Notes Shadow
+      - m.r.boxell@gmail.com # 1.30 Enhancements Shadow
+      - markrossetti@gmail.com # 1.30 Release Manager
+      - marosset@microsoft.com # 1.30 Release Manager
+      - maryam_tavakkoli@hotmail.com # 1.30 Release Signal Shadow
+      - megan@defenseunicorns.com # 1.30 Enhancements Shadow
+      - mofi@google.com # 1.30 Release Signal Shadow
+      - mr.salehsedghpour@yahoo.com # 1.30 Enhancements Lead
+      - namanlakhwani@gmail.com # 1.30 Release Signal Shadow
+      - natalivlatko@gmail.com # 1.30 Communications Shadow
+      - ninapolshakova@gmail.com # 1.30 Release Notes Shadow
+      - paco.xu@daocloud.io # 1.30 Release Signal Lead
+      - pnigelbrown@gmail.com # 1.30 Enhancements Shadow
+      - satyampsoni@gmail.com # 1.30 Release Notes Shadow
+      - smith.rashan@gmail.com # 1.30 Release Notes Lead
+      - sreeram.venkitesh@bigbinary.com # 1.30 Enhancements Shadow
+      - subhasmitaswain232@gmail.com # 1.30 Release Signal Shadow
+      - tyler.schade@solo.io # 1.30 Enhancements Shadow
+      - zelikangelina@gmail.com # 1.30 Release Signal Shadow
   - email-id: release-team-shadows@kubernetes.io
     name: release-team-shadows
     description: |-
@@ -374,41 +371,36 @@ groups:
       - k8s@auggie.dev
       - saschagrunert@gmail.com
     managers:
-      - priyankasaggu11929@gmail.com # 1.29 Lead
-      - xandergrzyw@gmail.com # 1.29 Emeritus Advisor
+      - kat.cosgrove@gmail.com # 1.30 RT Lead
+      - nng.grace@gmail.com # 1.30 RT EA
     members:
-      - abigailkmccarthy@gmail.com # 1.29 Communications Shadow
-      - AnaMMedina21@gmail.com # 1.29 Enhancements Shadow
-      - bradmccoydev@gmail.com # 1.29 Bug Triage Shadow
-      - drewhagendev@gmail.com # 1.29 Docs Shadow
-      - egbunaoluebube@gmail.com # 1.29 Docs Shadow
-      - faeka6@gmail.com # 1.29 Release Notes Shadow
-      - harshitasao@gmail.com # 1.29 Docs Shadow
-      - hkamel.msft@gmail.com # 1.29 Communications Shadow
-      - james@quigley.us # 1.29 Communications Shadow
-      - kcmartin2@mac.com # 1.29 Communications Shadow
-      - m.r.boxell@gmail.com # 1.29 Lead Shadow
-      - mankulka@redhat.com # 1.29 CI Signal Shadow
-      - markrossetti@gmail.com # 1.29 Release Manager associate
-      - marosset@microsoft.com # 1.29 Release Manager associate
-      - maryam_tavakkoli@hotmail.com # 1.29 Bug Triage Shadow
-      - mehabhalodiya@gmail.com # 1.29 Lead Shadow
-      - mengjiao.liu@daocloud.io # 1.29 Release Notes Shadow
-      - mofi@google.com # 1.29 Bug Triage Shadow
-      - mr.salehsedghpour@yahoo.com # 1.29 Enhancements Shadow
-      - msha.harshadithya@gmail.com # 1.29 Release Notes Shadow
-      - neoaggelos@gmail.com # 1.29 Lead Shadow
-      - paco.xu@daocloud.io # 1.29 CI Signal Shadow
-      - ramses.green.2@gmail.com # 1.29 Lead Shadow
-      - rayandas91@gmail.com # 1.29 Enhancements Shadow
-      - richard.j.sadowski@gmail.com # 1.29 CI Signal Shadow
-      - sanchita.mishra1718@gmail.com # 1.29 Enhancements Shadow
-      - singh.reeta66@gmail.com # 1.29 CI Signal Shadow
-      - smith.rashan@gmail.com # 1.29 Release Notes Shadow
-      - sontek@gmail.com # 1.29 CI Signal Shadow
-      - sreeram.venkitesh@bigbinary.com # 1.29 Enhancements Shadow
-      - taniaduggal60@gmail.com # 1.29 Docs Shadow
-      - zelikangelina@gmail.com # 1.29 Bug Triage Shadow
+      - abigailkmccarthy@gmail.com # 1.30 Communications Shadow
+      - amit@odysseycloud.io # 1.30 Communications Shadow
+      - AnaMMedina21@gmail.com # 1.30 Enhancements Shadow
+      - celeste.e.horgan@gmail.com # 1.30 Docs Shadow
+      - danieljoshuachan@gmail.com # 1.30 Docs Shadow
+      - egbunaoluebube@gmail.com # 1.30 Docs Shadow
+      - faeka6@gmail.com # 1.30 Release Notes Shadow
+      - frederick@kautz.dev # 1.30 Communications Shadow
+      - fsmunoz@gmail.com # 1.30 RT Lead Shadow
+      - jackhammervyom@gmail.com # 1.30 Docs Shadow
+      - orlin@orlix.org # 1.30 Release Notes Shadow
+      - m.r.boxell@gmail.com # 1.30 Enhancements Shadow
+      - maryam_tavakkoli@hotmail.com # 1.30 Release Signal Shadow
+      - megan@defenseunicorns.com # 1.30 Enhancements Shadow
+      - mofi@google.com # 1.30 Release Signal Shadow
+      - namanlakhwani@gmail.com # 1.30 Release Signal Shadow
+      - natalivlatko@gmail.com # 1.30 Communications Shadow
+      - neoaggelos@gmail.com # 1.30 Lead Shadow
+      - ninapolshakova@gmail.com # 1.30 Release Notes Shadow
+      - pnigelbrown@gmail.com # 1.30 Enhancements Shadow
+      - ramses.green.2@gmail.com # 1.30 Lead Shadow
+      - sanchita.mishra1718@gmail.com # 1.30 RT Lead Shadow
+      - satyampsoni@gmail.com # 1.30 Release Notes Shadow
+      - sreeram.venkitesh@bigbinary.com # 1.30 Enhancements Shadow
+      - subhasmitaswain232@gmail.com # 1.30 Release Signal Shadow
+      - tyler.schade@solo.io # 1.30 Enhancements Shadow
+      - zelikangelina@gmail.com # 1.30 Release Signal Shadow
 
   # RBAC groups:
   # - grant access to the `namespace-user` role for a single namespace on the `aaa` cluster
@@ -451,13 +443,13 @@ groups:
       ReconcileMembers: "true"
       WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW"
     members:
-      - jackhammervyom@gmail.com # 1.29 CI Signal Lead
       - k8s-infra-release-viewers@kubernetes.io
-      - mankulka@redhat.com # 1.29 CI Signal Shadow
-      - paco.xu@daocloud.io # 1.29 CI Signal Shadow
-      - richard.j.sadowski@gmail.com # 1.29 CI Signal Shadow
-      - singh.reeta66@gmail.com # 1.29 CI Signal Shadow
-      - sontek@gmail.com # 1.29 CI Signal Shadow
+      - maryam_tavakkoli@hotmail.com # 1.30 Release Signal Shadow
+      - mofi@google.com # 1.30 Release Signal Shadow
+      - namanlakhwani@gmail.com # 1.30 Release Signal Shadow
+      - paco.xu@daocloud.io # 1.30 Release Signal
+      - subhasmitaswain232@gmail.com # 1.30 Release Signal Shadow
+      - zelikangelina@gmail.com # 1.30 Release Signal Shadow
 
   - email-id: release-team-enhancements@kubernetes.io
     name: release-team-enhancements
@@ -475,16 +467,17 @@ groups:
       - k8s@auggie.dev
       - saschagrunert@gmail.com
     members:
-      - m.r.boxell@gmail.com # 1.29 Lead Shadow
-      - mehabhalodiya@gmail.com # 1.29 Lead Shadow
-      - mr.salehsedghpour@yahoo.com # 1.29 Enhancements Shadow
-      - neoaggelos@gmail.com # 1.29 Lead Shadow
-      - ninapolshakova@gmail.com # 1.29 Enhancements Lead
-      - priyankasaggu11929@gmail.com # 1.29 Release Lead
-      - ramses.green.2@gmail.com # 1.29 Lead Shadow
-      - rayandas91@gmail.com # 1.29 Enhancements Shadow
-      - sanchita.mishra1718@gmail.com # 1.29 Enhancements Shadow
-      - sreeram.venkitesh@bigbinary.com # 1.29 Enhancements Shadow
+      - AnaMMedina21@gmail.com # 1.30 Enhancements Shadow
+      - kat.cosgrove@gmail.com # 1.30 RT Lead
+      - m.r.boxell@gmail.com # 1.30 Enhancements Shadow
+      - mr.salehsedghpour@yahoo.com # 1.30 Enhancements Lead
+      - megan@defenseunicorns.com # 1.30 Enhancements Shadow
+      - neoaggelos@gmail.com # 1.30 Lead Shadow
+      - pnigelbrown@gmail.com # 1.30 Enhancements Shadow
+      - ramses.green.2@gmail.com # 1.30 Lead Shadow
+      - sanchita.mishra1718@gmail.com # 1.30 RT Lead Shadow
+      - sreeram.venkitesh@bigbinary.com # 1.30 Enhancements Shadow
+      - tyler.schade@solo.io # 1.30 Enhancements Shadow
 
   - email-id: k8s-infra-staging-zeitgeist@kubernetes.io
     name: k8s-infra-staging-zeitgeist


### PR DESCRIPTION
Adding release team to appropriate Google Groups/GCP IAM for v1.30 cycle.

cc: @kubernetes/sig-release-leads 