### PR TITLE
Add terraform for provisioning power build cluster on ibmcloud

### DIFF
--- a/infra/ibmcloud/OWNERS
+++ b/infra/ibmcloud/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+filters:
+  ".*":
+    approvers:
+    - sig-k8s-infra-leads
+    labels:
+    - sig/k8s-infra
+    - area/infra
+    - area/infra/ibmcloud
+  "\\.sh$":
+    labels:
+    - area/bash

--- a/infra/ibmcloud/terraform/k8s-infra-setup/README.md
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/README.md
@@ -1,0 +1,47 @@
+# _TF: IBM K8s Account Infrastructure_
+This Terraform configuration sets up an organized structure for deploying various IBM Cloud resources using modules. 
+
+---
+# To run the automation, follow these steps in order:
+
+**1. Navigate to the correct directory**
+<br> You need to be in the `k8s-infra-setup` directory to run the automation.
+
+**2. Check the `versions.tf` file**
+<br> Set `secret_key` and `access_key` in `versions.tf` to configure the remote S3 backend (IBM Cloud COS).
+
+**3. Initialize Terraform**
+<br> Execute the following command to initialize Terraform in your project directory. This command will download the necessary provider plugins and prepare the working environment.
+```
+terraform init -reconfigure
+```
+
+**4. Check the `variables.tf` file**
+<br> Open the `variables.tf` file to review all the available variables. This file lists all customizable inputs for your Terraform configuration.
+
+`ibmcloud_api_key` is the only required variable that you must set in order to proceed. You can set this key either by adding it to your `var.tfvars` file or by exporting it as an environment variable.
+
+**Option 1:** Set in `var.tfvars` file
+Add the following line to the `var.tfvars` file:
+```
+ibmcloud_api_key = "<YOUR_API_KEY>"
+```
+
+**Option 2:** Export as an environment variable
+Alternatively, you can export the ibmcloud_api_key as an environment variable before running Terraform:
+```
+export TF_VAR_ibmcloud_api_key="<YOUR_API_KEY>"
+```
+
+**5. Run Terraform Apply**
+<br> After setting the necessary variables (particularly the API_KEY), execute the following command to apply the Terraform configuration and provision the infrastructure:
+```
+terraform apply -var-file var.tfvars
+```
+Terraform will display a plan of the actions it will take, and you'll be prompted to confirm the execution. Type `yes` to proceed.
+
+**6 .Get Output Information**
+<br> Once the infrastructure has been provisioned, use the terraform output command to list details about the provisioned resources.
+```
+terraform output
+```

--- a/infra/ibmcloud/terraform/k8s-infra-setup/main.tf
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/main.tf
@@ -1,0 +1,43 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module "resource_group" {
+  source = "./modules/resource_group"
+}
+
+module "secrets_manager" {
+  source            = "./modules/secrets_manager"
+  resource_group_id = module.resource_group.k8s_rg_id
+}
+
+module "vpc" {
+  providers = {
+    ibm = ibm.vpc
+  }
+  source            = "./modules/vpc"
+  resource_group_id = module.resource_group.k8s_rg_id
+}
+
+module "transit_gateway" {
+  depends_on = [module.vpc]
+  providers = {
+    ibm = ibm.vpc
+  }
+  source            = "./modules/transit_gateway"
+  resource_group_id = module.resource_group.k8s_rg_id
+  vpc_crn           = module.vpc.crn
+  powervs_crn       = ibm_pi_workspace.build_cluster.crn
+}

--- a/infra/ibmcloud/terraform/k8s-infra-setup/modules/resource_group/outputs.tf
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/modules/resource_group/outputs.tf
@@ -1,0 +1,19 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+output "k8s_rg_id" {
+  value = ibm_resource_group.k8s_rg.id
+}

--- a/infra/ibmcloud/terraform/k8s-infra-setup/modules/resource_group/resource_group.tf
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/modules/resource_group/resource_group.tf
@@ -1,0 +1,19 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "ibm_resource_group" "k8s_rg" {
+  name = "k8s-project"
+}

--- a/infra/ibmcloud/terraform/k8s-infra-setup/modules/resource_group/versions.tf
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/modules/resource_group/versions.tf
@@ -1,0 +1,23 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+    }
+  }
+}

--- a/infra/ibmcloud/terraform/k8s-infra-setup/modules/secrets_manager/outputs.tf
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/modules/secrets_manager/outputs.tf
@@ -1,0 +1,23 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+output "k8s_secrets_manager_id" {
+  value = ibm_resource_instance.secrets_manager.guid
+}
+
+output "k8s_powervs_ssh_public_key" {
+  value = tls_private_key.private_key.public_key_openssh
+}

