### PR TITLE
Store credentials for Fastly service account

### DIFF
--- a/infra/gcp/terraform/k8s-infra-releases-prod/.terraform.lock.hcl
+++ b/infra/gcp/terraform/k8s-infra-releases-prod/.terraform.lock.hcl
@@ -2,9 +2,11 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/google" {
-  version = "5.2.0"
+  version     = "5.2.0"
+  constraints = "~> 5.2.0"
   hashes = [
     "h1:GuKgYrg5q36jxuqrntYHEhnCSsHoNm0tb1af8x8+WLc=",
+    "h1:psy0RRnGgKCsDKjdXCxQMKt4A1BlcbspWLB5UZK3A5U=",
     "zh:1d4c5b154d4764a0e3e8893193dc71ba5a4cdb2d9d9dd20f69312cc75399b038",
     "zh:26c5c6ad5edc27c643f43d950ffe982267b732723a09fef74c672ede7a7459f7",
     "zh:2b48824692ecc7fe8ae3366010a7cf8b441aa2ecb4b6e9777638952844eff19e",
@@ -25,6 +27,7 @@ provider "registry.terraform.io/hashicorp/google-beta" {
   constraints = "~> 5.2.0"
   hashes = [
     "h1:BU2RJbanotVXVA6EWPLgT1X0ktSPnU8DXRPWKmuGzwU=",
+    "h1:lPgmiosn4AzF9x1p+Xf0Pva1mlOWo2VL/rXr49Rcmv0=",
     "zh:09834404dd19d9191d29a2a58a6838ecd9f70b54e24e39c75f3063d4345671e5",
     "zh:34c8564245834b2f8a2ed7e70880b1553e79dd55083cdadc0791fb2f611cd5a1",
     "zh:7ee42223685859efea71bfe90c2b0e37a1ef0b79d523c415fa4196c307dc6024",

--- a/infra/gcp/terraform/k8s-infra-releases-prod/main.tf
+++ b/infra/gcp/terraform/k8s-infra-releases-prod/main.tf
@@ -33,26 +33,26 @@ resource "google_project" "project" {
 }
 
 module "k8s_releases_prod" {
-  source                   = "../modules/k8s-releases"
-  project_id               = google_project.project.project_id
-  bucket_name              = "767373bbdcb8270361b96548387bf2a9ad0d48758c35"
+  source      = "../modules/k8s-releases"
+  project_id  = google_project.project.project_id
+  bucket_name = "767373bbdcb8270361b96548387bf2a9ad0d48758c35"
 }
 
 resource "google_service_account" "fastly_reader" {
-  project = google_project.project.project_id
-  account_id = "fastly-reader"
+  project     = google_project.project.project_id
+  account_id  = "fastly-reader"
   description = "Used by Fastly for read-only actions against the bucket"
 }
 
 resource "google_storage_hmac_key" "fastly_reader_key" {
-  project = google_project.project.project_id
+  project               = google_project.project.project_id
   service_account_email = google_service_account.fastly_reader.email
 }
 
 resource "google_storage_bucket_iam_member" "fastly_reader" {
   bucket     = module.k8s_releases_prod.bucket_name
-  role = "roles/storage.objectViewer"
-  member = "serviceAccount:${google_service_account.fastly_reader.email}"
+  role       = "roles/storage.objectViewer"
+  member     = "serviceAccount:${google_service_account.fastly_reader.email}"
   depends_on = [module.k8s_releases_prod]
 }
 

--- a/infra/gcp/terraform/k8s-infra-releases-prod/secrets.tf
+++ b/infra/gcp/terraform/k8s-infra-releases-prod/secrets.tf
@@ -1,0 +1,33 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module "secrets" {
+  source  = "GoogleCloudPlatform/secret-manager/google"
+  version = "~> 0.3"
+
+  project_id = google_project.project.project_id
+
+  secrets = [
+    {
+      name        = "fastly_reader_sa_access_key"
+      secret_data = google_storage_hmac_key.fastly_reader_key.access_id
+    },
+    {
+      name        = "fastly_reader_sa_secret_key"
+      secret_data = google_storage_hmac_key.fastly_reader_key.secret
+    },
+  ]
+}


### PR DESCRIPTION
In order to define and access a private bucket as origin for the Fastly service defined for dl.k8s.io, we store the credentials required in GCP secrets.
Fastly don't support workload identity so the credentials will be accessible through [data sources](https://developer.hashicorp.com/terraform/language/data-sources) outside of this configuration.