### PR TITLE
chore: update external-dns maintainers

### DIFF
--- a/registry.k8s.io/images/k8s-staging-external-dns/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-external-dns/OWNERS
@@ -3,19 +3,18 @@
 # Synced to the root OWNERS file in sigs.k8s.io/external-dns as of 09/16/23
 
 approvers:
-  - johngmyers
   - mloiseleur
   - raffo
   - szuecs
 
 reviewers:
-  - johngmyers
   - mloiseleur
   - raffo
   - szuecs
 
 emeritus_approvers:
   - hjacobs
+  - johngmyers
   - linki
   - njuettner
   - seanmalloy


### PR DESCRIPTION
# Description

Update external-dns maintainers. 

Motivation detailed in https://github.com/kubernetes-sigs/external-dns/pull/4679