### PR TITLE
eks-prow-build-cluster: Increase the Karpenter capacity to 150 nodes

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/karpenter/nodepool-default.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/karpenter/nodepool-default.yaml
@@ -51,7 +51,7 @@ spec:
           values: ["2"]
 
   limits:
-    cpu: 800 # 50 x r5ad.4xlarge (16 vCPUs)
+    cpu: "2400" # 150 x r5ad.4xlarge (16 vCPUs)
 
   disruption:
     consolidationPolicy: WhenEmpty


### PR DESCRIPTION
We deployed Karpenter with the limit of 50 nodes, now we're increasing it to 150 nodes to match the limits that we use on GKE.

Also, the CPU limits value has been quoted as recommended by Karpenter: https://karpenter.sh/docs/concepts/nodepools/#speclimits

> CPU limits are described with a DecimalSI value. Note that the Kubernetes API will coerce this into a string, so we recommend against using integers to avoid GitOps skew.

/assign @dims @BenTheElder @koksay 