### PR TITLE
fix tag regex

### DIFF
--- a/infra/gcp/terraform/modules/oci-proxy/cloud-armor.tf
+++ b/infra/gcp/terraform/modules/oci-proxy/cloud-armor.tf
@@ -75,10 +75,11 @@ resource "google_compute_security_policy" "cloud-armor" {
         # our homepage info redirect: /
         # our privacy info redirect: /privacy
         # OCI ping: /v2
-        # OCI pull / list calls: /v2/<name>/(blobs|manifests|tags)/<reference>
+        # OCI content calls: /v2/<name>/(blobs|manifests)/<reference>
+        # tag list: /v2/(<name>/tags|tags)/list
         # https://github.com/opencontainers/distribution-spec/blob/main/spec.md#endpoints
         # NOTE: AR doesn't support referrers API
-        expression = "!request.path.matches('^/$|^/privacy$|^/v2/?$|^/v2/.+/blobs/.+$|^/v2/.+/manifests/.+$|^/v2/.+/tags/.+$')"
+        expression = "!request.path.matches('^/$|^/privacy$|^/v2/?$|^/v2/.+/blobs/.+$|^/v2/.+/manifests/.+$|^/v2/.*tags/$')"
       }
     }
   }


### PR DESCRIPTION
In staging image pulling is working as intended, as are the `/` and `/privacy` endpoints, but the list call is wrong, it's not the same pattern as the others and this is what happens when you write regex late at night :-)


Technically I think `/v2/tags/list` is non-standard without being `/v2/<name>/tags/list`, but we'll continue to permit it for now, versus other non-standard APIs that don't function correctly on AR. Something to note for the future.

https://github.com/opencontainers/distribution-spec/blob/main/spec.md#endpoints

We only support GET and HEAD type methods that read content, not deletion / upload. Of those we don't support the referrers API because Artifact Registry does not and it was added in v1.1 of the spec. https://github.com/opencontainers/distribution-spec/blob/main/spec.md#enabling-the-referrers-api