### PR TITLE
Sync CAPZ owners with Azure provider project

### DIFF
--- a/registry.k8s.io/images/k8s-staging-cluster-api-azure/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-cluster-api-azure/OWNERS
@@ -3,14 +3,14 @@
 
 approvers:
 - jackfrancis
+- Jont828
 - mboersma
 - nojnhuh
+- willie-yao
 reviewers:
-- Jont828
 - jsturtevant
 - marosset
 - nawazkh
-- willie-yao
 
 labels:
 - sig/cluster-lifecycle


### PR DESCRIPTION
Syncs up with recent changes to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES

Specifically, moves @Jont828 and @willie-yao to approvers.

/cc @jackfrancis @Jont828 @nojnhuh