### PR TITLE
Source Slack webhook token for k8s-infra-alerts from GCP SM

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/flux-system/slack-alerting-external-secret.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/flux-system/slack-alerting-external-secret.yaml
@@ -39,13 +39,12 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: aws-secerts-manager
+    name: k8s-infra-prow-build
     kind: ClusterSecretStore
   target:
     name: slack-k8s-infra-alerts-token
     creationPolicy: Owner
   data:
-  - secretKey: address
+  - secretKey: k8s-infra-alerts
     remoteRef:
-      key: prow-prod/slack-hooks/kubernetes
-      property: k8s-infra-alerts
+      key: slack-credentials

--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager-slack-token.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager-slack-token.yaml
@@ -39,13 +39,12 @@ metadata:
 spec:
   refreshInterval: 1h
   secretStoreRef:
-    name: aws-secerts-manager
+    name: k8s-infra-prow-build
     kind: ClusterSecretStore
   target:
     name: slack-k8s-infra-alerts-token
     creationPolicy: Owner
   data:
-  - secretKey: url
+  - secretKey: k8s-infra-alerts
     remoteRef:
-      key: prow-prod/slack-hooks/kubernetes
-      property: k8s-infra-alerts
+      key: slack-credentials


### PR DESCRIPTION
We copied the Slack webhook for the `#k8s-infra-alerts` channel to the GCP Secrets Manager so that we can use it in both k8s-infra-prow-build and eks-prow-build clusters without having them in two places (GCP SM and AWS SM). This PR changes ESO objects to reference the GCP SM and I'll remove the secret from the AWS SM after this is reconciled.

/assign @dims @upodroid @ameukam 