### PR TITLE
Promote agnhost:2.48 image

### DIFF
--- a/registry.k8s.io/images/k8s-staging-e2e-test-images/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-e2e-test-images/images.yaml
@@ -25,6 +25,7 @@
     "sha256:2c5b5b056076334e4cf431d964d102e44cbca8f1e6b16ac1e477a0ffbe6caac4": ["2.45"]
     # 2.46 was not built due to https://github.com/kubernetes/kubernetes/issues/123266
     "sha256:cc249acbd34692826b2b335335615e060fdb3c0bca4954507aa3a1d1194de253": ["2.47"]
+    "sha256:baeac1023bb8b281cffcd4246217331a9977c7cb8e285c0d6f07228855df49f6": ["2.48"]
 - name: apparmor-loader
   dmap:
     "sha256:60629fe42de6260c9b930b48a2923b69168dc1c71fa5f762f70036477ffd74b6": ["1.2"]


### PR DESCRIPTION
PR bumped the version: https://github.com/kubernetes/kubernetes/pull/123655

```shell
% manifest-tool inspect gcr.io/k8s-staging-e2e-test-images/agnhost:2.48
Name:   gcr.io/k8s-staging-e2e-test-images/agnhost:2.48 (Type: application/vnd.docker.distribution.manifest.list.v2+json)
Digest: sha256:baeac1023bb8b281cffcd4246217331a9977c7cb8e285c0d6f07228855df49f6
 * Contains 7 manifest references:
[1]     Type: application/vnd.docker.distribution.manifest.v2+json
[1]   Digest: sha256:f7f3d01322d029aa5b9fc2b0cc3d58007a154a2feb486f2a6b6e2bcbe1d3510e
[1]   Length: 2269
[1] Platform:
[1]    -      OS: linux
[1]    -    Arch: amd64
[1] # Layers: 10
     layer 01: digest = sha256:1b7ca6aea1ddfe716f3694edb811ab35114db9e93f3ce38d7dab6b4d9270cb0c
     layer 02: digest = sha256:ec347e53cc31ec8e2fe6276e047d00d7d144bf04e588f45db66f93f41887935b
     layer 03: digest = sha256:661d3888a6b1ee2aeded5af3b57cee184aba55521a7229768196dc9ae92b4e04
     layer 04: digest = sha256:ac9af3d034fdfaa4edde1415e0ec1913df2a310ec206cf6e1c15b865f4a33272
     layer 05: digest = sha256:9464c07b5ed5d32cdfa6128a0286a80c6b763b042f8fb92f92e22b6cacdfb0f9
     layer 06: digest = sha256:1cd4351b677d1e836e67330a3acf4bafff67534c2e4e7d179002c271a9ca94c2
     layer 07: digest = sha256:4ac9404f4584d3a13f73938d8d9794324edd8049df530b23a8ff27605f7767fb
     layer 08: digest = sha256:c7f7f95d1fd81070ddeee08ce751330a95175bea01c8000485165c333e7f5c9f
     layer 09: digest = sha256:95c80cf273479160c4b897be7c7ed1b00bf04d446f18dd469ce1171fbd0d63db
     layer 10: digest = sha256:9a10913873005e234600848215346d5b205d20dab1b91bc1d55d8e6c8d4dad02

[2]     Type: application/vnd.docker.distribution.manifest.v2+json
[2]   Digest: sha256:d4bfc1f8d70ac55f0429f5cd92bc7a556b5b58d4ac409a945a0dd87f695dd5ca
[2]   Length: 2467
[2] Platform:
[2]    -      OS: linux
[2]    -    Arch: arm
[2]    - Variant: v7
[2] # Layers: 11
     layer 01: digest = sha256:6c4809594a4b80d650b9951499cc7be9a90fc7b306e1dd8052f821b60733ae0c
     layer 02: digest = sha256:33e47e89dfd72a5bf39c145009ab614830c02fb4b9545b484e93bd572ccd7265
     layer 03: digest = sha256:f139ecc4400ddab1fc17ad022619a7fc4699d5c68584a155fb2ea0140b2f91f8
     layer 04: digest = sha256:350362f09a907a2df7dda3eacb4c7d735e777c6c1928dc15ae192af796a7b9ac
     layer 05: digest = sha256:a239fb85d7f6bac3341cda2561aaa006ca9c0fe450b15d82e68c2bf04e9084e3
     layer 06: digest = sha256:af0ea1b450bdc2e823855a5b46e872b0be2ff2fa8c3df774de1ff5ae1ff7a516
     layer 07: digest = sha256:e2ef8b54c1d0be462310a701f1bfa674c781938d6b2618c636548f7c3404c656
     layer 08: digest = sha256:1065755253386132833952fc825a43bab7b1cb3bb128afaf7144926200848d0d
     layer 09: digest = sha256:048280edf941ebd57dab8a34c47a172e010201dc83c7a46327d326e75fcdead6
     layer 10: digest = sha256:e1954e98376015ad206a1a4b3e48e4006284aa5a080b386b111dbe93d19c2d0d
     layer 11: digest = sha256:88915bf2689b2aeffc7bdf32ec51d3590f681545d4a7aa46b424051aeb9d8c24

[3]     Type: application/vnd.docker.distribution.manifest.v2+json
[3]   Digest: sha256:1992f0d3249ad7f672635fb62689daf768883d5da59b91b855a191f639e51ff2
[3]   Length: 2467
[3] Platform:
[3]    -      OS: linux
[3]    -    Arch: arm64
[3] # Layers: 11
     layer 01: digest = sha256:0eeab5c200691bd777e227c6eea27f7ca3c8232b67118a76edac2dcde3186aa1
     layer 02: digest = sha256:7f360fda93f8f0ee260d9b947b0cfe42e01d9c8228222eb27ca508aa8476fbbb
     layer 03: digest = sha256:83d57dd9045ed10e9ad7cb934d0acb65ec4402269f58b94ddf84928f25074535
     layer 04: digest = sha256:e336cff9d6bfbd3de5da81ff751af6dd149e074d29ce54849d74565885cc3e33
     layer 05: digest = sha256:fa9b6f03bdc2c5ccb9968ef8e34d76d241536a5c02ef79defeac2fe83b88b176
     layer 06: digest = sha256:1d55a31b96f08d7449fccd6ab1fffc2e9c5abec16a6786bb8ca0503e6d7b5c09
     layer 07: digest = sha256:4791ce3fcbb7f4508ac78d637fd3b4564b97c47f2b20ccddd152c0b877b3c0db
     layer 08: digest = sha256:e9d10373d15721a009b8498f274e62b8aabc1336afe881948984d3c3c4bba15c
     layer 09: digest = sha256:1e571483183258ceb149181b9dba77df9bd0f0b07c5fb891b822378688c24e98
     layer 10: digest = sha256:771c629e692913b0ed17910cdf2684d3b949aa3f9a4d4538cd3d29240e43b04b
     layer 11: digest = sha256:4389ab202bd0f8e445c8d15eccfeb3e87d818b1290a7bb108616b50e693567b0

[4]     Type: application/vnd.docker.distribution.manifest.v2+json
[4]   Digest: sha256:f4732a28980efa429716d4acd37a4635c05f9cdd55865cf0f0801d821baaaac1
[4]   Length: 2466
[4] Platform:
[4]    -      OS: linux
[4]    -    Arch: ppc64le
[4] # Layers: 11
     layer 01: digest = sha256:57c1475d5a6dc8e68a1b09bd09db22cc33e8f163a3841ce5100e0569acefcabe
     layer 02: digest = sha256:38848b387858dfbed09318ab10db2372f81309c35623219ff8a10c51113bb15a
     layer 03: digest = sha256:573616935fd07011da116f559216e0a2bf636d0039fa9ea821a87b55ecf4af2f
     layer 04: digest = sha256:71ab6ba8c4e6f3702096ab72b21f02ab2fc9e43db4df664cf219661e66b90fe8
     layer 05: digest = sha256:14c790d95add99b5cb448f06b772389f3f2e2c62f8f3be945e8022a10709358b
     layer 06: digest = sha256:e94ccb7796ccd04559aa5d0e8ef3729bb0c11b29542a83108947f4256c334b40
     layer 07: digest = sha256:fc05774566e3228aa42815ab24c06c873c71531dd4bf6e835009a5638f84a58d
     layer 08: digest = sha256:b2ca81a4cd708e88b8c6f9494b86fef92bc9f940877d68107ef3d4b93807fa6f
     layer 09: digest = sha256:38a6bd44c43bee0242b50e1657f9e76bf4b910a6f7ac93779b90d4968c5e215f
     layer 10: digest = sha256:40665708f5489d54e39f9159aa068ea302e1f0697f2cb51c2dad1aa49d75503c
     layer 11: digest = sha256:35ad0d0eb1ea8a9495b4dd7702a9852f6dcee1b43ed2bc736f65c1ac5c37cbb0

[5]     Type: application/vnd.docker.distribution.manifest.v2+json
[5]   Digest: sha256:b702a4e300d3797ae23c3d036f9ff36c09480a4ff9979e034f57d3a6d865ad4b
[5]   Length: 2467
[5] Platform:
[5]    -      OS: linux
[5]    -    Arch: s390x
[5] # Layers: 11
     layer 01: digest = sha256:1097ea795c9d7bf9c3f82172463982fdcb35c173957675c82cd2081c53d35a6d
     layer 02: digest = sha256:d6a4a5a9b4e2a4cec9e48ec712997330dcc57a3904617a610c704e39a842bbc3
     layer 03: digest = sha256:f7bf3153db9e6f507c6fc4313ffad0619510948df1ca8c89468e2e47305cd7a3
     layer 04: digest = sha256:ad006f9e3c388e1ccc87bf9b9b04426f978d6b99bc29e95661f764e62192820b
     layer 05: digest = sha256:19780aa3e692c761f90077284366200bc8a3aa7e85ac2eeef566148bbe2da3b8
     layer 06: digest = sha256:9d435f2387000673121e38a54ef99066d7fb484cda2f1d685663a0387bb96d16
     layer 07: digest = sha256:3c755a36738bafc2a86688042e410bca2e8ff2fa7b6903ae3d3093e397e571b8
     layer 08: digest = sha256:3ccd982709db9975bc51d23495bf29961b4dbaba697fc845890c5a932281ddc6
     layer 09: digest = sha256:10feed2d64e1b458a61ef6733330a03c173e4f0315cd7017248d6c7ddf2eaf9b
     layer 10: digest = sha256:8f46b70a3b7f9bea617e0b0a4dbcc443a1ac8978b05aa47b8ff86d6e7ec2569b
     layer 11: digest = sha256:0ed05b36e1234a52c348636dd810377645fc1a94e28f657fa06f85c7548e9e9c

[6]     Type: application/vnd.docker.distribution.manifest.v2+json
[6]   Digest: sha256:8908b2a2d07a286ea26753aab93befa14544959fead313d81e0f9aef9c7fcd5e
[6]   Length: 5025
[6] Platform:
[6]    -      OS: windows
[6]    - OS Vers: 10.0.17763.5458
[6]    -    Arch: amd64
[6] # Layers: 24
     layer 01: digest = sha256:bc8517709e9cfff223cb034ff5be8fcbfa5409de286cdac9ae1b8878ebea6b84
     layer 02: digest = sha256:1309a1c23a207f20be8f77fb1c16a241e2ef508dacedd36bdb20a32c37366a25
     layer 03: digest = sha256:3632da667caf9681f329587a5db5ae9aecc041513a6416b93ba5b4c67b5d8917
     layer 04: digest = sha256:a1eeacc36e3c4338c95c3c9f2756eaa82d7fbf502d91f2cd76d643487f5b032d
     layer 05: digest = sha256:1646853670ad8856f611906c13ed7624e1c1623fe168b5db160b9c48e77078a2
     layer 06: digest = sha256:90ce513435e580c05dd22999a737d3f230290dd33dc6a98297925babecc90707
     layer 07: digest = sha256:1d649ca76c5d9c4d3bdf2a35b130481e5485138ede3cb6260921809e9d4f25cb
     layer 08: digest = sha256:07d1e3bb416752579826a729a134d08f47630d5caac69e8fd637702df363fd85
     layer 09: digest = sha256:d0b43aad6e864b1a3f0ae74c6c726016aa61ffc47d97a8b91e894f8bc5e7a0ea
     layer 10: digest = sha256:141d277e4616bc33c81eb0e4a0639ef5a14e503eaab2aa1db5a71364464d4f5d
     layer 11: digest = sha256:a126f9db0b84c2dc61a582f2700903663d93f625e5b6c6e4d101c5087a7cd1ce
     layer 12: digest = sha256:35e8483e8f5946426c31e941db5eb9ccaf411cf6ff314eaab9dc79374006b1e2
     layer 13: digest = sha256:6ccee0876f17c5d197dfa33b8a173f50c75ea15b9c46779479ccdf7951f9410c
     layer 14: digest = sha256:b1461d1bdacd1095aed1f9d31b7f3da1155c98b3781122796ab2abedbd5ea7f6
     layer 15: digest = sha256:effdc2569928b3993fc39f407864d1f9e9c1c881934bf5d6559cbe849aa34933
     layer 16: digest = sha256:1eee63fc764223fd6c280c38c1182e76b5ecffe4ab8a84916ca17e6d77afc058
     layer 17: digest = sha256:b3267c16726d4ea51cdb82cf10dc7bbd70ce7a7d91a8fb9a94fa749edf8cae15
     layer 18: digest = sha256:63face1cac94ea90a056ac683d757051ce8deea60aab7c8ec39d931746dcba0b
     layer 19: digest = sha256:2ef2fcea3176f5b92f5ed09de450faffffdddd79f3e84004532b66896700667e
     layer 20: digest = sha256:16b9c1340d37d1fc86d3a57add3e5214ba2852189a3ad253493218094432781d
     layer 21: digest = sha256:0877620a1afee7aff61ea380b72f1f8eec805fdb27c30c7da935e7665a1ffa99
     layer 22: digest = sha256:15a9bf940fbc2817d44eac734352757f1d1a71cc83d7f078af5a327dfd911c89
     layer 23: digest = sha256:ce4568961f1dfe082e12f7f693d094afcf9f9b1d7aa255109c1aad3dc62d715c
     layer 24: digest = sha256:075808d0295ed586ca21c9b59de7d8d614d4837c89f38997ea143f60e5df731d

[7]     Type: application/vnd.docker.distribution.manifest.v2+json
[7]   Digest: sha256:439bc58388458ab5b68d2b75243be4a3e46d9e08c3a0354e24573beb018413e5
[7]   Length: 5025
[7] Platform:
[7]    -      OS: windows
[7]    - OS Vers: 10.0.20348.2322
[7]    -    Arch: amd64
[7] # Layers: 24
     layer 01: digest = sha256:ee7a9c9193e3d9bee1b6c8ddddddd5356aed50f77c78d18d377241f4aee6d676
     layer 02: digest = sha256:d811cf8ad12ad2810234ef11eed79f89352f69a021d32cb16cad5b5892f102ea
     layer 03: digest = sha256:1b413d863b1dd33f845d57fecd1fc2b9fa509c65d02192740b1c02f2e8a181a7
     layer 04: digest = sha256:59492558758f5c587470ad2576e2bdedac2b9a8dbcd1d28363b09d06efc7c087
     layer 05: digest = sha256:bd526ab874760ea64586481fb8e3c3bd436f465440c1ca8b1350efc9ec6844a3
     layer 06: digest = sha256:860c932aa8731aea7e606bac7928c72e3f253bad8553156de92cd7acfd94b3e2
     layer 07: digest = sha256:d17716e28ea681bf076e236ad307264ff5069a35666af14cd8b44d6c2c708376
     layer 08: digest = sha256:67904b0b8237954685315bc5af30ae1f8c317ad44ef98da0c2d0f5e81fce543e
     layer 09: digest = sha256:03873cdcecc3d9a995be920cce07f99d1ed2057da84c22537f3f7905a5905824
     layer 10: digest = sha256:ed0bacc9f51e321f18c87c114ade3726e56a21ff5cc40187432669e0bd7067c4
     layer 11: digest = sha256:1d58a42f3d09cddf6624122bb1f5b2aed336d1e5c3d929ac3c082e07152c9ffb
     layer 12: digest = sha256:4704a8b482b17b3c82bf92e46cad0f03a6da4c26087a1ec32f3a226877558e5b
     layer 13: digest = sha256:e81f9f4a189d3a594349ebfa18fa6683f73c4b00c202a3ef96c31a3176409be5
     layer 14: digest = sha256:232e635a4e0367df76b27cdcead1e594093e3d31b5b2170fc3dbb9ea07ab983b
     layer 15: digest = sha256:0f0675dc84c41582e2b97ce49cfcd581169dd0b79abc498ffd9ede235c9934b5
     layer 16: digest = sha256:1a6019e9cfc067541a76bcb5b42c6dcd4b6bbd40f6faac6f20756bd2509f2308
     layer 17: digest = sha256:514442ebcb8d963498d22fd158f4654634afcbac494a876e5f0414e63002ce58
     layer 18: digest = sha256:6bdb4d6bbea6ecd7f5904502791cce444b091a1d6425dab2a1a3aa06f223709d
     layer 19: digest = sha256:0e7c2236971d1cef27b7431a4d540faa0b6c35fdeeace10d009845a909f474a4
     layer 20: digest = sha256:285fd0c3ad772d6f1434acf312a61979b750116e13068990ea6d204bfc30777a
     layer 21: digest = sha256:6f41c7e9d848b902fcbaec2c1f81e4689aa8446cf2ab3543f8922052586fed05
     layer 22: digest = sha256:40d7358ec6b93a4b7c1882a30fae3335ac2e3f2e57e1fc8d7717b3bab48806ee
     layer 23: digest = sha256:7d8a465ef20274318fcd65740edcebce9ae62bcc3b749323aecd39475d0049d6
     layer 24: digest = sha256:f8eeafc97195db9303a269982552a3cdf6b6951316204eb7e0bc1c289ebadaa1
```