### PR TITLE
promote cloud provider kind to v0.5.0

### DIFF
--- a/registry.k8s.io/images/k8s-staging-cloud-provider-kind/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-cloud-provider-kind/images.yaml
@@ -1,3 +1,4 @@
 - name: cloud-controller-manager
   dmap:
+    "sha256:302f1b050c951ebdb384db98f5bc028b84bae727cc7fdf07264b46d148a386bb": ["v0.5.0"]
     "sha256:cacb2da53a0d3b363bf53f11c9e0f714d7605471130a43ae7d1e161da0c3cbdb": ["v0.4.0"]


### PR DESCRIPTION
See https://prow.k8s.io/log?job=post-cloud-provider-kind-image&id=1879515604977717248

```
19 exporting manifest list sha256:302f1b050c951ebdb384db98f5bc028b84bae727cc7fdf07264b46d148a386bb
#19 exporting manifest list sha256:302f1b050c951ebdb384db98f5bc028b84bae727cc7fdf07264b46d148a386bb 0.0s done
#19 pushing layers
#19 ...

#20 [auth] k8s-staging-images/cloud-provider-kind/cloud-controller-manager:pull,push token for us-central1-docker.pkg.dev
#20 DONE 0.0s

#19 exporting to image
#19 pushing layers 2.4s done
#19 pushing manifest for us-central1-docker.pkg.dev/k8s-staging-images/cloud-provider-kind/cloud-controller-manager:v20250115-36dd9ee@sha256:302f1b050c951ebdb384db98f5bc028b84bae727cc7fdf07264b46d148a386bb
#19 pushing manifest for us-central1-docker.pkg.dev/k8s-staging-images/cloud-provider-kind/cloud-controller-manager:v20250115-36dd9ee@sha256:302f1b050c951ebdb384db98f5bc028b84bae727cc7fdf07264b46d148a386bb 1.3s done
#19 DONE 6.0s
```
