### PR TITLE
Add Peter Schuurman (pwschuurman) as a prow viewer

### DIFF
--- a/groups/sig-testing/groups.yaml
+++ b/groups/sig-testing/groups.yaml
@@ -160,6 +160,7 @@ groups:
     - thejoycekung@gmail.com
     - neolit123@gmail.com
     - philjohnson96@gmail.com
+    - psch@google.com
 
   #
   # sig-testing k8s-infra owners


### PR DESCRIPTION
This PR adds [Peter Schuurman](https://github.com/pwschuurman) to the k8s-infra-prow-viewers Google Group so that he can see resources in the GKE Prow build cluster. This is needed to access GCP VM logs in projects where the [gcp-compute-persistent-disk-csi-driver](https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver) integration runs [example](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-gcp-compute-persistent-disk-csi-driver-kubernetes-integration).
