### PR TITLE
Sync CAPZ owners with Azure provider project

### DIFF
--- a/infra/azure/terraform/capz/OWNERS
+++ b/infra/azure/terraform/capz/OWNERS
@@ -5,12 +5,12 @@ approvers:
 - jackfrancis
 - Jont828
 - mboersma
+- nawazkh
 - nojnhuh
 - willie-yao
 reviewers:
 - jsturtevant
 - marosset
-- nawazkh
 
 labels:
 - sig/cluster-lifecycle

--- a/registry.k8s.io/images/k8s-staging-cluster-api-azure/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-cluster-api-azure/OWNERS
@@ -5,12 +5,12 @@ approvers:
 - jackfrancis
 - Jont828
 - mboersma
+- nawazkh
 - nojnhuh
 - willie-yao
 reviewers:
 - jsturtevant
 - marosset
-- nawazkh
 
 labels:
 - sig/cluster-lifecycle


### PR DESCRIPTION
Syncs up with recent changes to https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/main/OWNERS_ALIASES

Specifically, moves @nawazkh to approvers.

/cc @jackfrancis @Jont828 @nojnhuh @willie-yao