### PR TITLE
GCP: add a DL to provide access to codesearch

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -246,6 +246,7 @@ restrictions:
       - "^k8s-infra-okta-admins@kubernetes.io$"
       - "^k8s-infra-porche-admins@kubernetes.io$"
       - "^k8s-infra-rbac-cert-manager@kubernetes.io$"
+      - "^k8s-infra-rbac-codesearch@kubernetes.io$"
       - "^k8s-infra-rbac-k8s-io-canary@kubernetes.io$"
       - "^k8s-infra-rbac-k8s-io-packages-canary@kubernetes.io$"
       - "^k8s-infra-rbac-k8s-io-packages-prod@kubernetes.io$"

--- a/groups/sig-k8s-infra/groups.yaml
+++ b/groups/sig-k8s-infra/groups.yaml
@@ -106,6 +106,7 @@ groups:
       WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # needed for RBAC
     members:
       - k8s-infra-rbac-cert-manager@kubernetes.io
+      - k8s-infra-rbac-codesearch@kubernetes.io
       - k8s-infra-rbac-elekto@kubernetes.io
       - k8s-infra-rbac-gcsweb@kubernetes.io
       - k8s-infra-rbac-kettle@kubernetes.io
@@ -194,6 +195,16 @@ groups:
       - cblecker@gmail.com
       - james@munnelly.eu
       - sig-k8s-infra-leads@kubernetes.io
+
+  - email-id: k8s-infra-rbac-codesearch@kubernetes.io
+    name: k8s-infra-rbac-codesearch
+    description: |-
+      Grants access to the `namespace-user` role in the `codesearch` namespace on the `aaa` cluster
+    settings:
+      ReconcileMembers: "true"
+      WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW" # required
+    members:
+      - dec.soham@gmail.com
 
   - email-id: k8s-infra-rbac-k8s-io-canary@kubernetes.io
     name: k8s-infra-rbac-k8s-io-canary


### PR DESCRIPTION
Create a DL to provide access to codesearch on the aaa cluster.