### PR TITLE
[WIP] Fastly: Drop cookies and http headers for dl-sandbox

### DIFF
--- a/infra/fastly/terraform/dl-sandbox.k8s.dev/provider.tf
+++ b/infra/fastly/terraform/dl-sandbox.k8s.dev/provider.tf
@@ -29,7 +29,7 @@ terraform {
   required_providers {
     fastly = {
       source  = "fastly/fastly"
-      version = "~> 5.11.0"
+      version = "~> 5.13.0"
     }
   }
 }

--- a/infra/fastly/terraform/dl-sandbox.k8s.dev/vcl/binaries.vcl
+++ b/infra/fastly/terraform/dl-sandbox.k8s.dev/vcl/binaries.vcl
@@ -18,6 +18,13 @@ sub vcl_recv {
   if (req.method != "HEAD" && req.method != "GET" && req.method != "FASTLYPURGE") {
     return(pass);
   }
+
+  # Drop all the headers except the list providers
+  header.filter_except(req,"Fastly-Debug");
+
+  # Remove all cookies from the request
+  unset req.http.Cookie;
+
   return(lookup);
 }
 


### PR DESCRIPTION
Drop all cookies and only all specific HTTP headers for any client request.