### PR TITLE
Add DNS record for monitoring-gke.prow

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -296,6 +296,9 @@ monitoring-eks.prow:
 _bec7190baed957d2b71b4fc33bdec856.monitoring-eks.prow:
   type: CNAME
   value: _0ecdcf0799a37fa4bd5ba9bbe5877d56.dnzkjbsjxj.acm-validations.aws.
+monitoring-gke.prow:
+  type: A
+  value: 34.41.44.194
 prow-canary:
   type: A
   value: 35.244.182.122


### PR DESCRIPTION
Follow up on #6482 to add a DNS record for `monitroing-gke.prow` which points to Grafana hosted in the GKE Prow build cluster (`k8s-infra-prow`).

IP address from https://github.com/kubernetes/k8s.io/pull/6482#issuecomment-1968571311

/assign @ameukam 
cc @koksay 