### PR TITLE
Add kubernetes.io managed groups for all remaining SIG/WGs

### DIFF
--- a/groups/committee-steering/groups.yaml
+++ b/groups/committee-steering/groups.yaml
@@ -19,7 +19,7 @@ groups:
       - killen.bob@gmail.com
       - lachlan.evenson@microsoft.com
       - liggitt@google.com
-      - maszulik@redhat.com
+      - soltysh@gmail.com
       - michelle.noorali@gmail.com
       - nikhitaraghunath@gmail.com
       - paco.xu@daocloud.io
@@ -48,7 +48,7 @@ groups:
       - bentheelder@google.com
       - k8s@auggie.dev
       - killen.bob@gmail.com
-      - maszulik@redhat.com
+      - soltysh@gmail.com
       - paco.xu@daocloud.io
       - pal.nabarun95@gmail.com
       - patrick.ohly@intel.com
@@ -73,7 +73,7 @@ groups:
       - bentheelder@google.com
       - k8s@auggie.dev
       - killen.bob@gmail.com
-      - maszulik@redhat.com
+      - soltysh@gmail.com
       - paco.xu@daocloud.io
       - pal.nabarun95@gmail.com
       - patrick.ohly@intel.com

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -107,7 +107,7 @@ groups:
       - liggitt@google.com
       - maciekpytel@google.com # SIG Autoscaling
       - marosset@microsoft.com
-      - maszulik@redhat.com # SIG CLI, Apps
+      - soltysh@gmail.com # SIG CLI, Apps
       - matt.farina@gmail.com
       - mcqueenorama@gmail.com
       - michmike@gmail.com

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -6,7 +6,7 @@ groups:
   - email-id: leads@kubernetes.io
     name: leads
     description: |-
-      SIG/WG/UG Leads
+      SIG/WG/Committee Leads
     settings:
       AllowWebPosting: "true"
       WhoCanViewGroup: "ANYONE_CAN_VIEW"
@@ -18,141 +18,48 @@ groups:
       - cblecker@gmail.com
       - contributors@kubernetes.io
     managers:
-      - ihor@cncf.io
-      - alison@alisondowdney.com
-      - jdumars@gmail.com
       - kaslin.fields@gmail.com # SIG ContribEx
       - killen.bob@gmail.com
       - madhav.jiv@gmail.com # SIG ContribEx
       - nikitaraghunath@gmail.com
       - pal.nabarun95@gmail.com # SIG ContribEx
       - priyankasaggu11929@gmail.com # SIG ContribEx
-      - spiffxp@gmail.com
     members:
-      - AnaMMedina21@gmail.com # CoCC
-      - acondor@google.com
-      - adolfo.garcia@uservers.net # SIG Release
-      - ahg@google.com
-      - alarcj137@gmail.com
-      - amerai@google.com
-      - ameukam@gmail.com
-      - amim.knabben@gmail.com # SIG Windows
-      - antheabjung@gmail.com
-      - antonio.ojea.garcia@gmail.com
-      - apelisse@google.com
-      - aravindh.foss@pm.me # SIG Windows
-      - aguclu@redhat.com # SIG CLI
-      - augustus@cisco.com # SIG Release
-      - benjamin.ahrtr@gmail.com # SIG etcd
-      - bentheelder@google.com
-      - bpratt@redhat.com # SIG Testing
-      - bridget@kromhout.org # SIG Cloud Provider
+      - conduct@kubernetes.io
+      - steering-private@kubernetes.io
+      - security@kubernetes.io
+      - sig-api-machinery-leads@kubernetes.io
+      - sig-apps-leads@kubernetes.io
+      - sig-architecture-leads@kubernetes.io
+      - sig-auth-leads@kubernetes.io
+      - sig-autoscaling-leads@kubernetes.io
+      - sig-cli-leads@kubernetes.io
+      - sig-cloud-provider-leads@kubernetes.io
+      - sig-cluster-lifecycle-leads@kubernetes.io
+      - sig-contributor-experience-leads@kubernetes.io
+      - sig-docs-leads@kubernetes.io
+      - sig-etcd-leads@kubernetes.io
+      - sig-instrumentation-leads@kubernetes.io
+      - sig-k8s-infra-leads@kubernetes.io
+      - sig-multicluster-leads@kubernetes.io
+      - sig-network-leads@kubernetes.io
+      - sig-node-leads@kubernetes.io
+      - sig-release-leads@kubernetes.io
+      - sig-scalability-leads@kubernetes.io
+      - sig-scheduling-leads@kubernetes.io
+      - sig-security-leads@kubernetes.io
+      - sig-storage-leads@kubernetes.io
+      - sig-testing-leads@kubernetes.io
+      - sig-ui-leads@kubernetes.io
+      - sig-windows-leads@kubernetes.io
+      - wg-batch-leads@kubernetes.io
+      - wg-device-management-leads@kubernetes.io
+      - wg-etcd-operator-leads@kubernetes.io
+      - wg-lts-leads@kubernetes.io
+      - wg-serving-leads@kubernetes.io
       - caniszczyk@linuxfoundation.org
-      - cbelu@cloudbasesolutions.com
-      - cecilerobertm@gmail.com
-      - chiachenk@google.com
       - cncf-speakers@linuxfoundation.org
       - community@kubernetes.io
