### PR TITLE
fix: incorrect regex for smb csi driver plugin

### DIFF
--- a/registry.k8s.io/images/k8s-staging-sig-storage/generate.sh
+++ b/registry.k8s.io/images/k8s-staging-sig-storage/generate.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 readonly repo="gcr.io/k8s-staging-sig-storage"
 readonly tag_filter="tags~^v\d+\.\d+\.\d+\$"
-readonly win_hcp_tag_filter="tags~^v\d+\.\d+\.\d+(-\w+)*$" # only for image supporting windows host process deployment
+readonly win_hcp_tag_filter="tags~^v\d+\.\d+\.\d+[a-z-]*$" # only for image supporting windows host process deployment
 # List of repos under https://console.cloud.google.com/gcr/images/k8s-staging-sig-storage/GLOBAL
 readonly images=(
     csi-attacher


### PR DESCRIPTION
a proceeding fix of https://github.com/kubernetes/k8s.io/pull/7728

I have verified it works in my local env:
```
root@andydev:~/go/src/github.com/kubernetes/k8s.io/registry.k8s.io/images/k8s-staging-sig-storage# ./generate.sh
- name: smbplugin
  dmap:
tags~^v\d+\.\d+\.\d+[a-z-]*$
    "sha256:e7d37907128b9eadf5208e63ea926dd230ef1ebbdf0de2b6d9b7cd6fbe1ef053": [ "v1.10.0" ]
    "sha256:65f664c6e9cce565805b13fb82b40018d56e39f41616134f572c52f3964c6ee4": [ "v1.11.0" ]
    "sha256:885c1654bdffc8c034ba65798728a40022d6d2791ecf23c8b844955c22a27c79": [ "v1.12.0" ]
    "sha256:38b9827870311e5c4da344df8ab6d7856128779233cb4ed5b5a2d1a5a476d86f": [ "v1.13.0" ]
    "sha256:4e97e6f8c122c87253c89fce466e760f88122aa4a7b21677fad4c603144cc0dd": [ "v1.14.0" ]
    "sha256:76ead9378a4b92c4da92a934a234cdd4469dd3628fb51a845b15fca7d2a9979b": [ "v1.15.0" ]
    "sha256:1ec16928aa355e3dafdc84be2acf88d7d9124816e4cd580411536eae064f1d37": [ "v1.16.0" ]
    "sha256:7d4525de48a1b7e775120ea69828f3fefa0c65346964d7163e4bed16799772c9": [ "v1.17.0" ]
    "sha256:b4c6306c9f23ca8bb15c90b0c28e2823d7b64d2ced6fa8df9de3cc4c4f0a9d5c": [ "v1.17.0-windows-hp" ]
    "sha256:5bfa32e3f648c1fd0ded0c3866619e7e47678bceeae8233c28deeded81b5d175": [ "v1.7.0" ]
    "sha256:7eec32f7cb79193c71206827617832247d422e07dcd6efc09eaf718aa6a5edae": [ "v1.8.0" ]
    "sha256:cd17882742532add8cfad9230fffa5ea15beae918c0132165c7070247e4a2bd6": [ "v1.9.0" ]
```

/assign @xing-yang 