### PR TITLE
chore: update the owners for recent CAPA changes

### DIFF
--- a/registry.k8s.io/images/k8s-staging-cluster-api-aws/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-cluster-api-aws/OWNERS
@@ -4,7 +4,8 @@ approvers:
 - richardcase
 - Ankitasw
 - dlipovetsky
-- vincepri
+- nrb
+- AndiDog
 
 emeritus_approvers:
 - chuckha
@@ -14,4 +15,5 @@ emeritus_approvers:
 - rudoi
 - sedefsavas
 - Skarlso
+- vincepri
 


### PR DESCRIPTION
This update the owners for the image promotion with recent changes to the maintainers of CAPA.

Relates: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5119
Relates: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5082
Relates: https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5081