### PR TITLE
groups: update vmware email to broadcom for distributors-announce

### DIFF
--- a/groups/committee-security-response/groups.yaml
+++ b/groups/committee-security-response/groups.yaml
@@ -59,8 +59,7 @@ groups:
       - security@platform9.com
       - security@rancher.com
       - security@ubuntu.com
-      - security@vmware.com
-      - tkg-cve-disclosure@groups.vmware.com
+      - VMware.psirt@broadcom.com
       - vulnerabilityreports@cloudfoundry.org
 
   - email-id: security@kubernetes.io


### PR DESCRIPTION
Fixes https://github.com/kubernetes/committee-security-response/issues/198

This commit:
- VMware has been acquired by Broadcom so it moves from vmware emails to a broadcom one.
- It also consolidates the two vmware emails into a broadcom one.

/assign @enj 

