### PR TITLE
Raise progressDeadlineSeconds to 3600 for codesearch deployment

### DIFF
--- a/apps/codesearch/deployment.yaml
+++ b/apps/codesearch/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       maxSurge: 1
       maxUnavailable: 0
     type: RollingUpdate
+  progressDeadlineSeconds: 3600
   template:
     metadata:
       labels:


### PR DESCRIPTION
* The codesearch deployment handles plenty of data. This is causing deployment rollout to be considered failure as we are hitting deployment has failed progressing. This change should give the deployment controller 3600 seconds before telling that the deployment rollout has stalled. 
* Part of fixing [2182](https://github.com/kubernetes/k8s.io/issues/2182).