### PR TITLE
🌱 update capi alerts group

### DIFF
--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -56,10 +56,10 @@ groups:
       - yuvaraj-balaji-rao.kakaraparthi@broadcom.com
       - christi.schlotter@gmail.com
       - furkat.gofurov@suse.com
-      # CAPI release-1.5 team members
+      # CAPI release team members
       - muhammad.adil.ghaffar@est.tech
-      - codewithaniruddha@gmail.com
-      - tobiasgiese@gmail.com
+      - cahillsf9@gmail.com
+      - sunnat.samadov@est.tech
 
   - email-id: sig-cluster-lifecycle-cluster-api-operator-alerts@kubernetes.io
     name: sig-cluster-lifecycle-cluster-api-operator-alerts


### PR DESCRIPTION
- adding myself to the list as CAPI `release-1.9` CI signal lead: https://github.com/cahillsf/k8s.io/pull/new/update-capi-alerts
- removing those on the list no longer on the release team