### PR TITLE
Allow posting to sig security leads

### DIFF
--- a/groups/sig-security/groups.yaml
+++ b/groups/sig-security/groups.yaml
@@ -13,7 +13,7 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
       WhoCanModerateContent: "OWNERS_AND_MANAGERS"
-      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      MessageModerationLevel: "MODERATE_NONE"
 
   - email-id: sig-security@kubernetes.io
     name: sig-security


### PR DESCRIPTION
Set sig-security-leads@kubernetes.io to MODERATE_NONE so that messages will be delivered immediately.