### PR TITLE
registry.k8s.io: Add a DNS entry for the Cloudfront distribution

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -305,6 +305,11 @@ monitoring.prow-canary:
 prs:
   type: CNAME
   value: redirect.k8s.io.
+# Cloudfront endpoint for the distribution shielding
+# the S3 buckets hosting the container images blobs
+cloudfront.registry:
+  type: CNAME
+  value: d39mqg4b1dx9z1.cloudfront.net.
 # Sandbox OCI redirector service. (@ameukam,@BenTheElder,@thockin,@dims)
 registry-sandbox:
   - type: A

--- a/infra/aws/terraform/registry-k8s-io-prod/outputs.tf
+++ b/infra/aws/terraform/registry-k8s-io-prod/outputs.tf
@@ -1,0 +1,19 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+output "cloudfront_domain_name" {
+  value = aws_cloudfront_distribution.cloudfront_distribution.domain_name
+}


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/registry.k8s.io/issues/194

Follow-up of:
  - https://github.com/kubernetes/k8s.io/pull/6336

Add a CNAME DNS entry for the Cloudfront distribution domain name