### PR TITLE
Ingress NGINX: Promote controller v1.12.0-beta.0.

### DIFF
--- a/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -77,6 +77,7 @@
     "sha256:e6439a12b52076965928e83b7b56aae6731231677b01e81818bce7fa5c60161a": ["v1.11.1"]
     "sha256:d5f8217feeac4887cb1ed21f27c2674e58be06bd8f5184cacea2a69abaf78dce": ["v1.11.2"]
     "sha256:d56f135b6462cfc476447cfe564b83a45e8bb7da2774963b00d12161112270b7": ["v1.11.3"]
+    "sha256:9724476b928967173d501040631b23ba07f47073999e80e34b120e8db5f234d5": ["v1.12.0-beta.0"]
 
 # Ingress NGINX: Controller (chroot)
 - name: controller-chroot
@@ -120,6 +121,7 @@
     "sha256:7cabe4bd7558bfdf5b707976d7be56fd15ffece735d7c90fc238b6eda290fd8d": ["v1.11.1"]
     "sha256:21b55a2f0213a18b91612a8c0850167e00a8e34391fd595139a708f9c047e7a8": ["v1.11.2"]
     "sha256:22701f0fc0f2dd209ef782f4e281bfe2d8cccd50ededa00aec88e0cdbe7edd14": ["v1.11.3"]
+    "sha256:6e2f8f52e1f2571ff65bc4fc4826d5282d5def5835ec4ab433dcb8e659b2fbac": ["v1.12.0-beta.0"]
 
 # Ingress NGINX: CFSSL
 - name: cfssl


### PR DESCRIPTION
Commit: https://github.com/kubernetes/ingress-nginx/commit/80154a3694b52736c88de408811ebd1888712520
Job: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-ingress-nginx-controller/1843718703699464192
Build: https://storage.googleapis.com/kubernetes-jenkins/logs/post-ingress-nginx-controller/1843718703699464192/artifacts/build.log

/cc @strongjz @rikatz @cpanato