### PR TITLE
Bump CPU and Mem for codesearch pods

### DIFF
--- a/apps/codesearch/deployment.yaml
+++ b/apps/codesearch/deployment.yaml
@@ -45,9 +45,11 @@ spec:
             mountPath: /data
           resources:
             limits:
-              memory: 8Gi
+              cpu: 4
+              memory: 16Gi
             requests:
-              memory: 8Gi
+              cpu: 4
+              memory: 16Gi
       volumes:
       - name: config
         emptyDir: {}


### PR DESCRIPTION
Add missing CPU limit, codesearch/hound is very sensitive and needs CPU for serving requests. Needs more memory as well.