### PR TITLE
Fix promotion of ecr-credential-provider images

### DIFF
--- a/artifacts/manifests/k8s-staging-provider-aws/v1.27.5.yaml
+++ b/artifacts/manifests/k8s-staging-provider-aws/v1.27.5.yaml
@@ -1,13 +1,13 @@
 files:
-- name: linux/amd64/ecr-credential-provider-linux-amd64
+- name: v1.27.5/linux/amd64/ecr-credential-provider-linux-amd64
   sha256: 37d92688f3771b5d63d05ea30c4b8717984799527d3d3a71f84c7327b38b06ea
-- name: linux/amd64/ecr-credential-provider-linux-amd64.sha256
+- name: v1.27.5/linux/amd64/ecr-credential-provider-linux-amd64.sha256
   sha256: d30dd97135b34dab1f38d3a314b1a31a40a6c2fc66f2f3c4daa0278af1fd6a29
-- name: linux/arm64/ecr-credential-provider-linux-arm64
+- name: v1.27.5/linux/arm64/ecr-credential-provider-linux-arm64
   sha256: 3f497387741665137181c0fee34c8469c22cfefe064bbf427752cd6179160c8b
-- name: linux/arm64/ecr-credential-provider-linux-arm64.sha256
+- name: v1.27.5/linux/arm64/ecr-credential-provider-linux-arm64.sha256
   sha256: 2b0be8fec87515d9ecf3cbbd5d8622f821b1fca4bfc78f5c45e1deecff68119a
-- name: windows/amd64/ecr-credential-provider-windows-amd64
+- name: v1.27.5/windows/amd64/ecr-credential-provider-windows-amd64
   sha256: 65161c421740aeeefb42199ded2d5306b84afb18eb3373294fa2808a0fb2c061
-- name: windows/amd64/ecr-credential-provider-windows-amd64.sha256
+- name: v1.27.5/windows/amd64/ecr-credential-provider-windows-amd64.sha256
   sha256: f5fc10ac4418f602b13314638463a8e8855162347e884408a5cad7f9a549124a

--- a/artifacts/manifests/k8s-staging-provider-aws/v1.28.4.yaml
+++ b/artifacts/manifests/k8s-staging-provider-aws/v1.28.4.yaml
@@ -1,13 +1,13 @@
 files:
-- name: linux/amd64/ecr-credential-provider-linux-amd64
+- name: v1.28.4/linux/amd64/ecr-credential-provider-linux-amd64
   sha256: f3bbb7ef0f4bf370725d9ef4a2cdccd5da4acdc2198c82fe57489a25f61a765b
-- name: linux/amd64/ecr-credential-provider-linux-amd64.sha256
+- name: v1.28.4/linux/amd64/ecr-credential-provider-linux-amd64.sha256
   sha256: 926e8731b2147054dca11ac0e1fb6d4732fe4714985e9591ed02998280c54ac4
-- name: linux/arm64/ecr-credential-provider-linux-arm64
+- name: v1.28.4/linux/arm64/ecr-credential-provider-linux-arm64
   sha256: 19924b65d2ba580084b8506a6cf76b8d603c0c1ab6d0415742c2773bc43a550c
-- name: linux/arm64/ecr-credential-provider-linux-arm64.sha256
+- name: v1.28.4/linux/arm64/ecr-credential-provider-linux-arm64.sha256
   sha256: fbe84c6e89e7bb2643e45200d78ac8a9e3113e184be625c0b5e620756b7e5b60
-- name: windows/amd64/ecr-credential-provider-windows-amd64
+- name: v1.28.4/windows/amd64/ecr-credential-provider-windows-amd64
   sha256: a16369b5453ae8903e9b732e84d8685fa66f67adc42110f5548ce37f53af5b93
-- name: windows/amd64/ecr-credential-provider-windows-amd64.sha256
+- name: v1.28.4/windows/amd64/ecr-credential-provider-windows-amd64.sha256
   sha256: 9adca50bf2f0414648fc428db03d127503ac1e05251484918417bf67a5660699

--- a/artifacts/manifests/k8s-staging-provider-aws/v1.29.1.yaml
+++ b/artifacts/manifests/k8s-staging-provider-aws/v1.29.1.yaml
@@ -1,13 +1,13 @@
 files:
-- name: linux/amd64/ecr-credential-provider-linux-amd64
+- name: v1.29.1/linux/amd64/ecr-credential-provider-linux-amd64
   sha256: 758ba8d4808d4d8f1345aebfa3dfc1a072fe0b0b8187480fb7047a1110baa69a
-- name: linux/amd64/ecr-credential-provider-linux-amd64.sha256
+- name: v1.29.1/linux/amd64/ecr-credential-provider-linux-amd64.sha256
   sha256: 09d2c2f59ab7d385f6db4a5bbcec63d97d82d7a215afcd6c48493841aff38390
-- name: linux/arm64/ecr-credential-provider-linux-arm64
+- name: v1.29.1/linux/arm64/ecr-credential-provider-linux-arm64
   sha256: 880dc2b278c08bf569370b0131520c0dc8561dbbb31c56d5d528c8a5655aa802
-- name: linux/arm64/ecr-credential-provider-linux-arm64.sha256
+- name: v1.29.1/linux/arm64/ecr-credential-provider-linux-arm64.sha256
   sha256: 557d31f8f28a035b22b3f00b73ea47e8586637b330656d9a7c09bba8c6cf933f
