### PR TITLE
Bootstrap k8s-infra-prow GCP project

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,25 @@
+# IP Assignments
+
+This file is being stored temporarily here to track RFC 1918 IP space allocation to avoid network IP conflicts. It is important that our infrastructure across all vendors can be connected to each other.
+
+
+IP Allocation so far:
+
+Azure: TBD
+
+AWS:
+- 10.128.0.0/16 kops prow cluster
+- 10.0.0.0/16 eks-prow-build-cluster
+
+GCP:
+- 10.250.0.0/16 for k8s-infra-prow GCP project
+
+Oracle:
+
+
+VMWare SDDC: TBD
+
+
+## Clusters that must be rebuilt and moved to a new network:
+- k8s-infra-prow-build
+- k8s-infra-prow-build-trusted

--- a/infra/gcp/terraform/k8s-infra-prow/addresses.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/addresses.tf
@@ -1,0 +1,39 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "google_compute_global_address" "prow" {
+  for_each   = toset(["IPV4", "IPV6"])
+  project    = module.project.project_id
+  name       = "prow-ingress-${lower(substr(each.key, 2, 2))}"
+  ip_version = each.key
+}
+
+resource "google_compute_address" "prow_nat" {
+  count   = 4
+  name    = "prow-nat-${count.index}"
+  project = module.project.project_id
+  region  = "us-central1"
+}
+
+resource "google_compute_address" "utility_ingress" {
+  for_each           = toset(["IPV4", "IPV6"])
+  name               = "utility-ingress-${lower(substr(each.key, 2, 2))}"
+  project            = module.project.project_id
+  region             = "us-central1"
+  ip_version         = each.key
+  subnetwork         = each.key == "IPV6" ? module.vpc.subnets["us-central1/subnet-01"].id : null
+  ipv6_endpoint_type = each.key == "IPV6" ? "NETLB" : null
+}

--- a/infra/gcp/terraform/k8s-infra-prow/buckets.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/buckets.tf
@@ -33,12 +33,12 @@ module "gcb_bucket" {
   }]
 
   iam_members = [
-    # {
-    #   role   = "roles/storage.objectViewer"
-    #   member = "serviceAccount:${google_service_account.image_builder.email}"
-    # },
     {
-      role   = "roles/storage.objectCreator"
+      role   = "roles/storage.admin"
+      member = "serviceAccount:${google_service_account.image_builder.email}"
+    },
+    {
+      role   = "roles/storage.admin"
       member = "serviceAccount:gcb-builder@k8s-infra-prow-build-trusted.iam.gserviceaccount.com"
     }
   ]

--- a/infra/gcp/terraform/k8s-infra-prow/buckets.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/buckets.tf
@@ -1,0 +1,45 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module "gcb_bucket" {
+  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
+  version = "~> 5"
+
+  name       = "k8s-infra-prow-gcb"
+  project_id = module.project.project_id
+  location   = "us"
+
+  lifecycle_rules = [{
+    action = {
+      type = "Delete"
+    }
+    condition = {
+      age        = 7
+      with_state = "ANY"
+    }
+  }]
+
+  iam_members = [
+    # {
+    #   role   = "roles/storage.objectViewer"
+    #   member = "serviceAccount:${google_service_account.image_builder.email}"
+    # },
+    {
+      role   = "roles/storage.objectCreator"
+      member = "serviceAccount:gcb-builder@k8s-infra-prow-build-trusted.iam.gserviceaccount.com"
+    }
+  ]
+}

