### PR TITLE
Add a redirect for bluesky community list

### DIFF
--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -291,6 +291,7 @@ data:
         location / {
           rewrite ^/api-review$      https://github.com/kubernetes/community/blob/master/sig-architecture/api-review-process.md redirect;
           rewrite ^/bot-commands$    https://prow.k8s.io/command-help redirect;
+          rewrite ^/bsky$            https://bsky.app/profile/did:plc:kfztyuziv2i44b5kpecth77y/lists/3lau2wjkn3g2s redirect;
           rewrite ^/calendar$        https://www.k8s.dev/calendar redirect;
           rewrite ^/github-labels$   https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md redirect;
           rewrite ^/good-first-issue$ https://github.com/issues?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+no%3Aassignee redirect;


### PR DESCRIPTION
I have created a bluesky list with members of all our github orgs:
https://bsky.app/profile/did:plc:kfztyuziv2i44b5kpecth77y/lists/3lau2wjkn3g2s

Currently the list is under my bluesky id, I have a script that updates the bluesky list every 6 hours. It picks up the github id(s) listed in various org.yaml(s), searches GH profiles to see if there is a bluesky URL and then adds them auto-magically to that list above. the code is here:
https://github.com/dims/gh-bsky-sync/

Until we find a good spot for this list and being able to maintain this list, we need a redirect we can give to folks, So the URL remains the same even when we move the list to a better home.

proposing `https://go.k8s.io/bsky` as the redirect for the same!