### PR TITLE
Remove references to #alerting-cncf-prod in Kubermatic Slack

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/flux-system/flux-slack-notifications.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/flux-system/flux-slack-notifications.yaml
@@ -15,17 +15,6 @@
 apiVersion: notification.toolkit.fluxcd.io/v1beta2
 kind: Provider
 metadata:
-  name: slack
-  namespace: flux-system
-spec:
-  type: slack
-  channel: alerting-cncf-prod
-  secretRef:
-    name: slack-url
----
-apiVersion: notification.toolkit.fluxcd.io/v1beta2
-kind: Provider
-metadata:
   name: slack-k8s-infra-alerts
   namespace: flux-system
 spec:
@@ -34,22 +23,6 @@ spec:
   secretRef:
     name: slack-k8s-infra-alerts-token
 
----
-apiVersion: notification.toolkit.fluxcd.io/v1beta2
-kind: Alert
-metadata:
-  name: alerting-cncf-prod
-  namespace: flux-system
-spec:
-  summary: "EKS Prow Build Cluster"
-  providerRef:
-    name: slack
-  eventSeverity: error
-  eventSources:
-    - kind: GitRepository
-      name: '*'
-    - kind: Kustomization
-      name: '*'
 ---
 apiVersion: notification.toolkit.fluxcd.io/v1beta2
 kind: Alert

--- a/infra/aws/terraform/prow-build-cluster/resources/flux-system/slack-alerting-external-secret.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/flux-system/slack-alerting-external-secret.yaml
@@ -15,25 +15,6 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: slack-url
-  namespace: flux-system
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: aws-secerts-manager
-    kind: ClusterSecretStore
-  target:
-    name: slack-url
-    creationPolicy: Owner
-  data:
-  - secretKey: address
-    remoteRef:
-      key: secrets/kubermatic
-      property: slack-alerting-cncf-prod
----
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
   name: slack-k8s-infra-alerts-token
   namespace: flux-system
 spec:

--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager-config.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager-config.yaml
@@ -44,13 +44,6 @@ spec:
   - name: 'slack'
     slackConfigs:
     - apiURL:
-        name: alertmanager-k8c-slack-token
-        key: url
-      channel: '#alerting-cncf-prod'
-      sendResolved: true
-      title: ":warning: {{ .CommonLabels.alertname }}"
-      text: "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"
-    - apiURL:
         name: slack-k8s-infra-alerts-token
         key: url
       channel: '#k8s-infra-alerts'

--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager-slack-token.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager-slack-token.yaml
@@ -15,25 +15,6 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: alertmanager-k8c-slack-token
-  namespace: monitoring
-spec:
-  refreshInterval: 1h
-  secretStoreRef:
-    name: aws-secerts-manager
-    kind: ClusterSecretStore
-  target:
-    name: alertmanager-k8c-slack-token
-    creationPolicy: Owner
-  data:
-  - secretKey: url
-    remoteRef:
-      key: secrets/kubermatic
-      property: slack-alerting-cncf-prod
----
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
   name: slack-k8s-infra-alerts-token
   namespace: monitoring
 spec:


### PR DESCRIPTION
Originally we were sending alerts to the Kubermatic Slack (`#alerting-cncf-prod`) because we didn't have a webhook for the Kubernetes Slack. Given that this has been sorted out, we can phase out the Kubermatic Slack channel.

/assign @koksay @upodroid @ameukam 