### PR TITLE
set guyjtempleton email consistently

### DIFF
--- a/groups/sig-autoscaling/groups.yaml
+++ b/groups/sig-autoscaling/groups.yaml
@@ -25,7 +25,7 @@ groups:
     description: |-
       SIG autoscaling general discussion group
     owners:
-      - guyjtempleton@gmail.com
+      - guyjtempleton@googlemail.com
       - maciekpytel@google.com
     settings:
       WhoCanJoin: "ANYONE_CAN_JOIN"


### PR DESCRIPTION
when an account has been added to a group as @ googlemail.com it cannot also be added as @ gmail.com

https://testgrid.k8s.io/sig-k8s-infra-groups#ci-k8sio-groups

https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-k8sio-groups/1907660394361524224

FYI @gjtempleton 


> 2025/04/03 05:05:04 Adding guyjtempleton@gmail.com to "sig-autoscaling@kubernetes.io" as a OWNER
> 2025/04/03 05:05:04 unable to add guyjtempleton@gmail.com to "sig-autoscaling@kubernetes.io" as OWNER: googleapi: Error 409: Member already exists., duplicate
> 2025/04/03 05:05:05 Removing guyjtempleton@googlemail.com from "sig-autoscaling@kubernetes.io" as OWNER or MANAGER
> 2025/04/03 05:05:05 Removed guyjtempleton@googlemail.com from "sig-autoscaling@kubernetes.io" as OWNER or MANAGER
> 2025/04/03 05:05:40 unable to add guyjtempleton@gmail.com to "sig-autoscaling@kubernetes.io" as OWNER: googleapi: Error 409: Member already exists., duplicate
