### PR TITLE
Azure: Setup Prow build cluster

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -1,25 +1,28 @@
 # IP Assignments
 
-This file is being stored temporarily here to track RFC 1918 IP space allocation to avoid network IP conflicts. It is important that our infrastructure across all vendors can be connected to each other.
+This file is being stored temporarily here to track RFC 1918 IP space allocation to avoid network IP conflicts.
+It is important that our infrastructure across all vendors can be connected to each other.
 
+## IP Allocations
 
-IP Allocation so far:
+Azure:
 
-Azure: TBD
+- 10.152.0.0/16 k8s-infra-aks-prow-build
 
 AWS:
-- 10.128.0.0/16 kops prow cluster
+
+- 10.128.0.0/16 k8s-infra-kops-prow-build
 - 10.0.0.0/16 eks-prow-build-cluster
 
 GCP:
+
 - 10.250.0.0/16 for k8s-infra-prow GCP project
 
 Oracle:
 
-
 VMWare SDDC: TBD
 
+## Clusters that must be rebuilt and moved to a new network
 
-## Clusters that must be rebuilt and moved to a new network:
 - k8s-infra-prow-build
 - k8s-infra-prow-build-trusted

--- a/infra/azure/bash/ensure-resource-groups.sh
+++ b/infra/azure/bash/ensure-resource-groups.sh
@@ -56,7 +56,8 @@ function ensure_terraform_state_containers() {
         --kind StorageV2 \
         --min-tls-version 'TLS1_2' \
         --resource-group "$RESOURCE_GROUP" \
-        --sku Premium_ZRS \
+        --sku Standard_LRS \
+        --encryption-services blob \
         --tags "${TAGS}"
     fi
 

--- a/infra/azure/terraform/k8s-infra-prow-build/aks.tf
+++ b/infra/azure/terraform/k8s-infra-prow-build/aks.tf
@@ -1,0 +1,122 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module "prow_build" {
+  source                    = "Azure/aks/azurerm"
+  version                   = "9.1.0"
+  resource_group_name       = azurerm_resource_group.rg.name
+  location                  = azurerm_resource_group.rg.location
+  sku_tier                  = "Standard"
+  automatic_channel_upgrade = "patch"
+  kubernetes_version        = "1.30"
+  prefix                    = "k8s-infra"
+
+  role_based_access_control_enabled = true
+  workload_identity_enabled         = true
+  oidc_issuer_enabled               = true
+  rbac_aad                          = true
+  rbac_aad_managed                  = true
+  local_account_disabled            = false
+
+  identity_type = "UserAssigned"
+  identity_ids  = [azurerm_user_assigned_identity.aks_identity.id]
+
+  msi_auth_for_monitoring_enabled = true
+
+  kubelet_identity = {
+    client_id                 = azurerm_user_assigned_identity.aks_kubelet_identity.client_id
+    object_id                 = azurerm_user_assigned_identity.aks_kubelet_identity.principal_id
+    user_assigned_identity_id = azurerm_user_assigned_identity.aks_kubelet_identity.id
+  }
+
+  ebpf_data_plane     = "cilium"
+  network_plugin_mode = "overlay"
+  network_plugin      = "azure"
+  network_policy      = "cilium"
+
+  enable_auto_scaling = true
+  node_resource_group = "MC_${local.prefix}-prow-build-${azurerm_resource_group.rg.location}-aks-rg"
+
+  auto_scaler_profile_enabled                     = true
+  auto_scaler_profile_balance_similar_node_groups = true
+  auto_scaler_profile_max_unready_nodes           = 1
+
+  agents_pool_name             = "system"
+  agents_min_count             = 3
+  agents_max_count             = 9
+  agents_max_pods              = 110
+  agents_type                  = "VirtualMachineScaleSets"
+  agents_availability_zones    = ["1", "3"]
+  os_sku                       = "AzureLinux"
+  agents_size                  = "Standard_D4ds_v5"
+  only_critical_addons_enabled = true
+  temporary_name_for_rotation  = "tmpnodepool1"
+  agents_tags                  = var.common_tags
+  vnet_subnet_id               = module.prow_network.subnets.prow_build_aks.resource_id
+
+  storage_profile_enabled             = true
+  storage_profile_blob_driver_enabled = false
+  storage_profile_file_driver_enabled = false
+
+  maintenance_window_auto_upgrade = {
+    frequency   = "Weekly"
+    day_of_week = "Wednesday"
+    interval    = 1
+    duration    = 8
+    utc_offset  = "+00:00"
+    start_time  = "10:00" # UTC
+  }
+
+  maintenance_window_node_os = {
+    frequency   = "Weekly"
+    day_of_week = "Wednesday"
+    interval    = 1
+    duration    = 8
+    utc_offset  = "+00:00"
+    start_time  = "18:00" # UTC
+  }
+
+  maintenance_window = {
+    allowed = [
+      {
+        day   = "Wednesday",
+        hours = [8, 23]
+      },
+    ]
+  }
+
+  node_pools = {
+    pool1 = {
+      name                = "pool1"
+      vm_size             = "Standard_E8ds_v5"
+      enable_auto_scaling = true
+      kubelet_disk_type   = "OS"
+      min_count           = 3
+      max_count           = 200
+      os_disk_type        = "Ephemeral"
+      os_disk_size_gb     = 100
+      os_sku              = "Ubuntu"
+
+      upgrade_settings = {
+        max_surge                     = "33%"
+        drain_timeout_in_minutes      = 90
+        node_soak_duration_in_minutes = 1
+      }
+    }
+  }
+
+  depends_on = [module.prow_network]
+}

--- a/infra/azure/terraform/k8s-infra-prow-build/data.tf
+++ b/infra/azure/terraform/k8s-infra-prow-build/data.tf
@@ -1,0 +1,22 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+data "azurerm_client_config" "current" {}
+
+data "azurerm_kubernetes_service_versions" "current" {
+  location        = azurerm_resource_group.rg.location
+  include_preview = false
+}

--- a/infra/azure/terraform/k8s-infra-prow-build/diagnostic-settings.tf
+++ b/infra/azure/terraform/k8s-infra-prow-build/diagnostic-settings.tf
@@ -1,0 +1,45 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+data "azurerm_monitor_diagnostic_categories" "prow_build" {
+  resource_id = module.prow_build.aks_id
+}
+
+resource "azurerm_monitor_diagnostic_setting" "prow_build" {
+  name                           = "diag-${module.prow_build.aks_name}"
+  target_resource_id             = module.prow_build.aks_id
+  log_analytics_workspace_id     = module.prow_build.azurerm_log_analytics_workspace_id
+  log_analytics_destination_type = "Dedicated"
+
+  dynamic "enabled_log" {
+    iterator = entry
+    for_each = data.azurerm_monitor_diagnostic_categories.prow_build.log_category_types
+
+    content {
+      category = entry.value
+    }
+  }
+
+  dynamic "metric" {
+    iterator = entry
+    for_each = data.azurerm_monitor_diagnostic_categories.prow_build.metrics
+
+    content {
+      category = entry.value
+      enabled  = false
+    }
+  }
+}

--- a/infra/azure/terraform/k8s-infra-prow-build/identities.tf
+++ b/infra/azure/terraform/k8s-infra-prow-build/identities.tf
@@ -1,0 +1,39 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "azurerm_user_assigned_identity" "aks_identity" {
+  name                = "uami-${azurerm_resource_group.rg.name}-cluster-identity"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+
+  lifecycle {
+    ignore_changes = [
+      tags["DateCreated"]
+    ]
+  }
+}
+
+resource "azurerm_user_assigned_identity" "aks_kubelet_identity" {
+  name                = "uami-${azurerm_resource_group.rg.name}-kubelet-identity"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+
+  lifecycle {
+    ignore_changes = [
+      tags["DateCreated"]
+    ]
+  }
+}

--- a/infra/azure/terraform/k8s-infra-prow-build/logging.tf
+++ b/infra/azure/terraform/k8s-infra-prow-build/logging.tf
@@ -1,0 +1,23 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "azurerm_log_analytics_workspace_table" "this" {
+  for_each = toset(local.log_analytics_tables)
+
+  name         = each.value
+  workspace_id = module.prow_build.azurerm_log_analytics_workspace_id
+  plan         = "Basic"
+}

--- a/infra/azure/terraform/k8s-infra-prow-build/main.tf
+++ b/infra/azure/terraform/k8s-infra-prow-build/main.tf
@@ -1,0 +1,47 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+locals {
+  prefix               = "k8s-infra"
+  log_analytics_tables = ["AKSAudit", "AKSAuditAdmin", "AKSControlPlane", "ContainerLogV2"]
+}
+
+module "naming" {
+  source  = "Azure/naming/azurerm"
+  version = "0.4.1"
+  suffix  = ["k8s-infra-prow-build"]
+}
+
+module "azure_region" {
+  source  = "claranet/regions/azurerm"
+  version = "~> 7.2"
+
+  azure_region = var.default_region
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = module.naming.resource_group.name
+  location = module.azure_region.location
+  tags     = var.common_tags
+
+  lifecycle {
+    prevent_destroy = true
+    ignore_changes = [
+      tags["DateCreated"]
+    ]
+  }
+}
+

--- a/infra/azure/terraform/k8s-infra-prow-build/network.tf
+++ b/infra/azure/terraform/k8s-infra-prow-build/network.tf
@@ -1,0 +1,74 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module "prow_network" {
+  source              = "Azure/avm-res-network-virtualnetwork/azurerm"
+  version             = "0.6.0"
+  name                = "vnet-${azurerm_resource_group.rg.name}"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  address_space       = ["10.52.0.0/16"]
+  subnets = {
+    "prow_build_aks" = {
+      name                                      = "snet-${azurerm_resource_group.rg.name}"
+      address_prefixes                          = ["10.52.1.0/24"]
+      service_endpoints                         = ["Microsoft.Storage", "Microsoft.ContainerRegistry"]
+      private_endpoint_network_policies_enabled = false
+    }
+  }
+
+  tags             = var.common_tags
+  enable_telemetry = false
+}
+
+module "private_dns_zones" {
+  source                          = "Azure/avm-ptn-network-private-link-private-dns-zones/azurerm"
+  version                         = "0.4.0"
+  location                        = azurerm_resource_group.rg.location
+  resource_group_name             = azurerm_resource_group.rg.name
+  resource_group_creation_enabled = false
+  tags                            = var.common_tags
+  enable_telemetry                = false
+  private_link_private_dns_zones = {
+    azure_aks_mgmt = {
+      zone_name = "privatelink.{regionName}.azmk8s.io"
+    }
+    azure_acr_data = {
+      zone_name = "{regionName}.data.privatelink.azurecr.io"
+    }
+    azure_site_recovery = {
+      zone_name = "privatelink.siterecovery.windowsazure.com"
+    }
+    azure_monitor = {
+      zone_name = "privatelink.monitor.azure.com"
+    }
+    azure_log_analytics = {
+      zone_name = "privatelink.oms.opinsights.azure.com"
+    }
+    azure_log_analytics_data = {
+      zone_name = "privatelink.ods.opinsights.azure.com"
+    }
+    azure_monitor_agent = {
+      zone_name = "privatelink.agentsvc.azure-automation.net"
+    }
+  }
+
+  virtual_network_resource_ids_to_link_to = {
+    "vnet_prow_build_aks" = {
+      vnet_resource_id = module.prow_network.resource_id
+    }
+  }
+}

--- a/infra/azure/terraform/k8s-infra-prow-build/outputs.tf
+++ b/infra/azure/terraform/k8s-infra-prow-build/outputs.tf
@@ -1,0 +1,19 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+output "cluster_fqdn" {
+  value = module.prow_build.cluster_fqdn
+}

--- a/infra/azure/terraform/k8s-infra-prow-build/providers.tf
+++ b/infra/azure/terraform/k8s-infra-prow-build/providers.tf
@@ -1,0 +1,39 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  required_version = "~> 1.9.0"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.51, < 4.0"
+    }
+  }
+
+  backend "azurerm" {
+    resource_group_name  = "k8s-infra-tf-states-rg"
+    storage_account_name = "k8sinfratfstateprow"
+    container_name       = "terraform-state"
+    key                  = "prow-build.terraform.tfstate"
+  }
+}
+
+provider "azurerm" {
+  subscription_id = "46678f10-4bbb-447e-98e8-d2829589f2d8"
+  # Configuration options
+  features {}
+}
+