--- a/infra/ibmcloud/terraform/k8s-infra-setup/modules/secrets_manager/secrets_manager.tf
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/modules/secrets_manager/secrets_manager.tf
@@ -1,0 +1,56 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+locals {
+  secrets_manager_region = "us-south"
+  secrets_manager_name   = "k8s-secrets-ppc64le"
+}
+
+resource "ibm_resource_instance" "secrets_manager" {
+  name              = local.secrets_manager_name
+  resource_group_id = var.resource_group_id
+  service           = "secrets-manager"
+  plan              = "standard"
+  location          = local.secrets_manager_region
+
+  timeouts {
+    create = "15m"
+    update = "15m"
+    delete = "15m"
+  }
+}
+
+# RSA key of size 4096 bits
+resource "tls_private_key" "private_key" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "ibm_sm_arbitrary_secret" "ssh_private_key" {
+  name        = "powervs-ssh-private-key"
+  instance_id = ibm_resource_instance.secrets_manager.guid
+  region      = local.secrets_manager_region
+  labels      = ["powervs-ssh-private-key"]
+  payload     = tls_private_key.private_key.private_key_openssh
+}
+
+resource "ibm_sm_arbitrary_secret" "ssh_public_key" {
+  name        = "powervs-ssh-public-key"
+  instance_id = ibm_resource_instance.secrets_manager.guid
+  region      = local.secrets_manager_region
+  labels      = ["powervs-ssh-public-key"]
+  payload     = tls_private_key.private_key.public_key_openssh
+}

--- a/infra/ibmcloud/terraform/k8s-infra-setup/modules/secrets_manager/variables.tf
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/modules/secrets_manager/variables.tf
@@ -1,0 +1,17 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+variable "resource_group_id" {}

--- a/infra/ibmcloud/terraform/k8s-infra-setup/modules/secrets_manager/versions.tf
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/modules/secrets_manager/versions.tf
@@ -1,0 +1,27 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "4.0.6"
+    }
+  }
+}

--- a/infra/ibmcloud/terraform/k8s-infra-setup/modules/transit_gateway/tgw.tf
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/modules/transit_gateway/tgw.tf
@@ -1,0 +1,36 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "ibm_tg_gateway" "transit_gateway" {
+  name           = "k8s-tgw"
+  location       = "jp-osa"
+  global         = true
+  resource_group = var.resource_group_id
+}
+
+resource "ibm_tg_connection" "tg_connection_vpc" {
+  gateway      = ibm_tg_gateway.transit_gateway.id
+  network_type = "vpc"
+  name         = "k8s-conn-vpc"
+  network_id   = var.vpc_crn
+}
+
+resource "ibm_tg_connection" "tg_connection_powervs" {
+  gateway      = ibm_tg_gateway.transit_gateway.id
+  network_type = "power_virtual_server"
+  name         = "k8s-conn-powervs"
+  network_id   = var.powervs_crn
+}

--- a/infra/ibmcloud/terraform/k8s-infra-setup/modules/transit_gateway/variables.tf
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/modules/transit_gateway/variables.tf
@@ -1,0 +1,19 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+variable "resource_group_id" {}
+variable "vpc_crn" {}
+variable "powervs_crn" {}

--- a/infra/ibmcloud/terraform/k8s-infra-setup/modules/transit_gateway/versions.tf
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/modules/transit_gateway/versions.tf
@@ -1,0 +1,23 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+    }
+  }
+}

--- a/infra/ibmcloud/terraform/k8s-infra-setup/modules/vpc/outputs.tf
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/modules/vpc/outputs.tf
@@ -1,0 +1,19 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+output "crn" {
+  value = ibm_is_vpc.vpc.crn
+}

--- a/infra/ibmcloud/terraform/k8s-infra-setup/modules/vpc/variables.tf
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/modules/vpc/variables.tf
@@ -1,0 +1,17 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+variable "resource_group_id" {}

--- a/infra/ibmcloud/terraform/k8s-infra-setup/modules/vpc/versions.tf
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/modules/vpc/versions.tf
@@ -1,0 +1,23 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+    }
+  }
+}

--- a/infra/ibmcloud/terraform/k8s-infra-setup/modules/vpc/vpc.tf
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/modules/vpc/vpc.tf
@@ -1,0 +1,42 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "ibm_is_vpc" "vpc" {
+  name           = "k8s-vpc"
+  resource_group = var.resource_group_id
+}
+
+resource "ibm_is_subnet" "subnet" {
+  name                     = "k8s-subnet"
+  vpc                      = ibm_is_vpc.vpc.id
+  resource_group           = var.resource_group_id
+  total_ipv4_address_count = 256
+  zone                     = "jp-osa-1"
+}
+
+locals {
+  tcp_ports = [6443]
+}
+
+resource "ibm_is_security_group_rule" "inbound_ports" {
+  count     = length(local.tcp_ports)
+  group     = ibm_is_vpc.vpc.default_security_group
+  direction = "inbound"
+  tcp {
+    port_min = local.tcp_ports[count.index]
+    port_max = local.tcp_ports[count.index]
+  }
+}

--- a/infra/ibmcloud/terraform/k8s-infra-setup/outputs.tf
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/outputs.tf
@@ -1,0 +1,23 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+output "secrets_manager_id" {
+  value = module.secrets_manager.k8s_secrets_manager_id
+}
+
+output "powervs_service_instance_id" {
+  value = ibm_pi_workspace.build_cluster.id
+}

