### PR TITLE
Update wg data protection yaml

### DIFF
--- a/groups/wg-data-protection/groups.yaml
+++ b/groups/wg-data-protection/groups.yaml
@@ -1,4 +1,15 @@
-teams:
+groups:
+  #
+  # Mailing lists
+  #
+  # Each group here represents a mailing list for the WG or its subprojects,
+  # and is not intended to govern access to infrastructure
+  #
+
+  #
+  # WG Data Protection mailing lists
+  #
+
   - email-id: wg-data-protection-leads@kubernetes.io
     name: wg-data-protection-leads
     description: |-
@@ -32,5 +43,5 @@ teams:
       WhoCanModerateContent: "OWNERS_AND_MANAGERS"
       MembersCanPostAsTheGroup: "false"
       ReconcileMembers: "false"
-
-
+    members:
+      - wg-data-protection-leads@kubernetes.io


### PR DESCRIPTION
wg-data-protection-leads@kubernetes.io and wg-data-protection@kubernetes.io are not created due to a misconfiguration in groups.yaml. This PR tries to fix the issue.

Fixes: #7631 