-      - ctadeu@gmail.com # SIG Release
-      - cy@borg.dev # SIG K8s Infra
-      - danwinship@redhat.com # SIG Network
-      - davanum@gmail.com
-      - dawnchen@google.com
-      - dbosanac@redhat.com
-      - dcampau1@gmail.com
-      - dcbw@redhat.com
-      - ddebroy@gmail.com
-      - deads@redhat.com
-      - decarr@redhat.com
-      - dgrisonn@redhat.com
-      - divya.mohan0209@gmail.com
-      - eddiezane@gmail.com # CLI
-      - ehashman@apple.com
-      - fabrizio.pandini@gmail.com
-      - fbongiovanni@google.com
-      - fbranczyk@gmail.com
-      - frapposelli@vmware.com
-      - guyjtempleton@googlemail.com # SIG Autoscaling
-      - gveronicalg@gmail.com # SIG Release
-      - hankang@google.com
-      - hilliary.lipsig@gmail.com # CoCC
-      - hpandey@pivotal.io
-      - hweicdl@gmail.com
-      - ian@coldwater.io
-      - irvi.fa@gmail.com
-      - jablair@redhat.com # SIG etcd
-      - jameswangel@gmail.com
-      - jayunit100.apache@gmail.com
-      - jbelamaric@google.com
-      - jberkus@redhat.com
-      - jeef111x@gmail.com
-      - jeremy.r.rickard@gmail.com # SIG Release
-      - jeremyot@google.com
-      - jim@nirmata.com
-      - jonathan.berkhahn@gmail.com
-      - jpbetz@google.com
-      - jsafrane@redhat.com
-      - jshubheksha@gmail.com
-      - jsturtevant@gmail.com
-      - justin@fathomdb.com
-      - k8s@auggie.dev # SIG Release
-      - kaitlynbarnard10@gmail.com
-      - kat.cosgrove@gmail.com
-      - kbhawkey@gmail.com
-      - kikis.github@gmail.com
-      - klaus1982.cn@gmail.com
-      - ksemenov@vmware.com
-      - lachlan.evenson@gmail.com
-      - lancashiredanielle@gmail.com
-      - liggitt@google.com
-      - maciekpytel@google.com # SIG Autoscaling
-      - marosset@microsoft.com
-      - soltysh@gmail.com # SIG CLI, Apps
-      - matt.farina@gmail.com
-      - mcqueenorama@gmail.com
-      - michmike@gmail.com
-      - mikedanese@google.com
-      - mpuckett259@gmail.com # SIG CLI
-      - msau@google.com
-      - msm@opbstudios.com # SIG Cloud Provider
-      - mwielgus@google.com
-      - natalivlatko@gmail.com
-      - neolit123@gmail.com
-      - nospam.wong@gmail.com
-      - paco.xu@daocloud.io
-      - patrick.ohly@intel.com
-      - prydonius@gmail.com
-      - quinton@hoole.biz
-      - rficcaglia@gmail.com
+      - kikis.github@gmail.com #enhancements subproject
       - ricardo.katz@gmail.com # Sig Network Sub Project Ingress-nginx
-      - rita.z.zhang@gmail.com
-      - rlejano@gmail.com
-      - s.kanzhelev@gmail.com # SIG Node
-      - saadali@google.com
-      - saschagrunert@gmail.com # SIG Release
-      - saveetha13@gmail.com
-      - sutt@redhat.com # SIG Network
-      - shu.mutow@gmail.com
-      - siarkowicz@google.com
-      - stefan.schimanski@gmail.com
       - strong.james.e@gmail.com # Sig Network Sub Project Ingress-nginx
-      - swati.tcd@gmail.com
-      - szostok.mateusz@gmail.com
-      - tabitha.c.sable@gmail.com
-      - tasha.drew@gmail.com
-      - theenjeru@gmail.com
-      - thockin@google.com
-      - timallclair@gmail.com
-      - timothysc@gmail.com
-      - tpepper@vmware.com
-      - vince@vincepri.com
-      - vincepri@vmware.com
-      - wenjiazhang@google.com # SIG etcd
-      - wfender@google.com
-      - wojtekt@google.com
-      - xandergrzyw@gmail.com # CoCC
-      - xingyang105@gmail.com
-      - ynli@google.com
-      - arangogutierrez@gmail.com  # WG Serving
-      - terrytangyuan@gmail.com  # WG Serving
-      - seedjeffwan@gmail.com  # WG Serving

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -259,6 +259,7 @@ restrictions:
       - "^sig-ui-leads@kubernetes.io$"
   - path: "sig-windows/groups.yaml"
     allowedGroups:
+      - "^sig-windows@kubernetes.io$"
       - "^sig-windows-leads@kubernetes.io$"
       - "^k8s-infra-staging-gmsa-webhook@kubernetes.io$"
       - "^k8s-infra-staging-win-op-rdnss@kubernetes.io$"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -210,6 +210,8 @@ restrictions:
       - "^k8s-infra-rbac-triageparty-scalability@kubernetes.io$"
       - "^k8s-infra-sig-scalability-oncall@kubernetes.io$"
       - "^k8s-infra-staging-perf-tests@kubernetes.io$"
+      - "^sig-scalability@kubernetes.io$"
+      - "^sig-scalability-leads@kubernetes.io$"
   - path: "sig-scheduling/groups.yaml"
     allowedGroups:
       - "^k8s-infra-staging-descheduler@kubernetes.io$"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -146,6 +146,10 @@ restrictions:
       - "^k8s-infra-staging-prometheus-adapter@kubernetes.io$"
       - "^sig-instrumentation@kubernetes.io$"
       - "^sig-instrumentation-leads@kubernetes.io$"
