### PR TITLE
feat: add Mario to accounting and auditing

### DIFF
--- a/groups/sig-k8s-infra/groups.yaml
+++ b/groups/sig-k8s-infra/groups.yaml
@@ -308,6 +308,7 @@ groups:
       - k8s-infra-ii-coop@kubernetes.io
       - sig-k8s-infra-leads@kubernetes.io
       - steering-private@kubernetes.io
+      - mario@kubermatic.com
 
   #
   # k8s-infra org-wide infrastructure admin groups
@@ -331,6 +332,7 @@ groups:
       - k8s-infra-ii-coop@kubernetes.io
       - sig-k8s-infra-leads@kubernetes.io
       - cncf-aws-admins@lists.cncf.io
+      - mario@kubermatic.com
 
   - email-id: k8s-infra-aws-boskos-accounts@kubernetes.io
     name: k8s-infra-aws-boskos-accounts
@@ -464,6 +466,7 @@ groups:
       - k8s-infra-ii-coop@kubernetes.io
       - sig-k8s-infra-leads@kubernetes.io
       - steering-private@kubernetes.io
+      - mario@kubermatic.com
 
   - email-id: k8s-infra-aws-accounting@kubernetes.io
     name: k8s-infra-aws-accounting
@@ -476,6 +479,7 @@ groups:
       - k8s-infra-ii-coop@kubernetes.io
       - sig-k8s-infra-leads@kubernetes.io
       - steering-private@kubernetes.io
+      - mario@kubermatic.com
 
   - email-id: k8s-infra-yt-admins@kubernetes.io
     name: k8s-infra-yt-admins


### PR DESCRIPTION
add Mario to gcp-auditors, aws-admins, gcp-accounting, aws-accounting to take over k8s-infra cost reporting