### PR TITLE
images: promote node-feature-discovery v0.17.0

### DIFF
--- a/registry.k8s.io/images/k8s-staging-nfd/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-nfd/images.yaml
@@ -93,6 +93,8 @@
     "sha256:fa726d75263e1704e579207a611846de7d67b84c68c3c4e69cbad535a2a5dd7e": ["v0.16.5-full"]
     "sha256:19ebca8b3804bfe2ee7324de4873875ab0a9112b51e0ace9dfd7c470beecf4a9": ["v0.16.6","v0.16.6-minimal"]
     "sha256:3ecc4114c0f51876dd675032536e8e761d0051ca15b9f8a9101737b5522512d9": ["v0.16.6-full"]
+    "sha256:0a8da90533d8638d12c4f335189ee71f0a42f0ea147ae7171b9b4e0a33cf223e": ["v0.17.0","v0.17.0-minimal"]
+    "sha256:28bbdd155cf01714e96949397b143c752e0eea91d94493d31becd05ff2cfaf88": ["v0.17.0-full"]
 - name: node-feature-discovery-operator
   dmap:
     "sha256:36a9a2c9d40b08a72df2878fcb602a86c7cf5b71ee9a786bff67fb84b64dcd16": ["v0.2.0"]


### PR DESCRIPTION
```bash
$ skopeo inspect docker://gcr.io/k8s-staging-nfd/node-feature-discovery:v0.17.0 | jq .Digest
"sha256:0a8da90533d8638d12c4f335189ee71f0a42f0ea147ae7171b9b4e0a33cf223e"

$ skopeo inspect docker://gcr.io/k8s-staging-nfd/node-feature-discovery:v0.17.0-minimal | jq .Digest
"sha256:0a8da90533d8638d12c4f335189ee71f0a42f0ea147ae7171b9b4e0a33cf223e"

$ skopeo inspect docker://gcr.io/k8s-staging-nfd/node-feature-discovery:v0.17.0-full | jq .Digest
"sha256:28bbdd155cf01714e96949397b143c752e0eea91d94493d31becd05ff2cfaf88"
```