+  - path: "sig-multicluster/groups.yaml"
+    allowedGroups:
+      - "^sig-multicluster@kubernetes.io$"
+      - "^sig-multicluster-leads@kubernetes.io$"
   - path: "sig-network/groups.yaml"
     allowedGroups:
       - "^k8s-infra-push-cni@kubernetes.io$"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -78,6 +78,8 @@ restrictions:
       - "^k8s-infra-staging-cloud-pv-vsphere@kubernetes.io$"
       - "^k8s-infra-staging-kas-network-proxy@kubernetes.io$"
       - "^k8s-infra-staging-cloud-pv-labeler@kubernetes.io$"
+      - "^sig-cloud-provider@kubernetes.io$"
+      - "^sig-cloud-provider-leads@kubernetes.io$"
   - path: "sig-cluster-lifecycle/groups.yaml"
     allowedGroups:
       - "^sig-cluster-lifecycle@kubernetes.io$"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -136,6 +136,8 @@ restrictions:
     allowedGroups:
       - "^blog@kubernetes.io$"
       - "^k8s-infra-staging-sig-docs@kubernetes.io$"
+      - "^sig-docs@kubernetes.io$"
+      - "^sig-docs-leads@kubernetes.io$"
   - path: "sig-instrumentation/groups.yaml"
     allowedGroups:
       - "^k8s-infra-staging-kube-state-metrics@kubernetes.io$"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -31,6 +31,8 @@ restrictions:
       - "^k8s-infra-staging-examples@kubernetes.io$"
       - "^k8s-infra-staging-jobset@kubernetes.io$"
       - "^k8s-infra-staging-lws@kubernetes.io$"
+      - "^sig-apps@kubernetes.io$"
+      - "^sig-apps-leads@kubernetes.io$"
   - path: "sig-architecture/groups.yaml"
     allowedGroups:
       - "^k8s-infra-conform-inspur@kubernetes.io$"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -132,6 +132,7 @@ restrictions:
   - path: "sig-etcd/groups.yaml"
     allowedGroups:
       - "@etcd.io$"
+      - "^sig-etcd-leads@kubernetes.io$"
   - path: "sig-docs/groups.yaml"
     allowedGroups:
       - "^blog@kubernetes.io$"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -144,6 +144,8 @@ restrictions:
       - "^k8s-infra-staging-kube-state-metrics@kubernetes.io$"
       - "^k8s-infra-staging-metrics-server@kubernetes.io$"
       - "^k8s-infra-staging-prometheus-adapter@kubernetes.io$"
+      - "^sig-instrumentation@kubernetes.io$"
+      - "^sig-instrumentation-leads@kubernetes.io$"
   - path: "sig-network/groups.yaml"
     allowedGroups:
       - "^k8s-infra-push-cni@kubernetes.io$"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -58,6 +58,7 @@ restrictions:
   - path: "sig-autoscaling/groups.yaml"
     allowedGroups:
       - "^k8s-infra-staging-autoscaling@kubernetes.io$"
+      - "^sig-autoscaling@kubernetes.io$"
       - "^sig-autoscaling-leads@kubernetes.io$"
       - "^sig-autoscaling-karpenter-leads@kubernetes.io$"
   - path: "sig-cli/groups.yaml"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -166,6 +166,7 @@ restrictions:
       - "^sig-network-leads@kubernetes.io$"
   - path: "sig-node/groups.yaml"
     allowedGroups:
+      - "^sig-node@kubernetes.io$"
       - "^sig-node-leads@kubernetes.io$"
       - "^k8s-infra-push-cri-tools@kubernetes.io$"
       - "^k8s-infra-staging-cri-tools@kubernetes.io$"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -329,4 +329,8 @@ restrictions:
   - path: "wg-etcd-operator/groups.yaml"
     allowedGroups:
       - "^wg-etcd-operator.*@kubernetes.io$"
+  - path: "wg-structured-logging/groups.yaml"
+    allowedGroups:
+      - "^wg-structured-logging@kubernetes.io$"
+      - "^wg-structured-logging-leads@kubernetes.io$"
   - path: "**/*" # prevent any other file from containing anything

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -239,6 +239,7 @@ restrictions:
       - "^sig-storage-leads@kubernetes.io$"
   - path: "sig-testing/groups.yaml"
     allowedGroups:
+      - "^sig-testing@kubernetes.io$"
       - "^sig-testing-leads@kubernetes.io$"
       - "^k8s-infra-staging-boskos@kubernetes.io$"
       - "^k8s-infra-staging-e2e-test-images@kubernetes.io$"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -53,6 +53,8 @@ restrictions:
       - "^k8s-infra-staging-secrets-store-sync@kubernetes.io$"
       - "^k8s-infra-staging-multitenancy@kubernetes.io$"
       - "^k8s-infra-staging-sig-auth@kubernetes.io$"
+      - "^sig-auth@kubernetes.io$"
+      - "^sig-auth-leads@kubernetes.io$"
   - path: "sig-autoscaling/groups.yaml"
     allowedGroups:
       - "^k8s-infra-staging-autoscaling@kubernetes.io$"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -227,6 +227,8 @@ restrictions:
   - path: "sig-security/groups.yaml"
     allowedGroups:
       - "^security-tooling-private@kubernetes.io$"
+      - "^sig-security@kubernetes.io$"
+      - "^sig-security-leads@kubernetes.io$"
   - path: "sig-storage/groups.yaml"
     allowedGroups:
       - "^k8s-infra-push-csi@kubernetes.io$"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -311,6 +311,10 @@ restrictions:
     allowedGroups:
       - "^wg-data-protection@kubernetes.io$"
       - "^wg-data-protection-leads@kubernetes.io$"
