### PR TITLE
Redirect pkgs.k8s.io/ to the announcement blog post

### DIFF
--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -166,6 +166,7 @@ data:
         server_name packages.kubernetes.io pkgs.kubernetes.io packages.k8s.io pkgs.k8s.io;
         listen 80;
 
+        rewrite ^/$         https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/ redirect;
         rewrite ^/(.*)?$    https://prod-cdn.packages.k8s.io/repositories/isv:/kubernetes:/$1 redirect;
       }
 


### PR DESCRIPTION
It would be nice if pkgs.k8s.io (only the root path, not other paths) would redirect to some sort of a landing page so users can get more information about the new package repositories. Right now, pkgs.k8s.io throws a generic forbidden (403) page. This PR proposes redirecting the root path to [the announcement blog post](https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/) until we don't get a better landing page.

This is a temporary workaround for https://github.com/kubernetes/release/issues/3496

cc @kubernetes/release-engineering
/assign @upodroid @ameukam @dims 