### PR TITLE
GCP: bump terraform providers

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/00-provider.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/00-provider.tf
@@ -30,11 +30,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.45.0"
+      version = "~> 6.31.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.45.0"
+      version = "~> 6.31.0"
     }
   }
 }

--- a/infra/gcp/terraform/k8s-infra-prow-build/00-provider.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/00-provider.tf
@@ -30,11 +30,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.45.0"
+      version = "~> 6.31.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.45.0"
+      version = "~> 6.31.0"
     }
   }
 }

--- a/infra/gcp/terraform/modules/gke-cluster/versions.tf
+++ b/infra/gcp/terraform/modules/gke-cluster/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.45.0"
+      version = "~> 6.31.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.45.0"
+      version = "~> 6.31.0"
     }
   }
 }

--- a/infra/gcp/terraform/modules/gke-nodepool/versions.tf
+++ b/infra/gcp/terraform/modules/gke-nodepool/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.45.0"
+      version = "~> 6.31.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.45.0"
+      version = "~> 6.31.0"
     }
   }
 }

--- a/infra/gcp/terraform/modules/gke-project/versions.tf
+++ b/infra/gcp/terraform/modules/gke-project/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.45.0"
+      version = "~> 6.31.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.45.0"
+      version = "~> 6.31.0"
     }
   }
 }

--- a/infra/gcp/terraform/modules/workload-identity-service-account/versions.tf
+++ b/infra/gcp/terraform/modules/workload-identity-service-account/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.45.0"
+      version = "~> 6.31.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 5.45.0"
+      version = "~> 6.31.0"
     }
   }
 }


### PR DESCRIPTION
Bump the GCP provider so we can use external terraform modules requiring the 6.x provider