--- a/infra/ibmcloud/terraform/k8s-infra-setup/providers.tf
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/providers.tf
@@ -1,0 +1,33 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+locals {
+  key    = var.ibmcloud_api_key
+  region = "osa"
+  zone   = "osa21"
+}
+
+provider "ibm" {
+  ibmcloud_api_key = local.key
+  region           = local.region
+  zone             = local.zone
+}
+
+provider "ibm" {
+  alias            = "vpc"
+  ibmcloud_api_key = local.key
+  region           = "jp-osa"
+}

--- a/infra/ibmcloud/terraform/k8s-infra-setup/pvs.tf
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/pvs.tf
@@ -1,0 +1,45 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+locals {
+  image_name = "CentOS-Stream-9"
+}
+
+resource "ibm_pi_workspace" "build_cluster" {
+  pi_name              = "k8s-powervs-build-cluster-osa21"
+  pi_datacenter        = "osa21"
+  pi_resource_group_id = module.resource_group.k8s_rg_id
+}
+
+data "ibm_pi_catalog_images" "catalog_images" {
+  pi_cloud_instance_id = ibm_pi_workspace.build_cluster.id
+}
+
+locals {
+  catalog_image = [for x in data.ibm_pi_catalog_images.catalog_images.images : x if x.name == local.image_name]
+}
+
+# Copy image from catalog if not in the project and present in catalog
+resource "ibm_pi_image" "image" {
+  pi_image_id          = local.catalog_image[0].image_id
+  pi_cloud_instance_id = ibm_pi_workspace.build_cluster.id
+}
+
+resource "ibm_pi_key" "sshkey" {
+  pi_key_name          = "k8s-sshkey"
+  pi_ssh_key           = module.secrets_manager.k8s_powervs_ssh_public_key
+  pi_cloud_instance_id = ibm_pi_workspace.build_cluster.id
+}

--- a/infra/ibmcloud/terraform/k8s-infra-setup/var.tfvars
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/var.tfvars
@@ -1,0 +1,1 @@
+ibmcloud_api_key = "<YOUR_API_KEY>"

--- a/infra/ibmcloud/terraform/k8s-infra-setup/variables.tf
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/variables.tf
@@ -1,0 +1,26 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+variable "ibmcloud_api_key" {
+  type        = string
+  description = "IBM Cloud API key associated with user's identity"
+  sensitive   = true
+
+  validation {
+    condition     = var.ibmcloud_api_key != ""
+    error_message = "The ibmcloud_api_key is required and cannot be empty."
+  }
+}

--- a/infra/ibmcloud/terraform/k8s-infra-setup/versions.tf
+++ b/infra/ibmcloud/terraform/k8s-infra-setup/versions.tf
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  backend "s3" {
+    bucket                      = "k8s-infra-tf-states"
+    key                         = "k8s-infra-setup/terraform.tfstate"
+    region                      = "us-geo"
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_credentials_validation = true
+    skip_s3_checksum            = true
+    endpoints = {
+      s3 = "https://s3.us.cloud-object-storage.appdomain.cloud"
+    }
+    secret_key = "<YOUR_SECRET_KEY>"
+    access_key = "<YOUR_ACCESS_KEY>"
+  }
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+    }
+  }
+}

