### PR TITLE
promoting agnhost 2.50

### DIFF
--- a/registry.k8s.io/images/k8s-staging-e2e-test-images/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-e2e-test-images/images.yaml
@@ -26,6 +26,7 @@
     # 2.46 was not built due to https://github.com/kubernetes/kubernetes/issues/123266
     "sha256:cc249acbd34692826b2b335335615e060fdb3c0bca4954507aa3a1d1194de253": ["2.47"]
     "sha256:baeac1023bb8b281cffcd4246217331a9977c7cb8e285c0d6f07228855df49f6": ["2.48"]
+    "sha256:0737a4bf9ddaef39caf5ab80ba87d5581c13db9fe11ad96fb10a5a85c687d570": ["2.50"]
 - name: apparmor-loader
   dmap:
     "sha256:60629fe42de6260c9b930b48a2923b69168dc1c71fa5f762f70036477ffd74b6": ["1.2"]


### PR DESCRIPTION
build log: https://storage.googleapis.com/kubernetes-jenkins/logs/post-kubernetes-push-e2e-agnhost-test-images/1783200902094524416/artifacts/build.log

Also confirming the sha:
```
docker pull gcr.io/k8s-staging-e2e-test-images/agnhost:2.50
2.50: Pulling from k8s-staging-e2e-test-images/agnhost
1b7ca6aea1dd: Pull complete 
0fd59ae74c87: Pull complete 
661d3888a6b1: Pull complete 
ac9af3d034fd: Pull complete 
46d6467cb3eb: Pull complete 
b6487d92c17e: Pull complete 
feb541e3feaa: Pull complete 
8fc5b7718cf2: Pull complete 
bcaba971d881: Pull complete 
59cdd10a5c92: Pull complete 
Digest: sha256:0737a4bf9ddaef39caf5ab80ba87d5581c13db9fe11ad96fb10a5a85c687d570
Status: Downloaded newer image for gcr.io/k8s-staging-e2e-test-images/agnhost:2.50
gcr.io/k8s-staging-e2e-test-images/agnhost:2.50
```

