### PR TITLE
Turn off moderation for sig-network-leads

### DIFF
--- a/groups/sig-network/groups.yaml
+++ b/groups/sig-network/groups.yaml
@@ -35,7 +35,7 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
       WhoCanModerateContent: "OWNERS_AND_MANAGERS"
-      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      MessageModerationLevel: "MODERATE_NONE"
 
   - email-id: sig-network@kubernetes.io
     name: sig-network


### PR DESCRIPTION
It's silly to moderate all non-member messages and send notifications to the owner given that
1. the members don't actually use the list and so all messages to it are non-member messages
2. all of the members are also owners, so sending a moderation message to the owners about every message just means we see every message twice.

Possibly this change should be made in every SIG?

/cc @aojea @thockin @shaneutt @MikeZappa87 