### PR TITLE
fastly: bump terraform provider

### DIFF
--- a/infra/fastly/terraform/dl-sandbox.k8s.dev/provider.tf
+++ b/infra/fastly/terraform/dl-sandbox.k8s.dev/provider.tf
@@ -29,7 +29,7 @@ terraform {
   required_providers {
     fastly = {
       source  = "fastly/fastly"
-      version = "~> 5.6.0"
+      version = "~> 5.11.0"
     }
   }
 }

--- a/infra/fastly/terraform/dl.k8s.io/provider.tf
+++ b/infra/fastly/terraform/dl.k8s.io/provider.tf
@@ -29,7 +29,7 @@ terraform {
   required_providers {
     fastly = {
       source  = "fastly/fastly"
-      version = "~> 5.2.0"
+      version = "~> 5.11.0"
     }
   }
 }


### PR DESCRIPTION
Bump the provider to the latest version so we can define Fastly alerts.