--- a/infra/ibmcloud/terraform/k8s-power-build-cluster/README.md
+++ b/infra/ibmcloud/terraform/k8s-power-build-cluster/README.md
@@ -1,0 +1,120 @@
+# _TF: IBM K8s Power Build Cluster_
+These terraform resources define a IBM Cloud project containing a PowerVS cluster intended to serve as a "build cluster" for prow.k8s.io.
+
+---
+## Initial Setup
+
+### Supporting infrastructure
+
+#### Deploy k8s-infra-setup resources
+
+- this covers things like Resource Group, Power Virtual Server Workspace, Virtual Private Cloud, IBM Cloud Secret Manager Secrets, Transit Gateway, etc.
+- Once the deployment successfully completes, the `service_instance_id` and `secrets_manager_id` will be generated and should be used in the subsequent steps.
+
+---
+#### Deploy k8s-power-build-cluster resources
+
+**1. Navigate to the correct directory**
+<br> You need to be in the `k8s-power-build-cluster` directory to run the automation.
+
+**2. Check the `versions.tf` file**
+<br> Set `secret_key` and `access_key` in `versions.tf` to configure the remote S3 backend (IBM Cloud COS).
+
+**3. Initialize Terraform**
+<br> Execute the following command to initialize Terraform in your project directory. This command will download the necessary provider plugins and prepare the working environment.
+```
+terraform init -reconfigure
+```
+
+**4. Check the `variables.tf` file**
+<br> Open the `variables.tf` file to review all the available variables. This file lists all customizable inputs for your Terraform configuration.
+
+`ibmcloud_api_key`, `service_instance_id`, `secrets_manager_id` are the only required variables that you must set in order to proceed. You can set this key either by adding it to your `var.tfvars` file or by exporting it as an environment variable.
+
+**Option 1:** Set in `var.tfvars` file
+Add the following line to the `var.tfvars` file:
+```
+ibmcloud_api_key    = "<YOUR_API_KEY>"
+service_instance_id = "<POWERVS_SERVICE_INSTANCE_ID>"
+secrets_manager_id  = "<SECRETS_MANAGER_ID>"
+```
+
+**Option 2:** Export as an environment variable
+Alternatively, you can export above as an environment variable before running Terraform:
+```
+export TF_VAR_ibmcloud_api_key="<YOUR_API_KEY>"
+export TF_VAR_service_instance_id="<POWERVS_SERVICE_INSTANCE_ID>"
+export TF_VAR_secrets_manager_id="<SECRETS_MANAGER_ID>"
+```
+
+**5. Run Terraform Apply**
+<br> After setting the necessary variables (particularly the API_KEY), execute the following command to apply the Terraform configuration and provision the infrastructure:
+```
+terraform apply -var-file var.tfvars
+```
+Terraform will display a plan of the actions it will take, and you'll be prompted to confirm the execution. Type `yes` to proceed.
+
+**6. Get Output Information**
+<br> Once the infrastructure has been provisioned, use the terraform output command to list details about the provisioned resources.
+```
+terraform output
+```
+
+**7. Set up the Kubernetes cluster using ansible**
+Clone the repository `https://github.com/kubernetes-sigs/provider-ibmcloud-test-infra` and change the directory to `kubetest2-tf/data/k8s-ansible`:
+```
+cd kubetest2-tf/data/k8s-ansible
+```
+
+**8. Install ansible on the deployer VM**
+```
+dnf install ansible -y
+```
+
+**9. Update the fields under `group_vars/all` to include the Kubernetes version to install**
+<br> The following lines will update the version to the latest stable release of Kubernetes. You can modify it accordingly to set up the CI (alpha) version.
+```
+K8S_VERSION=$(curl -Ls https://dl.k8s.io/release/stable.txt)
+LOADBALANCER_EP=<mention the loadbalancer endpoint obtained from terraform output>
+sed -i \
+-e "s/^directory: .*/directory: release/" \
+-e "s/build_version: .*/build_version: $K8S_VERSION/" \
+-e "s/release_marker: .*/release_marker: $K8S_VERSION/" \
+-e "s/loadbalancer: .*/loadbalancer: $LOADBALANCER_EP/" group_vars/all
+```
+
+**10. Update the fields under `examples/k8s-build-cluster/hosts.yml` to contain IP addresses of the VMs to set up Kubernetes**
+```
+For example:
+
+[bastion]
+56.77.34.6
+
+[masters]
+192.168.100.3
+192.168.100.4
+
+[workers]
+192.168.100.5
+192.168.100.6
+192.168.100.7
+
+[workers:vars]
+ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -i <path/to/private-key> -q root@56.77.34.6" -i <path/to/private-key>'
+
+[masters:vars]
+ansible_ssh_common_args='-o ProxyCommand="ssh -W %h:%p -i <path/to/private-key> -q root@56.77.34.6" -i <path/to/private-key>'
+```
+
+**11. Update the fields under `group_vars/bastion_configuration` to contain the information of the private network.**
+```
+For example:
+
+bastion_private_gateway: 192.168.100.1
+bastion_private_ip: 192.168.100.2
+```
+
+**12. Trigger the installation using ansible**
+```
+ansible-playbook -v -i examples/k8s-build-cluster/hosts.yml install-k8s-ha.yaml -e @group_vars/bastion_configuration --extra-vars @group_vars/all
+```

