### PR TITLE
Use a dedicated kubernetes service account for azure jobs

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/test-pods/build-serviceaccounts.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/test-pods/build-serviceaccounts.yaml
@@ -27,3 +27,9 @@ metadata:
     eks.amazonaws.com/role-arn: arn:aws:iam::209411653980:role/aws-shared-testing-role
   name: aws-shared-testing-role
   namespace: test-pods
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: azure
+  namespace: test-pods

--- a/infra/azure/terraform/capz/iam-config/eks-param.json
+++ b/infra/azure/terraform/capz/iam-config/eks-param.json
@@ -1,7 +1,7 @@
 {
     "name": "prow-eks-identity-credential",
     "issuer": "https://oidc.eks.us-east-2.amazonaws.com/id/F8B73554FE6FBAF9B19569183FB39762",
-    "subject": "system:serviceaccount:test-pods:default",
+    "subject": "system:serviceaccount:test-pods:azure",
     "audiences": [
         "api://AzureADTokenExchange"
     ]

--- a/infra/azure/terraform/capz/iam-config/gce-param.json
+++ b/infra/azure/terraform/capz/iam-config/gce-param.json
@@ -1,7 +1,7 @@
 {
     "name": "prow-gce-identity-credential",
     "issuer": "https://container.googleapis.com/v1/projects/k8s-infra-prow-build/locations/us-central1/clusters/prow-build",
-    "subject": "system:serviceaccount:test-pods:default",
+    "subject": "system:serviceaccount:test-pods:azure",
     "audiences": [
         "api://AzureADTokenExchange"
     ]

--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/test-pods/build-serviceaccounts.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/test-pods/build-serviceaccounts.yaml
@@ -22,3 +22,9 @@ metadata:
     iam.gke.io/gcp-service-account: prow-build@k8s-infra-prow-build.iam.gserviceaccount.com
   name: k8s-kops-test
   namespace: test-pods
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: azure
+  namespace: test-pods


### PR DESCRIPTION
Azure jobs use workload identity but are bound to the default service account, allowing every job access to Azure. We should use a dedicated service account for easy identification and improved security.

/cc @jsturtevant @ritikaguptams @ameukam 