### PR TITLE
[WIP NO REVIEW YET] add minimum scoped locks rbac for write and delete for the CAS HasInstance e2e suite

### DIFF
--- a/infra/azure/terraform/capz/role-assignments/main.tf
+++ b/infra/azure/terraform/capz/role-assignments/main.tf
@@ -69,3 +69,26 @@ resource "azurerm_role_assignment" "sp_custom_role_assignment" {
   role_definition_name = azurerm_role_definition.custom_role.name
   scope                = "/subscriptions/${var.subscription_id}"
 }
+
+resource "azurerm_role_definition" "custom_lock_manager_role" {
+  name               = "LockManager"
+  scope              = "/subscriptions/${var.subscription_id}"
+
+  permissions {
+    actions = [
+      "Microsoft.Authorization/locks/write",
+      "Microsoft.Authorization/locks/delete"
+    ]
+    not_actions = []
+  }
+
+  assignable_scopes = [
+    "/subscriptions/${var.subscription_id}"
+  ]
+}
+
+resource "azurerm_role_assignment" "sp_custom_lock_manager_assignment" {
+  principal_id         = data.azuread_service_principal.az_service_principal.id
+  role_definition_name = azurerm_role_definition.custom_lock_manager_role.name
+  scope                = "/subscriptions/${var.subscription_id}"
+}


### PR DESCRIPTION
I am working on developing an [e2e suite](files) for testing the functionality of the cluster autoscaler cloudprovider method HasInstance. Its still in progress. 

This code requires us to verify that cluster autoscaler will not count nodes as Deleted when the virtual machine still exists when a node has the ToBeDeletedByClusterAutoscaler taint. 

The easiest way to simulate the vm still being there with the taint is to simply put a deletion lock to ensure CAS doesnt remove the vm before we can make that check.  For that reason I would like to introduce this new RBAC role.  

### More details on HasInstance
// HasInstance returns whether a given node has a corresponding instance in this cloud provider.
//
// Used to prevent undercount of existing VMs (taint-based overcount of deleted VMs),
// and so should not return false, nil (no instance) if uncertain; return error instead.
// (Think "has instance for sure, else error".) Returning an error causes fallback to taint-based
// determination; use ErrNotImplemented for silent fallback, any other error will be logged.
//
// Expected behavior (should work for VMSS Uniform/Flex, and VMs):
// -  exists            : return true, nil
// - !exists            : return *,    ErrNotImplemented (could use custom error for autoscaled nodes)
// - unimplemented case : return *,    ErrNotImplemented
// - any other error    : return *,    error

Code References for understanding more about has instance.
- https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/azure/azure_cloud_provider.go#L126C1-L137C45
- https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/clusterstate/clusterstate.go#L1065 

