### PR TITLE
Fix ESOs for slack-k8s-infra-alerts-token

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/flux-system/slack-alerting-external-secret.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/flux-system/slack-alerting-external-secret.yaml
@@ -26,6 +26,7 @@ spec:
     name: slack-k8s-infra-alerts-token
     creationPolicy: Owner
   data:
-  - secretKey: k8s-infra-alerts
+  - secretKey: address
     remoteRef:
       key: slack-credentials
+      property: k8s-infra-alerts

--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager-slack-token.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager-slack-token.yaml
@@ -26,6 +26,7 @@ spec:
     name: slack-k8s-infra-alerts-token
     creationPolicy: Owner
   data:
-  - secretKey: k8s-infra-alerts
+  - secretKey: url
     remoteRef:
       key: slack-credentials
+      property: k8s-infra-alerts


### PR DESCRIPTION
Follow up on https://github.com/kubernetes/k8s.io/pull/6557 to use a proper field (`property` instead of `secretKey`).

/assign @ameukam @dims @upodroid 