--- a/infra/azure/terraform/k8s-infra-prow-build/rbac.tf
+++ b/infra/azure/terraform/k8s-infra-prow-build/rbac.tf
@@ -1,0 +1,36 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "azurerm_role_assignment" "admin" {
+  role_definition_name = "Azure Kubernetes Service RBAC Cluster Admin"
+  scope                = module.prow_build.aks_id
+  principal_id         = data.azurerm_client_config.current.object_id # Me
+}
+
+# Control Plane
+
+resource "azurerm_role_assignment" "control_plane_mi" {
+  role_definition_name = "Managed Identity Operator"
+  scope                = azurerm_resource_group.rg.id
+  principal_id         = azurerm_user_assigned_identity.aks_identity.principal_id
+}
+
+# Kubelet
+resource "azurerm_role_assignment" "kubelet_mi_operator" {
+  role_definition_name = "Managed Identity Operator"
+  scope                = azurerm_resource_group.rg.id
+  principal_id         = azurerm_user_assigned_identity.aks_kubelet_identity.principal_id
+}

--- a/infra/azure/terraform/k8s-infra-prow-build/variables.tf
+++ b/infra/azure/terraform/k8s-infra-prow-build/variables.tf
@@ -1,0 +1,31 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+variable "common_tags" {
+  type = map(string)
+
+  default = {
+    "managed-by"    = "Terraform",
+    "group"         = "sig-k8s-infra",
+    "DO-NOT-DELETE" = "True",
+    "githubRepo"    = "git.k8s.io/k8s.io"
+  }
+}
+
+variable "default_region" {
+  type    = string
+  default = "eastus2"
+}


### PR DESCRIPTION
Setup an AKS cluster where we can run ProwJobs similarly to the GKE
cluster `k8s-infra-prow-build`.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>