### PR TITLE
Fastly: use a private bucket as origin for dl.k8s.io

### DIFF
--- a/infra/fastly/terraform/dl.k8s.io/data.tf
+++ b/infra/fastly/terraform/dl.k8s.io/data.tf
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubernetes Authors.
+Copyright 2024 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,30 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-/*
-This file defines:
-- Required provider versions
-- Storage backend details
-*/
-
-terraform {
-  backend "gcs" {
-    bucket = "k8s-infra-tf-fastly"
-    prefix = "cdn.dl.k8s.io"
-  }
-
-  required_providers {
-    google = {
-      source  = "hashicorp/google"
-      version = "~> 5.41.0"
-    }
-    fastly = {
-      source  = "fastly/fastly"
-      version = "~> 5.11.0"
-    }
-  }
+data "google_secret_manager_secret_version_access" "gcs_reader_access_key" {
+  secret  = "fastly_reader_sa_access_key"
+  project = "k8s-infra-releases-prod"
 }
 
-# Configure required providers
-provider "fastly" {}
-provider "google" {}
+data "google_secret_manager_secret_version_access" "gcs_reader_secret_key" {
+  secret  = "fastly_reader_sa_secret_key"
+  project = "k8s-infra-releases-prod"
+}

--- a/infra/fastly/terraform/dl.k8s.io/variables.tf
+++ b/infra/fastly/terraform/dl.k8s.io/variables.tf
@@ -14,13 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-variable "bucket" {
+variable "bucket_name" {
   type    = string
-  default = "kubernetes-release"
+  default = "767373bbdcb8270361b96548387bf2a9ad0d48758c35"
 }
 
-variable "fastly_api_key" {
-  type      = string
-  sensitive = true
-  default   = null
+variable "region" {
+  type    = string
+  default = "us-central1"
 }

--- a/infra/fastly/terraform/dl.k8s.io/vcl/gcs-auth.vcl
+++ b/infra/fastly/terraform/dl.k8s.io/vcl/gcs-auth.vcl
@@ -1,0 +1,75 @@
+# VCL snippet to authenticate Fastly requests to GCS.
+#
+# https://developer.fastly.com/solutions/examples/google-cloud-storage-origin-private/
+
+sub set_google_auth_header {
+
+declare local var.googleAccessKey STRING;
+declare local var.googleSecretKey STRING;
+declare local var.googleBucket STRING;
+declare local var.googleRegion STRING;
+declare local var.canonicalHeaders STRING;
+declare local var.signedHeaders STRING;
+declare local var.canonicalRequest STRING;
+declare local var.canonicalQuery STRING;
+declare local var.stringToSign STRING;
+declare local var.dateStamp STRING;
+declare local var.signature STRING;
+declare local var.scope STRING;
+
+#As of 8/2019, GCS now supports HMAC keys based on service accounts.
+#The below accessKey and secretKey should come from a service account based HMAC Key
+set var.googleAccessKey = "${access_key}";
+set var.googleSecretKey = "${secret_key}";
+set var.googleBucket = "${backend_bucket}";
+set var.googleRegion = "${region}";
+
+set bereq.http.x-amz-content-sha256 = digest.hash_sha256("");
+set bereq.http.x-amz-date = strftime({"%Y%m%dT%H%M%SZ"}, now);
+set bereq.http.host = var.googleBucket ".storage.googleapis.com";
+set bereq.url = querystring.remove(bereq.url);
+set bereq.url = regsuball(urlencode(urldecode(bereq.url.path)), {"%2F"}, "/");
+set var.dateStamp = strftime({"%Y%m%d"}, now);
+set var.canonicalHeaders = ""
+    "host:" + bereq.http.host + LF +
+    "x-amz-content-sha256:" + bereq.http.x-amz-content-sha256 + LF +
+    "x-amz-date:" + bereq.http.x-amz-date + LF
+  ;
+set var.canonicalQuery = "";
+set var.signedHeaders = "host;x-amz-content-sha256;x-amz-date";
+set var.canonicalRequest = "" +
+    "GET" + LF +
+    bereq.url.path + LF +
+    var.canonicalQuery + LF +
+    var.canonicalHeaders + LF +
+    var.signedHeaders + LF +
+    digest.hash_sha256("")
+  ;
+
+set var.scope = var.dateStamp "/" var.googleRegion "/s3/aws4_request";
+
+set var.stringToSign = "" +
+    "AWS4-HMAC-SHA256" + LF +
+    bereq.http.x-amz-date + LF +
+    var.scope + LF +
+    regsub(digest.hash_sha256(var.canonicalRequest),"^0x", "")
+  ;
+
+set var.signature = digest.awsv4_hmac(
+    var.googleSecretKey,
+    var.dateStamp,
+    var.googleRegion,
+    "s3",
+    var.stringToSign
+  );
+
+set bereq.http.Authorization = "AWS4-HMAC-SHA256 " +
+    "Credential=" + var.googleAccessKey + "/" + var.scope + ", " +
+    "SignedHeaders=" + var.signedHeaders + ", " +
+    "Signature=" + regsub(var.signature,"^0x", "")
+  ;
+unset bereq.http.Accept;
+unset bereq.http.Accept-Language;
+unset bereq.http.User-Agent;
+unset bereq.http.Fastly-Client-IP;
+}


### PR DESCRIPTION
  - Ensure the VCL service can use a GCS private bucket as origin using AWS
  auth headers. GCS API is S3-compatible. We apply the snippet from https://quic.fastly.com/documentation/solutions/examples/google-cloud-storage-origin-private/
  - Enable Shielding for the service. More informations on https://www.fastly.com/documentation/guides/concepts/shielding/
  - Disable the healthcheck for the service. This is not required since we
    have Origin Inspector activated and is currently not working with the
    private bucket.
- Only enable custom headers for debugging