### PR TITLE
Ingress NGINX: Promote Custom Error Pages v1.1.3.

### DIFF
--- a/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -150,6 +150,7 @@
     "sha256:a2342e403fc3c19f81f5625e1b93daa0f8fb3dfaa1df4905f85e32d2d98a5e96": ["v1.1.0"]
     "sha256:8c10776191ae44b5c387b8c7696d8bc17ceec90d7184a3a38b89ac8434b6c56b": ["v1.1.1"]
     "sha256:49a5154b3f918aae436ae342ac410a947524f1da8a2f9c249b564a092cf44955": ["v1.1.2"]
+    "sha256:5aeaf5d01470bcc7d73b8846458b00dbc62d54277cd110cec8f28e663c11f93e": ["v1.1.3"]
 
 # Ingress NGINX: E2E Test Echo
 - name: e2e-test-echo


### PR DESCRIPTION
Commit: https://github.com/kubernetes/ingress-nginx/commit/5bf90a1f49b4f36da4f87fcea26bbaf47d088531
Job: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-ingress-nginx-custom-error-pages/1915828513454166016
Build: https://storage.googleapis.com/kubernetes-ci-logs/logs/post-ingress-nginx-custom-error-pages/1915828513454166016/artifacts/build.log

/cc @strongjz