### PR TITLE
Add 2024 election officers.

### DIFF
--- a/groups/committee-steering/groups.yaml
+++ b/groups/committee-steering/groups.yaml
@@ -91,6 +91,6 @@ groups:
       MembersCanPostAsTheGroup: "true"
       ReconcileMembers: "true"
     owners:
-      - kaslinfields@gmail.com
-      - davanum@gmail.com
+      - cblecker@redhat.com
       - bridget@kromhout.org
+      - priyankasaggu11929@gmail.com


### PR DESCRIPTION
Adds the new election officers to the mailing list.

Depends on [the PR in community](https://github.com/kubernetes/community/pull/7970).  **Do not merge until that PR is approved**.

/sig contributor-experience
/committee steering