### PR TITLE
k8s-infra-prow-build: add ManagedCertificate for Grafana

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/monitoring/grafana/certificate.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/monitoring/grafana/certificate.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: grafana
+  namespace: monitoring
+  labels:
+    app: grafana
+spec:
+  domains:
+  - monitoring-gke.prow.k8s.io


### PR DESCRIPTION
Follow up #6484 based on https://kubernetes.slack.com/archives/CCK68P2Q2/p1709112749291129?thread_ts=1709051458.404019&cid=CCK68P2Q2

/assign @ameukam 
cc @koksay 

/hold
for DNS record to get created