### PR TITLE
Revert moving cblecker to DNS owners emeritus

### DIFF
--- a/dns/OWNERS
+++ b/dns/OWNERS
@@ -3,12 +3,12 @@
 options:
   no_parent_owners: true
 approvers:
+  - cblecker
   - sig-k8s-infra-leads
   - thockin
 emeritus_approvers:
   - bartsmykla
   - spiffxp
-  - cblecker
   - munnerz
 
 labels:


### PR DESCRIPTION
Looks like I was moved to emeritus here in #6047 -- I'm still active in this area so I'm preposing a revert of that change.