### PR TITLE
Use separate node pool for code search

### DIFF
--- a/apps/codesearch/deployment.yaml
+++ b/apps/codesearch/deployment.yaml
@@ -21,6 +21,13 @@ spec:
       labels:
         app: codesearch
     spec:
+      tolerations:
+      - key: "codesearch"
+        operator: "Equal"
+        value: "true"
+        effect: "NoSchedule"
+      nodeSelector:
+        cloud.google.com/gke-nodepool: "nap-c4-highmem-8"
       terminationGracePeriodSeconds: 30
       initContainers:
       - name: codesearch-fetch
@@ -45,11 +52,11 @@ spec:
             mountPath: /data
           resources:
             limits:
-              cpu: 4
-              memory: 16Gi
+              cpu: 6
+              memory: 24Gi
             requests:
-              cpu: 4
-              memory: 16Gi
+              cpu: 6
+              memory: 24Gi
       volumes:
       - name: config
         emptyDir: {}


### PR DESCRIPTION
Follow up to discussion in https://kubernetes.slack.com/archives/CCK68P2Q2/p1737466576201989

We now have a new Node pool named `codesearch` in `aaa` cluster on `kubernetes-public` that we can use for code search. This node pool has a taint ` codesearch=true:NoSchedule` so other jobs cannot be scheduled on this node. The nodes in this pool have 8 vCPU and 32 GB RAM. It has a 200 GB SSD as well.

```
gcloud beta container --project "kubernetes-public" node-pools create "codesearch" --cluster "aaa" --region "us-central1" --node-version "1.30.6-gke.1596000" --machine-type "n2-standard-16" --image-type "UBUNTU_CONTAINERD" --disk-type "pd-ssd" --disk-size "200" --metadata disable-legacy-endpoints=true --node-taints codesearch=true:NoSchedule --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" --num-nodes "1" --enable-autoscaling --min-nodes "0" --max-nodes "1" --location-policy "BALANCED" --enable-autoupgrade --enable-autorepair --max-surge-upgrade 1 --max-unavailable-upgrade 0
```

Updating the deployment to add the toleration + selector to the pods to enable them to be scheduled on this node. The Pods have been updated to use 6 vCPU and 24 GB RAM and leave room for other daemonsets etc to run.

EDIT: we are now on `c4-highmem-8` WITHOUT SSD