### PR TITLE
Change of external secret ID in ppc64le build cluster

### DIFF
--- a/kubernetes/ibm-ppc64le/prow/secrets.yaml
+++ b/kubernetes/ibm-ppc64le/prow/secrets.yaml
@@ -22,7 +22,7 @@ stringData:
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: k8s-infra-ibmcloud-iam
+  name: prow_job_api_key
   namespace: test-pods
 spec:
   refreshInterval: 60m
@@ -30,17 +30,17 @@ spec:
     name: secretstore-ibm-k8s
     kind: ClusterSecretStore
   target:
-    name: k8s-infra-ibmcloud-iam
+    name: prow_job_api_key
     creationPolicy: Owner
   data:
     - secretKey: key
       remoteRef:
-        key: iam_credentials/c4c5e90a-408d-69de-38b2-0d56d58d29db
+        key: iam_credentials/32412dc3-aa99-d54d-4b9b-7b33a8c741a3
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: k8s-infra-ssh-key
+  name: prow_job_ssh_private_key
   namespace: test-pods
 spec:
   refreshInterval: 60m
@@ -48,7 +48,7 @@ spec:
     name: secretstore-ibm-k8s
     kind: ClusterSecretStore
   target:
-    name: k8s-infra-ssh-key
+    name: prow_job_ssh_private_key
     creationPolicy: Owner
   data:
     - secretKey: ssh-privatekey
@@ -71,4 +71,4 @@ spec:
   data:
     - secretKey: api-key
       remoteRef:
-        key: iam_credentials/6db52764-fc6a-726f-b7b5-8f2e703793be
+        key: iam_credentials/51518fbd-1667-f811-99ba-72688fd6c703


### PR DESCRIPTION
Changed external secret names and hence the ID's got changed.
cc @upodroid 