### PR TITLE
gcp: Bump terraform providers for build clusters

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/00-provider.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/00-provider.tf
@@ -30,11 +30,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.73.2"
+      version = "~> 5.45.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.73.2"
+      version = "~> 5.45.0"
     }
   }
 }

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/iam.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/iam.tf
@@ -16,7 +16,7 @@ limitations under the License.
 
 module "iam" {
   source  = "terraform-google-modules/iam/google//modules/projects_iam"
-  version = "~> 7"
+  version = "~> 8.1"
 
   projects = [module.project.project_id]
 

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/secrets.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/secrets.tf
@@ -83,7 +83,7 @@ resource "google_secret_manager_secret" "build_cluster_secrets" {
     group = each.value.group
   }
   replication {
-    automatic = true
+    auto {}
   }
 }
 

--- a/infra/gcp/terraform/k8s-infra-prow-build/00-provider.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/00-provider.tf
@@ -30,11 +30,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.73.2"
+      version = "~> 5.45.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.73.2"
+      version = "~> 5.45.0"
     }
   }
 }

--- a/infra/gcp/terraform/k8s-infra-prow-build/iam.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/iam.tf
@@ -16,7 +16,7 @@ limitations under the License.
 
 module "iam" {
   source  = "terraform-google-modules/iam/google//modules/projects_iam"
-  version = "~> 7"
+  version = "~> 8.1"
 
   projects = [module.project.project_id]
 

--- a/infra/gcp/terraform/k8s-infra-prow-build/secrets.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/secrets.tf
@@ -39,7 +39,7 @@ resource "google_secret_manager_secret" "build_cluster_secrets" {
     group = each.value.group
   }
   replication {
-    automatic = true
+    auto {}
   }
 }
 

--- a/infra/gcp/terraform/modules/gke-cluster/versions.tf
+++ b/infra/gcp/terraform/modules/gke-cluster/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.73.2"
+      version = "~> 5.45.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.73.2"
+      version = "~> 5.45.0"
     }
   }
 }

--- a/infra/gcp/terraform/modules/gke-nodepool/main.tf
+++ b/infra/gcp/terraform/modules/gke-nodepool/main.tf
@@ -46,7 +46,6 @@ resource "google_container_node_pool" "node_pool" {
     disk_size_gb = var.disk_size_gb
     disk_type    = var.disk_type
     labels       = var.labels
-    taint        = var.taints
 
     service_account = var.service_account
     oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
@@ -64,6 +63,14 @@ resource "google_container_node_pool" "node_pool" {
     }
     metadata = {
       disable-legacy-endpoints = "true"
+    }
+    dynamic "taint" {
+      for_each = var.taints
+      content {
+        effect = taint.value.effect
+        key    = taint.value.key
+        value  = taint.value.value
+      }
     }
   }
 

--- a/infra/gcp/terraform/modules/gke-nodepool/versions.tf
+++ b/infra/gcp/terraform/modules/gke-nodepool/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.73.2"
+      version = "~> 5.45.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.73.2"
+      version = "~> 5.45.0"
     }
   }
 }

--- a/infra/gcp/terraform/modules/gke-project/versions.tf
+++ b/infra/gcp/terraform/modules/gke-project/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.73.2"
+      version = "~> 5.45.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.73.2"
+      version = "~> 5.45.0"
     }
   }
 }

--- a/infra/gcp/terraform/modules/workload-identity-service-account/versions.tf
+++ b/infra/gcp/terraform/modules/workload-identity-service-account/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.44.0"
+      version = "~> 5.45.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.44.0"
+      version = "~> 5.45.0"
     }
   }
 }


### PR DESCRIPTION
Bump to 5.x introduce a breaking changes for the nodepools.
See: https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/version_5_upgrade