### PR TITLE
add terraform code to deploy patch release notification service

### DIFF
--- a/infra/aws/terraform/sig-release/OWNERS
+++ b/infra/aws/terraform/sig-release/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - release-engineering-approvers
+  - sig-k8s-infra-leads
+reviewers:
+  - release-engineering-reviewers

--- a/infra/aws/terraform/sig-release/patch-release-notification/README.md
+++ b/infra/aws/terraform/sig-release/patch-release-notification/README.md
@@ -1,0 +1,32 @@
+# patch-release-notification service
+
+This terraform code deploys the code to notify the K8s community about the cherry pick deadline for the patch releases.
+
+The patch-release-notification code can be found in `cmd/patch-release-notification`
+
+Right now, the terraform is applied manually by the release managers that have access to the AWS account for the SIG-release.
+
+# Deploy
+
+To deploy will require to have both repositories cloned:
+
+- https://github.com/kubernetes/release/
+- https://github.com/kubernetes/k8s.io
+
+from https://github.com/kubernetes/k8s.io
+
+```
+# loging to the AWS ECR
+$ aws ecr get-login-password --region us-west-2 | docker login --username AWS --password-stdin 433650573627.dkr.ecr.us-west-2.amazonaws.com
+
+$ cd k8s.io/infra/aws/terraform/sig-release/patch-release-notification
+
+$ terraform init
+
+$ terraform plan -out=plan.out
+
+$ terraform apply "plan.out"
+```
+
+_note_: you will need to configure your AWS credentials before.
+_note2_: this is setup to run in the AWS SIG-Release account.

--- a/infra/aws/terraform/sig-release/patch-release-notification/main.tf
+++ b/infra/aws/terraform/sig-release/patch-release-notification/main.tf
@@ -1,0 +1,125 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_sesv2_email_identity" "sig_release_email_identity" {
+  email_identity = var.email_identity
+}
+
+resource "aws_iam_role" "lambda_ses_role" {
+  name = "lambda_ses_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "lambda_ses_policy" {
+  name        = "lambda_ses_policy"
+  description = "IAM policy for Lambda to access SES"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = [
+          "ses:SendEmail",
+          "ses:SendRawEmail"
+        ],
+        Effect   = "Allow",
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_ecr_repository" "repo" {
+  name                 = var.repository
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+}
+
+resource "aws_ecr_repository" "cherry_pick_notification_repo" {
+  name                 = "${var.repository}/patch-release-notification"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = false
+  }
+}
+
+resource "ko_build" "cherry_pick_notification_image" {
+  repo        = aws_ecr_repository.cherry_pick_notification_repo.repository_url
+  base_image  = "public.ecr.aws/lambda/provided:al2023"
+  working_dir = "${path.module}/../../../../../../release/cmd/patch-release-notification"
+  importpath  = "k8s.io/release/cmd/patch-release-notification"
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_ses_policy_attachment" {
+  role       = aws_iam_role.lambda_ses_role.name
+  policy_arn = aws_iam_policy.lambda_ses_policy.arn
+}
+
+resource "aws_lambda_function" "cherry_pick_notification" {
+  function_name = "patch-release-notification"
+  role          = aws_iam_role.lambda_ses_role.arn
+  image_uri     = ko_build.cherry_pick_notification_image.image_ref
+  package_type  = "Image"
+
+  environment {
+    variables = {
+      FROM_EMAIL    = var.email_identity
+      TO_EMAIL      = var.to_email
+      SCHEDULE_PATH = var.schedule_path
+      DAYS_TO_ALERT = var.days_to_alert
+      NO_MOCK       = var.no_mock
+      AWS_REGION    = var.region
+    }
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "trigger_lambda_cron" {
+  name                = "trigger-patch-release-notification-cron"
+  description         = "Trigger Lambda function on a schedule"
+  schedule_expression = "cron(0 16 * * ? *)" # Example cron expression to run at 16:00 PM UTC every day
+}
+
+resource "aws_cloudwatch_event_target" "trigger_lambda_target" {
+  rule      = aws_cloudwatch_event_rule.trigger_lambda_cron.name
+  target_id = "send_email_lambda"
+  arn       = aws_lambda_function.cherry_pick_notification.arn
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_to_invoke_lambda" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.cherry_pick_notification.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.trigger_lambda_cron.arn
+}

--- a/infra/aws/terraform/sig-release/patch-release-notification/outputs.tf
+++ b/infra/aws/terraform/sig-release/patch-release-notification/outputs.tf
@@ -1,0 +1,19 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+output "email_identity_arn" {
+  value = aws_sesv2_email_identity.sig_release_email_identity.arn
+}

--- a/infra/aws/terraform/sig-release/patch-release-notification/variables.tf
+++ b/infra/aws/terraform/sig-release/patch-release-notification/variables.tf
@@ -1,0 +1,51 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+variable "region" {
+  description = "The AWS region to deploy the resources"
+  type        = string
+}
+
+variable "email_identity" {
+  description = "The email address or domain to verify"
+  type        = string
+}
+
+variable "to_email" {
+  description = "The email address to send the notification"
+  type        = string
+}
+
+variable "no_mock" {
+  description = "if will send the message to dev@kubernetes.io or just internal"
+  type        = bool
+}
+
+variable "days_to_alert" {
+  description = "when to send the notification"
+  type        = number
+}
+
+variable "schedule_path" {
+  description = "path where we can find the schedule.yaml"
+  type        = string
+}
+
+variable "repository" {
+  description = "The ECR repository to use for the image"
+  type        = string
+  default     = ""
+}

--- a/infra/aws/terraform/sig-release/patch-release-notification/versions.tf
+++ b/infra/aws/terraform/sig-release/patch-release-notification/versions.tf
@@ -1,0 +1,36 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  backend "s3" {
+    bucket = "tf-state-sig-release"
+    key    = "cherry-pick-notification"
+    region = "us-west-2"
+  }
+
+  required_version = "1.8.0"
+
+  required_providers {
+    ko = {
+      source = "ko-build/ko"
+    }
+
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.51.1"
+    }
+  }
+}


### PR DESCRIPTION
this PR adds the terraform code to deploy the service we are building in https://github.com/kubernetes/release/pull/3627


/assign @xmudrii @saschagrunert @ameukam 
cc @kubernetes/release-managers 


xref: https://github.com/kubernetes/release/pull/3627