+  - path: "wg-policy/groups.yaml"
+    allowedGroups:
+      - "^wg-policy@kubernetes.io$"
+      - "^wg-policy-leads@kubernetes.io$"
   - path: "wg-serving/groups.yaml"
     allowedGroups:
       - "^wg-serving.*@kubernetes.io$"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -45,6 +45,8 @@ restrictions:
       - "^k8s-infra-code-organization@kubernetes.io$"
       - "^k8s-infra-prod-readiness@kubernetes.io$"
       - "^k8s-infra-keps@kubernetes.io$"
+      - "^sig-architecture@kubernetes.io$"
+      - "^sig-architecture-leads@kubernetes.io$"
   - path: "sig-auth/groups.yaml"
     allowedGroups:
       - "^k8s-infra-staging-csi-secrets-store@kubernetes.io$"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -253,6 +253,10 @@ restrictions:
       - "^k8s-infra-rbac-gcsweb@kubernetes.io$"
       - "^k8s-infra-rbac-kettle@kubernetes.io$"
       - "^k8s-infra-rbac-prow@kubernetes.io$"
+  - path: "sig-ui/groups.yaml"
+    allowedGroups:
+      - "^sig-ui@kubernetes.io$"
+      - "^sig-ui-leads@kubernetes.io$"
   - path: "sig-windows/groups.yaml"
     allowedGroups:
       - "^sig-windows-leads@kubernetes.io$"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -235,6 +235,8 @@ restrictions:
       - "^k8s-infra-staging-sig-storage@kubernetes.io$"
       - "^k8s-infra-staging-csi@kubernetes.io$"
       - "^k8s-infra-staging-git-sync@kubernetes.io$"
+      - "^sig-storage@kubernetes.io$"
+      - "^sig-storage-leads@kubernetes.io$"
   - path: "sig-testing/groups.yaml"
     allowedGroups:
       - "^sig-testing-leads@kubernetes.io$"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -199,6 +199,7 @@ restrictions:
       - "^release-managers-private@kubernetes.io$"
       - "^release-managers@kubernetes.io$"
       - "^security-release-team@kubernetes.io$"
+      - "^sig-release@kubernetes.io$"
       - "^sig-release-leads@kubernetes.io$"
       - "^release-team@kubernetes.io$"
       - "^release-team-shadows@kubernetes.io$"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -307,6 +307,10 @@ restrictions:
     allowedGroups:
       - "^wg-batch@kubernetes.io$"
       - "^wg-batch-leads@kubernetes.io$"
+  - path: "wg-data-protection/groups.yaml"
+    allowedGroups:
+      - "^wg-data-protection@kubernetes.io$"
+      - "^wg-data-protection-leads@kubernetes.io$"
   - path: "wg-serving/groups.yaml"
     allowedGroups:
       - "^wg-serving.*@kubernetes.io$"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -162,6 +162,8 @@ restrictions:
       - "^k8s-infra-staging-ingress-nginx@kubernetes.io$"
       - "^k8s-infra-staging-ingressconformance@kubernetes.io$"
       - "^ingress-nginx-dev@kubernetes.io$"
+      - "^sig-network@kubernetes.io$"
+      - "^sig-network-leads@kubernetes.io$"
   - path: "sig-node/groups.yaml"
     allowedGroups:
       - "^sig-node-leads@kubernetes.io$"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -63,6 +63,7 @@ restrictions:
       - "^sig-autoscaling-karpenter-leads@kubernetes.io$"
   - path: "sig-cli/groups.yaml"
     allowedGroups:
+      - "^sig-cli@kubernetes.io$"
       - "^sig-cli-leads@kubernetes.io$"
       - "^k8s-infra-staging-kustomize@kubernetes.io$"
       - "^k8s-infra-staging-krm-functions@kubernetes.io$"

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -221,6 +221,7 @@ restrictions:
       - "^k8s-infra-staging-kwok@kubernetes.io$"
       - "^k8s-infra-staging-wasm-scheduler@kubernetes.io$"
       - "^kueue-alerts@kubernetes.io$"
+      - "^sig-scheduling@kubernetes.io$"
       - "^sig-scheduling-alerts@kubernetes.io$"
       - "^sig-scheduling-leads@kubernetes.io$"
   - path: "sig-security/groups.yaml"

--- a/groups/sig-apps/groups.yaml
+++ b/groups/sig-apps/groups.yaml
@@ -19,6 +19,44 @@ groups:
   # subproject artifacts being stored in a given staging project
   #
 
+  - email-id: sig-apps-leads@kubernetes.io
+    name: sig-apps-leads
+    description: |-
+      sig-apps leads
+    owners:
+      - chiachenk@google.com
+      - killen.bob@gmail.com # temporary to finish configuration
+      - kowens0826@gmail.com
+      - soltysh@gmail.com
+    settings:
+      AllowWebPosting: "true"
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+
+  - email-id: sig-apps@kubernetes.io
+    name: sig-apps
+    description: |-
+      SIG apps general discussion group
+    owners:
+      - chiachenk@google.com
+      - killen.bob@gmail.com # temporary to finish configuration
+      - kowens0826@gmail.com
+      - soltysh@gmail.com
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MembersCanPostAsTheGroup: "false"
+      ReconcileMembers: "false"
+
   - email-id: k8s-infra-staging-jobset@kubernetes.io
     name: k8s-infra-staging-jobset
     description: |-

--- a/groups/sig-architecture/groups.yaml
+++ b/groups/sig-architecture/groups.yaml
@@ -19,6 +19,45 @@ groups:
   # subproject artifacts being stored in a given staging project
   #
 
