### PR TITLE
registry.k8s.io: Add europe-west3 and europe-west10 - Part 4

### DIFF
--- a/registry.k8s.io/manifests/k8s-staging-provider-os/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-provider-os/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/provider-os
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/provider-os
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/provider-os
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/provider-os
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/provider-os
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/provider-os
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/provider-os
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-publishing-bot/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-publishing-bot/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/publishing-bot
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/publishing-bot
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/publishing-bot
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/publishing-bot
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/publishing-bot
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/publishing-bot
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/publishing-bot
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-releng/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-releng/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/releng
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/releng
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/releng
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/releng
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/releng
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/releng
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/releng
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-sched-simulator/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-sched-simulator/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/scheduler-simulator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/scheduler-simulator
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/scheduler-simulator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/scheduler-simulator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/scheduler-simulator
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/scheduler-simulator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/scheduler-simulator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-scheduler-plugins/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-scheduler-plugins/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/scheduler-plugins
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/scheduler-plugins
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/scheduler-plugins
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/scheduler-plugins
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/scheduler-plugins
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/scheduler-plugins
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/scheduler-plugins
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-scl-image-builder/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-scl-image-builder/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/scl-image-builder
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/scl-image-builder
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/scl-image-builder
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/scl-image-builder
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/scl-image-builder
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/scl-image-builder
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/scl-image-builder
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-sig-auth/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-sig-auth/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/sig-auth
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/sig-auth
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/sig-auth
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/sig-auth
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/sig-auth
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/sig-auth
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/sig-auth
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-sig-storage/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-sig-storage/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/sig-storage
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/sig-storage
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/sig-storage
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/sig-storage
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/sig-storage
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/sig-storage
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/sig-storage
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-slack-infra/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-slack-infra/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/slack-infra
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/slack-infra
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/slack-infra
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/slack-infra
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/slack-infra
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/slack-infra
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/slack-infra
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-sp-operator/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-sp-operator/promoter-manifest.yaml
@@ -21,11 +21,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
@@ -61,11 +65,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator-bundle
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator-bundle
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator-bundle
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator-bundle
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator-bundle
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator-bundle
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator-bundle
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
@@ -101,11 +109,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator-catalog
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator-catalog
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator-catalog
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator-catalog
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator-catalog
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator-catalog
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/security-profiles-operator-catalog
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-storage-migrator/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-storage-migrator/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/storage-migrator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/storage-migrator
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/storage-migrator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/storage-migrator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/storage-migrator
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/storage-migrator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/storage-migrator
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-tejolote/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-tejolote/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/tejolote
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-tg-exporter/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-tg-exporter/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/testgrid-exporter
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/testgrid-exporter
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/testgrid-exporter
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/testgrid-exporter
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/testgrid-exporter
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/testgrid-exporter
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/testgrid-exporter
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-win-op-rdnss/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-win-op-rdnss/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/windows-op-readiness
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/windows-op-readiness
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/windows-op-readiness
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/windows-op-readiness
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/windows-op-readiness
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/windows-op-readiness
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/windows-op-readiness
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-win-svc-proxy/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-win-svc-proxy/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/windows-service-proxy
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/windows-service-proxy
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/windows-service-proxy
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/windows-service-proxy
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/windows-service-proxy
+  service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+- name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/windows-service-proxy
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
 - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/windows-service-proxy
   service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com

--- a/registry.k8s.io/manifests/k8s-staging-zeitgeist/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-zeitgeist/promoter-manifest.yaml
@@ -20,11 +20,15 @@ registries:
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
   - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/zeitgeist
     service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
Add GCP regions europe-west3 and europe-west10 to the promotion process.