### PR TITLE
azure: Define resources for the build cluster

### DIFF
--- a/infra/azure/terraform/k8s-infra-prow-build/resources/namespace.yaml
+++ b/infra/azure/terraform/k8s-infra-prow-build/resources/namespace.yaml
@@ -1,0 +1,17 @@
+# Copyright 2024 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-pods

--- a/infra/azure/terraform/k8s-infra-prow-build/resources/test-pods/cpu-limit-range_limitrange.yaml
+++ b/infra/azure/terraform/k8s-infra-prow-build/resources/test-pods/cpu-limit-range_limitrange.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: cpu-limit-range
+  namespace: test-pods
+spec:
+  limits:
+  - defaultRequest:
+      cpu: 250m
+    type: Container

--- a/infra/azure/terraform/k8s-infra-prow-build/resources/test-pods/mem-limit-range_limitrange.yaml
+++ b/infra/azure/terraform/k8s-infra-prow-build/resources/test-pods/mem-limit-range_limitrange.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: mem-limit-range
+  namespace: test-pods
+spec:
+  limits:
+  - defaultRequest:
+      memory: 1Gi
+    type: Container

--- a/infra/azure/terraform/k8s-infra-prow-build/resources/test-pods/test-pods-poddisruptionbudget.yaml
+++ b/infra/azure/terraform/k8s-infra-prow-build/resources/test-pods/test-pods-poddisruptionbudget.yaml
@@ -1,0 +1,31 @@
+# Copyright 2020 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The purpose of the PodDisruptionBudget here is to never allow evicting pods created by prow.
+# Eviction of pods can happen for one of two reasons:
+# * Cluster autoscaler downscaling
+# * Someome/Something using `kubectl drain`
+#
+# It is still possible to delete the pods via a normal delete call. See https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/#the-eviction-api
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: prow-pods
+  namespace: test-pods
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      created-by-prow: "true"


### PR DESCRIPTION
Follow-up of:
  - https://github.com/kubernetes/k8s.io/pull/7572

Add resources used by the build cluster. There are already used by the other build clusters.