### PR TITLE
eks-prow-build-cluster: Move ESO to the stable node group

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/external-secrets/external-secrets.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/external-secrets/external-secrets.yaml
@@ -11592,6 +11592,13 @@ spec:
               path: /readyz
             initialDelaySeconds: 20
             periodSeconds: 5
+      nodeSelector:
+        node-group: stable
+      tolerations:
+        - key: node-group
+          operator: Equal
+          value: stable
+          effect: NoSchedule
 ---
 # Source: external-secrets/templates/deployment.yaml
 apiVersion: apps/v1
@@ -11654,6 +11661,13 @@ spec:
               readOnly: true
             - mountPath: /etc/google
               name: google-adc
+      nodeSelector:
+        node-group: stable
+      tolerations:
+        - key: node-group
+          operator: Equal
+          value: stable
+          effect: NoSchedule
       volumes:
         - name: google-iam-token
           projected:
@@ -11737,6 +11751,13 @@ spec:
             - name: certs
               mountPath: /tmp/certs
               readOnly: true
+      nodeSelector:
+        node-group: stable
+      tolerations:
+        - key: node-group
+          operator: Equal
+          value: stable
+          effect: NoSchedule
       volumes:
         - name: certs
           secret:


### PR DESCRIPTION
This moves ESO deployments in eks-prow-build-cluster to the stable node group. This should silence alerts related to ESO/ESO webhook.

Ideally, we should use Kustomize for this, but given our recent bad experience with it, let's do this manually for now.

/assign @ameukam @koksay 