### PR TITLE
gcp: Add nodepool for tests

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/main.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/main.tf
@@ -105,6 +105,27 @@ module "prow_build_nodepool_n1_highmem_8_localssd" {
   service_account           = module.prow_build_cluster.cluster_node_sa.email
 }
 
+module "prow_build_nodepool_c4_highmem_8_localssd" {
+  source       = "../modules/gke-nodepool"
+  project_name = module.project.project_id
+  cluster_name = module.prow_build_cluster.cluster.name
+  location     = module.prow_build_cluster.cluster.location
+  node_locations = [
+    "us-central1-b",
+    "us-central1-c",
+    "us-central1-f",
+  ]
+  name            = "pool6"
+  initial_count   = 1
+  min_count       = 1
+  max_count       = 80
+  machine_type    = "c4-highmem-8"
+  disk_size_gb    = 500
+  disk_type       = "hyperdisk-balanced"
+  service_account = module.prow_build_cluster.cluster_node_sa.email
+  taints          = [{ key = "dedicated", value = "sig-testing", effect = "NO_SCHEDULE" }]
+}
+
 module "prow_build_nodepool_t2a_standard_8" {
   source       = "../modules/gke-nodepool"
   project_name = module.project.project_id

--- a/infra/gcp/terraform/modules/gke-nodepool/variables.tf
+++ b/infra/gcp/terraform/modules/gke-nodepool/variables.tf
@@ -31,7 +31,7 @@ variable "location" {
 
 variable "node_locations" {
   description = "The GCP locations (regions or zones) where the node_pool should be located"
-  type        = list
+  type        = list(any)
   default     = []
 }
 
@@ -63,7 +63,7 @@ variable "machine_type" {
 variable "image_type" {
   description = "The image_type of this node_pool"
   type        = string
-  default     = "COS"
+  default     = "COS_CONTAINERD"
 }
 
 variable "disk_size_gb" {


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/k8s.io/issues/2438

Setup a new nodepool with taints so we can schedule specific tests on it for evaluation before we move all the test to a new nodepool. This nodepool will also use COS and cgroups v2.