### PR TITLE
Add a subscription to gs://kubernetes-ci-logs.

### DIFF
--- a/infra/gcp/terraform/kubernetes-public/k8s-kettle.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-kettle.tf
@@ -95,3 +95,26 @@ resource "google_pubsub_subscription_iam_binding" "subscription_binding" {
     "serviceAccount:${module.aaa_kettle_sa.email}"
   ]
 }
+
+// Create a subscription in this project to the kubernetes-ci-logs-updates topic in k8s-infra-prow.
+data "google_pubsub_topic" "kubernetes_ci_logs_topic" {
+  name    = "kubernetes-ci-logs-updates"
+  project = "k8s-infra-prow"
+}
+
+resource "google_pubsub_subscription" "kettle_ci_logs_subscription" {
+  name = "k8s-infra-kettle"
+  topic = data.google_pubsub_topic.kubernetes_ci_logs_topic.name
+  project = data.google_project.project.project_id
+
+  filter = "attributes.eventType = \"OBJECT_FINALIZE\""
+}
+
+resource "google_pubsub_subscription_iam_binding" "ci_logs_subscription_binding" {
+  project      = data.google_project.project.project_id
+  subscription = google_pubsub_subscription.kettle_ci_logs_subscription.name
+  role         = "roles/pubsub.editor"
+  members = [
+    "serviceAccount:${module.aaa_kettle_sa.email}"
+  ]
+}


### PR DESCRIPTION
There's an existing PubSub topic for GCS changes to gs://kubernetes-ci-logs (in k8s-infra-prow). Attempt to add a new subscription to this in kubernetes-public so Kettle can use updates from the new logs bucket.

(Note: I don't have permissions to run terraform here, so I haven't verified that these additions are valid.)

/hold

Don't submit until we verify this will do something with `terraform plan`

Ref https://github.com/kubernetes/test-infra/issues/33381