### PR TITLE
Update metrics-server images OWNERS

### DIFF
--- a/registry.k8s.io/images/k8s-staging-metrics-server/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-metrics-server/OWNERS
@@ -1,7 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- s-urbaniak
-- piosz
-- brancz
+- dgrisonnet
+- logicalhan
 - serathius


### PR DESCRIPTION
Update the OWNERS file with the current active approvers from https://github.com/kubernetes-sigs/metrics-server/blob/master/OWNERS.