### PR TITLE
Ingress NGINX: Promote NGINX v1.0.0.

### DIFF
--- a/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -190,6 +190,9 @@
     "sha256:1686f4cd2e16f09a1e7d27529d21eb74a8b551dc06ef86189ac837d3d6548725": ["v0.0.10"]
     "sha256:05bec8b13129c54cf855ad1802b0fe302c5d63c992b76b5b9ba897650938a328": ["v0.0.11"]
     "sha256:2d471b3a34dc43d10c3f3d7f2a6e8a2ecf7654a4197e56374261c1c708b16365": ["v0.0.12"]
+- name: nginx
+  dmap:
+    "sha256:11ee0d0e3d063f1468f9a82958d57fa0718614fe10b676941f4dea0aef091faf": ["v1.0.0"]
 
 # Ingress NGINX: Test Runner
 - name: e2e-test-runner


### PR DESCRIPTION
Commit: https://github.com/kubernetes/ingress-nginx/commit/551c9ab8273752297dd8ef639dcfc8da98077ed1
Job: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-ingress-nginx-nginx/1841141580988157952
Build: https://storage.googleapis.com/kubernetes-jenkins/logs/post-ingress-nginx-nginx/1841141580988157952/artifacts/build.log