### PR TITLE
Update groups with work email for aojea

### DIFF
--- a/groups/committee-steering/groups.yaml
+++ b/groups/committee-steering/groups.yaml
@@ -7,6 +7,7 @@ groups:
       ReconcileMembers: "true"
     owners:
       - antonio.ojea.garcia@gmail.com
+      - aojea@google.com
       - augustus@cisco.com
       - bburns@microsoft.com
       - bentheelder@google.com
@@ -47,6 +48,7 @@ groups:
       ReconcileMembers: "true"
     owners:
       - antonio.ojea.garcia@gmail.com
+      - aojea@google.com
       - augustus@cisco.com
       - bentheelder@google.com
       - k8s@auggie.dev
@@ -72,6 +74,7 @@ groups:
       ReconcileMembers: "false"
     owners:
       - antonio.ojea.garcia@gmail.com
+      - aojea@google.com
       - augustus@cisco.com
       - bentheelder@google.com
       - k8s@auggie.dev


### PR DESCRIPTION
It is better for me to use the work email for notifications and calendar events,