### PR TITLE
redirect: add link for 1.33 enhancements board

### DIFF
--- a/apps/k8s-io/README.md
+++ b/apps/k8s-io/README.md
@@ -54,6 +54,7 @@ Redirections
 - https://go.k8s.io/sig-k8s-infra
 - https://go.k8s.io/sig-k8s-infra-notes
 - https://go.k8s.io/sig-k8s-infra-playlist
+- https://go.k8s.io/sig-release/1.33/enhancements
 - https://go.k8s.io/start
 - https://go.k8s.io/stuck-prs
 - https://go.k8s.io/test-health

--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -306,6 +306,7 @@ data:
           rewrite ^/sig-k8s-infra$    https://github.com/kubernetes/community/tree/master/sig-k8s-infra redirect;
           rewrite ^/sig-k8s-infra-notes$ https://docs.google.com/document/d/1VGMyAn_Pixdg0mTwbjxRcq_-oI7xtyomG9Hoa_RpryQ redirect;
           rewrite ^/sig-k8s-infra-playlist$ https://www.youtube.com/playlist?list=PL69nYSiGNLP2Ghq7VW8rFbMFoHwvORuDL redirect;
+          rewrite ^/sig-release/1.33/enhancements$ https://github.com/orgs/kubernetes/projects/200/views/1 redirect;
           rewrite ^/start$           https://kubernetes.io/docs/setup/ redirect;
           rewrite ^/stuck-prs$       https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Aopen%20label%3Algtm%20label%3Aapproved%20-label%3Ado-not-merge%20-label%3Aneeds-rebase%20sort%3Aupdated-asc%20-status%3Asuccess redirect;
           rewrite ^/test-history$    https://storage.googleapis.com/kubernetes-test-history/static/index.html redirect;


### PR DESCRIPTION
Add a redirect for the k8s 1.33 enhancements board, to stop relying on bit.ly redirects.

cc @npolshakova @gracenng @katcosgrove @kubernetes/release-team-enhancements @kubernetes/release-team-leads 