### PR TITLE
Typo _ in external secret names instead of -

### DIFF
--- a/kubernetes/ibm-ppc64le/prow/secrets.yaml
+++ b/kubernetes/ibm-ppc64le/prow/secrets.yaml
@@ -22,7 +22,7 @@ stringData:
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: prow_job_api_key
+  name: prow-job-api-key
   namespace: test-pods
 spec:
   refreshInterval: 60m
@@ -30,7 +30,7 @@ spec:
     name: secretstore-ibm-k8s
     kind: ClusterSecretStore
   target:
-    name: prow_job_api_key
+    name: prow-job-api-key
     creationPolicy: Owner
   data:
     - secretKey: key
@@ -40,7 +40,7 @@ spec:
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: prow_job_ssh_private_key
+  name: prow-job-ssh-private-key
   namespace: test-pods
 spec:
   refreshInterval: 60m
@@ -48,7 +48,7 @@ spec:
     name: secretstore-ibm-k8s
     kind: ClusterSecretStore
   target:
-    name: prow_job_ssh_private_key
+    name: prow-job-ssh-private-key
     creationPolicy: Owner
   data:
     - secretKey: ssh-privatekey


### PR DESCRIPTION
Typo in Secret names of https://github.com/kubernetes/k8s.io/pull/7936 (Gave _ instead of -)
Apologies for the extra noise! :|
 /cc @upodroid 