### PR TITLE
Kops - Create S3 bucket for hosting CI results

### DIFF
--- a/infra/aws/terraform/kops-infra-ci/main.tf
+++ b/infra/aws/terraform/kops-infra-ci/main.tf
@@ -76,3 +76,34 @@ resource "aws_s3_bucket_acl" "kops_oidc_store" {
   bucket   = aws_s3_bucket.kops_oidc_store.id
   acl      = "public-read"
 }
+
+## Used by kOps for hosting CI build artifacts and version markers
+resource "aws_s3_bucket" "kops_ci_results" {
+  provider = aws.kops-infra-ci
+  bucket   = "k8s-infra-kops-ci-results"
+  tags     = var.tags
+}
+
+resource "aws_s3_bucket_ownership_controls" "kops_ci_results" {
+  provider = aws.kops-infra-ci
+  bucket   = aws_s3_bucket.kops_ci_results.id
+  rule {
+    object_ownership = "BucketOwnerPreferred"
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "kops_ci_results" {
+  provider = aws.kops-infra-ci
+  bucket   = aws_s3_bucket.kops_ci_results.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_acl" "kops_ci_results" {
+  provider = aws.kops-infra-ci
+  bucket   = aws_s3_bucket.kops_ci_results.id
+  acl      = "public-read"
+}


### PR DESCRIPTION
Barring a better solution for interacting with both a GCS bucket and the Kops AWS account in one prow job (see https://github.com/kubernetes/kops/issues/16637#issuecomment-2199004031), I'm experimenting with storing Kops' version markers and CI artifacts on S3 instead of GCS, that way the prow jobs only need to interact with one cloud provider.

I will test this with https://github.com/kubernetes/kops/pull/16659 and https://github.com/kubernetes/test-infra/pull/32918

/cc @upodroid @hakman 