### PR TITLE
Promoting v0.1.0 release image

### DIFF
--- a/registry.k8s.io/images/k8s-staging-gateway-api-inference-extension/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-gateway-api-inference-extension/images.yaml
@@ -1,3 +1,4 @@
 - name: epp
   dmap:
     "sha256:a40d7c85b6ea5e8e25188edb614308c54ec0b495682c4e3a481d01074fa2468e": ["v0.1.0-rc.1"]
+    "sha256:966cd8e4795f366234e20c89bf2d27bd943745afebc190bfac40a001e6d73438": ["v0.1.0"]


### PR DESCRIPTION
This image is a necessary artifact of the GW API Inference Extension v0.1.0 release