### PR TITLE
[eks-prow-build] Upgrade karpenter to v1.0.2

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/karpenter.tf
+++ b/infra/aws/terraform/prow-build-cluster/karpenter.tf
@@ -25,6 +25,7 @@ module "karpenter" {
 
   node_iam_role_use_name_prefix = false
   node_iam_role_name            = "karpenter-nodes"
+  enable_v1_permissions         = true
   # Allows accessing instances via AWS System Manager (SSM)
   node_iam_role_additional_policies = {
     AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
@@ -33,4 +34,5 @@ module "karpenter" {
   queue_name = "karpenter-queue"
 
   tags = local.tags
+
 }

--- a/infra/aws/terraform/prow-build-cluster/resources/karpenter/flux-hr-karpenter-crd.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/karpenter/flux-hr-karpenter-crd.yaml
@@ -28,5 +28,5 @@ spec:
         kind: HelmRepository
         name: karpenter
         namespace: flux-system
-      version: 0.37.3
+      version: 1.0.2
   interval: 5m0s

--- a/infra/aws/terraform/prow-build-cluster/resources/karpenter/flux-hr-karpenter.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/karpenter/flux-hr-karpenter.yaml
@@ -28,7 +28,7 @@ spec:
         kind: HelmRepository
         name: karpenter
         namespace: flux-system
-      version: 0.37.3
+      version: 1.0.2
   dependsOn:
   - name: karpenter-crd
   interval: 5m0s


### PR DESCRIPTION
This PR will upgrade `karpenter` and `karpenter-crd` helmreleases to `v1.0.2`.

v1.0 migration requires some updates on the IAM side, this will be provided by adding `enable_v1_permissions = true` to `karpenter.tf` and running terraform.