### PR TITLE
Update boskos deployments on ibm-ppc64le cluster

### DIFF
--- a/kubernetes/ibm-ppc64le/prow/boskos-janitor.yaml
+++ b/kubernetes/ibm-ppc64le/prow/boskos-janitor.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: boskos-janitor
       containers:
         - name: boskos-janitor
-          image: gcr.io/k8s-staging-boskos/janitor:v20250210-1230f5b
+          image: gcr.io/k8s-staging-boskos/janitor:v20250316-840dd60
           args:
             - --boskos-url=http://boskos.test-pods.svc.cluster.local.
             - --resource-type=bar

--- a/kubernetes/ibm-ppc64le/prow/boskos-reaper.yaml
+++ b/kubernetes/ibm-ppc64le/prow/boskos-reaper.yaml
@@ -17,7 +17,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: boskos-reaper
-          image: gcr.io/k8s-staging-boskos/reaper:v20250210-1230f5b
+          image: gcr.io/k8s-staging-boskos/reaper:v20250316-840dd60
           args:
             - --boskos-url=http://boskos.test-pods.svc.cluster.local.
             - --resource-type=bar

--- a/kubernetes/ibm-ppc64le/prow/boskos.yaml
+++ b/kubernetes/ibm-ppc64le/prow/boskos.yaml
@@ -59,7 +59,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: boskos
-          image: gcr.io/k8s-staging-boskos/boskos:v20250210-1230f5b
+          image: gcr.io/k8s-staging-boskos/boskos:v20250316-840dd60
           args:
             - --config=/etc/config/config
             - --namespace=test-pods


### PR DESCRIPTION
The [PR](https://github.com/kubernetes-sigs/boskos/pull/219) to support multi arch images for Boskos was merged yesterday. Update the boskos image tags to use the latest tags.