### PR TITLE
fix/revert bad digest

### DIFF
--- a/registry.k8s.io/images/k8s-staging-build-image/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-build-image/images.yaml
@@ -1910,7 +1910,7 @@
     "sha256:c624f6fdbe7ebd9e2cc0db104561db14a67bf90a4e7d00e8b901dc6987c534b9": ["v1.31.0-go1.23.3-bullseye.0"]
     "sha256:a7a40f6288e9c9de9f16ea7fdd22a3a72b021371333531ea7a182fc53fab32ee": ["v1.31.0-go1.23.4-bullseye.0"]
     "sha256:acfea4d951a7cdf21c91e07f6a8b953b41cd0860b5bc264ba32cccf5362b92c9": ["v1.31.0-go1.23.5-bullseye.0"]
-    "sha256:a74a72d1a2f9df113b67a08e0cacfb458ea4f6ca1fcb956e6f0d3204c4e64fff": ["v1.31.0-go1.23.6-bullseye.0"]
+    "sha256:d8bf385f7265e3ae181c7744de3a33cc9c59cd6bd63aba9167ef8409e12b2b20": ["v1.31.0-go1.23.6-bullseye.0"]
     "sha256:d4b21fcb3e4466f11a209480d9e2cc6a77604f57130c2e36530a6ba1871a92b0": ["v1.31.0-go1.23rc1-bullseye.0"]
     "sha256:0b1bdc38df30d09242d0ec6d1f76a0fc1337cf482b9cae4b92ca299cebe014ae": ["v1.31.0-go1.23rc2-bullseye.0"]
     "sha256:251ca5be12a260b14c84cb475a8d792ea4be0d1dab9734703898566ac7796736": ["v1.32.0-go1.23.0-bullseye.0"]


### PR DESCRIPTION
follow up of #7799 and #7801 


deleted the wrong digest


```

in dest points to sha256:d8bf385f7265e3ae181c7744de3a33cc9c59cd6bd63aba9167ef8409e12b2b20, not sha256:a74a72d1a2f9df113b67a08e0cacfb458ea4f6ca1fcb956e6f0d3204c4e64fff (as per the manifest), but tag moves are not supported; skipping]" diff=14ms
```


/assign @saschagrunert @xmudrii 