### PR TITLE
feat: added tf infra for AWS ami account

### DIFF
--- a/infra/aws/terraform/cncf-k8s-infra-aws-capa-ami/README.md
+++ b/infra/aws/terraform/cncf-k8s-infra-aws-capa-ami/README.md
@@ -1,0 +1,32 @@
+# AWS Account for CAPA AMI Publication
+
+This contains Terraform used to manage users & permissions for the **cncf-k8s-infra-aws-capa-ami** AWS account (`arn:aws:organizations::348685125169:account/o-kz4vlkihvy/819546954734`).
+
+## Tool Requirements
+
+* [Terraform](https://developer.hashicorp.com/terraform/downloads) v1.6.0 or greater
+* AWS CLI
+
+## Pre-reqs
+
+This will need to be run by someone that is an admin in the account or by someone that can assume role to give admin in the account.
+
+## Running
+
+Set the AWS environment variables for the user that has access to the account.
+
+Then run the following to disable the blocking of public AMIs:
+
+```bash
+hack/disable-block.sh
+```
+
+> NOTE: the script is used to disable the block as it doesn't naturally fit well into Terraform when running it across many regions.
+
+Then do the usual terraform flow:
+
+```bash
+terraform init
+terraform plan
+terraform apply
+```

--- a/infra/aws/terraform/cncf-k8s-infra-aws-capa-ami/hack/disable-block.sh
+++ b/infra/aws/terraform/cncf-k8s-infra-aws-capa-ami/hack/disable-block.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## This script is used to disable the block on public access to AMIs
+
+AMI_REGIONS="ap-south-1,eu-west-3,eu-west-2,eu-west-1,ap-northeast-2,ap-northeast-1,sa-east-1,ca-central-1,ap-southeast-1,ap-southeast-2,eu-central-1,us-east-1,us-east-2,us-west-1,us-west-2"
+
+IFS=','
+read -ra arr <<<"$AMI_REGIONS"
+
+for val in "${arr[@]}"; do
+    aws ec2 disable-image-block-public-access --region "$val"
+done

--- a/infra/aws/terraform/cncf-k8s-infra-aws-capa-ami/iam.tf
+++ b/infra/aws/terraform/cncf-k8s-infra-aws-capa-ami/iam.tf
@@ -1,0 +1,68 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+# NOTE: this is the standard permissions from the TF docs.
+resource "aws_iam_policy" "imagebuilder" {
+  name        = "capa-image-builder-policy"
+  path        = "/"
+  description = "Recommended policy for image builder"
+
+  policy = jsonencode({
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+        "Effect": "Allow",
+        "Action": [
+            "ec2:AttachVolume",
+            "ec2:AuthorizeSecurityGroupIngress",
+            "ec2:CopyImage",
+            "ec2:CreateImage",
+            "ec2:CreateKeyPair",
+            "ec2:CreateSecurityGroup",
+            "ec2:CreateSnapshot",
+            "ec2:CreateTags",
+            "ec2:CreateVolume",
+            "ec2:DeleteKeyPair",
+            "ec2:DeleteSecurityGroup",
+            "ec2:DeleteSnapshot",
+            "ec2:DeleteVolume",
+            "ec2:DeregisterImage",
+            "ec2:DescribeImageAttribute",
+            "ec2:DescribeImages",
+            "ec2:DescribeInstances",
+            "ec2:DescribeInstanceStatus",
+            "ec2:DescribeRegions",
+            "ec2:DescribeSecurityGroups",
+            "ec2:DescribeSnapshots",
+            "ec2:DescribeSubnets",
+            "ec2:DescribeTags",
+            "ec2:DescribeVolumes",
+            "ec2:DetachVolume",
+            "ec2:GetPasswordData",
+            "ec2:ModifyImageAttribute",
+            "ec2:ModifyInstanceAttribute",
+            "ec2:ModifySnapshotAttribute",
+            "ec2:RegisterImage",
+            "ec2:RunInstances",
+            "ec2:StopInstances",
+            "ec2:TerminateInstances"
+        ],
+        "Resource": "*"
+        }
+    ]
+  })
+}

--- a/infra/aws/terraform/cncf-k8s-infra-aws-capa-ami/oidc.tf
+++ b/infra/aws/terraform/cncf-k8s-infra-aws-capa-ami/oidc.tf
@@ -1,0 +1,37 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module "iam_github_oidc_provider" {
+  source    = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-provider"
+
+  client_id_list = [
+    "sts.amazonaws.com",
+  ]
+
+  tags = var.tags
+}
+
+module "iam_github_oidc_role" {
+  source    = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
+
+  name = "gh-image-builder"
+  subjects = ["kubernetes-sigs/cluster-api-provider-aws:*"]
+  policies = {
+    ImageBuilder = aws_iam_policy.imagebuilder.arn
+  }
+
+  tags = var.tags
+}

--- a/infra/aws/terraform/cncf-k8s-infra-aws-capa-ami/providers.tf
+++ b/infra/aws/terraform/cncf-k8s-infra-aws-capa-ami/providers.tf
@@ -1,0 +1,40 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  backend "s3" {
+    bucket = "cncf-k8s-infra-aws-capa-ami-tf-state"
+    key    = "terraform.tfstate"
+    region = "us-east-2"
+  }
+
+  required_version = "~> 1.8.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.66"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+
+  default_tags {
+    tags = var.tags
+  }
+}

--- a/infra/aws/terraform/cncf-k8s-infra-aws-capa-ami/variables.tf
+++ b/infra/aws/terraform/cncf-k8s-infra-aws-capa-ami/variables.tf
@@ -1,0 +1,31 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+variable "tags" {
+  type = map(string)
+  default = {
+    "managed-by" = "Terraform",
+    "group"      = "sig-cluster-lifecycle",
+    "subproject" = "cluster-api-provider-aws"
+    "githubRepo" = "git.k8s.io/k8s.io"
+  }
+}
+
+variable "region" {
+  type        = string
+  description = "AWS region for region specific resources"
+  default     = "us-east-2"
+}


### PR DESCRIPTION
This adds AWS infra provisioning using terraform for the AWS account to be used to publish CAPA AMIs.

It adds the following:
- IAM role with the permissions required for packer AMI publishing
- OIDC provider for GitHub
- Associates the role to the provider and limits the kubernetes-sigs/cluster-api-provider-aws

Fixes: #5010 