### PR TITLE
k8s-infra-prow-build: use LoadBalancer Service for Grafana

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/monitoring/grafana/service.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/monitoring/grafana/service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: grafana
 spec:
-  type: ClusterIP
+  type: LoadBalancer
   ports:
     - name: http
       port: 3000


### PR DESCRIPTION
Follow up on https://github.com/kubernetes/k8s.io/pull/6487#discussion_r1505743984

/assign @ameukam 
cc @koksay 