### PR TITLE
[eks-prow-build] Kubernetes v1.31 upgrade

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/.terraform.lock.hcl
+++ b/infra/aws/terraform/prow-build-cluster/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.61.0"
   constraints = ">= 4.0.0, >= 4.33.0, >= 5.46.0, ~> 5.59, >= 5.61.0"
   hashes = [
+    "h1:QkFd6NehzBDH2q2QRNW4RoE3bqK2SxVBuZ09IP9CnlQ=",
     "h1:qYXhPfMOxgOYuSjfe7+P2wdqx4oMkPYgH4XUN3fJb54=",
     "zh:1a0a150b6adaeacc8f56763182e76c6219ac67de1217b269d24b770067b7bab0",
     "zh:1d9c3a8ac3934a147569254d6e2e6ea5293974d0595c02c9e1aa31499a8f0042",
@@ -74,7 +75,7 @@ provider "registry.terraform.io/hashicorp/helm" {
 
 provider "registry.terraform.io/hashicorp/kubernetes" {
   version     = "2.31.0"
-  constraints = ">= 2.20.0, ~> 2.31"
+  constraints = "~> 2.31"
   hashes = [
     "h1:+KpzTrSzd864Fd6+qAQl4cu0/x9N5TqgLAxvyyLSp88=",
     "h1:G8S89g+vfZOgJGbOpSKIQXrp+jIvTwapc89pMVsUo3s=",

--- a/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.canary.tfvars
@@ -31,9 +31,9 @@ eks_cluster_admins = [
 ]
 
 cluster_name    = "prow-canary-cluster"
-cluster_version = "1.29"
+cluster_version = "1.31"
 
-node_group_version_stable  = "1.29"
+node_group_version_stable  = "1.31"
 node_instance_types_stable = ["r5ad.xlarge"]
 node_desired_size_stable   = 1
 

--- a/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
+++ b/infra/aws/terraform/prow-build-cluster/terraform.prod.tfvars
@@ -33,9 +33,9 @@ eks_cluster_viewers = [
 ]
 
 cluster_name    = "prow-build-cluster"
-cluster_version = "1.30"
+cluster_version = "1.31"
 
-node_group_version_stable  = "1.30"
+node_group_version_stable  = "1.31"
 node_instance_types_stable = ["r5ad.2xlarge"]
 node_desired_size_stable   = 3
 


### PR DESCRIPTION
Canary and Prod EKS prow clusters are already upgraded to Kubernetes v1.31

```bash
k get nodes -o wide                                                                            
NAME                                         STATUS   ROLES    AGE     VERSION               INTERNAL-IP    EXTERNAL-IP      OS-IMAGE                                KERNEL-VERSION   CONTAINER-RUNTIME
ip-10-0-110-10.us-east-2.compute.internal    Ready    <none>   9m53s   v1.31.0-eks-5da6378   10.0.110.10    18.224.173.156   Bottlerocket OS 1.24.1 (aws-k8s-1.31)   6.1.109          containerd://1.7.22+bottlerocket
ip-10-0-12-219.us-east-2.compute.internal    Ready    <none>   38m     v1.31.0-eks-5da6378   10.0.12.219    18.191.31.66     Bottlerocket OS 1.24.1 (aws-k8s-1.31)   6.1.109          containerd://1.7.22+bottlerocket
ip-10-0-129-199.us-east-2.compute.internal   Ready    <none>   38m     v1.31.0-eks-5da6378   10.0.129.199   3.17.24.227      Bottlerocket OS 1.24.1 (aws-k8s-1.31)   6.1.109          containerd://1.7.22+bottlerocket
...
```