### PR TITLE
GCP/prow-build: Enable Cloud Key Management Service (KMS) API

### DIFF
--- a/infra/gcp/terraform/modules/gke-project/main.tf
+++ b/infra/gcp/terraform/modules/gke-project/main.tf
@@ -23,6 +23,7 @@ locals {
   project_services = [
     "bigquery.googleapis.com",
     "cloudbuild.googleapis.com",
+    "cloudkms.googleapis.com",
     "cloudresourcemanager.googleapis.com",
     "compute.googleapis.com",
     "container.googleapis.com",


### PR DESCRIPTION
Follow of:

 * https://github.com/kubernetes/test-infra/pull/31863

Some E2E tests requires the service to be enabled. Failure on https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/sigs.k8s.io_gcp-compute-persistent-disk-csi-driver/1375/pull-gcp-compute-persistent-disk-csi-driver-e2e/1704443546796298240/

Presubmit E2E tests are currently failing with:

```
rpc error: code = PermissionDenied desc = Cloud Key Management Service (KMS) API has not been used in project 773781448124 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/cloudkms.googleapis.com/overview?project=773781448124 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.
      error details: name = ErrorInfo reason = SERVICE_DISABLED domain = googleapis.com metadata = map[consumer:projects/773781448124 service:cloudkms.googleapis.com]
      error details: name = Help desc = Google developers console API activation url = https://console.developers.google.com/apis/api/cloudkms.googleapis.com/overview?project=773781448124
```