### PR TITLE
Image promotion for etcd 3.5.13-0

### DIFF
--- a/registry.k8s.io/images/k8s-staging-etcd/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-etcd/images.yaml
@@ -21,6 +21,7 @@
     "sha256:22f892d7672adc0b9c86df67792afdb8b2dc08880f49f669eaaa59c47d7908c2": ["3.5.10-0"]
     "sha256:29901446ff08461789b7cd8565fc5b538134e58f81ca1f50fd65d0371cf6571e": ["3.5.11-0"]
     "sha256:44a8e24dcbba3470ee1fee21d5e88d128c936e9b55d4bc51fbef8086f8ed123b": ["3.5.12-0"]
+    "sha256:f8b7ad2d8552d815ad85b3df088ca1a2cbc079ad216630ded0057cc79c2d257f": ["3.5.13-0"]
     "sha256:87cd0c2afe02de8dca78b8027852a6e8a18752ad5036be71ff21dea8c175abb9": ["3.6.0-alpha.0-0"]
 - name: etcd-empty-dir-cleanup
   dmap:


### PR DESCRIPTION

continue https://github.com/kubernetes/kubernetes/pull/124026


```shell
k8s.io$ docker inspect gcr.io/k8s-staging-etcd/etcd:3.5.13-0
[
    {
        "Id": "sha256:1b2ba9f3d2043b4c8010fdb3dbc98b9ccc684fdf28f589985d35db06e8252fad",
        "RepoTags": [
            "gcr.io/k8s-staging-etcd/etcd:3.5.13-0"
        ],
        "RepoDigests": [
            "gcr.io/k8s-staging-etcd/etcd@sha256:f8b7ad2d8552d815ad85b3df088ca1a2cbc079ad216630ded0057cc79c2d257f"
        ],
```

/assign @dims @saschagrunert
