### PR TITLE
Update OWNERS for CAAPH

### DIFF
--- a/registry.k8s.io/images/k8s-staging-cluster-api-helm/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-cluster-api-helm/OWNERS
@@ -4,8 +4,13 @@
 approvers:
 - fabriziopandini
 - Jont828
-- CecileRobertMichon
 - jackfrancis
+
+reviewers:
+- mboersma
+
+emeritus_approvers:
+- CecileRobertMichon
 
 labels:
 - sig/cluster-lifecycle


### PR DESCRIPTION
Syncs up the `OWNERS` file with current reality in [cluster-api-addon-provider-helm](https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/blob/main/OWNERS_ALIASES).

/cc @jackfrancis @Jont828