### PR TITLE
Migrate capi/kops digitalocean creds to community cluster

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/test-pods/externalsecrets.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/test-pods/externalsecrets.yaml
@@ -141,3 +141,45 @@ spec:
   - remoteRef:
       key: nfd-codecov-token
     secretKey: codecov-token
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: k8s-infra-prow-build
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: spaces-digitalocean-s3
+  namespace: test-pods
+spec:
+  dataFrom:
+  - extract:
+      key: spaces-digitalocean-s3
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: k8s-infra-prow-build
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: cluster-api-provider-digitalocean-token
+  namespace: test-pods
+spec:
+  dataFrom:
+  - extract:
+      key: cluster-api-provider-digitalocean-token
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: k8s-infra-prow-build
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: kops-e2e-do-ssh-key
+  namespace: test-pods
+spec:
+  dataFrom:
+  - extract:
+      key: kops-e2e-do-ssh-key
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: k8s-infra-prow-build

--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/test-pods/externalsecrets.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/test-pods/externalsecrets.yaml
@@ -100,3 +100,36 @@ spec:
   - key: nfd-codecov-token  # The name of the GSM Secret
     name: codecov-token     # The key to write to in the Kubernetes Secret
     version: latest         # The version of the GSM Secret
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: spaces-digitalocean-s3
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-infra-prow-build
+  dataFrom:
+  - spaces-digitalocean-s3
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: cluster-api-provider-digitalocean-token
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-infra-prow-build
+  dataFrom:
+   - cluster-api-provider-digitalocean-token
+---
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: kops-e2e-do-ssh-key
+  namespace: test-pods
+spec:
+  backendType: gcpSecretsManager
+  projectId: k8s-infra-prow-build
+  dataFrom:
+   - kops-e2e-do-ssh-key


### PR DESCRIPTION
This PR allows us to move 21 CAPI DigitalOcean jobs to community infrastructure.

https://github.com/kubernetes/test-infra/blob/master/docs/job-migration-todo.md

/cc @dims @BenTheElder @ameukam 