### PR TITLE
ci: promote secrets-store-sync/controller

### DIFF
--- a/registry.k8s.io/images/k8s-staging-secrets-store-sync/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-secrets-store-sync/images.yaml
@@ -1,0 +1,3 @@
+- name: controller
+  dmap:
+    "sha256:d44dde20a1cf7b83ceb8638d00ad2823648946f12cb01fbc42065f49e257b7ea": [ "v0.0.1" ]


### PR DESCRIPTION
Signed-off-by: Nilekh Chaudhari <1626598+nilekhc@users.noreply.github.com>

```shell
"sha256:d44dde20a1cf7b83ceb8638d00ad2823648946f12cb01fbc42065f49e257b7ea": [ "v0.0.1" ]
```

Build - https://console.cloud.google.com/cloud-build/builds/3ad3d4c3-3fca-4a50-8bfd-4cec847f927a?project=k8s-staging-images

Generated by running -
```shell
./registry.k8s.io/images/k8s-staging-secrets-store-sync/generate.sh > registry.k8s.io/images/k8s-staging-secrets-store-sync/images.yaml
```

Test run with the staging image: https://github.com/kubernetes-sigs/secrets-store-sync-controller/actions/runs/10518362862

/cc @aramase 