### PR TITLE
registry.k8s.io: Add europe-west3 and europe-west10 - Part 3

### DIFF
--- a/registry.k8s.io/manifests/k8s-staging-ingress-controller-conformance/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-ingress-controller-conformance/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/ingressconformance
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/ingressconformance
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/ingressconformance
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/ingressconformance
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/ingressconformance
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/ingressconformance
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/ingressconformance
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-ingress-nginx/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-ingress-nginx/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/ingress-nginx
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/ingress-nginx
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/ingress-nginx
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/ingress-nginx
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/ingress-nginx
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/ingress-nginx
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/ingress-nginx
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-jobset/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-jobset/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/jobset
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/jobset
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/jobset
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/jobset
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/jobset
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/jobset
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/jobset
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-kas-network-proxy/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-kas-network-proxy/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/kas-network-proxy
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/kas-network-proxy
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/kas-network-proxy
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/kas-network-proxy
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/kas-network-proxy
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/kas-network-proxy
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/kas-network-proxy
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-kops/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-kops/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/kops
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/kops
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/kops
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/kops
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/kops
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/kops
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/kops
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-kube-state-metrics/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-kube-state-metrics/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/kube-state-metrics
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/kube-state-metrics
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/kube-state-metrics
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/kube-state-metrics
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/kube-state-metrics
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/kube-state-metrics
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/kube-state-metrics
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-kubebuilder/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-kubebuilder/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/kubebuilder
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-kubernetes/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-kubernetes/promoter-manifest.yaml
@@ -37,11 +37,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
@@ -80,11 +84,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/kubernetes
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/kubernetes
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/kubernetes
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/kubernetes
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/kubernetes
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/kubernetes
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/kubernetes
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-kueue/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-kueue/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/kueue
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/kueue
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/kueue
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/kueue
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/kueue
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/kueue
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/kueue
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-kustomize/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-kustomize/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/kustomize
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/kustomize
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/kustomize
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/kustomize
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/kustomize
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/kustomize
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/kustomize
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-kwok/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-kwok/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/kwok
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/kwok
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/kwok
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/kwok
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/kwok
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/kwok
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/kwok
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-metrics-server/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-metrics-server/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/metrics-server
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/metrics-server
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/metrics-server
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/metrics-server
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/metrics-server
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/metrics-server
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/metrics-server
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-multitenancy/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-multitenancy/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/multitenancy
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/multitenancy
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/multitenancy
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/multitenancy
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/multitenancy
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/multitenancy
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/multitenancy
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-networking/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-networking/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/networking
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/networking
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/networking
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/networking
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/networking
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/networking
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/networking
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-nfd/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-nfd/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/nfd
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/nfd
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/nfd
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/nfd
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/nfd
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/nfd
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/nfd
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-npd/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-npd/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/node-problem-detector
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/node-problem-detector
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/node-problem-detector
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/node-problem-detector
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/node-problem-detector
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/node-problem-detector
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/node-problem-detector
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-prometheus-adapter/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-prometheus-adapter/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/prometheus-adapter
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/prometheus-adapter
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/prometheus-adapter
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/prometheus-adapter
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/prometheus-adapter
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/prometheus-adapter
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/prometheus-adapter
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-provider-aws/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-provider-aws/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/provider-aws
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/provider-aws
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/provider-aws
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/provider-aws
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/provider-aws
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/provider-aws
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/provider-aws
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
Add GCP regions europe-west3 and europe-west10 to the promotion process.