### PR TITLE
eks-prow-build: fix missing annotations on ESO ServiceAccount

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/external-secrets/external-secrets.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/external-secrets/external-secrets.yaml
@@ -18,6 +18,8 @@ kind: ServiceAccount
 metadata:
   name: external-secrets
   namespace: "external-secrets"
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::468814281478:role/SECRETSMANAGER-IRSA
   labels:
     helm.sh/chart: external-secrets-0.9.13
     app.kubernetes.io/name: external-secrets


### PR DESCRIPTION
We lost the `eks.amazonaws.com/role-arn` when updating ESO in the eks-prow-build cluster and now ESO cannot authenticate with the AWS Secrets Manager, resulting in some secrets failing to sync.

We need to find a better way to handle that, likely to be handled with #6442, but let's get this merged and iterate on it later on

/assign @upodroid @ameukam @dims 