### PR TITLE
Deploy arm64 nodepool on the GKE Build Cluster

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/main.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/main.tf
@@ -67,6 +67,11 @@ module "prow_build_nodepool" {
   cluster_name    = module.prow_build_cluster.cluster.name
   location        = module.prow_build_cluster.cluster.location
   name            = "trusted-pool1"
+  node_locations = [
+    "us-central1-a",
+    "us-central1-b",
+    "us-central1-f",
+  ]
   initial_count   = 1
   min_count       = 1
   max_count       = 6

--- a/infra/gcp/terraform/k8s-infra-prow-build/main.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/main.tf
@@ -84,10 +84,15 @@ module "prow_build_cluster" {
 # - ipv6 jobs need an ipv6 stack; COS lacks one, so use UBUNTU
 # - k8s-prow-builds/prow cluster uses _CONTAINERD variant, keep parity
 module "prow_build_nodepool_n1_highmem_8_localssd" {
-  source                    = "../modules/gke-nodepool"
-  project_name              = module.project.project_id
-  cluster_name              = module.prow_build_cluster.cluster.name
-  location                  = module.prow_build_cluster.cluster.location
+  source       = "../modules/gke-nodepool"
+  project_name = module.project.project_id
+  cluster_name = module.prow_build_cluster.cluster.name
+  location     = module.prow_build_cluster.cluster.location
+  node_locations = [
+    "us-central1-b",
+    "us-central1-c",
+    "us-central1-f",
+  ]
   name                      = "pool5"
   initial_count             = 1
   min_count                 = 1
@@ -101,10 +106,13 @@ module "prow_build_nodepool_n1_highmem_8_localssd" {
 }
 
 module "prow_build_nodepool_t2a_standard_8" {
-  source        = "../modules/gke-nodepool"
-  project_name  = module.project.project_id
-  cluster_name  = module.prow_build_cluster.cluster.name
-  location      = module.prow_build_cluster.cluster.location
+  source       = "../modules/gke-nodepool"
+  project_name = module.project.project_id
+  cluster_name = module.prow_build_cluster.cluster.name
+  location     = module.prow_build_cluster.cluster.location
+  node_locations = [
+    "us-central1-a"
+  ]
   name          = "pool5-arm64"
   initial_count = 1
   min_count     = 1

--- a/infra/gcp/terraform/k8s-infra-prow-build/main.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/main.tf
@@ -100,3 +100,21 @@ module "prow_build_nodepool_n1_highmem_8_localssd" {
   service_account           = module.prow_build_cluster.cluster_node_sa.email
 }
 
+module "prow_build_nodepool_t2a_standard_8" {
+  source        = "../modules/gke-nodepool"
+  project_name  = module.project.project_id
+  cluster_name  = module.prow_build_cluster.cluster.name
+  location      = module.prow_build_cluster.cluster.location
+  name          = "pool5-arm64"
+  initial_count = 1
+  min_count     = 1
+  max_count     = 10
+  image_type    = "UBUNTU_CONTAINERD"
+  machine_type  = "t2a-standard-8"
+  disk_size_gb  = 150
+  disk_type     = "pd-ssd"
+  // GKE automatically taints arm64 nodes
+  // https://cloud.google.com/kubernetes-engine/docs/how-to/prepare-arm-workloads-for-deployment#overview
+  # ephemeral_local_ssd_count = 2 # each is 375GB
+  service_account = module.prow_build_cluster.cluster_node_sa.email
+}

--- a/infra/gcp/terraform/modules/gke-nodepool/variables.tf
+++ b/infra/gcp/terraform/modules/gke-nodepool/variables.tf
@@ -29,6 +29,12 @@ variable "location" {
   type        = string
 }
 
+variable "node_locations" {
+  description = "The GCP locations (regions or zones) where the node_pool should be located"
+  type        = list
+  default     = []
+}
+
 variable "name" {
   description = "The name to use for this node_pool"
   type        = string


### PR DESCRIPTION
/cc @ameukam @BenTheElder 

According to the docs, arm64 nodepools are automatically tainted by GCP to block amd64 workloads running on there. Jobs have to either use nodeselectors or taint the pod to tolerate arm64 nodes if the image is multiarchitecture.

https://cloud.google.com/kubernetes-engine/docs/how-to/prepare-arm-workloads-for-deployment#overview

Fixes: 