### PR TITLE
GCP: ensure prow-build can administer KMS keys

### DIFF
--- a/infra/gcp/bash/prow/ensure-e2e-projects.sh
+++ b/infra/gcp/bash/prow/ensure-e2e-projects.sh
@@ -82,11 +82,18 @@ function ensure_e2e_project() {
       "roles/editor"
 
     # TODO: Remove this binding and clean up permissions in projects
+    # This permission is superseded by roles/cloudkms.admin below
     # Ensure GCP CSI driver tests can manage KMS keys
     ensure_project_role_binding "${prj}" \
       "serviceAccount:${PROW_BUILD_SVCACCT}" \
       "roles/cloudkms.cryptoKeyEncrypterDecrypter"
 
+    # Ensure GCP Default Compute Service Account can administer KMS keys
+    ensure_project_role_binding "${prj}" \
+      "serviceAccount:${PROW_BUILD_SVCACCT}" \
+      "roles/cloudkms.admin"
+
+    # TODO: Remove this binding and clean up permissions in projects
     # Ensure GCP Default Compute Service Account can manage KMS keys
     ensure_project_role_binding "${prj}" \
       "serviceAccount:${project_number}-compute@developer.gserviceaccount.com" \


### PR DESCRIPTION
Ensure the prow-build SA use KMS keys. PDCSI e2e tests use the prow-build SA by default to authenticate against the cloudkms API.

See https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_gcp-compute-persistent-disk-csi-driver/1762/pull-gcp-compute-persistent-disk-csi-driver-e2e/1806716408805986304

This is analogous to the existing cluster IAM model, where `pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com` had `roles/cloudkms.admin` permission.