### PR TITLE
Promote powervs-cloud-controller-manager image

### DIFF
--- a/registry.k8s.io/images/k8s-staging-capi-ibmcloud/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-capi-ibmcloud/images.yaml
@@ -23,3 +23,4 @@
 - name: powervs-cloud-controller-manager
   dmap:
     "sha256:5c311b5956141d6131397d5208edbfa8682a06ac428302bf80d759b122ed29ac": ["6256ccf"]
+    "sha256:d66fc56fc350e4fecd15ff717c85627980ece675badd83d6a1b73176cd1adcbd": ["7c51cd2"]


### PR DESCRIPTION
New powervs-cloud-controller-manager image has been built via PR: https://github.com/kubernetes-sigs/cluster-api-provider-ibmcloud/pull/2314
Its available here https://console.cloud.google.com/artifacts/docker/k8s-staging-capi-ibmcloud/us/gcr.io/powervs-cloud-controller-manager

```
./manifest-tool inspect gcr.io/k8s-staging-capi-ibmcloud/powervs-cloud-controller-manager:7c51cd2
Name:   gcr.io/k8s-staging-capi-ibmcloud/powervs-cloud-controller-manager:7c51cd2 (Type: application/vnd.oci.image.index.v1+json)
Digest: sha256:d66fc56fc350e4fecd15ff717c85627980ece675badd83d6a1b73176cd1adcbd
 * Contains 4 manifest references (2 images, 2 attestations):
[1]     Type: application/vnd.oci.image.manifest.v1+json
[1]   Digest: sha256:b1c05c35891f99c18d983634bf66701c3c5842b2df2cc0e2254c1933521ac869
[1]   Length: 675
[1] Platform:
[1]    -      OS: linux
[1]    -    Arch: amd64
[1] # Layers: 2
     layer 01: digest = sha256:3ca969c7b6d79946c6f10490fffc00028babe7df67f50ed53c7bc209325e0612
                 type = application/vnd.oci.image.layer.v1.tar+gzip
     layer 02: digest = sha256:91e95854f1e7bebe77c8a8bddad6e43de3b415edef41a70ca9a5375c90443e5e
                 type = application/vnd.oci.image.layer.v1.tar+gzip

[2]     Type: application/vnd.oci.image.manifest.v1+json
[2]   Digest: sha256:b1f701a004676ee8763bbb78f55431e63d6fbf01055fdb6511a73f673ba6c309
[2]   Length: 675
[2] Platform:
[2]    -      OS: linux
[2]    -    Arch: ppc64le
[2] # Layers: 2
     layer 01: digest = sha256:31adbefa8a79f990899742032a9eac220155b8c995f9a9fbb55c68a9268e65bd
                 type = application/vnd.oci.image.layer.v1.tar+gzip
     layer 02: digest = sha256:b2cf331cfca05331d4f8600e75dee208fac9a698a0be8aeaffa180b1fdc31419
                 type = application/vnd.oci.image.layer.v1.tar+gzip

[3]     Type: application/vnd.oci.image.manifest.v1+json (vnd.docker.reference.type=attestation-manifest)
[3]   Digest: sha256:ac0487bab4c5594d641ce035abfc5885dd7d87e4541be08763df57ae6a1e8d9f
[3]   Length: 566
[3]       >>> Attestation for digest: sha256:b1c05c35891f99c18d983634bf66701c3c5842b2df2cc0e2254c1933521ac869

[4]     Type: application/vnd.oci.image.manifest.v1+json (vnd.docker.reference.type=attestation-manifest)
[4]   Digest: sha256:06b365967096768acf918b81b87b6e015a92708817696c8ac55c4412781a332b
[4]   Length: 566
[4]       >>> Attestation for digest: sha256:b1f701a004676ee8763bbb78f55431e63d6fbf01055fdb6511a73f673ba6c309
```