### PR TITLE
Azure: fix virtual network for the build cluster

### DIFF
--- a/infra/azure/terraform/k8s-infra-prow-build/aks.tf
+++ b/infra/azure/terraform/k8s-infra-prow-build/aks.tf
@@ -109,6 +109,7 @@ module "prow_build" {
       os_disk_type        = "Ephemeral"
       os_disk_size_gb     = 100
       os_sku              = "Ubuntu"
+      vnet_subnet_id      = module.prow_network.subnets.prow_build_aks.resource_id
 
       upgrade_settings = {
         max_surge                     = "33%"


### PR DESCRIPTION
Follow-up of:
  - https://github.com/kubernetes/k8s.io/pull/7472

Fix a perma-diff in the node pool of AKS build cluster.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>
