### PR TITLE
Switch kettle to recently-built, tagged image.

### DIFF
--- a/apps/kettle/deployment.yaml
+++ b/apps/kettle/deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: kettle
       containers:
       - name: kettle
-        image: gcr.io/k8s-staging-infra-tools/kettle:latest
+        image: gcr.io/k8s-staging-test-infra/kettle:v20241015-f5fd905349
         imagePullPolicy: Always
         env:
         - name: DEPLOYMENT


### PR DESCRIPTION
The deployment is instead using an image built back in April, which doesn't include recent updates to the kettle code like the switched log bucket. This should hopefully fix the recent latency issues noted in https://kubernetes.slack.com/archives/C7J9RP96G/p1729535751254529?thread_ts=1729200222.410669&cid=C7J9RP96G and elsewhere.