### PR TITLE
k8s-infra-prow-build: disallow http on Grafana Ingress

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/monitoring/grafana/ingress.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/monitoring/grafana/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: grafana
   annotations:
-    kubernetes.io/ingress.allow-http: "true"
+    kubernetes.io/ingress.allow-http: "false"
     kubernetes.io/ingress.global-static-ip-name: grafana-ingress
     kubernetes.io/ingress.class: gce
     networking.gke.io/managed-certificates: grafana


### PR DESCRIPTION
SSL is now working properly for `monitoring-gke.prow` so we don't need to allow HTTP any longer.

/assign @ameukam @upodroid @dims 
cc @koksay 