### PR TITLE
Switch alpine images to new source.

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/kube-system/create-loop-devs_daemonset.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/kube-system/create-loop-devs_daemonset.yaml
@@ -40,7 +40,7 @@ spec:
                 done
                 sleep 100000000
               done
-          image: gcr.io/k8s-prow/alpine:latest
+          image: gcr.io/k8s-staging-test-infra/alpine:latest
           imagePullPolicy: IfNotPresent
           resources: {}
           securityContext:

--- a/infra/aws/terraform/prow-build-cluster/resources/kube-system/tune-sysctls_daemonset.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/kube-system/tune-sysctls_daemonset.yaml
@@ -33,7 +33,7 @@ spec:
             sysctl -w fs.inotify.max_user_instances=8192
             sleep 10
           done
-        image: gcr.io/k8s-prow/alpine:latest
+        image: gcr.io/k8s-staging-test-infra/alpine:latest
         imagePullPolicy: IfNotPresent
         resources: {}
         securityContext:

--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/kube-system/create-loop-devs_daemonset.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/kube-system/create-loop-devs_daemonset.yaml
@@ -40,7 +40,7 @@ spec:
             done
             sleep 100000000
           done
-        image: gcr.io/k8s-prow/alpine:latest
+        image: gcr.io/k8s-staging-test-infra/alpine:latest
         imagePullPolicy: IfNotPresent
         resources: {}
         securityContext:

--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/kube-system/tune-sysctls_daemonset.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/kube-system/tune-sysctls_daemonset.yaml
@@ -34,7 +34,7 @@ spec:
             sysctl -w fs.inotify.max_user_instances=8192
             sleep 10
           done
-        image: gcr.io/k8s-prow/alpine:latest
+        image: gcr.io/k8s-staging-test-infra/alpine:latest
         imagePullPolicy: IfNotPresent
         resources: {}
         securityContext:


### PR DESCRIPTION
The test-infra alpine image is now being published to a new location (k8s-staging-test-infra) in addition to the old one (k8s-prow). Use the images in the new location rather than the old one.

Ref https://github.com/kubernetes/test-infra/issues/32432