### PR TITLE
k8s-infra-prow-build: add external IP for Grafana

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/external-ips.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/external-ips.tf
@@ -29,3 +29,11 @@ resource "google_compute_address" "kubernetes_external_secrets_metrics" {
   region       = local.cluster_location
   address_type = "EXTERNAL"
 }
+
+resource "google_compute_address" "grafana_ingress" {
+  name         = "grafana-ingress"
+  description  = "to expose grafana running in-cluster via monitoring-gke.k8s.prow.io"
+  project      = module.project.project_id
+  region       = local.cluster_location
+  address_type = "EXTERNAL"
+}


### PR DESCRIPTION
Follow up on #6468, based on https://kubernetes.slack.com/archives/CCK68P2Q2/p1709062971792359?thread_ts=1709051458.404019&cid=CCK68P2Q2

/assign @ameukam 
/hold
for @ameukam to apply this resource