### PR TITLE
[eks-prow-build] Upgrade karpenter to v0.37.3

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/karpenter/flux-hr-karpenter-crd.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/karpenter/flux-hr-karpenter-crd.yaml
@@ -28,5 +28,5 @@ spec:
         kind: HelmRepository
         name: karpenter
         namespace: flux-system
-      version: 0.37.0
+      version: 0.37.3
   interval: 5m0s

--- a/infra/aws/terraform/prow-build-cluster/resources/karpenter/flux-hr-karpenter.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/karpenter/flux-hr-karpenter.yaml
@@ -28,7 +28,7 @@ spec:
         kind: HelmRepository
         name: karpenter
         namespace: flux-system
-      version: 0.37.0
+      version: 0.37.3
   dependsOn:
   - name: karpenter-crd
   interval: 5m0s


### PR DESCRIPTION
This PR upgrades Karpenter to latest minor version before the v1.0 upgrade as suggested on the [migration doc](https://karpenter.sh/docs/upgrading/v1-migration/)

Following steps with a separate PR:

- Upgrade `karpenter` and `karpenter-crd` helmreleases to v1.0.2
- At this point, there will be reconciliation errors due to some changes on the IAM side. We need to add `enable_v1_permissions = true` to `karpenter.tf` and run terraform.