--- a/infra/gcp/terraform/k8s-infra-prow/gke.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/gke.tf
@@ -1,0 +1,136 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// WARNING, MAKE SURE YOU DON"T DESTROY THESE CLUSTERS ACCIDENTALLY
+module "prow" {
+  source                       = "terraform-google-modules/kubernetes-engine/google//modules/beta-private-cluster"
+  version                      = "~> 30.2"
+  project_id                   = module.project.project_id
+  name                         = "prow"
+  region                       = "us-central1"
+  zones                        = ["us-central1-a", "us-central1-b"]
+  release_channel              = "REGULAR"
+  network                      = module.vpc.network_name
+  subnetwork                   = module.vpc.subnets["us-central1/subnet-01"].name
+  ip_range_pods                = "prow-pods"
+  ip_range_services            = "prow-services"
+  stack_type                   = "IPV4_IPV6"
+  http_load_balancing          = true
+  datapath_provider            = "ADVANCED_DATAPATH"
+  filestore_csi_driver         = false
+  create_service_account       = false
+  remove_default_node_pool     = true
+  enable_l4_ilb_subsetting     = true
+  enable_private_nodes         = true
+  enable_cost_allocation       = true
+  gateway_api_channel          = "CHANNEL_STANDARD"
+  master_ipv4_cidr_block       = "10.254.0.16/28"
+  authenticator_security_group = "gke-security-groups@kubernetes.io"
+  cluster_resource_labels = {
+    cluster     = "prow"
+    role        = "prow"
+    environment = "production"
+  }
+
+  node_pools = [
+    {
+      name               = "prod-v1"
+      machine_type       = "c3-standard-4"
+      node_locations     = "us-central1-a,us-central1-b"
+      min_count          = 1
+      max_count          = 6
+      disk_size_gb       = 100
+      disk_type          = "pd-ssd"
+      image_type         = "COS_CONTAINERD"
+      auto_repair        = true
+      auto_upgrade       = true
+      service_account    = google_service_account.gke_nodes.email
+      enable_secure_boot = true
+      initial_node_count = 1
+      location_policy    = "BALANCED"
+    },
+  ]
+
+  node_pools_labels = {
+    all = {
+      environment = "production"
+    }
+  }
+}
+
+module "utility_cluster" {
+  source                       = "terraform-google-modules/kubernetes-engine/google//modules/beta-private-cluster"
+  version                      = "~> 30.2"
+  project_id                   = module.project.project_id
+  name                         = "utility"
+  region                       = "us-central1"
+  zones                        = ["us-central1-a", "us-central1-b"]
+  release_channel              = "REGULAR"
+  network                      = module.vpc.network_name
+  subnetwork                   = module.vpc.subnets["us-central1/subnet-01"].name
+  ip_range_pods                = "utility-pods"
+  ip_range_services            = "utility-services"
+  stack_type                   = "IPV4_IPV6"
+  http_load_balancing          = true
+  datapath_provider            = "ADVANCED_DATAPATH"
+  filestore_csi_driver         = false
+  create_service_account       = false
+  remove_default_node_pool     = true
+  enable_l4_ilb_subsetting     = true
+  enable_private_nodes         = true
+  enable_cost_allocation       = true
+  master_ipv4_cidr_block       = "10.254.0.0/28"
+  authenticator_security_group = "gke-security-groups@kubernetes.io"
+
+  cluster_resource_labels = {
+    cluster     = "utility"
+    role        = "utility"
+    environment = "production"
+  }
+
+  master_authorized_networks = [
+    {
+      cidr_block   = "0.0.0.0/0"
+      display_name = "external-v4"
+    },
+  ]
+
+  node_pools = [
+    {
+      name               = "prod-v1"
+      machine_type       = "c3-standard-4"
+      node_locations     = "us-central1-a,us-central1-b"
+      min_count          = 1
+      max_count          = 3
+      disk_size_gb       = 100
+      disk_type          = "pd-ssd"
+      image_type         = "COS_CONTAINERD"
+      auto_repair        = true
+      auto_upgrade       = true
+      service_account    = google_service_account.gke_nodes.email
+      enable_secure_boot = true
+      initial_node_count = 1
+      location_policy    = "BALANCED"
+    },
+  ]
+
+  node_pools_labels = {
+    all = {
+      environment = "production"
+      type        = "system"
+    }
+  }
+}

--- a/infra/gcp/terraform/k8s-infra-prow/iam.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/iam.tf
@@ -1,0 +1,61 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module "iam" {
+  source  = "terraform-google-modules/iam/google//modules/projects_iam"
+  version = "~> 7"
+
+  projects = [module.project.project_id]
+
+  mode = "authoritative"
+
+  bindings = {
+    "roles/artifactregistry.reader" = [
+      "serviceAccount:${google_service_account.gke_nodes.email}",
+    ]
+    "roles/container.admin" = [
+      "serviceAccount:${google_service_account.argocd.email}",
+    ]
+
+    "roles/logging.logWriter" = [
+      "serviceAccount:${google_service_account.gke_nodes.email}",
+    ]
+
+    "roles/monitoring.metricWriter" = [
+      "serviceAccount:${google_service_account.gke_nodes.email}",
+    ]
+    // IF GCB needs additional privileges beyond the documented roles please use a custom service account with it
+    // https://cloud.google.com/build/docs/cloud-build-service-account
+    "roles/cloudbuild.builds.editor" = [
+      "serviceAccount:gcb-builder@k8s-infra-prow-build-trusted.iam.gserviceaccount.com",
+    ]
+    "roles/owner" = [
+      "group:k8s-infra-prow-oncall@kubernetes.io",
+    ]
+  }
+}
+
+resource "google_service_account" "gke_nodes" {
+  account_id   = "gke-nodes"
+  display_name = "GKE Nodes"
+  project      = module.project.project_id
+}
+
+resource "google_service_account" "argocd" {
+  account_id   = "argocd"
+  display_name = "ArgoCD"
+  project      = module.project.project_id
+}

