### PR TITLE
Add new github orgs to the fetch-repos.py script used by codesearch container

### DIFF
--- a/images/codesearch/cs-fetch-repos/src/fetch-repos.py
+++ b/images/codesearch/cs-fetch-repos/src/fetch-repos.py
@@ -27,8 +27,6 @@ REPOS = [
     'kubernetes-csi',
     'kubernetes-incubator',
     'kubernetes-sigs',
-    'kubernetes-nightly',
-    'kubernetes-retired',
     'etcd-io',
 ]
 

--- a/images/codesearch/cs-fetch-repos/src/fetch-repos.py
+++ b/images/codesearch/cs-fetch-repos/src/fetch-repos.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2021 The Kubernetes Authors.
+# Copyright 2024 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,6 +27,9 @@ REPOS = [
     'kubernetes-csi',
     'kubernetes-incubator',
     'kubernetes-sigs',
+    'kubernetes-nightly',
+    'kubernetes-retired',
+    'etcd-io',
 ]
 
 CONFIG = {

--- a/images/codesearch/cs-fetch-repos/src/fetch-repos.py
+++ b/images/codesearch/cs-fetch-repos/src/fetch-repos.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2024 The Kubernetes Authors.
+# Copyright 2021 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Part of [2182](https://github.com/kubernetes/k8s.io/issues/2182)
* Add remaining github organizations to the script