### PR TITLE
aws/kops: Setup AWS CloudWatch Observability agent

### DIFF
--- a/infra/aws/terraform/kops-infra-ci/eks.tf
+++ b/infra/aws/terraform/kops-infra-ci/eks.tf
@@ -44,6 +44,9 @@ module "eks" {
   cloudwatch_log_group_retention_in_days = 30
 
   cluster_addons = {
+    amazon-cloudwatch-observability = {
+      most_recent = true
+    }
     coredns = {
       most_recent = true
     }

--- a/infra/aws/terraform/kops-infra-ci/pod-identity.tf
+++ b/infra/aws/terraform/kops-infra-ci/pod-identity.tf
@@ -1,0 +1,25 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module "aws_cloudwatch_observability_pod_identity" {
+  source = "terraform-aws-modules/eks-pod-identity/aws"
+
+  name = "aws-cloudwatch-observability"
+
+  attach_aws_cloudwatch_observability_policy = true
+
+  tags = var.tags
+}


### PR DESCRIPTION
Temporarily install observability agent to collect metrics.