### PR TITLE
re-scope azure storage blob contributor role assignment to subscription

### DIFF
--- a/infra/azure/terraform/capz/main.tf
+++ b/infra/azure/terraform/capz/main.tf
@@ -118,7 +118,6 @@ module "role_assignments" {
   source                   = "./role-assignments"
   resource_group_name      = var.resource_group_name
   container_registry_scope = module.container_registry.container_registry_id
-  storage_account_scope    = azurerm_storage_account.k8sprowstorage.id
   subscription_id          = data.azurerm_client_config.current.subscription_id 
   depends_on = [
     azurerm_resource_group.capz_ci,

--- a/infra/azure/terraform/capz/role-assignments/main.tf
+++ b/infra/azure/terraform/capz/role-assignments/main.tf
@@ -22,10 +22,6 @@ variable "container_registry_scope" {
   type = string
 }
 
-variable "storage_account_scope" {
-  type = string
-}
-
 variable "subscription_id" {
   type = string
 }
@@ -43,7 +39,7 @@ resource "azurerm_role_assignment" "rg_contributor" {
 resource "azurerm_role_assignment" "storage_blob_data_contributor" {
   principal_id         = data.azuread_service_principal.az_service_principal.id
   role_definition_name = "Storage Blob Data Contributor"
-  scope                = var.storage_account_scope
+  scope                = "/subscriptions/${var.subscription_id}"
 }
 
 resource "azurerm_role_assignment" "acr_pull" {


### PR DESCRIPTION
This change increases the scope of the "Storage Blob Data Contributor" role assignment to the `az-cli-prow` Service Principal from only the `k8sprowstoragecomm` Storage Account to the entire subscription in order to also support the `--auth-mode login` flag for `az storage` commands against the ephemeral `capz-wi-*` Storage Accounts created by CAPZ for Workload Identity.