### PR TITLE
Promote image for v0.2.0 for lws

### DIFF
--- a/registry.k8s.io/images/k8s-staging-lws/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-lws/images.yaml
@@ -1,3 +1,4 @@
 - name: lws
   dmap:
     "sha256:1cf665fa003c830cd9105e0227a041e9f85dd3c86e7442f5ef6af313dc4fea55": ["v0.1.0"]
+    "sha256:6615ded334adea763e7e70675be37521c798b21918687fbb98463e59aa0e8410": ["v0.2.0"]


### PR DESCRIPTION
This for releasing Leaderworkerset v0.2.0: https://github.com/kubernetes-sigs/lws