### PR TITLE
Ingress NGINX: Promote NGINX v2.0.2.

### DIFF
--- a/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -242,6 +242,7 @@
     "sha256:9ed93911ae01d8cf4d8b3de0e62e718d7a76ad59ef88dd51bb3b9f87ef443c9a": ["v1.2.1"]
     "sha256:3e7bda4cf5111d283ed1e4ff5cc9a2b5cdc5ebe62d50ba67473d3e25b1389133": ["v2.0.0"]
     "sha256:0301aff18d076a3726a0c7c07c68db3218dc90d56a3ed419868e21c12114549e": ["v2.0.1"]
+    "sha256:d150d220752ed7479a1a1400be69bcca7bf5bf4b49d0d48890927f086eef5e2d": ["v2.0.2"]
 
 # Ingress NGINX: Test Runner
 - name: e2e-test-runner


### PR DESCRIPTION
Commit: https://github.com/kubernetes/ingress-nginx/commit/8eb2152d288994da60fd3f8852f17bf2dcd843ce
Job: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-ingress-nginx-nginx/1912239443666800640
Build: https://storage.googleapis.com/kubernetes-ci-logs/logs/post-ingress-nginx-nginx/1912239443666800640/artifacts/build.log