### PR TITLE
gcp: Allow GCB service agent for kubernetes-release-test

### DIFF
--- a/infra/gcp/terraform/k8s-infra-releases-prod/main.tf
+++ b/infra/gcp/terraform/k8s-infra-releases-prod/main.tf
@@ -49,6 +49,14 @@ resource "google_storage_hmac_key" "fastly_reader_key" {
   service_account_email = google_service_account.fastly_reader.email
 }
 
+// TODO: remove this after https://github.com/kubernetes/release/issues/3425
+resource "google_storage_bucket_iam_member" "release_object_admin" {
+  bucket     = module.k8s_releases_prod.bucket_name
+  role       = "roles/storage.objectAdmin"
+  member     = "serviceAccount:648026197307@cloudbuild.gserviceaccount.com"
+  depends_on = [module.k8s_releases_prod]
+}
+
 resource "google_storage_bucket_iam_member" "fastly_reader" {
   bucket     = module.k8s_releases_prod.bucket_name
   role       = "roles/storage.objectViewer"


### PR DESCRIPTION
Ref:
  - https://github.com/kubernetes/release/issues/3729

Temporary allow the Service Agent for the GCB Service from project `kubernetes-release-test`. This will enable artifacts release for Kubernetes to a community-owned bucket.