### PR TITLE
Increase max capacity for eks-prow-build-cluster to 102 nodes

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -47,15 +47,15 @@ node_instance_types_us_east_2c = ["r5ad.4xlarge"]
 node_instance_types_stable     = ["r5ad.2xlarge"]
 
 node_min_size_us_east_2a     = 7
-node_max_size_us_east_2a     = 25
+node_max_size_us_east_2a     = 34
 node_desired_size_us_east_2a = 7
 
 node_min_size_us_east_2b     = 7
-node_max_size_us_east_2b     = 25
+node_max_size_us_east_2b     = 34
 node_desired_size_us_east_2b = 7
 
 node_min_size_us_east_2c     = 7
-node_max_size_us_east_2c     = 25
+node_max_size_us_east_2c     = 34
 node_desired_size_us_east_2c = 7
 
 node_desired_size_stable = 3


### PR DESCRIPTION
The maximum capacity for the EKS Prow build cluster has been increased from 75 to 102 (34 nodes per the AZ), as we have had maxed out the capacity.

xref https://kubernetes.slack.com/archives/CCK68P2Q2/p1721745534898059

/assign @dims @ameukam @upodroid 