### PR TITLE
kops-ci: Bump EKS module

### DIFF
--- a/infra/aws/terraform/kops-infra-ci/terraform.tf
+++ b/infra/aws/terraform/kops-infra-ci/terraform.tf
@@ -27,7 +27,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.29.0"
+      version = "~> 5.40.0"
     }
   }
 }


### PR DESCRIPTION
Bump to v20.x version

Introducing:
- Access entries
- Karpenter support
- AL2023 support
- tags on launch templates instead of the node group

/hold