### PR TITLE
k8s-infra-prow-build: allow HTTP on Grafana Ingress

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/monitoring/grafana/ingress.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/monitoring/grafana/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: grafana
   annotations:
-    kubernetes.io/ingress.allow-http: "false"
+    kubernetes.io/ingress.allow-http: "true"
     kubernetes.io/ingress.global-static-ip-name: grafana-ingress
     kubernetes.io/ingress.class: gce
     networking.gke.io/managed-certificates: grafana


### PR DESCRIPTION
It seems that it might be required to allow HTTP at the beginning and then disable it later after TLS bootstrap is done.

/assign @ameukam @dims @upodroid 
cc @koksay 