### PR TITLE
Set mod level to none for leads lists

### DIFF
--- a/groups/sig-architecture/groups.yaml
+++ b/groups/sig-architecture/groups.yaml
@@ -33,7 +33,7 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
       WhoCanModerateContent: "OWNERS_AND_MANAGERS"
-      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      MessageModerationLevel: "MODERATE_NONE"
 
   - email-id: sig-architecture@kubernetes.io
     name: sig-architecture

--- a/groups/sig-auth/groups.yaml
+++ b/groups/sig-auth/groups.yaml
@@ -35,7 +35,7 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
       WhoCanModerateContent: "OWNERS_AND_MANAGERS"
-      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      MessageModerationLevel: "MODERATE_NONE"
 
   - email-id: sig-auth@kubernetes.io
     name: sig-auth

--- a/groups/sig-cloud-provider/groups.yaml
+++ b/groups/sig-cloud-provider/groups.yaml
@@ -33,7 +33,7 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
       WhoCanModerateContent: "OWNERS_AND_MANAGERS"
-      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      MessageModerationLevel: "MODERATE_NONE"
 
   - email-id: sig-cloud-provider@kubernetes.io
     name: sig-cloud-provider

--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -122,7 +122,7 @@ groups:
       WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
       WhoCanPostMessage: "ANYONE_CAN_POST"
       WhoCanJoin: "INVITED_CAN_JOIN"
-      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      MessageModerationLevel: "MODERATE_NONE"
       ReconcileMembers: "false"
     owners:
       - cecilerobertm@gmail.com

--- a/groups/sig-docs/groups.yaml
+++ b/groups/sig-docs/groups.yaml
@@ -23,7 +23,7 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
       WhoCanModerateContent: "OWNERS_AND_MANAGERS"
-      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      MessageModerationLevel: "MODERATE_NONE"
 
   - email-id: sig-docs@kubernetes.io
     name: sig-docs

--- a/groups/sig-etcd/groups.yaml
+++ b/groups/sig-etcd/groups.yaml
@@ -29,4 +29,4 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
       WhoCanModerateContent: "OWNERS_AND_MANAGERS"
-      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      MessageModerationLevel: "MODERATE_NONE"

--- a/groups/sig-instrumentation/groups.yaml
+++ b/groups/sig-instrumentation/groups.yaml
@@ -34,7 +34,7 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
       WhoCanModerateContent: "OWNERS_AND_MANAGERS"
-      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      MessageModerationLevel: "MODERATE_NONE"
 
   - email-id: sig-instrumentation@kubernetes.io
     name: sig-instrumentation

--- a/groups/sig-k8s-infra/groups.yaml
+++ b/groups/sig-k8s-infra/groups.yaml
@@ -57,7 +57,7 @@ groups:
       WhoCanViewGroup: "ANYONE_CAN_VIEW"
       WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
       WhoCanPostMessage: "ANYONE_CAN_POST"
-      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      MessageModerationLevel: "MODERATE_NONE"
       ReconcileMembers: "false"
     owners:
       - ameukam@gmail.com

--- a/groups/sig-multicluster/groups.yaml
+++ b/groups/sig-multicluster/groups.yaml
@@ -12,7 +12,7 @@ teams:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
       WhoCanModerateContent: "OWNERS_AND_MANAGERS"
-      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      MessageModerationLevel: "MODERATE_NONE"
 
   - email-id: sig-multicluster@kubernetes.io
     name: sig-multicluster

--- a/groups/sig-scalability/groups.yaml
+++ b/groups/sig-scalability/groups.yaml
@@ -55,7 +55,7 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
       WhoCanModerateContent: "OWNERS_AND_MANAGERS"
-      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      MessageModerationLevel: "MODERATE_NONE"
 
   - email-id: sig-scalability@kubernetes.io
     name: sig-scalability

--- a/groups/sig-storage/groups.yaml
+++ b/groups/sig-storage/groups.yaml
@@ -34,7 +34,7 @@ groups:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
       WhoCanModerateContent: "OWNERS_AND_MANAGERS"
-      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      MessageModerationLevel: "MODERATE_NONE"
 
   - email-id: sig-storage@kubernetes.io
     name: sig-storage

--- a/groups/sig-ui/groups.yaml
+++ b/groups/sig-ui/groups.yaml
@@ -13,7 +13,7 @@ teams:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
       WhoCanModerateContent: "OWNERS_AND_MANAGERS"
-      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      MessageModerationLevel: "MODERATE_NONE"
 
   - email-id: sig-ui@kubernetes.io
     name: sig-ui

--- a/groups/wg-data-protection/groups.yaml
+++ b/groups/wg-data-protection/groups.yaml
@@ -12,7 +12,7 @@ teams:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
       WhoCanModerateContent: "OWNERS_AND_MANAGERS"
-      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      MessageModerationLevel: "MODERATE_NONE"
 
   - email-id: wg-data-protection@kubernetes.io
     name: wg-data-protection

--- a/groups/wg-policy/groups.yaml
+++ b/groups/wg-policy/groups.yaml
@@ -13,7 +13,7 @@ teams:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
       WhoCanModerateContent: "OWNERS_AND_MANAGERS"
-      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      MessageModerationLevel: "MODERATE_NONE"
 
   - email-id: wg-policy@kubernetes.io
     name: wg-policy

--- a/groups/wg-structured-logging/groups.yaml
+++ b/groups/wg-structured-logging/groups.yaml
@@ -12,7 +12,7 @@ teams:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       WhoCanViewGroup: "ALL_MEMBERS_CAN_VIEW"
       WhoCanModerateContent: "OWNERS_AND_MANAGERS"
-      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      MessageModerationLevel: "MODERATE_NONE"
 
   - email-id: wg-structured-logging@kubernetes.io
     name: wg-structured-logging


### PR DESCRIPTION
Many leads are missing notifications (including cal invites) because their own lists are moderated and they miss the mod notification. This sets the general mod level to none. If it becomes an issue we can revert.

(want to do this before we send out the updated cal invite for the monthly chair/tl meeting)