### PR TITLE
WIP: Move staging repo away from gcr.io

### DIFF
--- a/registry.k8s.io/images/k8s-staging-sig-storage/generate.sh
+++ b/registry.k8s.io/images/k8s-staging-sig-storage/generate.sh
@@ -18,10 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly repo="gcr.io/k8s-staging-sig-storage"
+readonly repo="us-central1-docker.pkg.dev/k8s-staging-sig-storage"
 readonly tag_filter="tags~^v\d+\.\d+\.\d+\$"
 readonly win_hcp_tag_filter="tags~^v\d+\.\d+\.\d+(-\w+)*$" # only for image supporting windows host process deployment
-# List of repos under https://console.cloud.google.com/gcr/images/k8s-staging-sig-storage/GLOBAL
+# List of repos under https://console.cloud.google.com/artifacts/docker/k8s-staging-sig-storage
 readonly images=(
     csi-attacher
     csi-external-health-monitor-agent


### PR DESCRIPTION
As stated here https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr, gcr Container Registry will be shut down after March 18, 2025. We need to move our staging away from gcr.io.

Images on staging repo can be viewed here after we moved over (https://github.com/kubernetes-csi/csi-release-tools/pull/271):
https://console.cloud.google.com/artifacts/docker/k8s-staging-sig-storage