### PR TITLE
prow-build-trusted: switch to newer storage class for ghproxy

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/default/ghproxy-storage.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/default/ghproxy-storage.yaml
@@ -11,4 +11,4 @@ spec:
   resources:
     requests:
       storage: 100Gi
-  storageClassName: standard
+  storageClassName: standard-rwo


### PR DESCRIPTION
The PD CSI driver have been abled since GKE 1.25 and the new storage class introduced after an auto-upgrade operation to 1.25

This is done to address an issue reported in
https://github.com/kubernetes/test-infra/issues/31618 where the ghproxy was down due to the PV not deleted after the upgrade of the cluster to GKE 1.26