### PR TITLE
steering: Onboard/offboard members following 2024 election results

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -170,11 +170,11 @@ aliases:
     - tabbysable
   committee-steering:
     - BenTheElder
+    - aojea
     - justaugustus
-    - mrbobbytables
     - pacoxu
-    - palnabarun
     - pohly
+    - saschagrunert
     - soltysh
 ## BEGIN CUSTOM CONTENT
   promo-tools-approvers:


### PR DESCRIPTION
This is based on https://github.com/kubernetes/k8s.io/pull/7386

xref https://github.com/kubernetes/steering/issues/286

missing the OwnerAliases update. 
@justaugustus 