### PR TITLE
Ingress NGINX: Promote CFSSL v1.1.3.

### DIFF
--- a/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -141,6 +141,7 @@
     "sha256:31a195d7c3dc801575ca46919ff2b3f01afce54a744ab22ee83469f92a6e0965": ["v1.1.0"]
     "sha256:bcd576c6d0a01d4710969195e804c02da62b71b5c35c6816df9b7584d5445437": ["v1.1.1"]
     "sha256:fd43e7671a6c0338c0f3fe60866d58baef6baa7c13254d788b7180d215b4d933": ["v1.1.2"]
+    "sha256:68defb0ae012e3023e81c525958e5e19a0fac64841f17f488c798a2f582b67a5": ["v1.1.3"]
 
 # Ingress NGINX: Custom Error Pages
 - name: custom-error-pages


### PR DESCRIPTION
Commit: https://github.com/kubernetes/ingress-nginx/commit/5bf90a1f49b4f36da4f87fcea26bbaf47d088531
Job: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-ingress-nginx-cfssl/1915828513387057152
Build: https://storage.googleapis.com/kubernetes-ci-logs/logs/post-ingress-nginx-cfssl/1915828513387057152/artifacts/build.log

/cc @strongjz