### PR TITLE
chore: update external-dns Maintainers

### DIFF
--- a/registry.k8s.io/images/k8s-staging-external-dns/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-external-dns/OWNERS
@@ -4,17 +4,18 @@
 
 approvers:
   - johngmyers
+  - mloiseleur
   - raffo
-  - njuettner
   - szuecs
 
 reviewers:
   - johngmyers
-  - njuettner
+  - mloiseleur
   - raffo
   - szuecs
 
 emeritus_approvers:
   - hjacobs
   - linki
+  - njuettner
   - seanmalloy


### PR DESCRIPTION
# Description

Update external-dns maintainers. 

Motivation detailed in https://github.com/kubernetes-sigs/external-dns/pull/4304