### PR TITLE
Add LLM Instance Gateway to staging project list

### DIFF
--- a/infra/gcp/infra.yaml
+++ b/infra/gcp/infra.yaml
@@ -362,6 +362,7 @@ infra:
       k8s-staging-kustomize:
       k8s-staging-kwok:
       k8s-staging-lws:
+      k8s-staging-llm-instance-gw:
       k8s-staging-metrics-server:
       k8s-staging-multitenancy:
       k8s-staging-networking:


### PR DESCRIPTION
Our project: https://github.com/kubernetes-sigs/llm-instance-gateway has need to create images in a public repo.

Followed: https://github.com/kubernetes/k8s.io/blob/main/registry.k8s.io/README.md#creating-staging-repos to cut this PR