### PR TITLE
registry.k8s.io: Add europe-west3 and europe-west10 - Part 2

### DIFF
--- a/registry.k8s.io/manifests/k8s-staging-cluster-api-azure/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-cluster-api-azure/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-azure
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-azure
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-azure
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-azure
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-azure
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-azure
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-azure
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-cluster-api-do/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-cluster-api-do/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-do
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-do
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-do
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-do
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-do
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-do
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-do
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-cluster-api-gcp/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-cluster-api-gcp/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-gcp
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-gcp
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-gcp
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-gcp
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-gcp
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-gcp
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-gcp
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-cluster-api-helm/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-cluster-api-helm/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-helm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-helm
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-helm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-helm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-helm
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-helm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-helm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-cluster-api-kubeadm/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-cluster-api-kubeadm/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/capi-kubeadm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/capi-kubeadm
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/capi-kubeadm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/capi-kubeadm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/capi-kubeadm
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/capi-kubeadm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/capi-kubeadm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-cluster-api-nested/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-cluster-api-nested/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-nested
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-nested
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-nested
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-nested
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-nested
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-nested
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-api-nested
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-coredns/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-coredns/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/coredns
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/coredns
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/coredns
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/coredns
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/coredns
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/coredns
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/coredns
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-cpa/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-cpa/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/cpa
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/cpa
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/cpa
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/cpa
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/cpa
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/cpa
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/cpa
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-csi-secrets-store/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-csi-secrets-store/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/csi-secrets-store
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/csi-secrets-store
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/csi-secrets-store
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/csi-secrets-store
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/csi-secrets-store
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/csi-secrets-store
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/csi-secrets-store
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-descheduler/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-descheduler/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/descheduler
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/descheduler
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/descheduler
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/descheduler
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/descheduler
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/descheduler
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/descheduler
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-dns/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-dns/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/dns
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/dns
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/dns
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/dns
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/dns
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/dns
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/dns
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-e2e-test-images/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-e2e-test-images/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/e2e-test-images
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/e2e-test-images
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/e2e-test-images
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/e2e-test-images
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/e2e-test-images
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/e2e-test-images
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/e2e-test-images
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-etcd/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-etcd/promoter-manifest.yaml
@@ -31,11 +31,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
@@ -74,11 +78,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/kubernetes
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/kubernetes
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/kubernetes
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/kubernetes
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/kubernetes
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/kubernetes
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/kubernetes
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-etcdadm/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-etcdadm/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/etcdadm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/etcdadm
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/etcdadm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/etcdadm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/etcdadm
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/etcdadm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/etcdadm
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-experimental/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-experimental/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/experimental
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/experimental
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/experimental
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/experimental
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/experimental
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/experimental
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/experimental
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-external-dns/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-external-dns/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/external-dns
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/external-dns
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/external-dns
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/external-dns
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/external-dns
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/external-dns
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/external-dns
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-gateway-api/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-gateway-api/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-git-sync/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-git-sync/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/git-sync
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/git-sync
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/git-sync
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/git-sync
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/git-sync
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/git-sync
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/git-sync
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-gmsa-webhook/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-gmsa-webhook/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/gmsa-webhook
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/gmsa-webhook
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/gmsa-webhook
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/gmsa-webhook
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/gmsa-webhook
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/gmsa-webhook
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/gmsa-webhook
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-infra-tools/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-infra-tools/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/infra-tools
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/infra-tools
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/infra-tools
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/infra-tools
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/infra-tools
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/infra-tools
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/infra-tools
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
Add GCP regions europe-west3 and europe-west10 to the promotion process.