### PR TITLE
updating release signal shadows

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -366,7 +366,6 @@ groups:
       - jenny.shu@solo.io # 1.32 Enhancements Shadow
       - lvishpal408@gmail.com # 1.32 Release Notes Shadow
       - mdeep9771@gmail.com # 1.32 Enhancements Shadow
-      - michaelfromyeg@gmail.com # 1.32 Release Signal Shadow
       - michellengnx@gmail.com # 1.32 Docs Shadow
       - rawat.dipesh@gmail.com # 1.32 Enhancements Shadow
       - rayandas91@gmail.com # 1.32 Release Notes Shadow
@@ -410,7 +409,6 @@ groups:
       - james@spurin.com # 1.32 Docs Shadow
       - jenny.shu@solo.io # 1.32 Enhancements Shadow
       - mdeep9771@gmail.com # 1.32 Enhancements Shadow
-      - michaelfromyeg@gmail.com # 1.32 Release Signal Shadow
       - michellengnx@gmail.com # 1.32 Docs Shadow
       - mr.salehsedghpour@gmail.com # 1.32 Release Lead Shadow
       - ninapolshakova@gmail.com # 1.32 Release Lead Shadow


### PR DESCRIPTION
this one seems to have been lost in the shuffle.

Removes a Release Signal shadow

cc: @fsmunoz @gracenng @katcosgrove 