### PR TITLE
Add Kevin Hannon for owners for jobset images

### DIFF
--- a/registry.k8s.io/images/k8s-staging-jobset/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-jobset/OWNERS
@@ -4,5 +4,6 @@
 approvers:
 - ahg-g
 - danielvegamyhre
+- kannon92
 labels:
 - sig/apps


### PR DESCRIPTION
Kevin Hannon is now a maintainer for JobSet so adding him to owner to aide in releases.