### PR TITLE
prow: Setup secret for build cluster

### DIFF
--- a/kubernetes/gke-prow/prow/external-secrets.yaml
+++ b/kubernetes/gke-prow/prow/external-secrets.yaml
@@ -5,9 +5,9 @@ metadata:
   name: k8s-infra-cherrypick-robot-github-token
 spec:
   data:
-  - remoteRef:
-      key: k8s-infra-cherrypick-robot-github-token
-    secretKey: token
+    - remoteRef:
+        key: k8s-infra-cherrypick-robot-github-token
+      secretKey: token
   secretStoreRef:
     kind: ClusterSecretStore
     name: kubernetes-public
@@ -18,9 +18,22 @@ metadata:
   name: kubeconfig-eks-prow-build-cluster
 spec:
   data:
-  - remoteRef:
-      key: eks-prow-build-cluster-kubeconfig
-    secretKey: kubeconfig
+    - remoteRef:
+        key: eks-prow-build-cluster-kubeconfig
+      secretKey: kubeconfig
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: k8s-infra-prow
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: kubeconfig-k8s-infra-aks-prow-build
+spec:
+  data:
+    - remoteRef:
+        key: k8s-infra-aks-prow-build-kubeconfig
+      secretKey: kubeconfig
   secretStoreRef:
     kind: ClusterSecretStore
     name: k8s-infra-prow
@@ -31,9 +44,9 @@ metadata:
   name: kubeconfig-k8s-infra-kops-prow-build
 spec:
   data:
-  - remoteRef:
-      key: k8s-infra-kops-prow-build-kubeconfig
-    secretKey: kubeconfig
+    - remoteRef:
+        key: k8s-infra-kops-prow-build-kubeconfig
+      secretKey: kubeconfig
   secretStoreRef:
     kind: ClusterSecretStore
     name: k8s-infra-prow
@@ -44,9 +57,9 @@ metadata:
   name: kubeconfig-k8s-infra-prow-build
 spec:
   data:
-  - remoteRef:
-      key: k8s-infra-prow-build-kubeconfig
-    secretKey: kubeconfig
+    - remoteRef:
+        key: k8s-infra-prow-build-kubeconfig
+      secretKey: kubeconfig
   secretStoreRef:
     kind: ClusterSecretStore
     name: k8s-infra-prow
@@ -57,9 +70,9 @@ metadata:
   name: kubeconfig-k8s-infra-prow-build-trusted
 spec:
   data:
-  - remoteRef:
-      key: k8s-infra-prow-build-trusted-kubeconfig
-    secretKey: kubeconfig
+    - remoteRef:
+        key: k8s-infra-prow-build-trusted-kubeconfig
+      secretKey: kubeconfig
   secretStoreRef:
     kind: ClusterSecretStore
     name: k8s-infra-prow
@@ -70,9 +83,9 @@ metadata:
   name: kubeconfig-k8s-infra-prow
 spec:
   data:
-  - remoteRef:
-      key: k8s-infra-prow-kubeconfig
-    secretKey: kubeconfig
+    - remoteRef:
+        key: k8s-infra-prow-kubeconfig
+      secretKey: kubeconfig
   secretStoreRef:
     kind: ClusterSecretStore
     name: k8s-infra-prow
@@ -83,9 +96,9 @@ metadata:
   name: oauth-token
 spec:
   data:
-  - remoteRef:
-      key: oauth-token
-    secretKey: oauth
+    - remoteRef:
+        key: oauth-token
+      secretKey: oauth
   secretStoreRef:
     kind: ClusterSecretStore
     name: k8s-infra-prow
@@ -96,9 +109,9 @@ metadata:
   name: slack-token
 spec:
   data:
-  - remoteRef:
-      key: slack-token
-    secretKey: token
+    - remoteRef:
+        key: slack-token
+      secretKey: token
   secretStoreRef:
     kind: ClusterSecretStore
     name: k8s-infra-prow
@@ -109,9 +122,9 @@ metadata:
   name: hmac-token
 spec:
   data:
-  - remoteRef:
-      key: hmac-token
-    secretKey: hmac
+    - remoteRef:
+        key: hmac-token
+      secretKey: hmac
   secretStoreRef:
     kind: ClusterSecretStore
     name: k8s-infra-prow
@@ -122,9 +135,9 @@ metadata:
   name: github-oauth-config
 spec:
   data:
-  - remoteRef:
-      key: github-oauth-config
-    secretKey: secret
+    - remoteRef:
+        key: github-oauth-config
+      secretKey: secret
   secretStoreRef:
     kind: ClusterSecretStore
     name: k8s-infra-prow
@@ -135,9 +148,9 @@ metadata:
   name: cat-api-key
 spec:
   data:
-  - remoteRef:
-      key: cat-api-key
-    secretKey: api-key
+    - remoteRef:
+        key: cat-api-key
+      secretKey: api-key
   secretStoreRef:
     kind: ClusterSecretStore
     name: k8s-infra-prow
@@ -148,9 +161,9 @@ metadata:
   name: unsplash-api-key
 spec:
   data:
-  - remoteRef:
-      key: unsplash-api-key
-    secretKey: honk.txt
+    - remoteRef:
+        key: unsplash-api-key
+      secretKey: honk.txt
   secretStoreRef:
     kind: ClusterSecretStore
     name: k8s-infra-prow
@@ -161,9 +174,9 @@ metadata:
   name: cookie
 spec:
   data:
-  - remoteRef:
-      key: cookie
-    secretKey: secret
+    - remoteRef:
+        key: cookie
+      secretKey: secret
   secretStoreRef:
     kind: ClusterSecretStore
     name: k8s-infra-prow


### PR DESCRIPTION
Follow-up of:
  - https://github.com/kubernetes/k8s.io/pull/7472

Add a ExternalSecret for the kubeconfig of the AKS build cluster.