### PR TITLE
Add missing DNS record for www.discovery.etcd.io

### DIFF
--- a/dns/zone-configs/etcd.io._0_base.yaml
+++ b/dns/zone-configs/etcd.io._0_base.yaml
@@ -75,6 +75,10 @@ discovery:
   - type: A
     value: 35.225.64.149
 
+www.discovery:
+  - type: A
+    value: 35.225.64.149
+
 dev.discovery:
   - type: A
     value: 35.184.241.212


### PR DESCRIPTION
The ingress resource that is used for `discovery.etcd.io` uses both hosts `discovery.etcd.io` and `www.discovery.etcd.io`. Checking on the cert-manager pods I can see the error message `dial tcp: lookup www.discovery.etcd.io on 10.128.128.10:53: no such host` which indicates that the DNS lookup for [www.discovery.etcd.io](http://www.discovery.etcd.io/) failed. Also, with dig we are getting non-existent domain:

```
dig  www.discovery.etcd.io

; <<>> DiG 9.18.25 <<>> www.discovery.etcd.io
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 31045
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1
```
To solve this, we need to add the DNS record for `www.discovery`

See more details [here](https://github.com/etcd-io/discovery.etcd.io/issues/80).
