### PR TITLE
GCP: add a secret SIG CLI Triage Party instance

### DIFF
--- a/apps/triageparty-cli/secret.yaml
+++ b/apps/triageparty-cli/secret.yaml
@@ -9,6 +9,6 @@ spec:
   backendType: gcpSecretsManager
   projectId: kubernetes-public
   data:
-  - key: triage-party-github-token
-    name: token
-    version: latest
+    - key: triage-party-cli-github-token
+      name: token
+      version: latest

--- a/infra/gcp/terraform/kubernetes-public/secrets.tf
+++ b/infra/gcp/terraform/kubernetes-public/secrets.tf
@@ -60,6 +60,12 @@ locals {
         "slackin-token",
       ]
     },
+    triageparty-cli = {
+      group = "sig-cli"
+      secrets = [
+        "triage-party-cli-github-token",
+      ]
+    },
   }
   // Even though we could just use the list, we're going to keep parity with
   // the map structure used in k8s-infra-prow-build, so resource definitions
@@ -68,8 +74,8 @@ locals {
     for s in flatten([
       for app_name, app in local.aaa_apps : [
         for secret in app.secrets : {
-          app = app_name
-          group = app.group
+          app    = app_name
+          group  = app.group
           owners = "k8s-infra-rbac-${app_name}@kubernetes.io"
           secret = secret
         }
@@ -83,7 +89,7 @@ resource "google_secret_manager_secret" "aaa_app_secrets" {
   project   = data.google_project.project.project_id
   secret_id = each.key
   labels = {
-    app = each.value.app
+    app   = each.value.app
     group = each.value.group
   }
   replication {


### PR DESCRIPTION
Related:
  - https://github.com/kubernetes/k8s.io/issues/6435

The GitHub token used by cli.triage.k8s.io was accidentally deleted during https://github.com/kubernetes/k8s.io/issues/6435.

We create a new GCP secret so the SIG CLI can upload a new GitHub token.