### PR TITLE
Use new location for Prow images instead of old.

### DIFF
--- a/hack/autobump-config.yaml
+++ b/hack/autobump-config.yaml
@@ -26,12 +26,12 @@ prefixes:
     summarise: false
     consistentImages: true
   - name: "ghproxy"
-    prefix: "gcr.io/k8s-prow/ghproxy"
+    prefix: "us-docker.pkg.dev/k8s-infra-prow/images/ghproxy"
     refConfigFile: "infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/ghproxy-deployment.yaml"
     repo: "https://github.com/kubernetes/test-infra"
     summarise: false
   - name: "prow"
-    prefix: "gcr.io/k8s-prow/"
+    prefix: "us-docker.pkg.dev/k8s-infra-prow/images/"
     refConfigFile: "apps/prow/cluster/deck_deployment.yaml"
     repo: "https://github.com/kubernetes/test-infra"
     summarise: false

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/default/ghproxy-deployment.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/default/ghproxy-deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20240723-dbbd2d86b
+          image: us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:v20240723-dbbd2d86b
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99


### PR DESCRIPTION
Prow images have been published to a new location for a while now (us-docker.pkg.dev/k8s-infra-prow/images/). These should be the same images as published to the old location, so update images to pull from the new location instead.

Ref https://github.com/kubernetes/test-infra/issues/32432