### PR TITLE
Azure: update tag for resource group post cluster creation

### DIFF
--- a/infra/azure/terraform/k8s-infra-prow-build/aks.tf
+++ b/infra/azure/terraform/k8s-infra-prow-build/aks.tf
@@ -121,3 +121,13 @@ module "prow_build" {
 
   depends_on = [module.prow_network]
 }
+
+# Prevent resource group deletion
+resource "null_resource" "prow_nodepool_rg_tag" {
+
+  provisioner "local-exec" {
+    command = "az group update --resource-group ${module.prow_build.node_resource_group} --tags DO-NOT-DELETE=true"
+  }
+
+  depends_on = [module.prow_build]
+}


### PR DESCRIPTION
Follow-up of:
  - https://github.com/kubernetes/k8s.io/pull/7472

https://github.com/Azure/rg-cleanup/ is deployed at
the subscription level to delete resource groups older than 3 days to
clean resources left post prowjobs execution. This is also affect the resource
groups auto-created by AKS clusters.
`rg-cleanup` will not clean up resource groups with specific tags
(e.g.`DO-NOT-DELETE`)
Tag is added to ensure `rg-cleanup` do remove the resource groups of the
build cluster.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>
