### PR TITLE
Add TestGrid updater SA to test-pods list.

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-serviceaccounts.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/test-pods/test-pods-serviceaccounts.yaml
@@ -49,6 +49,14 @@ metadata:
     iam.gke.io/gcp-service-account: k8s-keps@k8s-infra-prow-build-trusted.iam.gserviceaccount.com
   name: k8s-keps
   namespace: test-pods
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: k8s-testgrid-config-updater@k8s-infra-prow-build-trusted.iam.gserviceaccount.com
+  name: k8s-testgrid-config-updater
+  namespace: test-pods
 
 # Infrastructure management service accounts
 ---


### PR DESCRIPTION
Forgot to add this alongside #6985, so the job is currently failing to create pods (ex. https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-test-infra-upload-testgrid-config-canary/1815878251545890816)