### PR TITLE
Allow the admin access to eks-prow-build-cluster for AdministratorAccess users via SSO

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/.terraform.lock.hcl
+++ b/infra/aws/terraform/prow-build-cluster/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.33.0"
-  constraints = ">= 4.0.0, >= 4.33.0, >= 4.57.0, >= 5.20.0, ~> 5.20"
+  constraints = ">= 4.0.0, >= 4.33.0, >= 4.57.0, ~> 5.20, >= 5.30.0"
   hashes = [
     "h1:6PKlIl26h6QJHXEYk1QEQvuzlGupJ0n5sX1aRE3XsxA=",
     "h1:CtvcLYjFQw/5shxQyhCKeL9FQ7OZ80PunYlnAucpkiw=",

--- a/infra/aws/terraform/prow-build-cluster/locals.tf
+++ b/infra/aws/terraform/prow-build-cluster/locals.tf
@@ -81,6 +81,16 @@ locals {
     }
   ]
 
+  sso_roles = [
+    {
+      rolearn  = "arn:aws:iam::468814281478:role/AWSReservedSSO_AdministratorAccess_abaef4db15a2c055"
+      username = "sso-admins"
+      groups   = [
+        "eks-cluster-admin"
+      ]
+    }
+  ]
+
   aws_auth_roles = flatten([
     local.configure_prow ? [
       # Allow access to the Prow-EKS-Admin IAM role (used by Prow directly).
@@ -93,6 +103,7 @@ locals {
       }
     ] : [],
     local.cluster_admin_roles,
-    local.cluster_viewer_roles
+    local.cluster_viewer_roles,
+    local.sso_roles
   ])
 }


### PR DESCRIPTION
This PR refreshes the Terraform configs for eks-prow-build-cluster to match some manual changes that we did in the past, and to ensure that `make plan` doesn't propose any changes.

Notably, this PR adds role permitting the admin access to the EKS Prow build cluster for folks having the AdministratorAccess via SSO.

This was originally part of #6895, but I thought it would be better to do this before migrating to Karpenter.

/assign @dims @ameukam @upodroid 