### PR TITLE
Redirect apt/yum.kubernetes.io to the deprecation announcement

### DIFF
--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -152,6 +152,7 @@ data:
         server_name apt.kubernetes.io apt.k8s.io;
         listen 80;
 
+        rewrite ^/$         https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/ redirect;
         rewrite ^/(.*)?$    https://packages.cloud.google.com/apt/$1 redirect;
       }
 
@@ -159,6 +160,7 @@ data:
         server_name yum.kubernetes.io yum.k8s.io;
         listen 80;
 
+        rewrite ^/$         https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/ redirect;
         rewrite ^/(.*)?$    https://packages.cloud.google.com/yum/$1 redirect;
       }
 

--- a/apps/k8s-io/test.py
+++ b/apps/k8s-io/test.py
@@ -221,13 +221,13 @@ class RedirTest(HTTPTestCase):
 
     def test_yum(self):
         for base in ('yum.k8s.io', 'yum.kubernetes.io'):
-            self.assert_temp_redirect(base, 'https://packages.cloud.google.com/yum/')
+            self.assert_temp_redirect(base, 'https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/')
             self.assert_temp_redirect(base + '/$id',
                 'https://packages.cloud.google.com/yum/$id', id=rand_num())
 
     def test_apt(self):
         for base in ('apt.k8s.io', 'apt.kubernetes.io'):
-            self.assert_temp_redirect(base, 'https://packages.cloud.google.com/apt/')
+            self.assert_temp_redirect(base, 'https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/')
             self.assert_temp_redirect(base + '/$id',
                 'https://packages.cloud.google.com/apt/$id', id=rand_num())
 


### PR DESCRIPTION
@BenTheElder proposed redirecting apt.kubernetes.io and yum.kubernetes.io (the root paths, not any of subpaths) to the deprecation announcement. See https://kubernetes.slack.com/archives/C2C40FMNF/p1708988257580149?thread_ts=1708546638.738649&cid=C2C40FMNF

This PR implements this in a similar way as for pkgs.k8s.io (#6544).

/assign @upodroid @dims @ameukam @BenTheElder 
/hold
to reach the consensus

