### PR TITLE
Add Mario Fahlandt to summit-team email

### DIFF
--- a/groups/sig-contributor-experience/groups.yaml
+++ b/groups/sig-contributor-experience/groups.yaml
@@ -171,6 +171,7 @@ groups:
       - jcaudill@linuxfoundation.org
       - justnitish06@gmail.com
       - kaslin.fields@gmail.com
+      - mario@kubermatic.com
       - natalivlatko@gmail.com
       - rlejano@gmail.com
   #


### PR DESCRIPTION
This PR adds Mario Fahlandt to the summit-team@kubernetes.io email group
Mario is the Day-Of Ops lead for KCS Europe 2024

Related to https://github.com/kubernetes/community/issues/7611

/priority important-soon