### PR TITLE
Add 8Gi memory limit and request to codesearch container

### DIFF
--- a/apps/codesearch/deployment.yaml
+++ b/apps/codesearch/deployment.yaml
@@ -43,10 +43,11 @@ spec:
           volumeMounts:
           - name: config
             mountPath: /data
-          # resources:
-          #   limits:
-          #     cpu: "1" # TODO - find baseline
-          #     memory: 8Gi # TODO - find baseline
+          resources:
+            limits:
+              memory: 8Gi
+            requests:
+              memory: 8Gi
       volumes:
       - name: config
         emptyDir: {}


### PR DESCRIPTION
* Part of [2182](https://github.com/kubernetes/k8s.io/issues/2182)
* Adds 8Gi memory limit and request to codesearch container