### PR TITLE
k8s-infra-prow-build: use global IP for Grafana Ingress

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/external-ips.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/external-ips.tf
@@ -30,10 +30,10 @@ resource "google_compute_address" "kubernetes_external_secrets_metrics" {
   address_type = "EXTERNAL"
 }
 
-resource "google_compute_address" "grafana_ingress" {
+resource "google_compute_global_address" "grafana_ingress" {
   name         = "grafana-ingress"
-  description  = "to expose grafana running in-cluster via monitoring-gke.k8s.prow.io"
+  description  = "to expose grafana running in-cluster on monitoring-gke.prow.k8s.io"
   project      = module.project.project_id
-  region       = local.cluster_location
   address_type = "EXTERNAL"
+  ip_version   = "IPV4"
 }


### PR DESCRIPTION
From https://cloud.google.com/kubernetes-engine/docs/tutorials/configuring-domain-name-static-ip:

> If you choose to expose your application using an [Ingress](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress), you must [reserve a global static IP address](https://cloud.google.com/compute/docs/ip-addresses/reserve-static-external-ip-address#reserve_new_static). Use the annotation kubernetes.io/ingress.global-static-ip-name to specify a global IP address.

I, by mistake, went with a regional IP address, so Ingress is failing to reconcile. This PR should fix this, but someone needs to run `terraform apply`. We also need to update DNS afterwards.

/assign @ameukam 
cc @koksay 