### PR TITLE
Fix cloud-provider-openstack approvers

### DIFF
--- a/registry.k8s.io/images/k8s-staging-provider-os/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-provider-os/OWNERS
@@ -1,5 +1,5 @@
 approvers:
-- provider-openstack-approvers
+- provider-openstack
 
 reviewers:
-- provider-openstack-reviewers
+- provider-openstack


### PR DESCRIPTION
PR #6115 broke this list of approvers by updating its name in OWNERS_ALIASES but never in OWNERS file using that alias. This commit solves that.