### PR TITLE
Deploy Istio to the utility cluster

### DIFF
--- a/kubernetes/apps/istio.yaml
+++ b/kubernetes/apps/istio.yaml
@@ -16,6 +16,11 @@ spec:
     - path: config/crd/experimental
       repoURL: https://github.com/kubernetes-sigs/gateway-api
       targetRevision: v1.1.0
+  ignoreDifferences:     
+    - group: admissionregistration.k8s.io                                                              
+      kind: ValidatingWebhookConfiguration
+      jsonPointers:                                                                                    
+      - /webhooks/0/failurePolicy
   syncPolicy:
     automated:
       prune: true
@@ -76,6 +81,11 @@ spec:
     - path: kubernetes/gke-utility/istio-system
       repoURL: https://github.com/borg-land/k8s.io
       targetRevision: istio
+  ignoreDifferences:     
+    - group: admissionregistration.k8s.io                                                              
+      kind: ValidatingWebhookConfiguration
+      jsonPointers:                                                                                    
+      - /webhooks/0/failurePolicy
   syncPolicy:
     automated:
       prune: true

--- a/kubernetes/apps/istio.yaml
+++ b/kubernetes/apps/istio.yaml
@@ -1,0 +1,82 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: istio-base
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+spec:
+  destination:
+    name: gke-utility
+    namespace: istio-system
+  project: default
+  sources:
+    - chart: base
+      repoURL: https://istio-release.storage.googleapis.com/charts
+      targetRevision: 1.23.2
+    - path: config/crd/experimental
+      repoURL: https://github.com/kubernetes-sigs/gateway-api
+      targetRevision: v1.1.0
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+    - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: istio
+spec:
+  destination:
+    name: gke-utility
+    namespace: istio-system
+  project: default
+  sources:
+    - chart: istiod
+      repoURL: https://istio-release.storage.googleapis.com/charts
+      targetRevision: 1.23.2
+      helm:
+        values: |
+          global:
+            hub: gcr.io/istio-release
+            istiod:
+              enableAnalysis: true
+          meshConfig:
+            accessLogFile: /dev/stdout
+            enablePrometheusMerge: true
+            protocolDetectionTimeout: 5s
+            enableTracing: true
+            extensionProviders:
+            - name: "oauth2-proxy"
+              envoyExtAuthzHttp:
+                service: "oauth2-proxy.oauth2-proxy.svc.cluster.local"
+                port: "80"
+                headersToDownstreamOnDeny:
+                  - content-type
+                  - set-cookie
+                headersToUpstreamOnAllow:
+                  - authorization
+                  - cookie
+                  - path
+                  - x-*
+                includeHeadersInCheck:
+                  - authorization
+                  - cookie
+                  - user-agent
+            defaultConfig:
+              gatewayTopology:
+                numTrustedProxies: 2
+          telemetry:
+            enabled: true
+            v2:
+              prometheus:
+                enabled: true
+                wasmEnabled: false
+    - path: kubernetes/gke-utility/istio-system
+      repoURL: https://github.com/borg-land/k8s.io
+      targetRevision: istio
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/kubernetes/apps/istio.yaml
+++ b/kubernetes/apps/istio.yaml
@@ -16,10 +16,10 @@ spec:
     - path: config/crd/experimental
       repoURL: https://github.com/kubernetes-sigs/gateway-api
       targetRevision: v1.1.0
-  ignoreDifferences:     
-    - group: admissionregistration.k8s.io                                                              
+  ignoreDifferences:
+    - group: admissionregistration.k8s.io
       kind: ValidatingWebhookConfiguration
-      jsonPointers:                                                                                    
+      jsonPointers:
       - /webhooks/0/failurePolicy
   syncPolicy:
     automated:
@@ -52,7 +52,11 @@ spec:
             enablePrometheusMerge: true
             protocolDetectionTimeout: 5s
             enableTracing: true
+            defaultConfig:
+              tracing:
             extensionProviders:
+            - name: stackdriver
+              stackdriver:
             - name: "oauth2-proxy"
               envoyExtAuthzHttp:
                 service: "oauth2-proxy.oauth2-proxy.svc.cluster.local"
@@ -69,6 +73,8 @@ spec:
                   - authorization
                   - cookie
                   - user-agent