+  - email-id: sig-architecture-leads@kubernetes.io
+    name: sig-architecture-leads
+    description: |-
+      sig-architecture leads
+    owners:
+      - davanum@gmail.com
+      - decarr@redhat.com
+      - jbelamaric@google.com
+      - killen.bob@gmail.com # temporary to finish configuration
+    settings:
+      AllowWebPosting: "true"
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+
+  - email-id: sig-architecture@kubernetes.io
+    name: sig-architecture
+    description: |-
+      SIG architecture general discussion group
+    owners:
+      - davanum@gmail.com
+      - decarr@redhat.com
+      - jbelamaric@google.com
+      - killen.bob@gmail.com # temporary to finish configuration
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MembersCanPostAsTheGroup: "false"
+      ReconcileMembers: "false"
+
+
   - email-id: k8s-infra-staging-apisnoop@kubernetes.io
     name: k8s-infra-staging-apisnoop
     description: |-

--- a/groups/sig-auth/groups.yaml
+++ b/groups/sig-auth/groups.yaml
@@ -19,6 +19,48 @@ groups:
   # subproject artifacts being stored in a given staging project
   #
 
+  - email-id: sig-auth-leads@kubernetes.io
+    name: sig-auth-leads
+    description: |-
+      sig-auth leads
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - deads@redhat.com
+      - liggitt@google.com
+      - mikedanese@google.com
+      - rita.z.zhang@gmail.com
+      - theenjeru@gmail.com
+    settings:
+      AllowWebPosting: "true"
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+
+  - email-id: sig-auth@kubernetes.io
+    name: sig-auth
+    description: |-
+      SIG auth general discussion group
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - deads@redhat.com
+      - liggitt@google.com
+      - mikedanese@google.com
+      - rita.z.zhang@gmail.com
+      - theenjeru@gmail.com
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MembersCanPostAsTheGroup: "false"
+      ReconcileMembers: "false"
+
   - email-id: k8s-infra-staging-sig-auth@kubernetes.io
     name: k8s-infra-staging-sig-auth
     description: |-

--- a/groups/sig-autoscaling/groups.yaml
+++ b/groups/sig-autoscaling/groups.yaml
@@ -20,6 +20,26 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
 
+  - email-id: sig-autoscaling@kubernetes.io
+    name: sig-autoscaling
+    description: |-
+      SIG autoscaling general discussion group
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - guyjtempleton@gmail.com
+      - maciekpytel@google.com
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MembersCanPostAsTheGroup: "false"
+      ReconcileMembers: "false"
+
   - email-id: sig-autoscaling-karpenter-leads@kubernetes.io
     name: sig-autoscaling-karpenter-leads
     description: |-

--- a/groups/sig-cli/groups.yaml
+++ b/groups/sig-cli/groups.yaml
@@ -20,6 +20,28 @@ groups:
       - soltysh@gmail.com
       - mpuckett259@gmail.com
 
+  - email-id: sig-cli@kubernetes.io
+    name: sig-cli
+    description: |-
+      SIG cli general discussion group
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - aguclu@redhat.com
+      - eddiezane@gmail.com
+      - soltysh@gmail.com
+      - mpuckett259@gmail.com
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MembersCanPostAsTheGroup: "false"
+      ReconcileMembers: "false"
+
   #
   # k8s-staging write access for SIG-owned subprojects
   #

--- a/groups/sig-cli/groups.yaml
+++ b/groups/sig-cli/groups.yaml
@@ -17,7 +17,7 @@ groups:
     owners:
       - aguclu@redhat.com
       - eddiezane@gmail.com
-      - maszulik@redhat.com
+      - soltysh@gmail.com
       - mpuckett259@gmail.com
 
   #
@@ -85,5 +85,5 @@ groups:
     members:
       - aguclu@redhat.com
       - eddiezane@gmail.com
-      - maszulik@redhat.com
+      - soltysh@gmail.com
       - mpuckett259@gmail.com

--- a/groups/sig-cloud-provider/groups.yaml
+++ b/groups/sig-cloud-provider/groups.yaml
@@ -19,6 +19,41 @@ groups:
   # subproject artifacts being stored in a given staging project
   #
 
+  - email-id: sig-cloud-provider-leads@kubernetes.io
+    name: sig-cloud-provider-leads
+    description: |-
+      sig-cloud-provider leads
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - bridget@kromhout.org
+      - msm@opbstudios.com
+      - wfender@google.com
+    settings:
+      AllowWebPosting: "true"
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+
+  - email-id: sig-cloud-provider@kubernetes.io
+    name: sig-cloud-provider
+    description: |-
+      SIG cloud provider general discussion group
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MembersCanPostAsTheGroup: "false"
+      ReconcileMembers: "false"
+
   - email-id: k8s-infra-staging-provider-aws@kubernetes.io
     name: k8s-infra-staging-provider-aws
     description: |-

--- a/groups/sig-docs/groups.yaml
+++ b/groups/sig-docs/groups.yaml
@@ -7,6 +7,48 @@ groups:
   # and is not intended to govern access to infrastructure
   #
 
+  - email-id: sig-docs-leads@kubernetes.io
+    name: sig-docs-leads
+    description: |-
+      sig-docs leads
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - divya.mohan0209@gmail.com
+      - kat.cosgrove@gmail.com
+      - natalivlatko@gmail.com
+      - rlejano@gmail.com
+      - xandergrzyw@gmail.com
+    settings:
+      AllowWebPosting: "true"
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+
+  - email-id: sig-docs@kubernetes.io
+    name: sig-docs
+    description: |-
+      SIG docs general discussion group
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - divya.mohan0209@gmail.com
+      - kat.cosgrove@gmail.com
+      - natalivlatko@gmail.com
+      - rlejano@gmail.com
+      - xandergrzyw@gmail.com
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MembersCanPostAsTheGroup: "false"
+      ReconcileMembers: "false"
+
   - email-id: blog@kubernetes.io
     name: blog
     description: |-

