### PR TITLE
bump kube-network-policies to v0.7.0

### DIFF
--- a/registry.k8s.io/images/k8s-staging-networking/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-networking/images.yaml
@@ -45,6 +45,7 @@
     "sha256:7eb7b3cee4d33c10c49893ad3c386232b86d4067de5251294d4c620d6e072b93": ["v1.10.11"]
 - name: kube-network-policies
   dmap:
+    "sha256:ba333c0eff1bee79dabf379142428a7d9c51f25b26d888a7cd8a60a86e84cba0": ["v0.7.0"]
     "sha256:e4e6580b71e310f8e8a56c6a3b7b8b31e4d8b6bf78ec32d9a0912a49cc4e37b8": ["v0.6.0"]
     "sha256:3ce05864a1943ca7cb0f09014dfb938e44dc0559533bd7e26e90b5e8193583ae": ["v0.5.0"]
     "sha256:fc9f1fcbebc53b3dfb06617fbd7be68df88e71ab6a6389894e52706bce5fe93b": ["v0.4.0"]


### PR DESCRIPTION
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-kube-network-policies-image/1877851045988667392

```
exporting manifest list sha256:ba333c0eff1bee79dabf379142428a7d9c51f25b26d888a7cd8a60a86e84cba0
#19 exporting manifest list sha256:ba333c0eff1bee79dabf379142428a7d9c51f25b26d888a7cd8a60a86e84cba0 0.0s done
#19 pushing layers
#19 ...
#20 [auth] k8s-staging-networking/kube-network-policies:pull,push token for gcr.io
#20 DONE 0.0s
#19 exporting to image
#19 pushing layers 4.0s done
#19 pushing manifest for gcr.io/k8s-staging-networking/kube-network-policies:v20250110-808dc01@sha256:ba333c0eff1bee79dabf379142428a7d9c51f25b26d888a7cd8a60a86e84cba0
#19 pushing manifest for gcr.io/k8s-staging-networking/kube-network-policies:v20250110-808dc01@sha256:ba333c0eff1bee79dabf[379](https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-kube-network-policies-image/1877851045988667392#1:build-log.txt%3A379)142428a7d9c51f25b26d888a7cd8a60a86e84cba0 7.2s done
#19 DONE 14.3s
```

/assign @BenTheElder @ameukam 