### PR TITLE
eks-prow-build-cluster: Add Karpenter resources and scale cluster-autoscaler to 0

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/cluster-autoscaler/deployment.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/cluster-autoscaler/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: cluster-autoscaler
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: cluster-autoscaler

--- a/infra/aws/terraform/prow-build-cluster/resources/karpenter/ec2nodeclass-default.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/karpenter/ec2nodeclass-default.yaml
@@ -1,0 +1,46 @@
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: karpenter.k8s.aws/v1beta1
+kind: EC2NodeClass
+metadata:
+  name: default
+spec:
+  role: "karpenter-nodes"
+
+  amiFamily: Bottlerocket
+  detailedMonitoring: true
+  associatePublicIPAddress: true
+
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "prow-build-cluster"
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "prow-build-cluster"
+
+  userData: |
+    # Bootstrap the instance using our bootstrap script embeded in a Docker image
+    [settings.bootstrap-containers.bootstrap]
+    source = "public.ecr.aws/q4o2z4d8/k8s-prow-bottlerocket:v0.0.2"
+    mode = "always"
+    essential = true
+
+    [settings.kernel.sysctl]
+    "fs.inotify.max_user_watches" = "1048576"
+    "fs.inotify.max_user_instances" = "8192"
+    "vm.min_free_kbytes" = "540672"
+
+  tags:
+    Cluster: prow-build-cluster

--- a/infra/aws/terraform/prow-build-cluster/resources/karpenter/nodepool-default.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/karpenter/nodepool-default.yaml
@@ -1,0 +1,61 @@
+# Copyright 2024 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: default
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
+        name: default
+
+      requirements: # r5ad.4xlarge amd64 non-spot
+        - key: topology.kubernetes.io/zone
+          operator: In
+          values: ["us-east-2a", "us-east-2b", "us-east-2c"]
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: NotIn
+          values: ["spot"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["r"]
+        - key: "karpenter.k8s.aws/instance-family"
+          operator: In
+          values: ["r5ad"]
+        - key: "karpenter.k8s.aws/instance-size"
+          operator: In
+          values: ["4xlarge"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["2"]
+
+  limits:
+    cpu: 800 # 50 x r5ad.4xlarge (16 vCPUs)
+
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 30s
+    expireAfter: 720h
+    budgets:
+      - nodes: "20%" # Allowing rotating 20% of instances at any given time


### PR DESCRIPTION
This PR adds the Karpenter resources (`EC2NodeClass` and `NodePool`) which enables Karpenter in the EKS Prow build cluster. The infrastructure has been introduced in #7063 and already deployed to both canary and production.

These two resources were already reviewed as part of #7063 

We'll run both old ASGs and Karpenter at the same time until we check that Karpenter is behaving well and that jobs are running properly on the Karpenter-managed nodes. The old ASGs are running with 10 replicas per AZ (30 replicas in total), other replicas will be managed by Karpenter. We'll reduce this number over the time until we don't get to zero, and then we'll completely remove the old ASGs. The stable node group is still managed via the ASG, we'll see how are we going to handle that one later.

cluster-autoscaler has been scaled to zero to avoid any possible conflicts, even though we also removed cluster-autoscaler tags from ASGs.

/assign @koksay 