### PR TITLE
gcsweb: Drop deleted bucket

### DIFF
--- a/apps/gcsweb/deployment.yaml
+++ b/apps/gcsweb/deployment.yaml
@@ -27,7 +27,6 @@ spec:
           args:
             - -upgrade-proxied-http-to-https
             # buckets owned by kubernetes.io
-            - -b=k8s-infra-prow-results
             - -b=k8s-infra-scalability-tests-logs
             - -b=k8s-release-dev
             # buckets owned by google.com


### PR DESCRIPTION
Stop serve deleted bucket in
https://github.com/kubernetes/k8s.io/pull/7075.