### PR TITLE
gcp: Drop usage of gs://kubernetes-release-dev for gcsweb

### DIFF
--- a/apps/gcsweb/deployment.yaml
+++ b/apps/gcsweb/deployment.yaml
@@ -33,7 +33,6 @@ spec:
             # buckets owned by google.com
             - -b=kubernetes-jenkins
             - -b=kubernetes-release
-            - -b=kubernetes-release-dev # TODO: remove when v1.22 unsupported, or no more builds exist her
             - -b=sig-scalability-logs
             - -p=8080
           ports:


### PR DESCRIPTION
Remove deleted bucket from gcsweb deployment.