--- a/infra/gcp/terraform/k8s-infra-prow/main.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/main.tf
@@ -1,0 +1,44 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module "project" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 14.5"
+
+  name            = "k8s-infra-prow"
+  project_id      = "k8s-infra-prow"
+  folder_id       = "411137699919" # manually created, will create via TF once I start working on the org
+  org_id          = "758905017065"
+  billing_account = "018801-93540E-22A20E"
+
+  # Sane project defaults
+  default_service_account     = "keep"
+  disable_services_on_destroy = false
+  create_project_sa           = false
+  random_project_id           = false
+  auto_create_network         = true
+
+
+  activate_apis = [
+    "secretmanager.googleapis.com",
+    "compute.googleapis.com",
+    "container.googleapis.com",
+    "cloudkms.googleapis.com",
+    "certificatemanager.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "secretmanager.googleapis.com"
+  ]
+}

--- a/infra/gcp/terraform/k8s-infra-prow/main.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/main.tf
@@ -39,6 +39,7 @@ module "project" {
     "cloudkms.googleapis.com",
     "certificatemanager.googleapis.com",
     "artifactregistry.googleapis.com",
-    "secretmanager.googleapis.com"
+    "secretmanager.googleapis.com",
+    "cloudbuild.googleapis.com"
   ]
 }

--- a/infra/gcp/terraform/k8s-infra-prow/provider.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/provider.tf
@@ -1,0 +1,35 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  required_version = "1.6.5"
+
+  backend "gcs" {
+    bucket = "k8s-infra-tf-prow-clusters"
+    prefix = "k8s-infra-prow/prow" // $project_name/$cluster_name
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.25.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 5.25.0"
+    }
+  }
+}

--- a/infra/gcp/terraform/k8s-infra-prow/registries.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/registries.tf
@@ -1,0 +1,31 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "google_artifact_registry_repository" "images" {
+  project       = module.project.project_id
+  location      = "us"
+  repository_id = "images"
+  description   = "Prow Images"
+  format        = "DOCKER"
+}
+
+resource "google_artifact_registry_repository_iam_member" "images" {
+  project    = google_artifact_registry_repository.images.project
+  location   = google_artifact_registry_repository.images.location
+  repository = google_artifact_registry_repository.images.name
+  role       = "roles/artifactregistry.reader"
+  member     = "allUsers"
+}

--- a/infra/gcp/terraform/k8s-infra-prow/registries.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/registries.tf
@@ -29,3 +29,11 @@ resource "google_artifact_registry_repository_iam_member" "images" {
   role       = "roles/artifactregistry.reader"
   member     = "allUsers"
 }
+
+resource "google_artifact_registry_repository_iam_member" "image_builder" {
+  project    = google_artifact_registry_repository.images.project
+  location   = google_artifact_registry_repository.images.location
+  repository = google_artifact_registry_repository.images.name
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:${google_service_account.image_builder.email}"
+}

--- a/infra/gcp/terraform/k8s-infra-prow/vpc.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/vpc.tf
@@ -1,0 +1,69 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module "vpc" {
+  source  = "terraform-google-modules/network/google"
+  version = "~> 9"
+
+  project_id      = module.project.project_id
+  network_name    = "prow"
+  routing_mode    = "GLOBAL"
+  enable_ipv6_ula = true
+
+  subnets = [
+    {
+      subnet_name           = "subnet-01"
+      subnet_ip             = "10.250.0.0/20"
+      subnet_region         = "us-central1"
+      subnet_private_access = "true"
+      ipv6_access_type      = "EXTERNAL"
+      stack_type            = "IPV4_IPV6"
+    },
+  ]
+
+  secondary_ranges = {
+    subnet-01 = [
+      {
+        range_name    = "prow-services"
+        ip_cidr_range = "10.250.128.0/20"
+      },
+      {
+        range_name    = "prow-pods"
+        ip_cidr_range = "10.250.160.0/20"
+      },
+      {
+        range_name    = "utility-services"
+        ip_cidr_range = "10.250.192.0/20"
+      },
+      {
+        range_name    = "utility-pods"
+        ip_cidr_range = "10.250.224.0/20"
+      }
+    ]
+  }
+}
+
+module "nat" {
+  source        = "terraform-google-modules/cloud-nat/google"
+  version       = "~> 5.0"
+  project_id    = module.project.project_id
+  nat_ips       = google_compute_address.prow_nat.*.self_link
+  region        = "us-central1"
+  network       = module.vpc.network_name
+  create_router = true
+  router        = "prow-nat"
+  name          = "prow-nat"
+}


### PR DESCRIPTION
This project will host 3 key services:
- The prow control plane
- A utility cluster that runs ArgoCD, Atlantis and our unified Grafana instance
- Host `gcr.io/k8s-prow` replacement at `us-docker.pkg.dev/k8s-infra-prow/images`

Before Aug 2024, I want to have the images being dual published to both locations and the utility cluster to be fully operational.

/cc @ameukam @dims @BenTheElder 