### PR TITLE
Add ClusterSecretStore for IBM provider's Secrets Manager

### DIFF
--- a/kubernetes/ibm-ppc64le/prow/external-secrets.yaml
+++ b/kubernetes/ibm-ppc64le/prow/external-secrets.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: k8s-infra-ibmcloud-iam
+  namespace: test-pods
+spec:
+  refreshInterval: 60m
+  secretStoreRef:
+    name: secretstore-ibm-k8s
+    kind: ClusterSecretStore
+  target:
+    name: k8s-infra-ibmcloud-iam
+    creationPolicy: Owner
+  data:
+  - secretKey: key
+    remoteRef:
+      key: iam_credentials/c4c5e90a-408d-69de-38b2-0d56d58d29db
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: k8s-infra-ssh-key
+  namespace: test-pods
+spec:
+  refreshInterval: 60m
+  secretStoreRef:
+    name: secretstore-ibm-k8s
+    kind: ClusterSecretStore
+  target:
+    name: k8s-infra-ssh-key
+    creationPolicy: Owner
+  data:
+  - secretKey: ssh-privatekey
+    remoteRef:
+      key: 72d8039f-6cfc-1bbf-ba8e-d85985b42ee0

--- a/kubernetes/ibm-ppc64le/prow/secretstore-ibm-k8s.yaml
+++ b/kubernetes/ibm-ppc64le/prow/secretstore-ibm-k8s.yaml
@@ -1,0 +1,14 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: secretstore-ibm-k8s
+spec:
+  provider:
+    ibm:
+      serviceUrl: "https://3297fd32-6322-45e2-af3f-00b1a5af3565.us-south.secrets-manager.appdomain.cloud"
+      auth:
+        secretRef:
+          secretApiKeySecretRef:
+            name: ibm-sm-apikey
+            key: API_KEY
+            namespace: external-secrets


### PR DESCRIPTION
This ClusterSecretStore is to fetch the secrets from Secrets Manager in IBM Cloud provider.
This would be deployed on IBM's ppc64le build cluster added by https://github.com/kubernetes/k8s.io/pull/7862