### PR TITLE
Remove invalid dash.etcd.io dns entry

### DIFF
--- a/dns/zone-configs/etcd.io._0_base.yaml
+++ b/dns/zone-configs/etcd.io._0_base.yaml
@@ -69,10 +69,6 @@ _jabber._tcp:
       target: xmpp-server4.l.google.com.
       weight: 20
 
-dash:
-  - type: A
-    value: 104.198.97.34
-
 play:
   - type: A
     value: 35.230.70.199


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes/k8s.io/pull/6601.

The `dash.etcd.io` service was stopped being used by the project in 2018, refer https://github.com/etcd-io/etcd/issues/10073

Fixes https://github.com/kubernetes/k8s.io/issues/6604.

cc @cblecker, @serathius, @ahrtr 