### PR TITLE
Allow Atlantis to manage GCP Infrastructure

### DIFF
--- a/.atlantis.yaml
+++ b/.atlantis.yaml
@@ -2,7 +2,6 @@ version: 3
 automerge: true
 autodiscover:
   mode: auto
-delete_source_branch_on_merge: true
 parallel_plan: true
 parallel_apply: true
 abort_on_execution_order_fail: true

--- a/kubernetes/gke-utility/atlantis/extras.yaml
+++ b/kubernetes/gke-utility/atlantis/extras.yaml
@@ -13,3 +13,10 @@ spec:
   secretStoreRef:
     kind: ClusterSecretStore
     name: k8s-infra-prow
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: atlantis
+  annotations:
+    iam.gke.io/gcp-service-account: atlantis@k8s-infra-seed.iam.gserviceaccount.com

--- a/kubernetes/gke-utility/atlantis/kustomization.yaml
+++ b/kubernetes/gke-utility/atlantis/kustomization.yaml
@@ -25,6 +25,7 @@ patchesStrategicMerge:
   spec:
     template:
       spec:
+        serviceAccountName: atlantis
         containers:
         - name: atlantis
           env:


### PR DESCRIPTION
/cc @BenTheElder @ameukam @dims 

This change will allow Atlantis to plan and apply changes to our GCP Terraform code.

The seed project holds the service account and the terraform state bucket. I want to migrate all the state buckets inside kubernetes-public project to a directory inside this new state bucket