### PR TITLE
Deploy new k8s-staging-images project

### DIFF
--- a/infra/gcp/terraform/k8s-staging-images/buckets.tf
+++ b/infra/gcp/terraform/k8s-staging-images/buckets.tf
@@ -1,0 +1,41 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module "gcb_bucket" {
+  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
+  version = "~> 5"
+
+  name       = "k8s-staging-images-gcb"
+  project_id = module.project.project_id
+  location   = "us"
+
+  lifecycle_rules = [{
+    action = {
+      type = "Delete"
+    }
+    condition = {
+      age        = 90 # 90d
+      with_state = "ANY"
+    }
+  }]
+
+  iam_members = [
+    {
+      role   = "roles/storage.admin"
+      member = "serviceAccount:gcb-builder@k8s-infra-prow-build-trusted.iam.gserviceaccount.com"
+    }
+  ]
+}

--- a/infra/gcp/terraform/k8s-staging-images/iam.tf
+++ b/infra/gcp/terraform/k8s-staging-images/iam.tf
@@ -1,0 +1,36 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module "iam" {
+  source  = "terraform-google-modules/iam/google//modules/projects_iam"
+  version = "~> 7"
+
+  projects = [module.project.project_id]
+
+  mode = "authoritative"
+
+  bindings = {
+    "roles/cloudbuild.builds.editor" = [
+      "serviceAccount:gcb-builder@k8s-infra-prow-build-trusted.iam.gserviceaccount.com",
+    ]
+    "roles/owner" = [
+      "group:k8s-infra-release-admins@kubernetes.io",
+    ]
+    "roles/viewer" = [
+      for _, group in local.registries : group
+    ]
+  }
+}

--- a/infra/gcp/terraform/k8s-staging-images/main.tf
+++ b/infra/gcp/terraform/k8s-staging-images/main.tf
@@ -1,0 +1,38 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module "project" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 14.5"
+
+  name            = "k8s-staging-images"
+  project_id      = "k8s-staging-images"
+  org_id          = "758905017065"
+  billing_account = "018801-93540E-22A20E"
+
+  # Sane project defaults
+  default_service_account     = "keep"
+  disable_services_on_destroy = false
+  create_project_sa           = false
+  random_project_id           = false
+  auto_create_network         = true
+
+
+  activate_apis = [
+    "artifactregistry.googleapis.com",
+    "cloudbuild.googleapis.com"
+  ]
+}

--- a/infra/gcp/terraform/k8s-staging-images/provider.tf
+++ b/infra/gcp/terraform/k8s-staging-images/provider.tf
@@ -1,0 +1,35 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  required_version = "1.6.5"
+
+  backend "gcs" {
+    bucket = "k8s-infra-tf-prow-clusters"
+    prefix = "k8s-infra-staging"
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.34.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 5.34.0"
+    }
+  }
+}

--- a/infra/gcp/terraform/k8s-staging-images/registries.tf
+++ b/infra/gcp/terraform/k8s-staging-images/registries.tf
@@ -1,0 +1,47 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+locals {
+  // The groups have to be created before applying this terraform code
+  registries = {
+    etcd-manager = "group:k8s-infra-staging-etcd-manager@kubernetes.io",
+    kubernetes = "group:k8s-infra-staging-kubernetes@kubernetes.io",
+    test-infra = "group:k8s-infra-staging-test-infra@kubernetes.io"
+  }
+}
+
+module "artifact_registry" {
+  for_each = local.registries
+  source   = "GoogleCloudPlatform/artifact-registry/google"
+  version  = "~> 0.2"
+
+  project_id    = module.project.project_id
+  location      = "us-central1"
+  format        = "DOCKER"
+  repository_id = each.key
+  members = {
+    readers = ["allUsers"],
+    writers = [each.value],
+  }
+  cleanup_policies = {
+    "delete-images-older-than-90-days" = {
+      action = "DELETE"
+      condition = {
+        older_than = "7776000s" # 90d
+      }
+    }
+  }
+}


### PR DESCRIPTION
/cc @BenTheElder @dims @ameukam 

Fixes: #3961

This has been deployed already.

etcd-manager is unblocked. I also created one for test-infra and kubernetes(@kubernetes/release-engineering please get in touch to kick off the GCR to AR migration) images.

The new registries:
- Are located in us-central1 region
- All images expire and are autodeleted after 90 days. Images must either be rebuilt or promoted within 90 days.
- Cloud Build has a private scratch bucket to hold source code and logs and objects are retained for 90 days.
- Registries are public(expect this to change in the future) BUT please don't serve images from there to end users
- Privileged groups can see the rest of the project but have no privileges except pushing to their own registries.