--- a/infra/ibmcloud/terraform/k8s-power-build-cluster/bastion.tf
+++ b/infra/ibmcloud/terraform/k8s-power-build-cluster/bastion.tf
@@ -1,0 +1,126 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+data "ibm_pi_image" "image" {
+  pi_image_name        = var.image_name
+  pi_cloud_instance_id = var.service_instance_id
+}
+
+data "ibm_pi_key" "key" {
+  pi_key_name          = var.keypair_name
+  pi_cloud_instance_id = var.service_instance_id
+}
+
+data "ibm_sm_arbitrary_secret" "secret" {
+  instance_id       = var.secrets_manager_id
+  region            = "us-south"
+  name              = "powervs-ssh-private-key"
+  secret_group_name = "default"
+}
+
+resource "ibm_pi_network" "private_network" {
+  pi_network_name      = "private-net"
+  pi_cloud_instance_id = var.service_instance_id
+  pi_network_type      = "vlan"
+  pi_dns               = ["9.9.9.9"]
+  pi_cidr              = "192.168.25.0/24"
+  pi_gateway           = "192.168.25.1"
+  pi_ipaddress_range {
+    pi_starting_ip_address = "192.168.25.2"
+    pi_ending_ip_address   = "192.168.25.254"
+  }
+}
+
+resource "ibm_pi_network" "public_network" {
+  pi_network_name      = "public-net"
+  pi_cloud_instance_id = var.service_instance_id
+  pi_network_type      = "pub-vlan"
+  pi_dns               = ["9.9.9.9"]
+}
+
+resource "ibm_pi_instance" "bastion" {
+
+  pi_memory            = var.bastion["memory"]
+  pi_processors        = var.bastion["processors"]
+  pi_instance_name     = "bastion"
+  pi_proc_type         = var.processor_type
+  pi_image_id          = data.ibm_pi_image.image.id
+  pi_key_pair_name     = var.keypair_name
+  pi_sys_type          = var.system_type
+  pi_storage_type      = var.storage_type
+  pi_cloud_instance_id = var.service_instance_id
+  pi_health_status     = var.bastion_health_status
+
+  pi_network {
+    network_id = ibm_pi_network.public_network.network_id
+  }
+  pi_network {
+    network_id = ibm_pi_network.private_network.network_id
+    ip_address = "192.168.25.2"
+  }
+}
+
+resource "null_resource" "bastion_setup" {
+  depends_on = [ibm_pi_instance.bastion]
+
+  connection {
+    type        = "ssh"
+    user        = "root"
+    host        = data.ibm_pi_instance_ip.bastion_public_ip.external_ip
+    private_key = data.ibm_sm_arbitrary_secret.secret.payload
+    agent       = var.ssh_agent
+    timeout     = "${var.connection_timeout}m"
+  }
+  provisioner "remote-exec" {
+    inline = [<<EOF
+sudo sed -i.bak -e 's/^ - set_hostname/# - set_hostname/' -e 's/^ - update_hostname/# - update_hostname/' /etc/cloud/cloud.cfg
+sudo hostnamectl set-hostname --static bastion.power-iaas.cloud.ibm.com
+echo 'HOSTNAME=bastion.power-iaas.cloud.ibm.com' | sudo tee -a /etc/sysconfig/network > /dev/null
+sudo hostname -F /etc/hostname
+EOF
+    ]
+  }
+  provisioner "remote-exec" {
+    inline = [<<EOF
+dnf update -y
+systemctl reboot
+EOF
+    ]
+  }
+}
+
+data "ibm_pi_instance_ip" "bastion_ip" {
+  depends_on = [ibm_pi_instance.bastion]
+
+  pi_instance_name     = ibm_pi_instance.bastion.pi_instance_name
+  pi_network_name      = ibm_pi_network.private_network.pi_network_name
+  pi_cloud_instance_id = var.service_instance_id
+}
+
+data "ibm_pi_instance_ip" "bastion_public_ip" {
+  depends_on = [ibm_pi_instance.bastion]
+
+  pi_instance_name     = ibm_pi_instance.bastion.pi_instance_name
+  pi_network_name      = ibm_pi_network.public_network.pi_network_name
+  pi_cloud_instance_id = var.service_instance_id
+}
+
+data "ibm_pi_network" "private_network" {
+  depends_on = [ibm_pi_network.private_network]
+
+  pi_network_name      = "private-net"
+  pi_cloud_instance_id = var.service_instance_id
+}

--- a/infra/ibmcloud/terraform/k8s-power-build-cluster/load_balancer.tf
+++ b/infra/ibmcloud/terraform/k8s-power-build-cluster/load_balancer.tf
@@ -1,0 +1,29 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+module "load_balancer" {
+
+  providers = {
+    ibm = ibm.vpc
+  }
+
+  depends_on          = [ibm_pi_instance.control_plane]
+  source              = "./modules/load_balancer"
+  control_plane_count = var.control_plane["count"]
+  control_plane_ips   = data.ibm_pi_instance_ip.control_plane_ip.*.ip
+  vpc_name            = var.vpc_name
+  resource_group_name = var.resource_group_name
+}

--- a/infra/ibmcloud/terraform/k8s-power-build-cluster/modules/load_balancer/load_balancer.tf
+++ b/infra/ibmcloud/terraform/k8s-power-build-cluster/modules/load_balancer/load_balancer.tf
@@ -1,0 +1,66 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+locals {
+  api_servers       = var.control_plane_ips
+  api_servers_count = var.control_plane_count
+}
+
+data "ibm_is_vpc" "vpc" {
+  name = var.vpc_name
+}
+
+data "ibm_resource_group" "group" {
+  name = var.resource_group_name
+}
+
+resource "ibm_is_lb" "load_balancer_external" {
+  name           = "k8s-control-plane-api-lb"
+  resource_group = data.ibm_resource_group.group.id
+  subnets        = data.ibm_is_vpc.vpc.subnets.*.id
+  type           = "public"
+}
+
+# api listener and backend pool (external)
+resource "ibm_is_lb_listener" "api_listener_external" {
+  lb           = ibm_is_lb.load_balancer_external.id
+  port         = 6443
+  protocol     = "tcp"
+  default_pool = ibm_is_lb_pool.api_pool_external.id
+}
+
+resource "ibm_is_lb_pool" "api_pool_external" {
+  depends_on = [ibm_is_lb.load_balancer_external]
+
+  name           = "api-server"
+  lb             = ibm_is_lb.load_balancer_external.id
+  algorithm      = "round_robin"
+  protocol       = "tcp"
+  health_delay   = 60
+  health_retries = 5
+  health_timeout = 30
+  health_type    = "tcp"
+}
+
+resource "ibm_is_lb_pool_member" "api_member_external" {
+  depends_on = [ibm_is_lb_listener.api_listener_external]
+  count      = local.api_servers_count
+
+  lb             = ibm_is_lb.load_balancer_external.id
+  pool           = ibm_is_lb_pool.api_pool_external.id
+  port           = 6443
+  target_address = local.api_servers[count.index]
+}