+                includeAdditionalHeadersInCheck:
+                  X-Auth-Request-Redirect: https://%REQ(Host)%%REQ(:PATH)%
             defaultConfig:
               gatewayTopology:
                 numTrustedProxies: 2
@@ -79,12 +85,12 @@ spec:
                 enabled: true
                 wasmEnabled: false
     - path: kubernetes/gke-utility/istio-system
-      repoURL: https://github.com/borg-land/k8s.io
-      targetRevision: istio
-  ignoreDifferences:     
-    - group: admissionregistration.k8s.io                                                              
+      repoURL: https://github.com/kubernetes/k8s.io
+      targetRevision: main
+  ignoreDifferences:
+    - group: admissionregistration.k8s.io
       kind: ValidatingWebhookConfiguration
-      jsonPointers:                                                                                    
+      jsonPointers:
       - /webhooks/0/failurePolicy
   syncPolicy:
     automated:

--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - cert-manager.yaml
   # - ingress-nginx.yaml
   - prow.yaml
+  - istio.yaml
+  - oauth2-proxy.yaml

--- a/kubernetes/apps/oauth2-proxy.yaml
+++ b/kubernetes/apps/oauth2-proxy.yaml
@@ -1,0 +1,39 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: oauth2-proxy
+spec:
+  goTemplate: true
+  generators:
+    - clusters:
+        selector:
+          matchLabels:
+            clusterType: 'utility'
+  template:
+    metadata:
+      name: 'oauth2-proxy-{{ .name }}'
+    spec:
+      destination:
+        namespace: oauth2-proxy
+        server: "{{ .server }}"
+      project: default
+      sources:
+        - chart: oauth2-proxy
+          repoURL: 'https://oauth2-proxy.github.io/manifests'
+          targetRevision: 7.7.19
+          helm:
+            releaseName: oauth2-proxy
+            valueFiles:
+            - $values/kubernetes/{{ .name }}/helm/oauth2-proxy.yaml
+        - repoURL: 'https://github.com/kubernetes/k8s.io.git'
+          targetRevision: main
+          ref: values
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+        managedNamespaceMetadata:
+          labels:
+            istio-injection: enabled

--- a/kubernetes/gke-utility/argocd/argocd-cm-rbac.yaml
+++ b/kubernetes/gke-utility/argocd/argocd-cm-rbac.yaml
@@ -4,6 +4,3 @@ metadata:
   name: argocd-rbac-cm
 data:
   policy.default: role:readonly
-  policy.csv: |
-    g, kubernetes:sig-k8s-infra-leads, role:admin
-  scopes: '[groups, email]'

--- a/kubernetes/gke-utility/argocd/argocd-cm.yaml
+++ b/kubernetes/gke-utility/argocd/argocd-cm.yaml
@@ -12,17 +12,11 @@ data:
       ignoreDifferences: |
         jqPathExpressions:
         - '.webhooks[]?.clientConfig.caBundle'
+  resource.exclusions: |
+    - apiGroups:
+        - cilium.io
+      kinds:
+        - CiliumIdentity
+      clusters:
+        - "*"
   kustomize.buildOptions: --load-restrictor LoadRestrictionsNone --enable-alpha-plugins
-  dex.config: |
-    connectors:
-      - type: github
-        id: github
-        name: GitHub
-        config:
-          clientID: $dex.github.clientId
-          clientSecret: $dex.github.clientSecret
-          orgs:
-          - name: kubernetes
-          useLoginAsID: true
-          loadAllGroups: true
-          teamNameField: slug

--- a/kubernetes/gke-utility/argocd/argocd-cmd-params-cm.yaml
+++ b/kubernetes/gke-utility/argocd/argocd-cmd-params-cm.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cmd-params-cm
+data:
+  server.insecure: "true" # Safe as we are using Istio Mesh

--- a/kubernetes/gke-utility/argocd/extras.yaml
+++ b/kubernetes/gke-utility/argocd/extras.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     argocd.argoproj.io/secret-type: repository
 stringData:
-  url: https://github.com/kubernetes
+  url: https://github.com/kubernetes/k8s.io
   name: kubernetes
   type: git
 ---
@@ -43,3 +43,25 @@ spec:
     - backendRefs:
         - name: argocd-server
           port: 80
