### PR TITLE
promote nat64 image

### DIFF
--- a/registry.k8s.io/images/k8s-staging-networking/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-networking/images.yaml
@@ -55,3 +55,6 @@
 - name: network-policy-finalizer
   dmap:
     "sha256:535783864fd470ff8e3336a9370ab6a94fecd4120df31cda5372b25ee7ccb83c": ["v0.1.0"]
+- name: nat64
+  dmap:
+    "sha256:9de9b3197f3084f836bba58e16e02738ff95ceaaf58b108fdba8b5f0dbaabaf7": ["v0.2.0"]


### PR DESCRIPTION
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-nat64-image/1909040552582582272

```
#37 exporting manifest list sha256:9de9b3197f3084f836bba58e16e02738ff95ceaaf58b108fdba8b5f0dbaabaf7 0.0s done
#37 pushing layers
#37 ...
#38 [auth] k8s-staging-networking/gcr.io/nat64:pull,push k8s-staging-networking/nat64:pull,push token for gcr.io
#38 DONE 0.0s
#37 exporting to image
#37 pushing layers 5.8s done
#37 pushing manifest for gcr.io/k8s-staging-networking/nat64:v20250407-48d1413@sha256:9de9b3197f3084f836bba58e16e02738ff95ceaaf58b108fdba8b5f0dbaabaf7
#37 pushing manifest for gcr.io/k8s-staging-networking/nat64:v20250407-48d1413@sha256:9de9b3197f3084f836bba58e16e02738ff95ceaaf58b108fdba8b5f0dbaabaf7 4.6s done
#37 DONE 12.7s
```

Fixes: https://github.com/kubernetes-sigs/nat64/issues/4

/assign  @siwiutki @ampanasiuk