### PR TITLE
sig-scheduling: add group for CI failures

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -194,6 +194,7 @@ restrictions:
       - "^k8s-infra-staging-kwok@kubernetes.io$"
       - "^k8s-infra-staging-wasm-scheduler@kubernetes.io$"
       - "^kueue-alerts@kubernetes.io$"
+      - "^sig-scheduling-alerts@kubernetes.io$"
       - "^sig-scheduling-leads@kubernetes.io$"
   - path: "sig-security/groups.yaml"
     allowedGroups:

--- a/groups/sig-scheduling/groups.yaml
+++ b/groups/sig-scheduling/groups.yaml
@@ -34,6 +34,30 @@ groups:
       - ahg@google.com
       - hweicdl@gmail.com
 
+  - email-id: sig-scheduling-alerts@kubernetes.io
+    name: sig-scheduling-alerts
+    description: |-
+      SIG Scheduling Alerts - mail alias for CI failure messages.
+
+      Open to everyone.
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      ReconcileMembers: "false"
+    owners:
+      - acondor@google.com
+      - ahg@google.com
+      - hweicdl@gmail.com
+    members:
+      # This is just the initial list of group members.
+      - kerthcet@gmail.com
+      - patrick.ohly@intel.com
+      - handbomusic@gmail.com # @sanposhiho
+      - noreply+testgrid@google.com
+
   - email-id: k8s-infra-staging-kueue@kubernetes.io
     name: k8s-infra-staging-kueue
     description: |-


### PR DESCRIPTION
This will be used initially to receive testgrid alerts for the scheduler_perf job.
See https://github.com/kubernetes/test-infra/pull/32707#discussion_r1628157415

/cc @sanposhiho @Huang-Wei @alculquicondor @kerthcet @ahg-g 