### PR TITLE
Kueue: Promote HelmChart v0.9.3 and v0.10.1

### DIFF
--- a/registry.k8s.io/images/charts/images.yaml
+++ b/registry.k8s.io/images/charts/images.yaml
@@ -1,1 +1,4 @@
-# TODO: add images
+- name: kueue
+  dmap:
+    "sha256:56acd0d3805fee0ec8f071e0dfa41b926d4e5b6f5cf60436ffa42300f6dc17d5": ["v0.10.1"]
+    "sha256:577b280e31a978a82d82da097c236b8ec4ae8323f1c3bfcc06d25eed45d0d874": ["v0.9.3"]


### PR DESCRIPTION
As we discussed in https://docs.google.com/document/d/1xa2me_O0N5sHMD_np9ztr2O9GL3uX1yKBgDcApDqV_8/edit?usp=sharing&resourcekey=0-JHI0r4CeitKdIEJII7c8eg, I promoted Kueue Helm Charts to registry.k8s.io.

Promotion Image Hashes: https://github.com/kubernetes-sigs/kueue/issues/4143#issuecomment-2674437040

/assign @mimowo