### PR TITLE
images: promote node-feature-discovery v0.16.0

### DIFF
--- a/registry.k8s.io/images/k8s-staging-nfd/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-nfd/images.yaml
@@ -73,6 +73,8 @@
     "sha256:b340d283b934c270f08b3eecbf921a01364d7db472c5d84f7394275c0c316828": ["v0.15.3-full"]
     "sha256:21c2681deb07aaa1eac74daef2c576392fcc9c72c87ffd4f43769e8a7cd39ddd": ["v0.15.4","v0.15.4-minimal"]
     "sha256:d3f25344bfd95012108a7b71bd88a1f014d97871305fa4628aa0b7df779cd0bc": ["v0.15.4-full"]
+    "sha256:fb3b6815b74fd31379697cb73ad684d521c58b0c5c22ac2d6b25132922c0232f": ["v0.16.0","v0.16.0-minimal"]
+    "sha256:5aa9c8fb4983dc341536231ec6a261737f7b392c08266ee1891194a2912b4ff1": ["v0.16.0-full"]
 - name: node-feature-discovery-operator
   dmap:
     "sha256:36a9a2c9d40b08a72df2878fcb602a86c7cf5b71ee9a786bff67fb84b64dcd16": ["v0.2.0"]


### PR DESCRIPTION
```bash
$ skopeo inspect docker://gcr.io/k8s-staging-nfd/node-feature-discovery:v0.16.0 | jq .Digest
"sha256:fb3b6815b74fd31379697cb73ad684d521c58b0c5c22ac2d6b25132922c0232f"

$ skopeo inspect docker://gcr.io/k8s-staging-nfd/node-feature-discovery:v0.16.0-minimal | jq .Digest
"sha256:fb3b6815b74fd31379697cb73ad684d521c58b0c5c22ac2d6b25132922c0232f"

$ skopeo inspect docker://gcr.io/k8s-staging-nfd/node-feature-discovery:v0.16.0-full | jq .Digest
"sha256:5aa9c8fb4983dc341536231ec6a261737f7b392c08266ee1891194a2912b4ff1"
```