--- a/groups/sig-etcd/groups.yaml
+++ b/groups/sig-etcd/groups.yaml
@@ -13,3 +13,21 @@ groups:
       - siarkowicz@google.com
       - spzala@us.ibm.com
       - wenjiazhang@google.com
+
+  - email-id: sig-etcd-leads@kubernetes.io
+    name: sig-etcd-leads
+    description: |-
+      sig-etcd leads
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - benjamin.ahrtr@gmail.com
+      - jablair@redhat.com
+      - siarkowicz@google.com
+      - wenjiazhang@google.com
+    settings:
+      AllowWebPosting: "true"
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"

--- a/groups/sig-instrumentation/groups.yaml
+++ b/groups/sig-instrumentation/groups.yaml
@@ -19,6 +19,47 @@ groups:
   # subproject artifacts being stored in a given staging project
   #
 
+  - email-id: sig-instrumentation-leads@kubernetes.io
+    name: sig-instrumentation-leads
+    description: |-
+      sig-instrumentation leads
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - dashpole@google.com
+      - dgrisonn@redhat.com
+      - hankang@google.com
+      - rexagod@gmail.com
+    settings:
+      AllowWebPosting: "true"
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+
+  - email-id: sig-instrumentation@kubernetes.io
+    name: sig-instrumentation
+    description: |-
+      SIG instrumentation general discussion group
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - dashpole@google.com
+      - dgrisonn@redhat.com
+      - hankang@google.com
+      - rexagod@gmail.com
+
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MembersCanPostAsTheGroup: "false"
+      ReconcileMembers: "false"
+
   - email-id: k8s-infra-staging-kube-state-metrics@kubernetes.io
     name: k8s-infra-staging-kube-state-metrics
     description: |-

--- a/groups/sig-multicluster/OWNERS
+++ b/groups/sig-multicluster/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- sig-multicluster-leads
+reviewers:
+- sig-multicluster-leads
+
+labels:
+- sig/multicluster

--- a/groups/sig-multicluster/groups.yaml
+++ b/groups/sig-multicluster/groups.yaml
@@ -1,0 +1,36 @@
+teams:
+  - email-id: sig-multicluster-leads@kubernetes.io
+    name: sig-multicluster-leads
+    description: |-
+      sig-multicluster leads
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - jeremyot@google.com
+      - skitt@redhat.com
+    settings:
+      AllowWebPosting: "true"
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+
+  - email-id: sig-multicluster@kubernetes.io
+    name: sig-multicluster
+    description: |-
+      SIG multicluster general discussion group
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - jeremyot@google.com
+      - skitt@redhat.com
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MembersCanPostAsTheGroup: "false"
+      ReconcileMembers: "false"

--- a/groups/sig-network/groups.yaml
+++ b/groups/sig-network/groups.yaml
@@ -19,6 +19,49 @@ groups:
   # subproject artifacts being stored in a given staging project
   #
 
+  - email-id: sig-network-leads@kubernetes.io
+    name: sig-network-leads
+    description: |-
+      sig-network leads
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - antonio.ojea.garcia@gmail.com
+      - danwinship@redhat.com
+      - michael.zappa@gmail.com
+      - sutt@redhat.com
+      - thockin@google.com
+    settings:
+      AllowWebPosting: "true"
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+
+  - email-id: sig-network@kubernetes.io
+    name: sig-network
+    description: |-
+      SIG network general discussion group
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - antonio.ojea.garcia@gmail.com
+      - danwinship@redhat.com
+      - michael.zappa@gmail.com
+      - sutt@redhat.com
+      - thockin@google.com
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MembersCanPostAsTheGroup: "false"
+      ReconcileMembers: "false"
+
+
   - email-id: k8s-infra-staging-networking@kubernetes.io
     name: k8s-infra-staging-networking
     description: |-

--- a/groups/sig-node/groups.yaml
+++ b/groups/sig-node/groups.yaml
@@ -32,6 +32,28 @@ groups:
       - mpatel@redhat.com
       - s.kanzhelev@gmail.com
 
+  - email-id: sig-node@kubernetes.io
+    name: sig-node
+    description: |-
+      SIG node general discussion group
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - dawnchen@google.com
+      - decarr@redhat.com
+      - mpatel@redhat.com
+      - s.kanzhelev@gmail.com
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MembersCanPostAsTheGroup: "false"
+      ReconcileMembers: "false"
+
   - email-id: k8s-infra-staging-cri-tools@kubernetes.io
     name: k8s-infra-staging-cri-tools
     description: |-

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -305,6 +305,30 @@ groups:
       - k8s@auggie.dev
       - saschagrunert@gmail.com
 
+  - email-id: sig-release@kubernetes.io
+    name: sig-release
+    description: |-
+      SIG release general discussion group
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - adolfo.garcia@uservers.net
+      - ctadeu@gmail.com
+      - gveronicalg@gmail.com
+      - jeremy.r.rickard@gmail.com
+      - k8s@auggie.dev
+      - saschagrunert@gmail.com
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MembersCanPostAsTheGroup: "false"
+      ReconcileMembers: "false"
+
   - email-id: release-team@kubernetes.io
     name: release-team
     description: |-

--- a/groups/sig-scalability/groups.yaml
+++ b/groups/sig-scalability/groups.yaml
@@ -41,6 +41,44 @@ groups:
   # subproject artifacts being stored in the GCS bucket
   #
 
