### PR TITLE
Serve kube-rbac-proxy images from registry.k8s.io

### DIFF
--- a/registry.k8s.io/images/k8s-staging-kubebuilder/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-kubebuilder/images.yaml
@@ -1,5 +1,20 @@
 # kube-rbac-proxy images
 # https://github.com/kubernetes-sigs/kubebuilder/tree/kube-rbac-proxy-releases/build
-#- name: kube-rbac-proxy
-#  dmap:
-#    "sha256:56633bd00dab33d92ba14c6e709126a762d54a75a6e72437adefeaaca0abb069": ["v0.34.0"] #<- should be the sha image from cloudbuild and the release version
+- name: kube-rbac-proxy
+  dmap:
+    "sha256:771a9a173e033a3ad8b46f5c00a7036eaa88c8d8d1fbd89217325168998113ea": ["v0.16.0"]
+    "sha256:d8cc6ffb98190e8dd403bfe67ddcb454e6127d32b87acc237b3e5240f70a20fb": ["v0.15.0"]
+    "sha256:fcca9269424da38cfd216f4731de9fe5dea9f98e32c00da767b8e6e1ce9613cb": ["v0.14.4"]
+    "sha256:928e64203edad8f1bba23593c7be04f0f8410c6e4feb98d9e9c2d00a8ff59048": ["v0.14.1"]
+    "sha256:e2670fb55b3211fb101f17afa3d81ba816d7c0b76ed31bd3d93fa2affb491595": ["v0.14.0"]
+    "sha256:d4883d7c622683b3319b5e6b3a7edfbf2594c18060131a8bf64504805f875522": ["v0.13.1"]
+    "sha256:d99a8d144816b951a67648c12c0b988936ccd25cf3754f3cd85ab8c01592248f": ["v0.13.0"]
+    "sha256:5542d9a8d8472772733ad4ad1cdd6634e3e4f0e9d7542b1a2d3e6f4947ddca95": ["v0.12.0"]
+    "sha256:0df4ae70e3bd0feffcec8f5cdb428f4abe666b667af991269ec5cb0bbda65869": ["v0.11.0"]
+    "sha256:1c62bc13a710f2306d47fa922c146a97e230c77470f8a8635a8cc82537dc91a3": ["v0.10.0"]
+    "sha256:12178caa19e0500f3ed5c1da72f8ec1758291b38cbcd9fd1d6ed4ad0978b5cb4": ["v0.9.0"]
+    "sha256:db06cc4c084dd0253134f156dddaaf53ef1c3fb3cc809e5d81711baa4029ea4c": ["v0.8.0"]
+    # images older than 0.8 are not multiarch images
+    "sha256:e10d1d982dd653db74ca87a1d1ad017bc5ef1aeb651bdea089debf16485b080b": ["v0.5.0"]
+    "sha256:6c915d948d4781d366300d6e75d67a7830a941f078319f0fecc21c7744053eff": ["v0.4.1"]
+    "sha256:297896d96b827bbcb1abd696da1b2d81cab88359ac34cce0e8281f266b4e08de": ["v0.4.0"]


### PR DESCRIPTION
I recently copied the contents of `gcr.io/kubebuilder/kube-rbac-proxy` to `gcr.io/k8s-staging-kubebuilder/kube-rbac-proxy` to promote the kube-rbac-proxy images as GCR is being shut down next year and kubebuilder project is hosted inside google.com GCP org.

https://explore.ggcr.dev/?repo=gcr.io%2Fk8s-staging-kubebuilder%2Fkube-rbac-proxy

/cc @camilamacedo86 @ibihim 

Fixes: https://github.com/kubernetes/k8s.io/issues/2647

Once this PR is merged, kube-rbac-proxy image are available at `registry.k8s.io/kubebuilder/kube-rbac-proxy`