### PR TITLE
SIG Cloud Provider update

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -27,11 +27,9 @@ aliases:
     - mpuckett159
     - soltysh
   sig-cloud-provider-leads:
-    - andrewsykim
     - bridgetkromhout
     - cheftako
     - elmiko
-    - nckturner
   sig-cluster-lifecycle-leads:
     - CecileRobertMichon
     - fabriziopandini

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -97,7 +97,6 @@ groups:
       - kat.cosgrove@gmail.com
       - kbhawkey@gmail.com
       - kikis.github@gmail.com
-      - kim.andrewsy@gmail.com
       - klaus1982.cn@gmail.com
       - ksemenov@vmware.com
       - lachlan.evenson@gmail.com


### PR DESCRIPTION
Updated [OWNERS_ALIASES](https://git.k8s.io/k8s.io/OWNERS_ALIASES) in [kubernetes/k8s.io](https://git.k8s.io/k8s.io/).for https://github.com/kubernetes/community/issues/7865.
Updated [membership](https://git.k8s.io/k8s.io//groups/groups.yaml) of the [leads mailing list](https://groups.google.com/a/kubernetes.io/g/leads).

/sig cloud-provider