### PR TITLE
Owners: Add Gacko to Ingress NGINX approvers.

### DIFF
--- a/registry.k8s.io/images/k8s-staging-ingress-nginx/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-ingress-nginx/OWNERS
@@ -2,11 +2,11 @@
 #  https://github.com/kubernetes/community/blob/master/contributors/devel/owners.md
 
 approvers:
-- elvinefendi
+- cpanato
+- Gacko
+- puerco
 - rikatz
 - strongjz
 - tao12345666333
-- puerco
-- cpanato
 labels:
 - sig/network


### PR DESCRIPTION
/cc @strongjz @cpanato @rikatz

Also remove @ElvinEfendi as he [stepped back](https://github.com/kubernetes/ingress-nginx/commit/9d9ff90eddcb8d514ecceb78b432e75f02a9b917) a year ago.