### PR TITLE
Add raywainman to autoscaling image OWNERS

### DIFF
--- a/registry.k8s.io/images/k8s-staging-autoscaling/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-autoscaling/OWNERS
@@ -11,3 +11,4 @@ approvers:
 - bigdarkclown
 - kwiesmueller
 - x13n
+- raywainman


### PR DESCRIPTION
I am already an owner for the VPA and addon-resizer sub-projects within the autoscaling directory.

Having this access will facilitate the release process for these components.