### PR TITLE
[eks-prow-build] K8s upgrade from 1.28 to 1.30

### DIFF
--- a/infra/aws/terraform/modules/eks-prow-iam/policy_plan.tf
+++ b/infra/aws/terraform/modules/eks-prow-iam/policy_plan.tf
@@ -96,7 +96,8 @@ data "aws_iam_policy_document" "eks_plan" {
       "s3:GetObject",
       "s3:ListBucket",
       "sqs:GetQueueAttributes",
-      "sqs:ListQueueTags"
+      "sqs:ListQueueTags",
+      "ssm:GetParameter"
     ]
   }
 }

--- a/infra/aws/terraform/prow-build-cluster/iam.tf
+++ b/infra/aws/terraform/prow-build-cluster/iam.tf
@@ -49,8 +49,7 @@ resource "aws_iam_role" "eks_prow_admin" {
       {
         "Effect" : "Allow",
         "Principal" : {
-                      // aws_iam_openid_connect_provider.k8s_infra_prow[0].arn
-          "Federated" : "arn:aws:iam::468814281478:oidc-provider/container.googleapis.com/v1/projects/k8s-infra-prow/locations/us-central1/clusters/prow"
+          "Federated" : aws_iam_openid_connect_provider.k8s_infra_prow[0].arn
         },
         "Action" : "sts:AssumeRoleWithWebIdentity",
         "Condition" : {

--- a/infra/aws/terraform/prow-build-cluster/iam.tf
+++ b/infra/aws/terraform/prow-build-cluster/iam.tf
@@ -45,6 +45,26 @@ resource "aws_iam_role" "eks_prow_admin" {
             ]
           }
         }
+      },
+      {
+        "Effect" : "Allow",
+        "Principal" : {
+                      // aws_iam_openid_connect_provider.k8s_infra_prow[0].arn
+          "Federated" : "arn:aws:iam::468814281478:oidc-provider/container.googleapis.com/v1/projects/k8s-infra-prow/locations/us-central1/clusters/prow"
+        },
+        "Action" : "sts:AssumeRoleWithWebIdentity",
+        "Condition" : {
+          "StringEquals" : {
+            "container.googleapis.com/v1/projects/k8s-infra-prow/locations/us-central1/clusters/prow:sub" : [
+              "system:serviceaccount:default:deck",
+              "system:serviceaccount:default:config-bootstrapper",
+              "system:serviceaccount:default:crier",
+              "system:serviceaccount:default:sinker",
+              "system:serviceaccount:default:prow-controller-manager",
+              "system:serviceaccount:default:hook"
+            ]
+          }
+        }
       }
     ]
   })

