### PR TITLE
Promote the wasm scheduler image v0.1.0

### DIFF
--- a/registry.k8s.io/images/k8s-staging-wasm-scheduler/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-wasm-scheduler/images.yaml
@@ -1,1 +1,3 @@
-# No images yet
+- name: scheduler
+  dmap:
+    "sha256:ee368d640709f716e6a064187aba206985d9d62d002d47a42adfae270bc49bf0": ["v0.1.0"]


### PR DESCRIPTION
- https://console.cloud.google.com/gcr/images/k8s-staging-wasm-scheduler/global/scheduler@sha256:ee368d640709f716e6a064187aba206985d9d62d002d47a42adfae270bc49bf0/details
- https://github.com/kubernetes-sigs/kube-scheduler-wasm-extension/releases/tag/v0.1.0

/cc @Gekko0114 @utam0k 