### PR TITLE
Add Kubermatic to k8s-infra-staging-apisnoop project

### DIFF
--- a/groups/sig-architecture/groups.yaml
+++ b/groups/sig-architecture/groups.yaml
@@ -68,6 +68,9 @@ groups:
       - hh@ii.coop
       - jbelamaric@google.com
       - zz@ii.coop
+      - koray@kubermatic.com
+      - mario@kubermatic.com
+      - marko@kubermatic.com
 
   #
   # k8s-infra gcs write access

--- a/groups/sig-architecture/groups.yaml
+++ b/groups/sig-architecture/groups.yaml
@@ -68,9 +68,9 @@ groups:
       - hh@ii.coop
       - jbelamaric@google.com
       - zz@ii.coop
-      - koray@kubermatic.com
+      - koray.oksay@gmail.com
       - mario@kubermatic.com
-      - marko@kubermatic.com
+      - mudrinic.mare@gmail.com
 
   #
   # k8s-infra gcs write access


### PR DESCRIPTION
Access to `k8s-infra-staging-apisnoop` project to work on apisnoop and conformance tests.

Fyi, @xmudrii @mfahlandt @jeefy 

/cc @BobyMCbobs 