### PR TITLE
Sync CAPZ owners with Azure provider project

### DIFF
--- a/registry.k8s.io/images/k8s-staging-cluster-api-azure/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-cluster-api-azure/OWNERS
@@ -2,11 +2,9 @@
 # Should always mirror the maintainers/reviewers in https://sigs.k8s.io/cluster-api-provider-azure/OWNERS_ALIASES
 
 approvers:
-- CecileRobertMichon
 - jackfrancis
 - mboersma
 - nojnhuh
-- sonasingh46
 reviewers:
 - Jont828
 - jsturtevant


### PR DESCRIPTION
Updates maintainers and reviewers of the cluster-api-provider-azure (CAPZ) project to match its current [`OWNERS_ALIASES`](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES).