### PR TITLE
Kettle subscribes to gs://kubernetes-ci-logs changes.

### DIFF
--- a/apps/kettle/deployment.yaml
+++ b/apps/kettle/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - name: DEPLOYMENT
           value: prod
         - name: SUBSCRIPTION_PATH
-          value: kubernetes-jenkins/gcs-changes/kettle-filtered
+          value: kubernetes-public/kubernetes-ci-logs-updates/k8s-infra-kettle
         resources:
           requests:
             memory: 4Gi


### PR DESCRIPTION
Switch kettle from the old PubSub subscription on kubernetes-jenkins to one on kubernetes-ci-logs.

Ref: https://github.com/kubernetes/test-infra/issues/33381

/hold

This will auto-deploy once submitted, so unhold only once the new subscription is purged and the existing kettle deployment is stopped.