### PR TITLE
redirect: Add short link for K8S Infra meeting notes

### DIFF
--- a/apps/k8s-io/README.md
+++ b/apps/k8s-io/README.md
@@ -51,6 +51,7 @@ Redirections
 - https://go.k8s.io/partner-request
 - https://go.k8s.io/pr-dashboard
 - https://go.k8s.io/redirects
+- https://go.k8s.io/sig-k8s-infra-notes
 - https://go.k8s.io/start
 - https://go.k8s.io/stuck-prs
 - https://go.k8s.io/test-health

--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -303,6 +303,7 @@ data:
           rewrite ^/owners/([^/]*)/?$ https://cs.k8s.io/?q=$1&i=fosho&files=OWNERS&excludeFiles=vendor%2F&repos= redirect;
           rewrite ^/partner-request$ https://docs.google.com/forms/d/e/1FAIpQLSdN1KtSKX2VAOPGABFlShkSd6CajQynoL4QCVtY0dj76MNDKg/viewform redirect;
           rewrite ^/redirects$       https://github.com/kubernetes/k8s.io/tree/main/apps/k8s-io/README.md#redirections redirect;
+          rewrite ^/sig-k8s-infra-notes https://docs.google.com/document/d/1VGMyAn_Pixdg0mTwbjxRcq_-oI7xtyomG9Hoa_RpryQ redirect;
           rewrite ^/start$           https://kubernetes.io/docs/setup/ redirect;
           rewrite ^/stuck-prs$       https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Aopen%20label%3Algtm%20label%3Aapproved%20-label%3Ado-not-merge%20-label%3Aneeds-rebase%20sort%3Aupdated-asc%20-status%3Asuccess redirect;
           rewrite ^/test-history$    https://storage.googleapis.com/kubernetes-test-history/static/index.html redirect;


### PR DESCRIPTION
Add a redirect for the meeting notes of SIG K8S Infra bi-weekly so we can walk away from bit.ly.
`http://bit.ly/sig-k8s-infra-notes` is currently not owned by the community.