### PR TITLE
Configure AWS SSO for aws-capa-ami account

### DIFF
--- a/infra/aws/terraform/management-account/organization-accounts-capa-playground.tf
+++ b/infra/aws/terraform/management-account/organization-accounts-capa-playground.tf
@@ -21,4 +21,9 @@ module "k8s-infra-sandbox-capa" {
   email                      = "k8s-infra-sandbox-capa@kubernetes.io"
   iam_user_access_to_billing = "ALLOW"
   parent_id                  = aws_organizations_organizational_unit.production.id
+  permissions_map = {
+    "aws-capa-maintainers" = [
+      "AdministratorAccess",
+    ]
+  }
 }

--- a/infra/aws/terraform/management-account/organization-accounts-workloads-prod.tf
+++ b/infra/aws/terraform/management-account/organization-accounts-workloads-prod.tf
@@ -59,3 +59,27 @@ module "obs-k8s-io" {
     "service"     = "obs"
   }
 }
+
+
+module "capa-ami" {
+  source = "../modules/org-account"
+
+  account_name = "cncf-k8s-infra-aws-capa-ami"
+  email        = "cncf-k8s-infra-aws-capa-ami@lists.cncf.io"
+  parent_id    = aws_organizations_organizational_unit.production.id
+  tags = {
+    "production"  = "true",
+    "environment" = "prod",
+    "group"       = "sig-cluster-lifecycle",
+  }
+  permissions_map = {
+    "aws-capa-maintainers" = [
+      "AdministratorAccess",
+    ]
+  }
+  aws_account_regions = [
+    "ap-east-1",
+    "ap-southeast-3",
+    "eu-south-2",
+  ]
+}

--- a/infra/aws/terraform/management-account/provider.tf
+++ b/infra/aws/terraform/management-account/provider.tf
@@ -30,7 +30,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.67.0"
+      version = "~> 5.67.0"
     }
   }
 }

--- a/infra/aws/terraform/modules/org-account/main.tf
+++ b/infra/aws/terraform/modules/org-account/main.tf
@@ -40,3 +40,10 @@ resource "aws_organizations_account" "this" {
     ]
   }
 }
+
+resource "aws_account_region" "this" {
+  for_each    = toset(var.aws_account_regions)
+  region_name = each.key
+  account_id  = aws_organizations_account.this.id
+  enabled     = true
+}

--- a/infra/aws/terraform/modules/org-account/variables.tf
+++ b/infra/aws/terraform/modules/org-account/variables.tf
@@ -58,3 +58,10 @@ variable "permissions_map" {
   type        = map(any)
   description = "A map of permissions"
 }
+
+variable "aws_account_regions" {
+  default     = []
+  type        = list(string)
+  description = "List of opt-in AWS regions to enable for this account"
+}
+


### PR DESCRIPTION
Required for #6517

I imported the account in TF(this account already exists in AWS) and added the groups required for access.

I also created an Okta account for @richardcase and added him to the aws-capa-maintainers group