### PR TITLE
Add cip-test ExternalSecrets to k8s-infra-prow-build cluster

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/test-pods/externalsecrets.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/test-pods/externalsecrets.yaml
@@ -61,3 +61,29 @@ spec:
     name: aws-ssh-public                                                         # The key to write to in the Kubernetes Secret
     version: latest                                                              # The version of the GSM Secret
     property: aws-ssh-public
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: k8s-cip-test-prod-service-account
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-public
+  data:
+  - key: k8s-cip-test-prod-service-account
+    name: service-account.json
+    version: latest
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: k8s-gcr-audit-test-prod-service-account
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: kubernetes-public
+  data:
+  - key: k8s-gcr-audit-test-prod-service-account
+    name: service-account.json
+    version: latest


### PR DESCRIPTION
This PR adds two ExternalSecrets to the `k8s-infra-prow-build` cluster:

- `k8s-cip-test-prod-service-account` (ServiceAccount for the `k8s-cip-test-prod` GCP project)
- `k8s-gcr-audit-test-prod-service-account` (ServiceAccount for the `k8s-gcr-audit-test-prod` GCP project)

These two GCP projects appear to contain only resources used for running tests and no other production-related resources. At the moment, we have these ExternalSecrets in the `k8s-infra-prow-build-trusted` cluster, however, we can't run presubmit jobs in that cluster (see https://github.com/kubernetes/test-infra/pull/32749). Given that I didn't find any production-related resource in these accounts, I believe it is safe to add these two ExternalSecrets to the non-trusted cluster.

~However, I'm not sure if this is going to work out of the box because I don't know if ESO in the non-trusted cluster can access the `kubernetes-public` project.~ Checked with @upodroid and this should work.

/assign @saschagrunert @cpanato @puerco @Verolop @upodroid @BenTheElder @dims 
cc @kubernetes/release-engineering 