### PR TITLE
Add Danil-Grigorev to CAPI Operator OWNERS

### DIFF
--- a/registry.k8s.io/images/k8s-staging-capi-operator/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-capi-operator/OWNERS
@@ -5,3 +5,4 @@ approvers:
 - JoelSpeed
 - Fedosin
 - alexander-demicev
+- Danil-Grigorev


### PR DESCRIPTION
Reference: https://github.com/kubernetes-sigs/cluster-api-operator/blob/main/OWNERS_ALIASES#L17