### PR TITLE
Revert adding IPs and DNS records for k8s-io-packages

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -91,16 +91,6 @@ _github-challenge-kubernetes-sigs:
 apt:
   type: CNAME
   value: redirect.k8s.io.
-legacy.apt:
-  - type: A
-    value: 34.128.166.11
-  - type: AAAA
-    value: "2600:1901:0:95e7::"
-legacy.yum:
-  - type: A
-    value: 34.128.166.11
-  - type: AAAA
-    value: "2600:1901:0:95e7::"
 yum:
   type: CNAME
   value: redirect.k8s.io.

--- a/infra/gcp/terraform/kubernetes-public/external-ips.tf
+++ b/infra/gcp/terraform/kubernetes-public/external-ips.tf
@@ -30,13 +30,6 @@ locals {
       name = "k8s-io-ingress-canary-v6",
       ipv6 = true
     },
-    canary-packages = {
-      name = "k8s-io-packages-ingress-canary",
-    },
-    canary-packages-v6 = {
-      name = "k8s-io-packages-ingress-canary-v6",
-      ipv6 = true
-    },
     cs = {
       name = "cs-k8s-io-ingress",
       description = "Used for cs-canary.k8s.io"
@@ -57,13 +50,6 @@ locals {
     },
     ingress-prod-v6 = {
       name = "k8s-io-ingress-prod-v6",
-      ipv6 = true
-    },
-    ingress-packages-prod = {
-      name = "k8s-io-packages-ingress-prod",
-    },
-    ingress-packages-prod-v6 = {
-      name = "k8s-io-packages-ingress-prod-v6",
       ipv6 = true
     },
     perf-dash = {


### PR DESCRIPTION
Fully revert https://github.com/kubernetes/k8s.io/pull/6156
Requires `terraform apply` after DNS changes are applied

The `k8s-io-packages` app was supposed to be used a playground for https://github.com/kubernetes/k8s.io/pull/6239 which was later applied to the production `k8s-io` app (https://github.com/kubernetes/k8s.io/pull/6251)

Given the legacy repos are gone, we're not going to do any further experiments and we don't need this `k8s-io-packages` app any longer

Follow up PRs will remove other parts of the app

/assign @upodroid @ameukam @dims 