### PR TITLE
Add Chris Privitere to CAPI alerts list

### DIFF
--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -72,6 +72,7 @@ groups:
       - cahillsf9@gmail.com
       - sunnat.samadov@est.tech
       - shibuuuu5@gmail.com
+      - sabin@figarocastle.org
 
   - email-id: sig-cluster-lifecycle-cluster-api-operator-alerts@kubernetes.io
     name: sig-cluster-lifecycle-cluster-api-operator-alerts


### PR DESCRIPTION
Add myself to the CAPI alerts list. I'm the CI Signal/Bug triage/Automation Manage for CAPI 1.10 so I should get subscribed to the alerts list.