### PR TITLE
Fastly: Ensure specific file types are not cached.

### DIFF
--- a/infra/fastly/terraform/dl-sandbox.k8s.dev/vcl/binaries.vcl
+++ b/infra/fastly/terraform/dl-sandbox.k8s.dev/vcl/binaries.vcl
@@ -44,8 +44,15 @@ sub vcl_fetch {
     set beresp.stale_while_revalidate = 60s; // 1 minute
   }
 
-  //Ensure version markers are not cached
-  if (req.url.ext == "txt") {
+  # Ensure version markers are not cached at the edge
+  if (req.url.path ~ "^/release/(latest|stable)(-\d+(\.\d+))?\.txt\z") {
+    set beresp.cacheable = false;
+    set beresp.ttl = 0s;
+    return (pass);
+  }
+
+  # Ensure HTML and JSON files are not cached at the edge
+  if (req.url.ext ~ "(html|json)\z") {
     set beresp.cacheable = false;
     set beresp.ttl = 0s;
     return (pass);

--- a/infra/fastly/terraform/dl.k8s.io/vcl/binaries.vcl
+++ b/infra/fastly/terraform/dl.k8s.io/vcl/binaries.vcl
@@ -44,8 +44,15 @@ sub vcl_fetch {
     set beresp.stale_while_revalidate = 60s; # 1 minute
   }
 
-  # Ensure version markers are not cached
-  if (req.url.ext == "txt") {
+  # Ensure version markers are not cached at the edge
+  if (req.url.path ~ "^/release/(latest|stable)(-\d+(\.\d+))?\.txt\z") {
+    set beresp.cacheable = false;
+    set beresp.ttl = 0s;
+    return (pass);
+  }
+
+  # Ensure HTML and JSON files are not cached at the edge
+  if (req.url.ext ~ "(html|json)\z") {
     set beresp.cacheable = false;
     set beresp.ttl = 0s;
     return (pass);


### PR DESCRIPTION
Ensure HTML and JSON are not cached at the edge and are directly
served.
We are also specific about the sub-paths for the different version
markers.
This will required to purge some objects from the cache.