--- a/infra/ibmcloud/terraform/k8s-power-build-cluster/modules/load_balancer/outputs.tf
+++ b/infra/ibmcloud/terraform/k8s-power-build-cluster/modules/load_balancer/outputs.tf
@@ -1,0 +1,19 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+output "hostname" {
+  value = ibm_is_lb.load_balancer_external.hostname
+}

--- a/infra/ibmcloud/terraform/k8s-power-build-cluster/modules/load_balancer/variables.tf
+++ b/infra/ibmcloud/terraform/k8s-power-build-cluster/modules/load_balancer/variables.tf
@@ -1,0 +1,20 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+variable "control_plane_count" {}
+variable "control_plane_ips" {}
+variable "vpc_name" {}
+variable "resource_group_name" {}

--- a/infra/ibmcloud/terraform/k8s-power-build-cluster/modules/load_balancer/versions.tf
+++ b/infra/ibmcloud/terraform/k8s-power-build-cluster/modules/load_balancer/versions.tf
@@ -1,0 +1,23 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+    }
+  }
+}

--- a/infra/ibmcloud/terraform/k8s-power-build-cluster/nodes.tf
+++ b/infra/ibmcloud/terraform/k8s-power-build-cluster/nodes.tf
@@ -1,0 +1,119 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+resource "ibm_pi_instance" "control_plane" {
+
+  count                = var.control_plane["count"]
+  pi_memory            = var.control_plane["memory"]
+  pi_processors        = var.control_plane["processors"]
+  pi_instance_name     = "control-plane-${count.index}"
+  pi_proc_type         = var.processor_type
+  pi_image_id          = data.ibm_pi_image.image.id
+  pi_key_pair_name     = var.keypair_name
+  pi_sys_type          = var.system_type
+  pi_storage_type      = var.storage_type
+  pi_cloud_instance_id = var.service_instance_id
+  pi_health_status     = "WARNING"
+
+  pi_network {
+    network_id = ibm_pi_network.private_network.network_id
+  }
+}
+
+resource "null_resource" "control_plane_setup" {
+  depends_on = [ibm_pi_instance.control_plane]
+  count      = var.control_plane["count"]
+
+  connection {
+    type         = "ssh"
+    user         = "root"
+    host         = data.ibm_pi_instance_ip.control_plane_ip[count.index].ip
+    private_key  = data.ibm_sm_arbitrary_secret.secret.payload
+    agent        = var.ssh_agent
+    timeout      = "${var.connection_timeout}m"
+    bastion_host = data.ibm_pi_instance_ip.bastion_public_ip.external_ip
+  }
+  provisioner "remote-exec" {
+    inline = [<<EOF
+sudo sed -i.bak -e 's/^ - set_hostname/# - set_hostname/' -e 's/^ - update_hostname/# - update_hostname/' /etc/cloud/cloud.cfg
+sudo hostnamectl set-hostname --static control-plane-${count.index}.power-iaas.cloud.ibm.com
+echo 'HOSTNAME=control-plane-${count.index}.power-iaas.cloud.ibm.com' | sudo tee -a /etc/sysconfig/network > /dev/null
+sudo hostname -F /etc/hostname
+EOF
+    ]
+  }
+}
+
+resource "ibm_pi_instance" "compute" {
+
+  count                = var.compute["count"]
+  pi_memory            = var.compute["memory"]
+  pi_processors        = var.compute["processors"]
+  pi_instance_name     = "compute-${count.index}"
+  pi_proc_type         = var.processor_type
+  pi_image_id          = data.ibm_pi_image.image.id
+  pi_key_pair_name     = var.keypair_name
+  pi_sys_type          = var.system_type
+  pi_storage_type      = var.storage_type
+  pi_cloud_instance_id = var.service_instance_id
+  pi_health_status     = "WARNING"
+
+  pi_network {
+    network_id = ibm_pi_network.private_network.network_id
+  }
+}
+
+resource "null_resource" "compute_setup" {
+  depends_on = [ibm_pi_instance.compute]
+  count      = var.compute["count"]
+
+  connection {
+    type         = "ssh"
+    user         = "root"
+    host         = data.ibm_pi_instance_ip.compute_ip[count.index].ip
+    private_key  = data.ibm_sm_arbitrary_secret.secret.payload
+    agent        = var.ssh_agent
+    timeout      = "${var.connection_timeout}m"
+    bastion_host = data.ibm_pi_instance_ip.bastion_public_ip.external_ip
+  }
+  provisioner "remote-exec" {
+    inline = [<<EOF
+sudo sed -i.bak -e 's/^ - set_hostname/# - set_hostname/' -e 's/^ - update_hostname/# - update_hostname/' /etc/cloud/cloud.cfg
+sudo hostnamectl set-hostname --static compute-${count.index}.power-iaas.cloud.ibm.com
+echo 'HOSTNAME=compute-${count.index}.power-iaas.cloud.ibm.com' | sudo tee -a /etc/sysconfig/network > /dev/null
+sudo hostname -F /etc/hostname
+EOF
+    ]
+  }
+}
+
+data "ibm_pi_instance_ip" "control_plane_ip" {
+  depends_on = [ibm_pi_instance.control_plane]
+  count      = var.control_plane["count"]
+
+  pi_instance_name     = ibm_pi_instance.control_plane[count.index].pi_instance_name
+  pi_network_name      = var.network_name
+  pi_cloud_instance_id = var.service_instance_id
+}
+
+data "ibm_pi_instance_ip" "compute_ip" {
+  depends_on = [ibm_pi_instance.compute]
+  count      = var.compute["count"]
+
+  pi_instance_name     = ibm_pi_instance.compute[count.index].pi_instance_name
+  pi_network_name      = var.network_name
+  pi_cloud_instance_id = var.service_instance_id
+}

