### PR TITLE
GCP: ensure prow-build can has iam.serviceAccountUser role

### DIFF
--- a/infra/gcp/bash/prow/ensure-e2e-projects.sh
+++ b/infra/gcp/bash/prow/ensure-e2e-projects.sh
@@ -83,6 +83,12 @@ function ensure_e2e_project() {
       "serviceAccount:${PROW_BUILD_SVCACCT}" \
       "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
+    # Ensure GCP CSI driver tests can use prow-build service account to
+    # act as all other service accounts (eg: Compute Engine default service account)
+    ensure_project_role_binding "${prj}" \
+      "serviceAccount:${PROW_BUILD_SVCACCT}" \
+      "roles/iam.serviceAccountUser"
+
     # TODO: this is what prow.k8s.io uses today, but seems overprivileged, we
     #       could consider using a more limited custom IAM role instead
     color 6 "Empower boskos-janitor service account to clean e2e project: ${prj}"


### PR DESCRIPTION
Ensure the GCP SA prow-build can act as other service accounts. This is required for the GCP PDCSI tests to call the GCE `instances.insert` API, as VMs are created with the Compute Engine default service account.

The GCP PDCSI e2e test prowjobs have failed after migrating to `prow-build` serviceAccount
e.g. https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_gcp-compute-persistent-disk-csi-driver/1764/pull-gcp-compute-persistent-disk-csi-driver-e2e/1805708508784496640