### PR TITLE
promote images for vpshere csi driver

### DIFF
--- a/registry.k8s.io/images/k8s-staging-csi-vsphere/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-csi-vsphere/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- divyenpatel
+- xing-yang
+- SandeepPissay
+- deepakkinni
+
+reviewers:
+- divyenpatel
+- xing-yang
+- SandeepPissay
+- deepakkinni

--- a/registry.k8s.io/images/k8s-staging-csi-vsphere/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-csi-vsphere/images.yaml
@@ -1,1 +1,8 @@
-# TODO: add images
+- name: driver
+  dmap:
+    "sha256:346249308622d5efcbd5873aff2a30b849ec117e5fa3235dc06f0e419b6a6f9a": [ "v3.3.0" ]
+    "sha256:adb820cc2e0abe5f89aaa648c9e9bc8f4adab282fe706fa371f10e3476a65bfd": [ "v3.3.1" ]
+- name: syncer
+  dmap:
+    "sha256:7287c311d72356e544e19928b7787787ca5dc7229d78c911bb6f4e04d940c588": [ "v3.3.0" ]
+    "sha256:0fccc2de2a32882140bf0c683afc5dc1eb087b8a2a731957b012d7c1d4970ad4": [ "v3.3.1" ]


### PR DESCRIPTION
/cc @xing-yang @divyenpatel 

Fixes: https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/3053

driver images:
- https://console.cloud.google.com/artifacts/docker/k8s-staging-images/us-central1/csi-vsphere/driver/sha256:346249308622d5efcbd5873aff2a30b849ec117e5fa3235dc06f0e419b6a6f9a?project=k8s-staging-images
- https://console.cloud.google.com/artifacts/docker/k8s-staging-images/us-central1/csi-vsphere/driver/sha256:adb820cc2e0abe5f89aaa648c9e9bc8f4adab282fe706fa371f10e3476a65bfd?project=k8s-staging-images

syncer images:
- https://console.cloud.google.com/artifacts/docker/k8s-staging-images/us-central1/csi-vsphere/syncer/sha256:7287c311d72356e544e19928b7787787ca5dc7229d78c911bb6f4e04d940c588?project=k8s-staging-images
- https://console.cloud.google.com/artifacts/docker/k8s-staging-images/us-central1/csi-vsphere/syncer/sha256:0fccc2de2a32882140bf0c683afc5dc1eb087b8a2a731957b012d7c1d4970ad4?project=k8s-staging-images
