### PR TITLE
update sig-storage image list and promotion script

### DIFF
--- a/registry.k8s.io/images/k8s-staging-sig-storage/generate.sh
+++ b/registry.k8s.io/images/k8s-staging-sig-storage/generate.sh
@@ -61,5 +61,8 @@ for image in "${images[@]}"; do
         --format="get(digest, tags)" \
         --sort-by="tags" \
         --filter="${filter}" \
+        | grep --invert-match ';' \
         | sed -e 's/\([^ ]*\)\t\(.*\)/    "\1": [ "\2" ]/'
+    # note: grep invert ';': for images with multiple tags, listed tags are separated by semicolons
+    # this script doesn't handle multi-tagged images, so ignore them to avoid image promotion errors
 done

--- a/registry.k8s.io/images/k8s-staging-sig-storage/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-sig-storage/images.yaml
@@ -287,8 +287,10 @@
     "sha256:3cdf324ca24f0900b1f639b1177a939a3d99ba66cec3db1e2ccfb1d52f2ad7f4": [ "v4.9.0" ]
 - name: objectstorage-controller
   dmap:
+    "sha256:068530265e6099c7e06f969a0b239096b512319c5fa6c1ebcbd310802dcc68c8": [ "v0.2.1" ]
 - name: objectstorage-sidecar
   dmap:
+    "sha256:c2c422ad625cebd861c9d2be443c9c2abebcfd925b09a779fa5186e63351b24e": [ "v0.2.1" ]
 - name: smbplugin
   dmap:
     "sha256:e7d37907128b9eadf5208e63ea926dd230ef1ebbdf0de2b6d9b7cd6fbe1ef053": [ "v1.10.0" ]


### PR DESCRIPTION
The COSI project has 2 images that need to be promoted to the k8s.io registry for its latest release.

COSI staged images previously had multiple tags including the semver tag. The sig-storage `generate.sh` script doesn't output multi-tagged images correctly, so COSI modified its release tagging to use only the semver tag for staged release images. In order to filter out existing staged COSI images that have multiple tags, introduce an inverted grep to the script in this commit.

Run the script to generate an updated `images.yaml`.