### PR TITLE
Sync CAAPH maintainers

### DIFF
--- a/registry.k8s.io/images/k8s-staging-cluster-api-helm/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-cluster-api-helm/OWNERS
@@ -5,8 +5,6 @@ approvers:
 - fabriziopandini
 - Jont828
 - jackfrancis
-
-reviewers:
 - mboersma
 
 emeritus_approvers:


### PR DESCRIPTION
Syncs up maintainers with the [OWNERS_ALIASES](https://github.com/kubernetes-sigs/cluster-api-addon-provider-helm/blob/main/OWNERS_ALIASES) in CAAPH. Specifically, @mboersma moves to maintainer from reviewer.

/assign @Jont828