### PR TITLE
GCP: add GKE nodepool for SIG Testing

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/main.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/main.tf
@@ -105,6 +105,51 @@ module "prow_build_nodepool_n1_highmem_8_localssd" {
   service_account           = module.prow_build_cluster.cluster_node_sa.email
 }
 
+module "sig_testing_node_pool_1_c4_highmem_8" {
+
+  source       = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/gke-nodepool?ref=v39.0.0&depth=1"
+  project_id   = module.project.project_id
+  name         = "sig-testing-pool1"
+  location     = module.prow_build_cluster.cluster.location
+  cluster_name = module.prow_build_cluster.cluster.name
+
+  service_account = {
+    email        = module.prow_build_cluster.cluster_node_sa.email
+    oauth_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+  }
+  node_locations = [
+    "us-central1-b",
+    "us-central1-c",
+    "us-central1-f",
+  ]
+
+  nodepool_config = {
+    autoscaling = {
+      max_node_count = 30
+      min_node_count = 1 # 1 per zone
+    }
+    management = {
+      auto_repair  = true
+      auto_upgrade = true
+    }
+  }
+
+  node_config = {
+    machine_type                  = "c4-highmem-8"
+    disk_size_gb                  = 500
+    disk_type                     = "hyperdisk-balanced"
+    image_type                    = "COS_CONTAINERD"
+    gvnic                         = true
+    workload_metadata_config_mode = "GKE_METADATA"
+    shielded_instance_config = {
+      enable_secure_boot = true
+    }
+  }
+
+
+  taints = { dedicated = { value = "sig-testing", effect = "NO_SCHEDULE" } }
+}
+
 module "prow_build_nodepool_c4_highmem_8_localssd" {
   source       = "../modules/gke-nodepool"
   project_name = module.project.project_id


### PR DESCRIPTION
Add another pool so we can use an external terraform module and drop what we currently maintain and reduce our maintenance burden