### PR TITLE
Add DNS for CAPI release-1.9 branch

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -393,7 +393,7 @@ docs.prow:
 # https://github.com/kubernetes-sigs/cluster-api docs (@dwat, @jdetiber, @justinsb)
 cluster-api.sigs:
   type: CNAME
-  value: release-1-8--kubernetes-sigs-cluster-api.netlify.app.
+  value: release-1-9--kubernetes-sigs-cluster-api.netlify.app.
 # https://github.com/kubernetes-sigs/cluster-api-provider-aws docs (@randomvariable, @detiber, @ncdc, @rudoi, @vincepri)
 cluster-api-aws.sigs:
   type: CNAME
@@ -467,6 +467,9 @@ release-1-7.cluster-api.sigs:
 release-1-8.cluster-api.sigs:
   type: CNAME
   value: release-1-8--kubernetes-sigs-cluster-api.netlify.app.
+release-1-9.cluster-api.sigs:
+  type: CNAME
+  value: release-1-9--kubernetes-sigs-cluster-api.netlify.app.
 # https://github.com/kubernetes-sigs/cluster-api development docs (@CecileRobertMichon, @vincepri)
 main.cluster-api.sigs:
   type: CNAME


### PR DESCRIPTION
DNS updates for Cluster API release-1.9 branch.

Part of: [#1109](https://github.com/kubernetes-sigs/cluster-api/issues/11092)