### PR TITLE
Create a staging repo for kubernetes-sigs/cluster-capacity

### DIFF
--- a/infra/gcp/infra.yaml
+++ b/infra/gcp/infra.yaml
@@ -328,6 +328,7 @@ infra:
       k8s-staging-cluster-api-gcp:
       k8s-staging-cluster-api-helm:
       k8s-staging-cluster-api-nested:
+      k8s-staging-cluster-capacity:
       k8s-staging-coredns:
       k8s-staging-cpa:
       k8s-staging-cri-tools:


### PR DESCRIPTION
To enable container image builds from kubernetes-sigs/cluster-capacity.

Part of https://github.com/kubernetes-sigs/cluster-capacity/issues/181