### PR TITLE
Start autobumping Community Prow

### DIFF
--- a/hack/autobump-config.yaml
+++ b/hack/autobump-config.yaml
@@ -9,30 +9,24 @@ gitHubRepo: "k8s.io"
 remoteName: "k8s.io"
 upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/k8s.io/main"
 includedConfigPaths:
-  - "apps/prow/cluster"
+  - "kubernetes"
   - "infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources"
   - "infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources"
 excludedConfigPaths:
-  - "k8s.gcr.io"
-extraFiles:
-  - "hack/verify-yamllint.sh"
-  - "apps/prow/config.yaml"
+  - "registry.k8s.io"
 targetVersion: "latest"
 prefixes:
   - name: "boskos"
     prefix: "gcr.io/k8s-staging-boskos/"
-    refConfigFile: "infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/boskos.yaml"
     repo: "https://github.com/kubernetes-sigs/boskos"
     summarise: false
     consistentImages: true
   - name: "ghproxy"
     prefix: "us-docker.pkg.dev/k8s-infra-prow/images/ghproxy"
-    refConfigFile: "infra/gcp/terraform/k8s-infra-prow-build-trusted/prow-build-trusted/resources/ghproxy-deployment.yaml"
-    repo: "https://github.com/kubernetes/test-infra"
+    repo: "https://github.com/kubernetes-sigs/prow"
     summarise: false
   - name: "prow"
     prefix: "us-docker.pkg.dev/k8s-infra-prow/images/"
-    refConfigFile: "apps/prow/cluster/deck_deployment.yaml"
-    repo: "https://github.com/kubernetes/test-infra"
+    repo: "https://github.com/kubernetes-sigs/prow"
     summarise: false
     consistentImages: true


### PR DESCRIPTION
1. refConfigFile isn't required, have a look at https://github.com/kubernetes-sigs/prow/blob/main/cmd/generic-autobumper/main.go#L158
2. We want to bump any images for prow/boskos in the kubernetes folder
3. I cleaned up some directories that don't hold prow deployments

/cc @BenTheElder @ameukam 