-- name: windows/amd64/ecr-credential-provider-windows-amd64
+- name: v1.29.1/windows/amd64/ecr-credential-provider-windows-amd64
   sha256: c324ab2ed3c6b45659ee2586b7d9e4808c327d270baa3a25a2b3277a59b70dc9
-- name: windows/amd64/ecr-credential-provider-windows-amd64.sha256
+- name: v1.29.1/windows/amd64/ecr-credential-provider-windows-amd64.sha256
   sha256: a82aebed964d32ee37d0554677f95b4b44476fe5a28eebe7fac3bb3c170be4c6

--- a/artifacts/manifests/k8s-staging-provider-aws/v1.30.0-rc.0.yaml
+++ b/artifacts/manifests/k8s-staging-provider-aws/v1.30.0-rc.0.yaml
@@ -1,13 +1,13 @@
 files:
-- name: linux/amd64/ecr-credential-provider-linux-amd64
+- name: v1.30.0-rc.0/linux/amd64/ecr-credential-provider-linux-amd64
   sha256: 9f3729ea7a7cf2cdcb70eb6fd2b03f7fb3c8fc3137c54652b0dd52a9741d31be
-- name: linux/amd64/ecr-credential-provider-linux-amd64.sha256
+- name: v1.30.0-rc.0/linux/amd64/ecr-credential-provider-linux-amd64.sha256
   sha256: c69c9c35b6021d71b44260b88d17acbf037ae99558445fb64b0ed6e67413ddf2
-- name: linux/arm64/ecr-credential-provider-linux-arm64
+- name: v1.30.0-rc.0/linux/arm64/ecr-credential-provider-linux-arm64
   sha256: be34cd91d2ac8eafdb1df5d6a2537ea6243f3ddf3f50c13a2b91147bd475deff
-- name: linux/arm64/ecr-credential-provider-linux-arm64.sha256
+- name: v1.30.0-rc.0/linux/arm64/ecr-credential-provider-linux-arm64.sha256
   sha256: 7cedd48925d7638efcf271d5b277df7c4e48ebc265a5d1d3660a1d9314892339
-- name: windows/amd64/ecr-credential-provider-windows-amd64
+- name: v1.30.0-rc.0/windows/amd64/ecr-credential-provider-windows-amd64
   sha256: c150baeadb5617e03d414119710ba73daaa352ca10bdbd8775e9e6c00f9e41bf
-- name: windows/amd64/ecr-credential-provider-windows-amd64.sha256
+- name: v1.30.0-rc.0/windows/amd64/ecr-credential-provider-windows-amd64.sha256
   sha256: bdb50dbcf796f5e6b580b8b9bb6e6e731f396ff5f450212da5cf315a948f0e78

--- a/artifacts/manifests/k8s-staging-provider-aws/v1.30.0.yaml
+++ b/artifacts/manifests/k8s-staging-provider-aws/v1.30.0.yaml
@@ -1,13 +1,13 @@
 files:
-- name: linux/amd64/ecr-credential-provider-linux-amd64
+- name: v1.30.0/linux/amd64/ecr-credential-provider-linux-amd64
   sha256: 7df3fb71a3bd81b5ae33e80a40042fdcc4064e92feba3cf4debf7be269bc81be
-- name: linux/amd64/ecr-credential-provider-linux-amd64.sha256
+- name: v1.30.0/linux/amd64/ecr-credential-provider-linux-amd64.sha256
   sha256: 83481d29a7bd9be62e0f60ffc33a6dbc3eec146a4be131aaf28d65d3d2de53d7
-- name: linux/arm64/ecr-credential-provider-linux-arm64
+- name: v1.30.0/linux/arm64/ecr-credential-provider-linux-arm64
   sha256: 42ecec6eb5302c54301f31c1e5a5f96c901d45a1ff45dd134b8e1d5e2737871e
-- name: linux/arm64/ecr-credential-provider-linux-arm64.sha256
+- name: v1.30.0/linux/arm64/ecr-credential-provider-linux-arm64.sha256
   sha256: 90ecd5d654b9920864a46bcbaf79d8282982c415a4f4b93a23ddebd131aac125
-- name: windows/amd64/ecr-credential-provider-windows-amd64
+- name: v1.30.0/windows/amd64/ecr-credential-provider-windows-amd64
   sha256: beaa1b0780e6cda3fe4f915f2f873f11cf9b7a6ee68436dc8ecf90868868b1ca
-- name: windows/amd64/ecr-credential-provider-windows-amd64.sha256
+- name: v1.30.0/windows/amd64/ecr-credential-provider-windows-amd64.sha256
   sha256: 81982ebc8e7810711a72efe8d06e229d63c5d04a669b802299c8bf95f313604e


### PR DESCRIPTION
ecr-credential-provider v1.30.0 are not present in https://storage.googleapis.com/k8s-artifacts-prod/:

1.29.0: https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.29.0/linux/amd64/ecr-credential-provider-linux-amd64 => works
1.30.0: https://artifacts.k8s.io/binaries/cloud-provider-aws/v1.30.0/linux/amd64/ecr-credential-provider-linux-amd64 => does not work

Comparing v1.29.0.yaml and v1.30.0.yaml files I suspect that v1.30.0.yaml is missing the version prefix in the name. Can someone confirm that this is the case?