### PR TITLE
LWS: Remove 'v' prefix from version tag for Helm compatibility

### DIFF
--- a/registry.k8s.io/images/k8s-staging-lws/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-lws/images.yaml
@@ -12,4 +12,4 @@
     "sha256:29fe8fce8787dc766a56add08a1150a7e0ca3df644bbb621651a2fb0a6d9b2f9": ["v0.6.1"]
 - name: charts/lws
   dmap:
-    "sha256:045f28d5cffba910fa2f7c6ae1a3b2f6aee8f44b8d57f02802a49180d5dd732b": ["v0.6.1"]
+    "sha256:045f28d5cffba910fa2f7c6ae1a3b2f6aee8f44b8d57f02802a49180d5dd732b": ["v0.6.1", "0.6.1"]


### PR DESCRIPTION
**Context**:
As discussed in [kubernetes/k8s.io#7877](https://github.com/kubernetes/k8s.io/pull/7877) and [kubernetes-sigs/kueue#4445](https://github.com/kubernetes-sigs/kueue/issues/4445), Helm cannot properly handle version tags with a 'v' prefix in OCI registries.

**Problem**:
After the https://github.com/kubernetes/k8s.io/pull/7985 , running:
```bash
helm show chart oci://registry.k8s.io/lws/charts/lws
```
Results in:
```
Error: Unable to locate any tags in provided repository: oci://registry.k8s.io/lws/charts/lws
```

**Solution**:
This PR removes the 'v' prefix from the version tag, changing: From: `v0.6.1` To: `0.6.1` . like: https://github.com/kubernetes/k8s.io/blob/main/registry.k8s.io/images/k8s-staging-kueue/images.yaml

Why not keep both tags? Maintaining both `v0.6.1` and `0.6.1` would create confusion, so we're simply updating the tag rather than keeping both versions.
