### PR TITLE
Publish new 1.4 NFS image

### DIFF
--- a/registry.k8s.io/images/k8s-staging-e2e-test-images/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-e2e-test-images/images.yaml
@@ -174,6 +174,7 @@
   dmap:
     "sha256:124a375b4f930627c65b2f84c0d0f09229a96bc527eec18ad0eeac150b96d1c2": ["1.2"]
     "sha256:3bda73f2428522b0e342af80a0b9679e8594c2126f2b3cca39ed787589741b9e": ["1.3"]
+    "sha256:c3e380bb5a92095288b4dd586a250c560612afbabf53fb2a057e99fff75f038f": ["1.4"]
 - name: volume/rbd
   dmap:
     "sha256:eae2077ff658ce99e1224afbba6c18ffbcab0f3cf8b0a6536ac57643c7d950d0": ["1.0.3"]


### PR DESCRIPTION
PR in k/k:
https://github.com/kubernetes/kubernetes/pull/123362/files

published by this job:
https://prow.k8s.io/log?container=test&id=1759388580553166848&job=post-kubernetes-push-e2e-volume-nfs-test-images

```
❯ manifest-tool inspect gcr.io/k8s-staging-e2e-test-images/volume/nfs:1.4
Name:   gcr.io/k8s-staging-e2e-test-images/volume/nfs:1.4 (Type: application/vnd.docker.distribution.manifest.list.v2+json)
Digest: sha256:c3e380bb5a92095288b4dd586a250c560612afbabf53fb2a057e99fff75f038f
 * Contains 4 manifest references (4 images, 0 attestation):
[1]     Type: application/vnd.docker.distribution.manifest.v2+json
[1]   Digest: sha256:c552b8ef28db6683ec89873d6afb9618a70e1f836601b2490349dbeee65d631f
[1]   Length: 1478
[1] Platform:
[1]    -      OS: linux
[1]    -    Arch: amd64
[1] # Layers: 6
     layer 01: digest = sha256:2d473b07cdd5f0912cd6f1a703352c82b512407db6b05b43f2553732b55df3bc
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 02: digest = sha256:f3f7c3503b86b3745c540c1de735c07eebb07db2d3e7d913f46ed0431348f170
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 03: digest = sha256:71cfc4d1a3a371c6ae0cb321a7e67e124090a9275b6526fe0f463ca90daa0577
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 04: digest = sha256:d760c98d6a8315c20a9a199b18f1f7aef7b3c865b9230b893de7567266535f06
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 05: digest = sha256:b7f51ed010c74995a7fc2b25daf9163af0e30d176866de37e0fb35ab3733981a
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 06: digest = sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip

[2]     Type: application/vnd.docker.distribution.manifest.v2+json
[2]   Digest: sha256:ed864cba407a0cbf824955f1951c02250d3adac8bc61e066e57261501d8b6c69
[2]   Length: 1677
[2] Platform:
[2]    -      OS: linux
[2]    -    Arch: arm64
[2] # Layers: 7
     layer 01: digest = sha256:6717b8ec66cd6add0272c6391165585613c31314a43ff77d9751b53010e531ec
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 02: digest = sha256:7dc2db857a2e2e409c522669b3db416afbef658edc4aea3270cdedddee81dd1a
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 03: digest = sha256:b8d700e6ae75e8fd02779032381a36eb256e208a70be0394e70cb557b8f6bec4
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 04: digest = sha256:db05ef3ce71694e6b80900920b869add3c0972a396b96e95e790a6560ba7545d
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 05: digest = sha256:72fadf15392ea17df80072da0b4fc583161ba1ab5f6b9956b1e02a08eff69430
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 06: digest = sha256:82a78a22c645e790fa36661b14399b0cfbb07219a9f991156ed20034965b1e20
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 07: digest = sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip

[3]     Type: application/vnd.docker.distribution.manifest.v2+json
[3]   Digest: sha256:372af773fed829fe7364e7ad2e8a8e112b7e88b4947f8580140436241c97b035
[3]   Length: 1676
[3] Platform:
[3]    -      OS: linux
[3]    -    Arch: ppc64le
[3] # Layers: 7
     layer 01: digest = sha256:3fe478aaff9b8f3ba958253e7339e9016ec07c075b805ebfc8cd372ddd01ee64
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 02: digest = sha256:edcbb2b0ba5ed29326b8ca3a5ddbec3f7a70e14e593bd708c79b6411ab73b87b
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 03: digest = sha256:e807176ecef2c99d91dee754890cf4abdebd5d2ae5ae2ece91d34d3f4c7627cb
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 04: digest = sha256:fc6eae4660986ba79337bd012b39cae4af56b8f1d8ec4cef48ccd23b7fd03ff2
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 05: digest = sha256:be2434043d6700bf1e9726b1298a5d651e2f73553ec3ee78dd1ccf8c3725407b
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 06: digest = sha256:3f42e96ba0c9afa8f885b97068bb03192eacf4efe4ee225f24f70c4c5ac8d063
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 07: digest = sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip

[4]     Type: application/vnd.docker.distribution.manifest.v2+json
[4]   Digest: sha256:70a804164b380fd80a631dadd8e234d89c1a1694e5c57dd2024ee26e3ed07326
[4]   Length: 1676
[4] Platform:
[4]    -      OS: linux
[4]    -    Arch: s390x
[4] # Layers: 7
     layer 01: digest = sha256:0bcda6d6228a18040d1ef31f38278ac342c958aeeb1bf528b5f9a17a0dfa17c7
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 02: digest = sha256:84f4779c1ba8c7c7f64206b4ecf0a43d0b03e794d01df70fc9d15f0efed33f0a
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 03: digest = sha256:b13dae6164b42930b607192a5d49903d516e87e03c72c4c6253dfb3237b4f33b
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 04: digest = sha256:2dd99ac80b30535e26c2f906a0abded9d824fa2657e5574d6bd7181365838b53
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 05: digest = sha256:35107d697942e98175795d0c1fa12eec91b86dbaba27f3becd227e8711019a23
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 06: digest = sha256:181607b9e3298a6f0ecb176128ecc3a6c7125fbac6a74d6f6f06d5dbb6730cf7
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
     layer 07: digest = sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1
                 type = application/vnd.docker.image.rootfs.diff.tar.gzip
```
