### PR TITLE
Add access for kettle SA to kubernetes-public project

### DIFF
--- a/infra/gcp/terraform/kubernetes-public/k8s-kettle.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-kettle.tf
@@ -58,6 +58,14 @@ data "google_iam_policy" "prod_kettle_dataset_iam_policy" {
   }
 }
 
+// grant bigquery jobUser role to the service account
+// so the job transfer can launch BigQuery jobs
+resource "google_project_iam_member" "kettle_jobuser_binding" {
+  project = data.google_project.project.project_id
+  role    = "roles/bigquery.jobUser"
+  member  = "serviceAccount:${module.aaa_kettle_sa.email}"
+}
+
 resource "google_bigquery_dataset_iam_policy" "prod_kettle_dataset" {
   dataset_id  = google_bigquery_dataset.prod_kettle_dataset.dataset_id
   project     = google_bigquery_dataset.prod_kettle_dataset.project


### PR DESCRIPTION
the service account does not have permissions to the project.

```
root@kettle:/# bq show <<< $'\n'
BigQuery error in show operation: Unknown project 'kubernetes-public'
root@kettle:/# gcloud config list account --format "value(core.account)"
kettle@kubernetes-public.iam.gserviceaccount.com
```

Comparing the other SA that seems to be working fine, looks like we were missing what's in this PR.

![image](https://github.com/kubernetes/k8s.io/assets/23304/4e6c612c-a346-4a53-b676-5cf8de9feb61)
