### PR TITLE
Promote powervs-cloud-controller-manager:6256ccf image

### DIFF
--- a/registry.k8s.io/images/k8s-staging-capi-ibmcloud/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-capi-ibmcloud/images.yaml
@@ -20,3 +20,6 @@
     "sha256:279e1df7efa64066396de02fbcc6a917ae23008cbcac7bce7a120ca09b1c9da1": ["v0.8.0"]
     "sha256:c7c571d112ccb804acc6fe81ec9eb4a741515f576439805b33269a418a139d6b": ["v0.9.0"]
     "sha256:112910167f407582e359cebe1c77c93f37deab69220a5cb62135ccf5e16d55c5": ["v0.10.0"]
+- name: powervs-cloud-controller-manager
+  dmap:
+    "sha256:5c311b5956141d6131397d5208edbfa8682a06ac428302bf80d759b122ed29ac": ["6256ccf"]


### PR DESCRIPTION
**powervs-cloud-controller-manager:6256ccf**

> manifest-tool inspect gcr.io/k8s-staging-capi-ibmcloud/powervs-cloud-controller-manager:6256ccf              
> Name:   gcr.io/k8s-staging-capi-ibmcloud/powervs-cloud-controller-manager:6256ccf (Type: application/vnd.docker.distribution.manifest.list.v2+json)
> Digest: sha256:5c311b5956141d6131397d5208edbfa8682a06ac428302bf80d759b122ed29ac
>  * Contains 2 manifest references (2 images, 0 attestation):
> [1]     Type: application/vnd.docker.distribution.manifest.v2+json
> [1]   Digest: sha256:85a45c17cb16808cab25f72801639c546fe03a367492d411a222722b6e0afcf1
> [1]   Length: 741
> [1] Platform:
> [1]    -      OS: linux
> [1]    -    Arch: amd64
> [1] # Layers: 2
>      layer 01: digest = sha256:af69b09546d25b2712a5f90ac31d2e30767efcbc3aedd7340bba90339bb1443f
>                  type = application/vnd.docker.image.rootfs.diff.tar.gzip
>      layer 02: digest = sha256:2dc71ad4da95734cc346c4c9966377dcaea2f45e1a95edbd9e8091eb666bdd0f
>                  type = application/vnd.docker.image.rootfs.diff.tar.gzip
> 
> [2]     Type: application/vnd.docker.distribution.manifest.v2+json
> [2]   Digest: sha256:1fe88a1aa84df88e5f234fd185a45bc41b3d79b6f7d7f31c6d944d265698f9cc
> [2]   Length: 741
> [2] Platform:
> [2]    -      OS: linux
> [2]    -    Arch: ppc64le
> [2] # Layers: 2
>      layer 01: digest = sha256:4267401cbb33f4f6380c53a7271753615ad8c3ea4a34cc27ba4ed4ec490d27f5
>                  type = application/vnd.docker.image.rootfs.diff.tar.gzip
>      layer 02: digest = sha256:e70bb04e6c51b194084ac19b3d66deac776ebb3f15c1eedbf683afc84ec6bf49
>                  type = application/vnd.docker.image.rootfs.diff.tar.gzip

      
      
In reference to: [2189](https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/issues/2189)