--- a/infra/ibmcloud/terraform/k8s-power-build-cluster/outputs.tf
+++ b/infra/ibmcloud/terraform/k8s-power-build-cluster/outputs.tf
@@ -1,0 +1,47 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+output "bastion_private_ip" {
+  value = data.ibm_pi_instance_ip.bastion_ip.ip
+}
+
+output "bastion_private_cidr" {
+  value = data.ibm_pi_network.private_network.cidr
+}
+
+output "bastion_private_gateway" {
+  value = data.ibm_pi_network.private_network.gateway
+}
+
+output "bastion_internal_ip" {
+  value = data.ibm_pi_instance_ip.bastion_public_ip.ip
+}
+
+output "bastion_public_ip" {
+  value = data.ibm_pi_instance_ip.bastion_public_ip.external_ip
+}
+
+output "control_plane_ips" {
+  value = data.ibm_pi_instance_ip.control_plane_ip.*.ip
+}
+
+output "compute_ips" {
+  value = data.ibm_pi_instance_ip.compute_ip.*.ip
+}
+
+output "loadbalancer_hostname" {
+  value = module.load_balancer.hostname
+}

--- a/infra/ibmcloud/terraform/k8s-power-build-cluster/providers.tf
+++ b/infra/ibmcloud/terraform/k8s-power-build-cluster/providers.tf
@@ -1,0 +1,31 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+locals {
+  key = var.ibmcloud_api_key
+}
+
+provider "ibm" {
+  ibmcloud_api_key = local.key
+  region           = var.ibmcloud_region
+  zone             = var.ibmcloud_zone
+}
+
+provider "ibm" {
+  alias            = "vpc"
+  ibmcloud_api_key = local.key
+  region           = var.vpc_region
+}

--- a/infra/ibmcloud/terraform/k8s-power-build-cluster/var.tfvars
+++ b/infra/ibmcloud/terraform/k8s-power-build-cluster/var.tfvars
@@ -1,0 +1,3 @@
+ibmcloud_api_key    = "<YOUR_API_KEY>"
+service_instance_id = "<POWERVS_SERVICE_INSTANCE_ID>"
+secrets_manager_id  = "<SECRETS_MANAGER_ID>"

