### PR TITLE
Fix GCS notification terraform.

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow/buckets.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/buckets.tf
@@ -123,7 +123,7 @@ module "prow_bucket" {
 resource "google_storage_notification" "notification" {
   bucket         = module.prow_bucket.name
   payload_format = "JSON_API_V1"
-  topic          = google_pubsub_topic.kubernetes_ci_logs_topic.name
+  topic          = google_pubsub_topic.kubernetes_ci_logs_topic.id
   depends_on     = [google_pubsub_topic_iam_binding.publish_binding]
 }
 

--- a/infra/gcp/terraform/k8s-infra-prow/iam.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/iam.tf
@@ -122,6 +122,7 @@ data "google_storage_project_service_account" "gcs_account" {
 // Bind storage SA to publish to PubSub.
 resource "google_pubsub_topic_iam_binding" "publish_binding" {
   topic   = google_pubsub_topic.kubernetes_ci_logs_topic.name
+  project = module.project.project_id
   role    = "roles/pubsub.publisher"
   members = ["serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"]
 }
@@ -129,6 +130,7 @@ resource "google_pubsub_topic_iam_binding" "publish_binding" {
 // Also bind TestGrid and Kettle as subscribers of this topic.
 resource "google_pubsub_topic_iam_binding" "read_binding" {
   topic = google_pubsub_topic.kubernetes_ci_logs_topic.name
+  project = module.project.project_id
   role  = "roles/pubsub.subscriber"
   members = [
     "serviceAccount:testgrid-canary@k8s-testgrid.iam.gserviceaccount.com",


### PR DESCRIPTION
Minor fixes to ensure terraform apply actually succeeds. (This is posthoc; the terraform has already been applied and was successful).

- Specify project when required.
- Use the topic ID instead of name so it includes reference to the correct project

Ref https://github.com/kubernetes/test-infra/issues/33386