### PR TITLE
Fastly: fix the cache rule for the version markers.

### DIFF
--- a/infra/fastly/terraform/dl-sandbox.k8s.dev/vcl/binaries.vcl
+++ b/infra/fastly/terraform/dl-sandbox.k8s.dev/vcl/binaries.vcl
@@ -45,7 +45,7 @@ sub vcl_fetch {
   }
 
   # Ensure version markers are not cached at the edge
-  if (req.url.path ~ "^/release/(latest|stable)(-\d+(\.\d+))?\.txt\z") {
+  if (req.url.path ~ "^/release/(latest|stable)([^/]*)\.txt\z") {
     set beresp.cacheable = false;
     set beresp.ttl = 0s;
     return (pass);

--- a/infra/fastly/terraform/dl.k8s.io/vcl/binaries.vcl
+++ b/infra/fastly/terraform/dl.k8s.io/vcl/binaries.vcl
@@ -45,7 +45,7 @@ sub vcl_fetch {
   }
 
   # Ensure version markers are not cached at the edge
-  if (req.url.path ~ "^/release/(latest|stable)(-\d+(\.\d+))?\.txt\z") {
+  if (req.url.path ~ "^/release/(latest|stable)([^/]*)\.txt\z") {
     set beresp.cacheable = false;
     set beresp.ttl = 0s;
     return (pass);


### PR DESCRIPTION
Related:
  - https://github.com/kubernetes/k8s.io/issues/7447

We do not capture the latest-1.txt and stable-1.txt due to the regex
rule define for all the version markers.
