### PR TITLE
Update leads email group with to reflect SIG Docs leadership changes

### DIFF
--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -94,6 +94,7 @@ groups:
       - k8s@auggie.dev # SIG Release
       - kaitlynbarnard10@gmail.com
       - kaslin.fields@gmail.com
+      - kat.cosgrove@gmail.com
       - kbhawkey@gmail.com
       - kikis.github@gmail.com
       - kim.andrewsy@gmail.com
@@ -141,7 +142,6 @@ groups:
       - tasha.drew@gmail.com
       - theenjeru@gmail.com
       - thockin@google.com
-      - tim@scalefactory.com
       - timallclair@gmail.com
       - timothysc@gmail.com
       - tpepper@vmware.com


### PR DESCRIPTION
This PR updates the leads@kubernetes.io to reflect the changes in SIG Docs leadership:
- Kat Cosgrove is new Tech Lead (Xander Grzywinski is also a new Tech Lead but is already on the leads@kubernetes.io from CoCC)
- Tim Bannister has stepped down as Tech Lead

/cc @natalisucks @divya-mohan0209 