### PR TITLE
eks-prow-build-cluster: remove unused sda1 instance volume and adjust prod cluster size

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/node_group_stable.tf
+++ b/infra/aws/terraform/prow-build-cluster/node_group_stable.tf
@@ -67,22 +67,6 @@ locals {
 
     key_name = aws_key_pair.eks_nodes.key_name
 
-    block_device_mappings = {
-      # This must be sda1 in order to match the root volume,
-      # otherwise a new volume is created.
-      sda1 = {
-        device_name = "/dev/sda1"
-        ebs = {
-          volume_size           = var.node_volume_size
-          volume_type           = "gp3"
-          iops                  = 16000 # Maximum for gp3 volume.
-          throughput            = 1000  # Maximum for gp3 volume.
-          encrypted             = false
-          delete_on_termination = true
-        }
-      }
-    }
-
     enclave_options = {
       enabled = true
     }

--- a/infra/aws/terraform/prow-build-cluster/node_group_us-east-2a.tf
+++ b/infra/aws/terraform/prow-build-cluster/node_group_us-east-2a.tf
@@ -68,22 +68,6 @@ locals {
 
     key_name = aws_key_pair.eks_nodes.key_name
 
-    block_device_mappings = {
-      # This must be sda1 in order to match the root volume,
-      # otherwise a new volume is created.
-      sda1 = {
-        device_name = "/dev/sda1"
-        ebs = {
-          volume_size           = var.node_volume_size
-          volume_type           = "gp3"
-          iops                  = 16000 # Maximum for gp3 volume.
-          throughput            = 1000  # Maximum for gp3 volume.
-          encrypted             = false
-          delete_on_termination = true
-        }
-      }
-    }
-
     enclave_options = {
       enabled = true
     }

--- a/infra/aws/terraform/prow-build-cluster/node_group_us-east-2b.tf
+++ b/infra/aws/terraform/prow-build-cluster/node_group_us-east-2b.tf
@@ -68,22 +68,6 @@ locals {
 
     key_name = aws_key_pair.eks_nodes.key_name
 
-    block_device_mappings = {
-      # This must be sda1 in order to match the root volume,
-      # otherwise a new volume is created.
-      sda1 = {
-        device_name = "/dev/sda1"
-        ebs = {
-          volume_size           = var.node_volume_size
-          volume_type           = "gp3"
-          iops                  = 16000 # Maximum for gp3 volume.
-          throughput            = 1000  # Maximum for gp3 volume.
-          encrypted             = false
-          delete_on_termination = true
-        }
-      }
-    }
-
     enclave_options = {
       enabled = true
     }

--- a/infra/aws/terraform/prow-build-cluster/node_group_us-east-2c.tf
+++ b/infra/aws/terraform/prow-build-cluster/node_group_us-east-2c.tf
@@ -68,22 +68,6 @@ locals {
 
     key_name = aws_key_pair.eks_nodes.key_name
 
-    block_device_mappings = {
-      # This must be sda1 in order to match the root volume,
-      # otherwise a new volume is created.
-      sda1 = {
-        device_name = "/dev/sda1"
-        ebs = {
-          volume_size           = var.node_volume_size
-          volume_type           = "gp3"
-          iops                  = 16000 # Maximum for gp3 volume.
-          throughput            = 1000  # Maximum for gp3 volume.
-          encrypted             = false
-          delete_on_termination = true
-        }
-      }
-    }
-
     enclave_options = {
       enabled = true
     }

--- a/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
@@ -34,48 +34,32 @@ cluster_name               = "prow-canary-cluster"
 cluster_version            = "1.28"
 cluster_autoscaler_version = "v1.28.0"
 
-# TODO(xmudrii): Remove these two variables once rollout is complete
-node_group_version_blue  = "1.28"
-node_group_version_green = "1.28"
-
 node_group_version_us_east_2a = "1.28"
 node_group_version_us_east_2b = "1.28"
 node_group_version_us_east_2c = "1.28"
 node_group_version_stable     = "1.28"
 
-# TODO(xmudrii): Remove these two variables once rollout is complete
-node_instance_types_blue  = ["r5ad.2xlarge"]
-node_instance_types_green = ["r5ad.2xlarge"]
-
-node_instance_types_us_east_2a = ["r5ad.xlarge"]
+node_instance_types_us_east_2a = ["r5ad.2xlarge"]
 node_instance_types_us_east_2b = ["r5ad.xlarge"]
 node_instance_types_us_east_2c = ["r5ad.xlarge"]
 
 node_instance_types_stable = ["r5ad.xlarge"]
 
-# TODO(xmudrii): Remove these two variables once rollout is complete
-node_min_size_blue     = 0
-node_max_size_blue     = 1
-node_desired_size_blue = 0
-
-# TODO(xmudrii): Remove these two variables once rollout is complete
-node_min_size_green     = 0
-node_max_size_green     = 1
-node_desired_size_green = 0
-
 node_min_size_us_east_2a     = 1
 node_max_size_us_east_2a     = 1
 node_desired_size_us_east_2a = 1
 
-node_min_size_us_east_2b     = 1
+# cluster-autoscaler has been manually disabled for this ASG because we don't need that many nodes in the canary cluster
+node_min_size_us_east_2b     = 0
 node_max_size_us_east_2b     = 1
-node_desired_size_us_east_2b = 1
+node_desired_size_us_east_2b = 0
 
-node_min_size_us_east_2c     = 1
+# cluster-autoscaler has been manually disabled for this ASG because we don't need that many nodes in the canary cluster
+node_min_size_us_east_2c     = 0
 node_max_size_us_east_2c     = 1
-node_desired_size_us_east_2c = 1
+node_desired_size_us_east_2c = 0
 
-node_desired_size_stable = 2
+node_desired_size_stable = 1
 
 node_taints_stable = [
   {

--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -46,17 +46,17 @@ node_instance_types_us_east_2b = ["r5ad.4xlarge"]
 node_instance_types_us_east_2c = ["r5ad.4xlarge"]
 node_instance_types_stable     = ["r5ad.2xlarge"]
 
-node_min_size_us_east_2a     = 10
+node_min_size_us_east_2a     = 7
 node_max_size_us_east_2a     = 25
-node_desired_size_us_east_2a = 10
+node_desired_size_us_east_2a = 7
 
-node_min_size_us_east_2b     = 10
+node_min_size_us_east_2b     = 7
 node_max_size_us_east_2b     = 25
-node_desired_size_us_east_2b = 10
+node_desired_size_us_east_2b = 7
 
-node_min_size_us_east_2c     = 10
+node_min_size_us_east_2c     = 7
 node_max_size_us_east_2c     = 25
-node_desired_size_us_east_2c = 10
+node_desired_size_us_east_2c = 7
 
 node_desired_size_stable = 3
 


### PR DESCRIPTION
We had an instance volume mounted as `sda1`. This volume was used for Ubuntu as an operating system volume. However, since switching to Bottlerocket, this volume is not used and mounted at all because of differences in the filesystem between Ubuntu and Bottlerocket. This was also observed by AWS/EKS folks:

> On a closing note, I noticed that the launch template used for your node group is also increasing the size of the "/dev/sda1" volume. I suspect that you may be increasing the size of the root volume, however note that the root volume for bottlerocket is "/dev/xvda":
https://github.com/bottlerocket-os/bottlerocket/issues/1203#issuecomment-725775145
>
>> Hello! /dev/xvda is used to hold the operating system itself and contains the active & passive partitions, the bootloader, the dm-verity data, and the data store for the Bottlerocket API. /dev/xvdb is used for all of the things you run on top of Bottlerocket: container images, storage for running containers, and persistent storage/volumes.
>
> As such, /dev/sda1 is regarded as an additional volume attached to your node. As such this volume would not be used by your node.

I dropped this volume because it turns out that we don't need it. This will save us up to $4k monthly as we don't pay for provisioned IOPS and throughput.

Besides that, I adjusted the cluster size for prod, so that we have 7 instead of 10 instances in each node group. This would bring the minimum cluster size to 21, which is close to what we had prior to fixing cluster instability issues.

I also adjusted the cluster and instance size for canary so that we don't waste resources/credits there. I disabled cluster-autoscaler for some node groups in canary because it's not needed.

These changes are already applied to both prod and canary.

cc @ameukam @upodroid @dims 