### PR TITLE
k8s-infra-prow-build: update IP address for monitoring-gke DNS record

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -298,7 +298,7 @@ _bec7190baed957d2b71b4fc33bdec856.monitoring-eks.prow:
   value: _0ecdcf0799a37fa4bd5ba9bbe5877d56.dnzkjbsjxj.acm-validations.aws.
 monitoring-gke.prow:
   type: A
-  value: 34.41.44.194
+  value: 34.49.83.245
 prow-canary:
   type: A
   value: 35.244.182.122


### PR DESCRIPTION
This PR updates the IP address of the `monitoring-gke.prow` DNS record. The external address has been recreated as I created a regional IP address instead of a global IP address (#6496)

Ref https://github.com/kubernetes/k8s.io/pull/6496#issuecomment-1972685726

/assign @ameukam @upodroid @dims 