+---
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: argocd
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-server
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            namespaces:
+              - istio-system
+      when:
+        - key: request.headers[X-Auth-Request-User]
+          values:
+            - dims
+            - upodroid
+            - ameukam
+            - BenTheElder

--- a/kubernetes/gke-utility/argocd/extras.yaml
+++ b/kubernetes/gke-utility/argocd/extras.yaml
@@ -27,3 +27,19 @@ spec:
     automated:
       prune: false
       selfHeal: true
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: argocd
+spec:
+  hostnames:
+    - argo.k8s.io
+  parentRefs:
+    - name: istio-ingressgateway
+      namespace: istio-system
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: argocd-server
+          port: 80

--- a/kubernetes/gke-utility/argocd/kustomization.yaml
+++ b/kubernetes/gke-utility/argocd/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
 - clusters.yaml
 
 patches:
+- path: argocd-cmd-params-cm.yaml
 - path: argocd-cm.yaml
 - path: argocd-cm-rbac.yaml
 - path: argocd-sa.yaml

--- a/kubernetes/gke-utility/helm/cert-manager.yaml
+++ b/kubernetes/gke-utility/helm/cert-manager.yaml
@@ -1,6 +1,8 @@
-installCRDs: true
+crds:
+  enabled: true
 extraObjects:
-  - apiVersion: cert-manager.io/v1
+  - |
+    apiVersion: cert-manager.io/v1
     kind: ClusterIssuer
     metadata:
       name: letsencrypt-prod
@@ -11,6 +13,5 @@ extraObjects:
         privateKeySecretRef:
           name: letsencrypt-prod
         solvers:
-          - http01:
-              ingress:
-                ingressClassName: nginx
+          - cloudDNS:
+              project: kubernetes-public

--- a/kubernetes/gke-utility/helm/oauth2-proxy.yaml
+++ b/kubernetes/gke-utility/helm/oauth2-proxy.yaml
@@ -1,11 +1,9 @@
-
 config:
   existingSecret: oauth2-proxy-creds
 
 extraArgs:
   provider: github
   github-org: kubernetes
-  github-team: sig-k8s-infra-leads,sig-k8s-infra
   redirect-url: https://oauth2-proxy.k8s.io/oauth2/callback
   reverse-proxy: true
   pass-access-token: true

--- a/kubernetes/gke-utility/helm/oauth2-proxy.yaml
+++ b/kubernetes/gke-utility/helm/oauth2-proxy.yaml
@@ -5,6 +5,7 @@ config:
 extraArgs:
   provider: github
   github-org: kubernetes
+  github-team: sig-k8s-infra-leads,sig-k8s-infra
   redirect-url: https://oauth2-proxy.k8s.io/oauth2/callback
   reverse-proxy: true
   pass-access-token: true
@@ -13,7 +14,7 @@ extraArgs:
   cookie-samesite: lax
   cookie-domain: .k8s.io
   set-xauthrequest: true
-  whitelist-domain: "*..k8s.io"
+  whitelist-domain: "*.k8s.io"
   skip-provider-button: true
   skip-jwt-bearer-tokens: true
   upstream: static://200

--- a/kubernetes/gke-utility/helm/oauth2-proxy.yaml
+++ b/kubernetes/gke-utility/helm/oauth2-proxy.yaml
@@ -1,0 +1,55 @@
+
+config:
+  existingSecret: oauth2-proxy-creds
+
+extraArgs:
+  provider: github
+  github-org: kubernetes
+  redirect-url: https://oauth2-proxy.k8s.io/oauth2/callback
+  reverse-proxy: true
+  pass-access-token: true
+  pass-user-headers: true
+  pass-authorization-header: true
+  cookie-samesite: lax
+  cookie-domain: .k8s.io
+  set-xauthrequest: true
+  whitelist-domain: "*..k8s.io"
+  skip-provider-button: true
+  skip-jwt-bearer-tokens: true
+  upstream: static://200
+  silence-ping-logging: true
+  show-debug-on-error: true
+
+metrics:
+  serviceMonitor:
+    enabled: false #enable when observability stack is ready
+
+extraObjects:
+  - apiVersion: external-secrets.io/v1beta1
+    kind: ExternalSecret
+    metadata:
+      name: oauth2-proxy-creds
+      namespace: "{{ .Release.Namespace }}"
+    spec:
+      dataFrom:
+      - extract:
+          key: oauth2-proxy-creds
+      secretStoreRef:
+        kind: ClusterSecretStore
+        name: k8s-infra-prow
+  - apiVersion: gateway.networking.k8s.io/v1
+    kind: HTTPRoute
+    metadata:
+      name: oauth2-proxy
+      namespace: "{{ .Release.Namespace }}"
+    spec:
+      hostnames:
+        - oauth2-proxy.k8s.io
+      parentRefs:
+        - name: istio-ingressgateway
+          namespace: istio-system
+          sectionName: https
+      rules:
+        - backendRefs:
+            - name: oauth2-proxy
+              port: 80

