### PR TITLE
Adds EPP v0.1.0-rc.1

### DIFF
--- a/registry.k8s.io/images/k8s-staging-gateway-api-inference-extension/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-gateway-api-inference-extension/images.yaml
@@ -1,1 +1,3 @@
-# TODO: add images
+- name: epp
+  dmap:
+    "sha256:a40d7c85b6ea5e8e25188edb614308c54ec0b495682c4e3a481d01074fa2468e": ["v0.1.0-rc.1"]


### PR DESCRIPTION
Adds the `epp:v0.1.0-rc.1` image for Gateway API Inference Extension project.