### PR TITLE
Add bucket + service account for TestGrid upload.

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/serviceaccounts.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/serviceaccounts.tf
@@ -57,6 +57,11 @@ locals {
       project_roles     = ["roles/secretmanager.secretAccessor"]
       cluster_namespace = "kubernetes-external-secrets"
     }
+    // also assigned roles by:
+    // - terraform/k8s-infra-prow
+    k8s-testgrid-config-updater = {
+      description = "writes TestGrid config to gs://k8s-testgrid-config"
+    }
   }
 }
 

--- a/infra/gcp/terraform/k8s-infra-prow/buckets.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/buckets.tf
@@ -43,3 +43,30 @@ module "gcb_bucket" {
     }
   ]
 }
+
+// Create gs://k8s-testgrid-config to store K8s TestGrid config.
+module "testgrid_config_bucket" {
+  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
+  version = "~> 5"
+
+  name       = "k8s-testgrid-config"
+  project_id = module.project.project_id
+  location   = "us"
+
+  lifecycle_rules = [{
+    action = {
+      type = "Delete"
+    }
+    condition = {
+      age        = 90 # 90d
+      with_state = "ANY"
+    }
+  }]
+
+  iam_members = [
+    {
+      role   = "roles/storage.objectAdmin"
+      member = "serviceAccount:k8s-testgrid-config-updater@k8s-infra-prow-build-trusted.iam.gserviceaccount.com"
+    }
+  ]
+}


### PR DESCRIPTION
Adding the infra needed to duplicate the TestGrid config upload job (post-test-infra-upload-testgrid-config in config/jobs/kubernetes/test-infra/ test-infra-trusted.yaml).

Follow-up: Add a duplicate upload job under
config/jobs/kubernetes/sig-k8s-infra/trusted/sig-k8s-infra-test-infra.yaml, verify it works, and swap the new config for the old config in the TestGrid config mergelists.

Partially verified: `terraform validate` in both folders passes. I couldn't run `terraform plan` in `k8s-infra-prow-build-trusted` (lacking permissions to view org roles), but in `k8s-infra-prow` I get:

```
...

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.testgrid_config_bucket.google_storage_bucket.bucket will be created
  + resource "google_storage_bucket" "bucket" {
      + effective_labels            = (known after apply)
      + force_destroy               = false
      + id                          = (known after apply)
      + location                    = "US"
      + name                        = "k8s-testgrid-config"
      + project                     = "k8s-infra-prow"
      + project_number              = (known after apply)
      + public_access_prevention    = "inherited"
      + rpo                         = (known after apply)
      + self_link                   = (known after apply)
      + storage_class               = "STANDARD"
      + terraform_labels            = (known after apply)
      + uniform_bucket_level_access = true
      + url                         = (known after apply)

      + autoclass {
          + enabled                = false
          + terminal_storage_class = (known after apply)
        }

      + lifecycle_rule {
          + action {
              + type = "Delete"
            }
          + condition {
              + age                   = 30
              + matches_prefix        = []
              + matches_storage_class = []
              + matches_suffix        = []
              + with_state            = "ANY"
            }
        }

      + soft_delete_policy {
          + effective_time             = (known after apply)
          + retention_duration_seconds = 604800
        }

      + versioning {
          + enabled = true
        }
    }

  # module.testgrid_config_bucket.google_storage_bucket_iam_member.members["roles/storage.objectAdmin serviceAccount:k8s-testgrid-config-updater@k8s-infra-prow-build-trusted.iam.gserviceaccount.com"] will be created
  + resource "google_storage_bucket_iam_member" "members" {
      + bucket = "k8s-testgrid-config"
      + etag   = (known after apply)
      + id     = (known after apply)
      + member = "serviceAccount:k8s-testgrid-config-updater@k8s-infra-prow-build-trusted.iam.gserviceaccount.com"
      + role   = "roles/storage.objectAdmin"
    }

Plan: 2 to add, 0 to change, 0 to destroy.
...
```

Ref [k8s/test-infra#32432](https://github.com/kubernetes/test-infra/issues/32432)