### PR TITLE
Add snyk-token ExternalSecret to eks-prow-build-cluster

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/test-pods/externalsecrets.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/test-pods/externalsecrets.yaml
@@ -183,3 +183,17 @@ spec:
   secretStoreRef:
     kind: ClusterSecretStore
     name: k8s-infra-prow-build
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: snyk-token
+  namespace: test-pods
+spec:
+  data:
+  - remoteRef:
+      key: snyk-token
+    secretKey: SNYK_TOKEN
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: k8s-infra-prow-build


### PR DESCRIPTION
This PR adds `snyk-token` ExternalSecret to the EKS Prow Build cluster as requested on Slack: https://kubernetes.slack.com/archives/CCK68P2Q2/p1734371958722229

The `snyk-token` Secret in the GCP Secret Manager in the `k8s-infra-prow-build` project has been created already.

/assign @koksay @upodroid @dims @ameukam 