+  - email-id: sig-scalability-leads@kubernetes.io
+    name: sig-scalability-leads
+    description: |-
+      sig-scalability leads
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - marcel.zieba@isovalent.com
+      - shyam123.jvs95@gmail.com
+      - wojtekt@google.com
+    settings:
+      AllowWebPosting: "true"
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+
+  - email-id: sig-scalability@kubernetes.io
+    name: sig-scalability
+    description: |-
+      SIG scalability general discussion group
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - marcel.zieba@isovalent.com
+      - shyam123.jvs95@gmail.com
+      - wojtekt@google.com
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MembersCanPostAsTheGroup: "false"
+      ReconcileMembers: "false"
+
 
   #
   # k8s-infra owners for sig-owned subprojects

--- a/groups/sig-scheduling/groups.yaml
+++ b/groups/sig-scheduling/groups.yaml
@@ -34,6 +34,27 @@ groups:
       - ahg@google.com
       - hweicdl@gmail.com
 
+  - email-id: sig-scheduling@kubernetes.io
+    name: sig-scheduling
+    description: |-
+      SIG scheduling general discussion group
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - acondor@google.com
+      - ahg@google.com
+      - hweicdl@gmail.com
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MembersCanPostAsTheGroup: "false"
+      ReconcileMembers: "false"
+
   - email-id: sig-scheduling-alerts@kubernetes.io
     name: sig-scheduling-alerts
     description: |-

--- a/groups/sig-security/groups.yaml
+++ b/groups/sig-security/groups.yaml
@@ -1,4 +1,41 @@
 groups:
+
+  - email-id: sig-security-leads@kubernetes.io
+    name: sig-security-leads
+    description: |-
+      sig-security leads
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - ian@coldwater.io
+      - tabitha.c.sable@gmail.com
+    settings:
+      AllowWebPosting: "true"
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+
+  - email-id: sig-security@kubernetes.io
+    name: sig-security
+    description: |-
+      SIG security general discussion group
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - ian@coldwater.io
+      - tabitha.c.sable@gmail.com
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MembersCanPostAsTheGroup: "false"
+      ReconcileMembers: "false"
+
   - email-id: security-tooling-private@kubernetes.io
     name: security-tooling-private
     description: |-

--- a/groups/sig-storage/groups.yaml
+++ b/groups/sig-storage/groups.yaml
@@ -19,6 +19,46 @@ groups:
   # subproject artifacts being stored in a given staging project
   #
 
+  - email-id: sig-storage-leads@kubernetes.io
+    name: sig-storage-leads
+    description: |-
+      sig-storage leads
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - jsafrane@redhat.com
+      - msau@google.com
+      - saadali@google.com
+      - xingyang105@gmail.com
+    settings:
+      AllowWebPosting: "true"
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+
+  - email-id: sig-storage@kubernetes.io
+    name: sig-storage
+    description: |-
+      SIG storage general discussion group
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - jsafrane@redhat.com
+      - msau@google.com
+      - saadali@google.com
+      - xingyang105@gmail.com
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MembersCanPostAsTheGroup: "false"
+      ReconcileMembers: "false"
+
   - email-id: k8s-infra-staging-sig-storage@kubernetes.io
     name: k8s-infra-staging-sig-storage
     description: |-

--- a/groups/sig-testing/groups.yaml
+++ b/groups/sig-testing/groups.yaml
@@ -20,9 +20,35 @@ groups:
       WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
     owners:
     - amerai@google.com
+    - antonio.ojea.garcia@gmail.com
+    - bentheelder@google.com$
     - bpratt@redhat.com
     - mcqueenorama@gmail.com
+    - patrick.ohly@intel.com
+
+  - email-id: sig-testing@kubernetes.io
+    name: sig-testing
+    description: |-
+      SIG testing general discussion group
+    owners:
+    - killen.bob@gmail.com # temporary to finish configuration
+    - amerai@google.com
     - antonio.ojea.garcia@gmail.com
+    - bentheelder@google.com
+    - bpratt@redhat.com
+    - mcqueenorama@gmail.com
+    - patrick.ohly@intel.com
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MembersCanPostAsTheGroup: "false"
+      ReconcileMembers: "false"
 
   #
   # sig-testing k8s-staging write access

--- a/groups/sig-ui/OWNERS
+++ b/groups/sig-ui/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- sig-ui-leads
+reviewers:
+- sig-ui-leads
+
+labels:
+- sig/ui

--- a/groups/sig-ui/groups.yaml
+++ b/groups/sig-ui/groups.yaml
@@ -1,0 +1,38 @@
+teams:
+  - email-id: sig-ui-leads@kubernetes.io
+    name: sig-ui-leads
+    description: |-
+      sig-ui leads
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - marcin9yk@icloud.com
+      - sebastian@plural.sh
+      - shu.mutow@gmail.com
+    settings:
+      AllowWebPosting: "true"
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+
+  - email-id: sig-ui@kubernetes.io
+    name: sig-ui
+    description: |-
+      SIG ui general discussion group
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - marcin9yk@icloud.com
+      - sebastian@plural.sh
+      - shu.mutow@gmail.com
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MembersCanPostAsTheGroup: "false"
+      ReconcileMembers: "false"

--- a/groups/sig-windows/groups.yaml
+++ b/groups/sig-windows/groups.yaml
@@ -15,11 +15,35 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     owners:
+      - amim.knabben@gmail.com
       - aravindh.foss@pm.me
       - cbelu@cloudbasesolutions.com
-      - jayunit100.apache@gmail.com
       - jsturtevant@gmail.com
       - marosset@microsoft.com