--- a/infra/aws/terraform/prow-build-cluster/node_group_stable.tf
+++ b/infra/aws/terraform/prow-build-cluster/node_group_stable.tf
@@ -33,8 +33,10 @@ locals {
 
     iam_role_permissions_boundary = data.aws_iam_policy.eks_resources_permission_boundary.arn
 
-    ami_type             = "BOTTLEROCKET_x86_64"
-    platform             = "bottlerocket"
+    ami_type                       = "BOTTLEROCKET_x86_64"
+    platform                       = "bottlerocket"
+    use_latest_ami_release_version = true
+
     bootstrap_extra_args = <<-EOT
       # Bottlerocket instances don't have SSH installed by default, but
       # there's the admin container that can be enabled and that comes
@@ -56,7 +58,7 @@ locals {
 
     force_update_version = false
     update_config = {
-      max_unavailable_percentage = var.node_max_unavailable_percentage
+      max_unavailable = var.node_max_unavailable
     }
 
     capacity_type  = "ON_DEMAND"

--- a/infra/aws/terraform/prow-build-cluster/prow.tf
+++ b/infra/aws/terraform/prow-build-cluster/prow.tf
@@ -26,10 +26,10 @@ resource "aws_iam_openid_connect_provider" "k8s_prow" {
   thumbprint_list = ["08745487e891c19e3078c1f2a07e452950ef36f6"]
 }
 
-#resource "aws_iam_openid_connect_provider" "k8s_infra_prow" {
-#  count = local.configure_prow ? 1 : 0
-#
-#  url             = "https://container.googleapis.com/v1/projects/k8s-infra-prow/locations/us-central1-f/clusters/prow"
-#  client_id_list  = ["sts.amazonaws.com"]
-#  thumbprint_list = ["08745487e891c19e3078c1f2a07e452950ef36f6"]
-#}
+resource "aws_iam_openid_connect_provider" "k8s_infra_prow" {
+  count = local.configure_prow ? 1 : 0
+
+  url             = "https://container.googleapis.com/v1/projects/k8s-infra-prow/locations/us-central1/clusters/prow"
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = ["08745487e891c19e3078c1f2a07e452950ef36f6"]
+}

--- a/infra/aws/terraform/prow-build-cluster/prow.tf
+++ b/infra/aws/terraform/prow-build-cluster/prow.tf
@@ -25,3 +25,11 @@ resource "aws_iam_openid_connect_provider" "k8s_prow" {
   client_id_list  = ["sts.amazonaws.com"]
   thumbprint_list = ["08745487e891c19e3078c1f2a07e452950ef36f6"]
 }
+
+#resource "aws_iam_openid_connect_provider" "k8s_infra_prow" {
+#  count = local.configure_prow ? 1 : 0
+#
+#  url             = "https://container.googleapis.com/v1/projects/k8s-infra-prow/locations/us-central1-f/clusters/prow"
+#  client_id_list  = ["sts.amazonaws.com"]
+#  thumbprint_list = ["08745487e891c19e3078c1f2a07e452950ef36f6"]
+#}

--- a/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
@@ -31,9 +31,9 @@ eks_cluster_admins = [
 ]
 
 cluster_name               = "prow-canary-cluster"
-cluster_version            = "1.28"
+cluster_version            = "1.29"
 
-node_group_version_stable  = "1.28"
+node_group_version_stable  = "1.29"
 node_instance_types_stable = ["r5ad.xlarge"]
 node_desired_size_stable   = 1
 
@@ -50,4 +50,4 @@ node_labels_stable = {
 
 node_volume_size = 100
 
-node_max_unavailable_percentage = 100 # To ease testing
+node_max_unavailable = 1

--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -33,9 +33,9 @@ eks_cluster_viewers = [
 ]
 
 cluster_name               = "prow-build-cluster"
-cluster_version            = "1.28"
+cluster_version            = "1.29"
 
-node_group_version_stable  = "1.28"
+node_group_version_stable  = "1.29"
 node_instance_types_stable = ["r5ad.2xlarge"]
 node_desired_size_stable   = 3
 
@@ -52,4 +52,4 @@ node_labels_stable = {
 
 node_volume_size = 100
 
-node_max_unavailable_percentage = 100 # To ease testing
+node_max_unavailable = 1

--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -33,9 +33,9 @@ eks_cluster_viewers = [
 ]
 
 cluster_name               = "prow-build-cluster"
-cluster_version            = "1.29"
+cluster_version            = "1.30"
 
-node_group_version_stable  = "1.29"
+node_group_version_stable  = "1.30"
 node_instance_types_stable = ["r5ad.2xlarge"]
 node_desired_size_stable   = 3
 

--- a/infra/aws/terraform/prow-build-cluster/variables.tf
+++ b/infra/aws/terraform/prow-build-cluster/variables.tf
@@ -113,7 +113,7 @@ variable "node_desired_size_stable" {
   nullable    = false
 }
 
-variable "node_max_unavailable_percentage" {
+variable "node_max_unavailable" {
   type        = number
   description = "Maximum unavailable nodes in a node group"
 }


### PR DESCRIPTION
This PR contains all the changes to Terraform to upgrade the EKS prow build cluster from Kubernetes 1.28 to 1.29.

It will be applied 2 phases:

1. Upgrade the control plane (excluding changes related to stable node group)
2. Upgrade the stable node group.

Changes are already applied to the canary environment.

PS: The `iam.tf` file contains a hardcoded arn setting. This will be corrected later. I was not sure if the plan output would be correctly applied.