### PR TITLE
gcp/kettle: fix PubSub topic attributes

### DIFF
--- a/infra/gcp/terraform/kubernetes-public/k8s-kettle.tf
+++ b/infra/gcp/terraform/kubernetes-public/k8s-kettle.tf
@@ -51,8 +51,7 @@ data "google_iam_policy" "prod_kettle_dataset_iam_policy" {
   // Ensure service accounts can create/update/get/delete dataset's table
   binding {
     members = [
-      "serviceAccount:${module.aaa_kettle_sa.email}",
-      "serviceAccount:${google_service_account.bq_kettle_data_transfer_writer.email}"
+      "serviceAccount:${module.aaa_kettle_sa.email}"
     ]
     role = "roles/bigquery.user"
   }
@@ -98,13 +97,13 @@ resource "google_pubsub_subscription_iam_binding" "subscription_binding" {
 
 // Create a subscription in this project to the kubernetes-ci-logs-updates topic in k8s-infra-prow.
 data "google_pubsub_topic" "kubernetes_ci_logs_topic" {
-  name    = "kubernetes-ci-logs-updates"
+  name    = "projects/k8s-infra-prow/topics/kubernetes-ci-logs-updates"
   project = "k8s-infra-prow"
 }
 
 resource "google_pubsub_subscription" "kettle_ci_logs_subscription" {
-  name = "k8s-infra-kettle"
-  topic = data.google_pubsub_topic.kubernetes_ci_logs_topic.name
+  name    = "k8s-infra-kettle"
+  topic   = data.google_pubsub_topic.kubernetes_ci_logs_topic.id
   project = data.google_project.project.project_id
 
   filter = "attributes.eventType = \"OBJECT_FINALIZE\""


### PR DESCRIPTION
Follow-up of:
  - https://github.com/kubernetes/k8s.io/pull/7370

The id of the PubSub topic is required instead of the topic's name.
