### PR TITLE
use the new registry for archeio

### DIFF
--- a/dns/octodns-docker/cloudbuild.yaml
+++ b/dns/octodns-docker/cloudbuild.yaml
@@ -1,12 +1,18 @@
 steps:
-- name: gcr.io/cloud-builders/docker
-  args: ['build', '-t', 'gcr.io/$PROJECT_ID/octodns:$_GIT_TAG',
-          '--build-arg', 'IMAGE_ARG=gcr.io/$PROJECT_ID/octodns:$_GIT_TAG',
-          '.']
+  - name: gcr.io/cloud-builders/docker
+    args:
+      [
+        "build",
+        "-t",
+        "us-central1-docker.pkg.dev/k8s-staging-images/infra-tools/octodns:$_GIT_TAG",
+        "--build-arg",
+        "IMAGE_ARG=us-central1-docker.pkg.dev/k8s-staging-images/infra-tools/octodns:$_GIT_TAG",
+        ".",
+      ]
 substitutions:
   _GIT_TAG: "12345"
-  _PULL_BASE_REF: 'main'
+  _PULL_BASE_REF: "main"
 images:
-- "gcr.io/$PROJECT_ID/octodns:$_GIT_TAG"
+  - "us-central1-docker.pkg.dev/k8s-staging-images/infra-tools/octodns:$_GIT_TAG"
 options:
-  substitution_option: 'ALLOW_LOOSE'
+  substitution_option: "ALLOW_LOOSE"

--- a/infra/gcp/terraform/k8s-staging-images/provider.tf
+++ b/infra/gcp/terraform/k8s-staging-images/provider.tf
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 terraform {
-  required_version = "1.6.5"
+  required_version = "1.10.5"
 
   backend "gcs" {
     bucket = "k8s-infra-tf-prow-clusters"

--- a/infra/gcp/terraform/k8s-staging-images/registries.tf
+++ b/infra/gcp/terraform/k8s-staging-images/registries.tf
@@ -31,6 +31,13 @@ locals {
     test-infra                      = "group:k8s-infra-staging-test-infra@kubernetes.io"
     csi-vsphere                     = "group:k8s-infra-staging-csi-vsphere@kubernetes.io"
   }
+
+  # Only registries used internally by CI should be listed here
+  registries_excluded_from_cleanup = [
+    "infra-tools",
+    "test-infra",
+    "boskos"
+  ]
 }
 
 module "artifact_registry" {
@@ -46,6 +53,7 @@ module "artifact_registry" {
     readers = ["allUsers"],
     writers = [each.value],
   }
+  cleanup_policy_dry_run = contains(local.registries_excluded_from_cleanup, each.key)
   cleanup_policies = {
     "delete-images-older-than-90-days" = {
       action = "DELETE"

--- a/infra/gcp/terraform/modules/oci-proxy/main.tf
+++ b/infra/gcp/terraform/modules/oci-proxy/main.tf
@@ -483,7 +483,7 @@ resource "google_cloud_run_service" "oci-proxy" {
         // - We need to be able to deploy registry fixes ASAP
         // - We will eventually auto-deploy staging by overriding the project and digest on the production config to avoid skew
         // If you're interested in running this image yourself releases are available at registry.k8s.io/infra-tools/archeio
-        image = "gcr.io/k8s-staging-infra-tools/archeio@${var.digest}"
+        image = "us-central1-docker.pkg.dev/k8s-staging-images/infra-tools/archeio@${var.digest}"
         args  = ["-v=${var.verbosity}"]
 
         dynamic "env" {


### PR DESCRIPTION
Fixing @BenTheElder's comment at https://github.com/kubernetes/registry.k8s.io/pull/298#discussion_r1939996266

I'm going to backfill the new registry before merging the PR.