### PR TITLE
Create staging project for k/sig-security repo cloud build

### DIFF
--- a/infra/gcp/infra.yaml
+++ b/infra/gcp/infra.yaml
@@ -381,6 +381,7 @@ infra:
       k8s-staging-scl-image-builder:
       k8s-staging-sig-auth:
       k8s-staging-sig-docs:
+      k8s-staging-sig-security:
       k8s-staging-sig-storage:
       k8s-staging-slack-infra:
       k8s-staging-sp-operator:


### PR DESCRIPTION
As part of [the work to add near-real-time refresh to the CVE feed](https://github.com/kubernetes/website/issues/43968#issuecomment-2602038504), we need to migrate the job out of direct Prow and into Cloud Build.

I believe this PR is the first step in getting the necessary project to run Cloud Build jobs; please let me know if there are any changes needed.