### PR TITLE
Promote cs-canary to prod cs.k8s.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Kubernetes project infrastructure, managed by the kubernetes community via [sig-k8s-infra]
 
 - `apps`: community-managed apps that run on the community-managed `aaa` cluster
-  - `codesearch`: instance of [codesearch] at <https://cs-canary.k8s.io> - owned by [sig-k8s-infra]
+  - `codesearch`: instance of [codesearch] at <https://cs.k8s.io> - owned by [sig-k8s-infra]
   - `elekto`: instance of [elekto] at <https://elections.k8s.io> - owned by Elections officers (on behalf of [sig-contributor-experience])
   - `gcsweb`: instance of [gcsweb] at <https://gcsweb.k8s.io> - owned by [sig-testing]
   - `k8s.io`: instance of nginx that provides redirects/reverse-proxying for k8s.io and its subdomains - owned by [sig-contributor-experience] and [sig-testing]
@@ -33,7 +33,7 @@ Please see <https://git.k8s.io/community/sig-k8s-infra> for more information
 
 <!-- apps -->
 
-[codesearch]: https://cs-canary.k8s.io
+[codesearch]: https://cs.k8s.io
 [elekto]: https://elekto.dev/
 [gcsweb]: https://git.k8s.io/test-infra/gcsweb
 [kubernetes-external-secrets]: https://github.com/external-secrets/kubernetes-external-secrets

--- a/apps/codesearch/certificate.yaml
+++ b/apps/codesearch/certificate.yaml
@@ -7,4 +7,4 @@ metadata:
     app: codesearch
 spec:
   domains:
-  - cs-canary.k8s.io
+  - cs.k8s.io

--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -168,13 +168,7 @@ code:
 conduct:
   type: CNAME
   value: redirect.k8s.io.
-# Code search (@dims)
-# This service runs in a equinix host managed by @dims
 cs:
-  type: A
-  value: 86.109.7.36
-# Canary for Code Search on GKE cluster aaa (@dims @jimdaga)
-cs-canary:
   type: A
   value: 34.117.143.16
 # sig-contributor-experience

--- a/infra/gcp/terraform/kubernetes-public/external-ips.tf
+++ b/infra/gcp/terraform/kubernetes-public/external-ips.tf
@@ -32,7 +32,7 @@ locals {
     },
     cs = {
       name        = "cs-k8s-io-ingress",
-      description = "Used for cs-canary.k8s.io"
+      description = "Used for cs.k8s.io"
     },
     elections = {
       name        = "k8s-io-elections",


### PR DESCRIPTION
Fixes https://github.com/kubernetes/k8s.io/issues/2182

With the recent changes in https://github.com/kubernetes/k8s.io/pull/7707 and https://github.com/kubernetes/k8s.io/pull/7695 the performance is on par with the baremetal host we were running on equinix. Let's switch over the default cs.k8s.io to our own infra so we can turn down the equinix host. Thanks for all the support all these years to Equinix/Packet folks!