### PR TITLE
Promote dra-example-driver image v0.1.0 and chart 0.1.3

### DIFF
--- a/registry.k8s.io/images/k8s-staging-dra-example-driver/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-dra-example-driver/images.yaml
@@ -1,0 +1,6 @@
+- name: charts/dra-example-driver
+  dmap:
+    "sha256:ab5cd9fd898b2ff79bea030520170a7feb579ff463dce9758775f7cce7d7231f": ["0.1.3"]
+- name: dra-example-driver
+  dmap:
+    "sha256:50358e27c213a483c23d15f1cd9ea47cf59ae706cbf7e6dc56d38db8fbf7ec05": ["v0.1.0"]


### PR DESCRIPTION
This PR promotes the artifacts for the [v0.1.0 release of the dra-example-driver](https://github.com/kubernetes-sigs/dra-example-driver/releases/tag/v0.1.0):
- registry.k8s.io/dra-example-driver/dra-example-driver:v0.1.0 (docker image)
  - from https://console.cloud.google.com/artifacts/docker/k8s-staging-images/us-central1/dra-example-driver/dra-example-driver/sha256:50358e27c213a483c23d15f1cd9ea47cf59ae706cbf7e6dc56d38db8fbf7ec05?project=k8s-staging-images
- registry.k8s.io/dra-example-driver/charts/dra-example-driver:0.1.3 (Helm chart)
  - from https://console.cloud.google.com/artifacts/docker/k8s-staging-images/us-central1/dra-example-driver/charts%2Fdra-example-driver/sha256:ab5cd9fd898b2ff79bea030520170a7feb579ff463dce9758775f7cce7d7231f?invt=AbsY8w&project=k8s-staging-images