### PR TITLE
remove kubernetes-sigs-vsphere-csi-driver.netlify.app

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -475,10 +475,6 @@ cloud-provider-aws.sigs:
 cloud-provider-vsphere.sigs:
   type: CNAME
   value: kubernetes-sigs-cloud-provider-vsphere.netlify.app.
-# https://github.com/kubernetes-sigs/vsphere-csi-driver docs (@divyenpatel, @SandeepPissay, @xing-yang)
-vsphere-csi-driver.sigs:
-  type: CNAME
-  value: kubernetes-sigs-vsphere-csi-driver.netlify.app.
 # https://github.com/kubernetes/minikube docs (@tstromberg, @afbjorklund)
 minikube.sigs:
   type: CNAME


### PR DESCRIPTION
We have moved vSphere CSI Driver documentation to https://docs.vmware.com/en/VMware-vSphere-Container-Storage-Plug-in/index.html

We no longer need netlify doc site - kubernetes-sigs-vsphere-csi-driver.netlify.app

cc: @xing-yang 