### PR TITLE
sig-cluster-lifecycle/cluster-api: add chrischdi to maintainers

### DIFF
--- a/registry.k8s.io/images/k8s-staging-cluster-api/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-cluster-api/OWNERS
@@ -2,6 +2,7 @@
 
 approvers:
 - CecileRobertMichon
+- chrischdi
 - enxebre
 - fabriziopandini
 - detiber


### PR DESCRIPTION
Adding myself to the approvers for cluster-api relevant staging images.

xref:

https://github.com/kubernetes-sigs/cluster-api/pull/9997

/assign sbueringer 