### PR TITLE
fix disk size for arm nodepools

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/main.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/main.tf
@@ -111,15 +111,16 @@ module "prow_build_nodepool_t2a_standard_8" {
   cluster_name = module.prow_build_cluster.cluster.name
   location     = module.prow_build_cluster.cluster.location
   node_locations = [
-    "us-central1-a"
+    "us-central1-a",
+    "us-central1-b",
   ]
-  name          = "pool5-arm64"
+  name          = "pool6-arm64"
   initial_count = 1
   min_count     = 1
   max_count     = 10
   image_type    = "UBUNTU_CONTAINERD"
   machine_type  = "t2a-standard-8"
-  disk_size_gb  = 150
+  disk_size_gb  = 500
   disk_type     = "pd-ssd"
   // GKE automatically taints arm64 nodes
   // https://cloud.google.com/kubernetes-engine/docs/how-to/prepare-arm-workloads-for-deployment#overview

--- a/infra/gcp/terraform/modules/gke-nodepool/main.tf
+++ b/infra/gcp/terraform/modules/gke-nodepool/main.tf
@@ -37,6 +37,7 @@ resource "google_container_node_pool" "node_pool" {
     min_node_count = var.min_count
     max_node_count = var.max_count
   }
+  node_locations = var.node_locations
 
   // Set machine type, and enable all oauth scopes tied to the service account
   node_config {


### PR DESCRIPTION
https://kubernetes.slack.com/archives/CCK68P2Q2/p1724975407113939

etcd robustness CI jobs were failing, logs indicated `The node was low on resource: ephemeral-storage` was the cause, so adding higher local 500GB ssd boot disk for the arm nodepools in more regions as well.