### PR TITLE
Promote gcr.io/k8s-staging-e2e-test-images/sample-apiserver:1.29.2

### DIFF
--- a/registry.k8s.io/images/k8s-staging-e2e-test-images/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-e2e-test-images/images.yaml
@@ -153,6 +153,7 @@
     "sha256:f9c93b92b6ff750b41a93c4e4fe0bfe384597aeb841e2539d5444815c55b2d8f": ["1.17.5"]
     "sha256:8d70890151aa5d096f331cb9da1b9cd5be0412b7363fe67b5c3befdcaa2a28d0": ["1.17.7"]
     "sha256:ae9f1d64e333f802753ab82d9cf65f0565ef2efbdbc94346f868d7771bdc2466": ["1.27.1"]
+    "sha256:19d4ecf1e0731b9ea55aca9c070d520f68b96ed0defbcc0e4eefe97b3d663ca3": ["1.29.2"]
 - name: sample-device-plugin
   dmap:
     "sha256:e84f6ca27c51ddedf812637dd2bcf771ad69fdca1173e5690c372370d0f93c40": ["1.3"]


### PR DESCRIPTION
PR: https://github.com/kubernetes/kubernetes/pull/123476

```
% manifest-tool inspect gcr.io/k8s-staging-e2e-test-images/sample-apiserver:1.29.2
Name:   gcr.io/k8s-staging-e2e-test-images/sample-apiserver:1.29.2 (Type: application/vnd.docker.distribution.manifest.list.v2+json)
Digest: sha256:19d4ecf1e0731b9ea55aca9c070d520f68b96ed0defbcc0e4eefe97b3d663ca3
 * Contains 7 manifest references:
[1]     Type: application/vnd.docker.distribution.manifest.v2+json
[1]   Digest: sha256:86e176c6b4d9b5eba5a6984efe10de23f0a6562f60b45be708ad6b9e33e78c30
[1]   Length: 702
[1] Platform:
[1]    -      OS: linux
[1]    -    Arch: amd64
[1] # Layers: 2
     layer 01: digest = sha256:486039affc0ad0f17f473efe8fb25c947515a8929198879d1e64210ef142372f
     layer 02: digest = sha256:85a870200ba265f207fc087ec60f2e5a99aa9482c8b351b8e80f9e18d02f875d

[2]     Type: application/vnd.docker.distribution.manifest.v2+json
[2]   Digest: sha256:8f7b6b05ecec25fbad04b06df3c7c3ba3ceb8745258f8f773a7b42d086861626
[2]   Length: 702
[2] Platform:
[2]    -      OS: linux
[2]    -    Arch: arm
[2]    - Variant: v7
[2] # Layers: 2
     layer 01: digest = sha256:e99479a55eec4052e95cb33c043fb7cf744165186fae58c09249b79593e2eb50
     layer 02: digest = sha256:c6b25242b98e5809cf5fec3f9c04ce7df597f8c52f6aebba229fe9e2a9b07447

[3]     Type: application/vnd.docker.distribution.manifest.v2+json
[3]   Digest: sha256:50cf1ec0e9dde3a96df5330804a85c2eebfda8019a5801face88290da966f995
[3]   Length: 702
[3] Platform:
[3]    -      OS: linux
[3]    -    Arch: arm64
[3] # Layers: 2
     layer 01: digest = sha256:788aef77d06ba65af872cf0c2da5b49362f6c05a5c8d1f8ceb4fd8b070e56876
     layer 02: digest = sha256:f7c3345644723b2a42015b2dfdce3bfa552d591a72088352c416f8bcf4ff410d

[4]     Type: application/vnd.docker.distribution.manifest.v2+json
[4]   Digest: sha256:0ccfbd333d6965baa916e42c026c2cf31bff822a825f7e59150d99122dae6da7
[4]   Length: 702
[4] Platform:
[4]    -      OS: linux
[4]    -    Arch: ppc64le
[4] # Layers: 2
     layer 01: digest = sha256:b48411a89febb8d129afc14af1221313ae639ffb5bf408cb5cf10b97a871c597
     layer 02: digest = sha256:fc63a3555fb0e4f82fe2a8a2b41dfa5cf306b85aa6a7b76b0a3b7b6f5ea45fc6

[5]     Type: application/vnd.docker.distribution.manifest.v2+json
[5]   Digest: sha256:490562a9e8668531b5c8224e1000c8f1eb7bf59b7457e9add0395c7b54a60f9d
[5]   Length: 702
[5] Platform:
[5]    -      OS: linux
[5]    -    Arch: s390x
[5] # Layers: 2
     layer 01: digest = sha256:71138ef63f9a401efe9f1f78e9ca48919c109c4a79639b87eff93000e0fe8c1d
     layer 02: digest = sha256:e6314684903c5466397ba7792d08fb4b65d998753f8faec01397fd1cff7d9108

[6]     Type: application/vnd.docker.distribution.manifest.v2+json
[6]   Digest: sha256:e7f3fbfbca8732f72e9c3bb9a0eedde392157ab8e9b8e5c26fc77dcf6cee1b7b
[6]   Length: 900
[6] Platform:
[6]    -      OS: windows
[6]    - OS Vers: 10.0.17763.5458
[6]    -    Arch: amd64
[6] # Layers: 3
     layer 01: digest = sha256:d948562ae7b7d940da7b962d2dd00aa2c34900338258a756826a6d29e70a0498
     layer 02: digest = sha256:e576e16241eb5c27af95f77c191f431173d7ed9db0f54f92e930df72c975ed26
     layer 03: digest = sha256:d230c3fd7aaa337f944847f359ccc312024b810f9dd1f9b8bbec95c87d55b640

[7]     Type: application/vnd.docker.distribution.manifest.v2+json
[7]   Digest: sha256:0731dc69ec805c10edff80cf70312cfd76c1c52a01dc5ad509dfea45c2f560f8
[7]   Length: 900
[7] Platform:
[7]    -      OS: windows
[7]    - OS Vers: 10.0.20348.2322
[7]    -    Arch: amd64
[7] # Layers: 3
     layer 01: digest = sha256:0de484043f1248d5382233de81d1687426c4c64b6507d0f768eff763724f1bac
     layer 02: digest = sha256:5655091537d5f5a4d09338a7a6f255ce085795856312ddd4b484375789125298
     layer 03: digest = sha256:c6cd6d0f147759091564c541e5078a06cb02822213b92aaaa39f10fddf4d5f3a
```