### PR TITLE
GCP: ensure default compute SA can use KMS keys

### DIFF
--- a/infra/gcp/bash/prow/ensure-e2e-projects.sh
+++ b/infra/gcp/bash/prow/ensure-e2e-projects.sh
@@ -55,6 +55,9 @@ function ensure_e2e_project() {
 
     ensure_project "${prj}"
 
+    local project_number
+    project_number=$(gcloud projects describe "${prj}" --format='value(projectNumber)')
+
     color 6 "Ensure stale role bindings have been removed from e2e project: ${prj}"
     (
         echo "no stale bindings slated for removal"
@@ -78,11 +81,18 @@ function ensure_e2e_project() {
       "serviceAccount:${PROW_BUILD_SVCACCT}" \
       "roles/editor"
 
+    # TODO: Remove this binding and clean up permissions in projects
     # Ensure GCP CSI driver tests can manage KMS keys
     ensure_project_role_binding "${prj}" \
       "serviceAccount:${PROW_BUILD_SVCACCT}" \
       "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
+    # Ensure GCP Default Compute Service Account can manage KMS keys
+    ensure_project_role_binding "${prj}" \
+      "serviceAccount:${project_number}-compute@developer.gserviceaccount.com" \
+      "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+    # TODO: Remove this binding and clean up permissions in projects
     # Ensure GCP CSI driver tests can use prow-build service account to
     # act as all other service accounts (eg: Compute Engine default service account)
     ensure_project_role_binding "${prj}" \


### PR DESCRIPTION
Ensure the default compute SA can use KMS keys. This is required for the GCP PDCSI tests to call the GCE `instances.insert` API, as VMs are created with the Compute Engine default service account.

The GCP PDCSI e2e test prowjobs have failed after migrating to use the k8s-infra-prow-build cluster: https://github.com/kubernetes/test-infra/pull/32809