### PR TITLE
Adds Gateway API Inference Extension OWNERS

### DIFF
--- a/registry.k8s.io/images/k8s-staging-gateway-api-inference-extension/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-gateway-api-inference-extension/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - ahg-g
+  - danehans
+  - jeffwan
+  - kfswain
+
+labels:
+  - sig/network


### PR DESCRIPTION
Adds project maintainers to Gateway API Inference Extension `OWNERS` file.