--- a/kubernetes/gke-utility/istio-system/auth-policy.yaml
+++ b/kubernetes/gke-utility/istio-system/auth-policy.yaml
@@ -1,0 +1,18 @@
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: oauth-policy
+  namespace: istio-system
+spec:
+  targetRefs:
+    - name: istio-ingressgateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  action: CUSTOM
+  provider:
+    name: oauth2-proxy
+  rules:
+  - to:
+    - operation:
+        hosts:
+        - argo.k8s.io

--- a/kubernetes/gke-utility/istio-system/auth-policy.yaml
+++ b/kubernetes/gke-utility/istio-system/auth-policy.yaml
@@ -2,7 +2,6 @@ apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy
 metadata:
   name: oauth-policy
-  namespace: istio-system
 spec:
   targetRefs:
     - name: istio-ingressgateway

--- a/kubernetes/gke-utility/istio-system/gateway.yaml
+++ b/kubernetes/gke-utility/istio-system/gateway.yaml
@@ -1,0 +1,57 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: istio-ingressgateway
+  annotations:
+    cloud.google.com/l4-rbs: enabled
+spec:
+  gatewayClassName: istio
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+  - name: https
+    port: 443
+    protocol: HTTPS
+    allowedRoutes:
+      namespaces:
+        from: All
+    tls:
+      mode: Terminate
+      certificateRefs:
+      - name: k8s-io-wild-cert
+  addresses:
+  - type: IPAddress
+    value: 34.66.218.218
+  - type: IPAddress
+    value: "2600:1900:4000:627b:8000::"
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: https-gateway-redirect
+spec:
+  parentRefs:
+  - name: istio-ingressgateway
+    sectionName: http
+  hostnames:
+  - '*.k8s.io'
+  rules:
+  - filters:
+    - type: RequestRedirect
+      requestRedirect:
+        scheme: https
+        statusCode: 302
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: k8s-io-wild
+spec:
+  secretName: k8s-io-wild-cert
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  commonName: '*.k8s.io'
+  dnsNames:
+  - '*.k8s.io'

--- a/kubernetes/gke-utility/istio-system/gateway.yaml
+++ b/kubernetes/gke-utility/istio-system/gateway.yaml
@@ -4,6 +4,7 @@ metadata:
   name: istio-ingressgateway
   annotations:
     cloud.google.com/l4-rbs: enabled
+    networking.gke.io/load-balancer-ip-addresses: utility-ingress-v4,utility-ingress-v6
 spec:
   gatewayClassName: istio
   listeners:
@@ -20,11 +21,6 @@ spec:
       mode: Terminate
       certificateRefs:
       - name: k8s-io-wild-cert
-  addresses:
-  - type: IPAddress
-    value: 34.66.218.218
-  - type: IPAddress
-    value: "2600:1900:4000:627b:8000::"
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/kubernetes/gke-utility/istio-system/kustomization.yaml
+++ b/kubernetes/gke-utility/istio-system/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - auth-policy.yaml
+  - gateway.yaml

--- a/kubernetes/gke-utility/istio-system/kustomization.yaml
+++ b/kubernetes/gke-utility/istio-system/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: istio-system
 resources:
   - auth-policy.yaml
   - gateway.yaml


### PR DESCRIPTION
This PR does a few things:

We are using Istio in the Utility cluster because:
1. We need auth, grpc(required for multicluster observability) loadbalancing which I can't easily do with GCE Ingress
2. We deploy an oauth2 proxy and secure the argocd UI. Its now available for viewing over the internet for specific users.
3. We'll be deploying Atlantis next for terraform automation and that needs public endpoints with traffic restricted to GitHub webhooks

Fixed a bug in https://github.com/istio/istio/pull/53245
