### PR TITLE
Add Chart Image approval to Kueue maintainers

### DIFF
--- a/registry.k8s.io/images/charts/OWNERS
+++ b/registry.k8s.io/images/charts/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS file documentation:
+#  https://github.com/kubernetes/community/blob/master/contributors/devel/owners.md
+
+approvers:
+- tenzen-y
+- mimowo


### PR DESCRIPTION
Based on this discussion, I added the chart directory approval permissions to Kueue maintainers.

https://kubernetes.slack.com/archives/CCK68P2Q2/p1739983650931409?thread_ts=1739869280.030129&cid=CCK68P2Q2

Related to https://github.com/kubernetes-sigs/kueue/issues/4143