### PR TITLE
Add secret rotator

### DIFF
--- a/kubernetes/ibm-ppc64le/helm/external-secrets.yaml
+++ b/kubernetes/ibm-ppc64le/helm/external-secrets.yaml
@@ -52,6 +52,60 @@ extraObjects:
             }
           }
         }
+  - apiVersion: external-secrets.io/v1beta1
+    kind: ExternalSecret
+    metadata:
+      name: secret-rotator-api-key
+    spec:
+      refreshInterval: 60m
+      secretStoreRef:
+        name: secretstore-ibm-k8s
+        kind: ClusterSecretStore
+      target:
+        name: secret-rotator-api-key
+        creationPolicy: Owner
+      data:
+        - secretKey: api-key
+          remoteRef:
+            key: iam_credentials/2067d245-e61c-11b2-2c5a-b2be281ea4b8
+  - apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      name: ibmcloud-secret-rotator
+      labels:
+        app: ibmcloud-secret-rotator
+    spec:
+      schedule: "0 */2 * * *"
+      jobTemplate:
+        spec:
+          template:
+            spec:
+              containers:
+              - name: rotator-container
+                image: public.ecr.aws/docker/library/golang:1.24
+                imagePullPolicy: Always
+                command:
+                - /bin/bash
+                args:
+                - -c
+                - |
+                  set -o errexit
+                  set -o nounset
+                  set -o pipefail
+
+                  go install sigs.k8s.io/provider-ibmcloud-test-infra/secret-manager@71ef4d8
+                  secret-manager rotate --instance-id 3297fd32-6322-45e2-af3f-00b1a5af3565 --labels rotate:true --confirm
+                env:
+                - name: IBMCLOUD_ENV_FILE
+                  value: "/home/.ibmcloud/api-key"
+                volumeMounts:
+                - name: credentials
+                  mountPath: /home/.ibmcloud
+              restartPolicy: OnFailure
+              volumes:
+              - name: credentials
+                secret:
+                  secretName: secret-rotator-api-key
 
 extraVolumes:
   - name: google-iam-token


### PR DESCRIPTION
This PR adds the following resources
- Adds a external secret for secret-manager
- The secret-manager cron job that runs every two hours to rotate the secrets aggressively and mitigate potential leaks.