### PR TITLE
/tags/list

### DIFF
--- a/infra/gcp/terraform/modules/oci-proxy/cloud-armor.tf
+++ b/infra/gcp/terraform/modules/oci-proxy/cloud-armor.tf
@@ -79,7 +79,7 @@ resource "google_compute_security_policy" "cloud-armor" {
         # tag list: /v2/(<name>/tags|tags)/list
         # https://github.com/opencontainers/distribution-spec/blob/main/spec.md#endpoints
         # NOTE: AR doesn't support referrers API
-        expression = "!request.path.matches('^/$|^/privacy$|^/v2/?$|^/v2/.+/blobs/.+$|^/v2/.+/manifests/.+$|^/v2/.*tags/$')"
+        expression = "!request.path.matches('^/$|^/privacy$|^/v2/?$|^/v2/.+/blobs/.+$|^/v2/.+/manifests/.+$|^/v2/.*tags/list$')"
       }
     }
   }


### PR DESCRIPTION
... it was even in the comment, just not the regex

`curl -L https://registry.k8s.io/v2/pause/tags/list`
versus
`curl -L https://registry-sandbox.k8s.io/v2/pause/tags/list`