--- a/infra/ibmcloud/terraform/k8s-power-build-cluster/variables.tf
+++ b/infra/ibmcloud/terraform/k8s-power-build-cluster/variables.tf
@@ -1,0 +1,213 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+################################################################
+# Configure the IBM Cloud provider
+################################################################
+variable "ibmcloud_api_key" {
+  type        = string
+  description = "IBM Cloud API key associated with user's identity"
+  sensitive   = true
+
+  validation {
+    condition     = var.ibmcloud_api_key != ""
+    error_message = "The ibmcloud_api_key is required and cannot be empty."
+  }
+}
+
+variable "service_instance_id" {
+  type        = string
+  description = "The cloud instance ID of your account"
+  default     = ""
+
+  validation {
+    condition     = var.service_instance_id != ""
+    error_message = "The service_instance_id is required and cannot be empty."
+  }
+}
+
+variable "secrets_manager_id" {
+  type        = string
+  description = "The instance ID of your secrets manager"
+  default     = ""
+
+  validation {
+    condition     = var.secrets_manager_id != ""
+    error_message = "The secrets_manager_id is required and cannot be empty."
+  }
+}
+
+variable "vpc_name" {
+  type        = string
+  description = "The name of your VPC"
+  default     = "k8s-vpc"
+
+  validation {
+    condition     = var.vpc_name != ""
+    error_message = "The vpc_name is required and cannot be empty."
+  }
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "The name of your resource group"
+  default     = "k8s-project"
+
+  validation {
+    condition     = var.resource_group_name != ""
+    error_message = "The resource_group_name is required and cannot be empty."
+  }
+}
+
+variable "network_name" {
+  type        = string
+  description = "The name of the network to be used for deploy operations"
+  default     = "private-net"
+
+  validation {
+    condition     = var.network_name != ""
+    error_message = "The network_name is required and cannot be empty."
+  }
+}
+
+variable "image_name" {
+  type        = string
+  description = "The name of the image that you want to use for the nodes"
+  default     = "CentOS-Stream-9"
+
+  validation {
+    condition     = var.image_name != ""
+    error_message = "The image_name is required and cannot be empty."
+  }
+}
+
+variable "keypair_name" {
+  type        = string
+  description = "The name of the keypair that you want to use for connecting with the nodes"
+  default     = "k8s-sshkey"
+
+  validation {
+    condition     = var.keypair_name != ""
+    error_message = "The keypair_name is required and cannot be empty."
+  }
+}
+
+variable "ibmcloud_region" {
+  type        = string
+  description = "The IBM Cloud region where you want to create the resources"
+  default     = "osa"
+
+  validation {
+    condition     = var.ibmcloud_region != ""
+    error_message = "The ibmcloud_region is required and cannot be empty."
+  }
+}
+
+variable "ibmcloud_zone" {
+  type        = string
+  description = "The zone of an IBM Cloud region where you want to create Power System resources"
+  default     = "osa21"
+
+  validation {
+    condition     = var.ibmcloud_zone != ""
+    error_message = "The ibmcloud_zone is required and cannot be empty."
+  }
+}
+
+variable "vpc_region" {
+  type        = string
+  description = "IBM Cloud VPC Infrastructure region."
+  default     = "jp-osa"
+
+  validation {
+    condition     = var.vpc_region != ""
+    error_message = "The vpc_region is required and cannot be empty."
+  }
+}
+
+################################################################
+# Configure the Instance details
+################################################################
+
+variable "bastion" {
+  type = object({ memory = string, processors = string })
+  default = {
+    memory     = "8"
+    processors = "0.5"
+  }
+}
+
+variable "control_plane" {
+  default = {
+    count      = 3
+    memory     = "8"
+    processors = "0.5"
+  }
+  validation {
+    condition     = var.control_plane["count"] == 3
+    error_message = "The control_plane.count value should be 3."
+  }
+}
+
+variable "compute" {
+  default = {
+    count      = 2
+    memory     = "8"
+    processors = "0.5"
+  }
+}
+
+variable "processor_type" {
+  type        = string
+  description = "The type of processor mode (shared/dedicated)"
+  default     = "shared"
+}
+
+variable "system_type" {
+  type        = string
+  description = "The type of system"
+  default     = "e980"
+}
+
+variable "storage_type" {
+  type        = string
+  description = "The type of storage"
+  default     = "tier0"
+}
+
+################################################################
+### Instrumentation
+################################################################
+variable "ssh_agent" {
+  type        = bool
+  description = "Enable or disable SSH Agent. Can correct some connectivity issues. Default: false"
+  default     = false
+}
+
+variable "connection_timeout" {
+  description = "Timeout in minutes for SSH connections"
+  default     = 30
+}
+
+variable "bastion_health_status" {
+  type        = string
+  description = "Specify if bastion should poll for the Health Status to be OK or WARNING. Default is OK."
+  default     = "WARNING"
+  validation {
+    condition     = contains(["OK", "WARNING"], var.bastion_health_status)
+    error_message = "The bastion_health_status value must be either OK or WARNING."
+  }
+}

--- a/infra/ibmcloud/terraform/k8s-power-build-cluster/versions.tf
+++ b/infra/ibmcloud/terraform/k8s-power-build-cluster/versions.tf
@@ -1,0 +1,37 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  backend "s3" {
+    bucket                      = "k8s-infra-tf-states"
+    key                         = "k8s-power-build-cluster/terraform.tfstate"
+    region                      = "us-geo"
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_credentials_validation = true
+    skip_s3_checksum            = true
+    endpoints = {
+      s3 = "https://s3.us.cloud-object-storage.appdomain.cloud"
+    }
+    secret_key = "<YOUR_SECRET_KEY>"
+    access_key = "<YOUR_ACCESS_KEY>"
+  }
+  required_providers {
+    ibm = {
+      source = "IBM-Cloud/ibm"
+    }
+  }
+}


### PR DESCRIPTION
Add terraform for provisioning power build cluster on ibmcloud

- k8s-infra-setup: Terraform resources to set up the necessary infrastructure in an IBM Cloud account, which will serve as prerequisites for the `k8s-power-build-cluster` automation.

- k8s-power-build-cluster: Terraform resources to provision the Power Build Cluster infrastructure in IBM Cloud.