### PR TITLE
Add Peter Rifel (rifelpet) as prow viewer

### DIFF
--- a/groups/sig-testing/groups.yaml
+++ b/groups/sig-testing/groups.yaml
@@ -154,6 +154,7 @@ groups:
     - koray@kubermatic.com
     - liggitt@google.com
     - mrfaizal@google.com
+    - pgrifel@gmail.com
     - ricardo.katz@gmail.com
     - rob.kielty@gmail.com
     - spiffxp@gmail.com


### PR DESCRIPTION
This adds my personal email to the prow viewer group. I'm working on migrating kops jobs to the community-owned prow clusters and having this viewer access will be helpful for troubleshooting.