### PR TITLE
Add github-management-alerts mailing list

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -107,6 +107,7 @@ restrictions:
       - "^community@kubernetes.io$"
       - "^dev@kubernetes.io$"
       - "^github@kubernetes.io$"
+      - "^github-managment-alerts@kubernetes.io$"
       - "^lwkd@kubernetes.io$"
       - "^moderators@kubernetes.io$"
       - "^sig-contribex@kubernetes.io$"

--- a/groups/sig-contributor-experience/groups.yaml
+++ b/groups/sig-contributor-experience/groups.yaml
@@ -69,6 +69,27 @@ groups:
       - pal.nabarun95@gmail.com
       - priyankasaggu11929@gmail.com
 
+  - email-id: github-managment-alerts@kubernetes.io
+    name: github-managment-alerts
+    description: |-
+      Open mailing list for alerts from Kubernetes GitHub management applications. All other posts will be moderated. Please do not attempt to reply to this list.
+
+      For more information, refer https://git.k8s.io/community/github-management
+    owners:
+      - cblecker@gmail.com
+    managers:
+      - killen.bob@gmail.com
+      - madhav.jiv@gmail.com
+      - nikitaraghunath@gmail.com
+      - pal.nabarun95@gmail.com
+      - priyankasaggu11929@gmail.com
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_ALL_MESSAGES"
+      ReconcileMembers: "true"
+
   - email-id: lwkd@kubernetes.io
     name: lwkd
     description: |-


### PR DESCRIPTION
PR adds a new kubernetes-github-management-alerts@kubernetes.io mailing list.

Part of migration of [kubernetes-github-managment-alerts@googlegroups.com](mailto:kubernetes-github-managment-alerts@googlegroups.com) to kubernetes.io managed groups.

cc: @kubernetes/owners 
