### PR TITLE
GCP: ensure default engine service agent SA can use KMS keys

### DIFF
--- a/infra/gcp/bash/prow/ensure-e2e-projects.sh
+++ b/infra/gcp/bash/prow/ensure-e2e-projects.sh
@@ -92,6 +92,12 @@ function ensure_e2e_project() {
       "serviceAccount:${project_number}-compute@developer.gserviceaccount.com" \
       "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
+    # Ensure GCP Default Compute Engine Service Agent Account can manage KMS
+    # keys
+    ensure_project_role_binding "${prj}" \
+      "serviceAccount:service-${project_number}@compute-system.iam.gserviceaccount.com" \
+      "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
     # TODO: Remove this binding and clean up permissions in projects
     # Ensure GCP CSI driver tests can use prow-build service account to
     # act as all other service accounts (eg: Compute Engine default service account)


### PR DESCRIPTION
Ensure the default compute engine service agent SA can use KMS keys. Compute engine has a special service agent account that needs access to cloudkms. This is required for the GCP PDCSI tests to call the GCE `instances.insert` API, as VMs are created with the Compute Engine default service account. See https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/pull/1762#issuecomment-2195525892

The GCP PDCSI e2e test prowjobs have failed after migrating to use the k8s-infra-prow-build cluster: https://github.com/kubernetes/test-infra/pull/32809