+
+  - email-id: sig-windows@kubernetes.io
+    name: sig-windows
+    description: |-
+      SIG windows general discussion group
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - amim.knabben@gmail.com
+      - aravindh.foss@pm.me
+      - cbelu@cloudbasesolutions.com
+      - jsturtevant@gmail.com
+      - marosset@microsoft.com
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MembersCanPostAsTheGroup: "false"
+      ReconcileMembers: "false"
+
 
   #
   # k8s-staging write access for SIG-owned subprojects

--- a/groups/wg-batch/groups.yaml
+++ b/groups/wg-batch/groups.yaml
@@ -15,7 +15,7 @@ groups:
     owners:
       - acondor@google.com
       - mwielgus@google.com
-      - maszulik@redhat.com
+      - soltysh@gmail.com
       - swati.tcd@gmail.com
 
   - email-id: wg-batch@kubernetes.io
@@ -32,7 +32,7 @@ groups:
     owners:
       - acondor@google.com
       - mwielgus@google.com
-      - maszulik@redhat.com
+      - soltysh@gmail.com
       - swati.tcd@gmail.com
     members:
       - wg-batch-leads@kubernetes.io

--- a/groups/wg-data-protection/OWNERS
+++ b/groups/wg-data-protection/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- wg-data-protection-leads
+reviewers:
+- wg-data-protection-leads
+
+labels:
+- wg/data-protection

--- a/groups/wg-data-protection/groups.yaml
+++ b/groups/wg-data-protection/groups.yaml
@@ -1,0 +1,36 @@
+teams:
+  - email-id: wg-data-protection-leads@kubernetes.io
+    name: wg-data-protection-leads
+    description: |-
+      wg-data-protection leads
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - xiangqian@google.com
+      - xingyang105@gmail.com
+    settings:
+      AllowWebPosting: "true"
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+
+  - email-id: wg-data-protection@kubernetes.io
+    name: wg-data-protection
+    description: |-
+      wg data-protection general discussion group
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - xiangqian@google.com
+      - xingyang105@gmail.com
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MembersCanPostAsTheGroup: "false"
+      ReconcileMembers: "false"

--- a/groups/wg-policy/OWNERS
+++ b/groups/wg-policy/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- wg-policy-leads
+reviewers:
+- wg-policy-leads
+
+labels:
+- wg/policy

--- a/groups/wg-policy/groups.yaml
+++ b/groups/wg-policy/groups.yaml
@@ -1,0 +1,38 @@
+teams:
+  - email-id: wg-policy-leads@kubernetes.io
+    name: wg-policy-leads
+    description: |-
+      wg-policy leads
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - andy@suderman.dev
+      - jim@nirmata.com
+      - poonamlamba83@gmail.com
+    settings:
+      AllowWebPosting: "true"
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+
+  - email-id: wg-policy@kubernetes.io
+    name: wg-policy
+    description: |-
+      wg policy general discussion group
+    owners:
+      - killen.bob@gmail.com # temporary to finish configuration
+      - andy@suderman.dev
+      - jim@nirmata.com
+      - poonamlamba83@gmail.com
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
+      WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
+      WhoCanModerateContent: "OWNERS_AND_MANAGERS"
+      MembersCanPostAsTheGroup: "false"
+      ReconcileMembers: "false"

--- a/groups/wg-structured-logging/OWNERS
+++ b/groups/wg-structured-logging/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- wg-structured-logging-leads
+reviewers:
+- wg-structured-logging-leads
+
+labels:
+- wg/structured-logging

--- a/groups/wg-structured-logging/groups.yaml
+++ b/groups/wg-structured-logging/groups.yaml
@@ -1,12 +1,12 @@
 teams:
-  - email-id: wg-data-protection-leads@kubernetes.io
-    name: wg-data-protection-leads
+  - email-id: wg-structured-logging-leads@kubernetes.io
+    name: wg-structured-logging-leads
     description: |-
-      wg-data-protection leads
+      wg-structured-logging leads
     owners:
       - killen.bob@gmail.com # temporary to finish configuration
-      - xiangqian@google.com
-      - xingyang105@gmail.com
+      - liumengjiao.dev@gmail.com
+      - patrick.ohly@intel.com
     settings:
       AllowWebPosting: "true"
       ReconcileMembers: "true"
@@ -15,14 +15,14 @@ teams:
       WhoCanModerateContent: "OWNERS_AND_MANAGERS"
       MessageModerationLevel: "MODERATE_NON_MEMBERS"
 
-  - email-id: wg-data-protection@kubernetes.io
-    name: wg-data-protection
+  - email-id: wg-structured-logging@kubernetes.io
+    name: wg-structured-logging
     description: |-
-      wg data-protection general discussion group
+      wg structured-logging general discussion group
     owners:
       - killen.bob@gmail.com # temporary to finish configuration
-      - xiangqian@google.com
-      - xingyang105@gmail.com
+      - liumengjiao.dev@gmail.com
+      - patrick.ohly@intel.com
     settings:
       WhoCanJoin: "ANYONE_CAN_JOIN"
       WhoCanViewGroup: "ANYONE_CAN_VIEW"


### PR DESCRIPTION
This PR creates managed kubernetes.io groups for all remaining sigs/wgs that do not currently have them. Migrating to managed groups will resolve several issues we've had with  public googlegroups (e.g. mailing list limits on calendar invites or leads losing control of mailing lists), and enable us to use a common shared drive.

To complete this, I am adding myself to each new list to complete configuration (some settings can't currently be set via our automation). Once complete, I will remove myself from all the groups.

It also cleans up the general leads list and references each individual sig/wgs leads list so it won't have to be updated in more than one place. There are a few remaining emails in there that I'm waiting for acks on, but all in all its a significant improvement.

/hold