### PR TITLE
Update the search filter for help-wanted and good-first-issue

### DIFF
--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -294,8 +294,8 @@ data:
           rewrite ^/bsky$            https://bsky.app/profile/did:plc:kfztyuziv2i44b5kpecth77y/lists/3lau2wjkn3g2s redirect;
           rewrite ^/calendar$        https://www.k8s.dev/calendar redirect;
           rewrite ^/github-labels$   https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md redirect;
-          rewrite ^/good-first-issue$ https://github.com/issues?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+no%3Aassignee redirect;
-          rewrite ^/help-wanted$     https://github.com/issues?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+no%3Aassignee redirect;
+          rewrite ^/good-first-issue$ https://github.com/issues?q=(org%3Akubernetes%20OR%20org%3Akubernetes-sigs%20OR%20org%3Akubernetes-csi%20OR%20org%3Akubernetes-client)%20is%3Aopen%20is%3Aissue%20label%3A%22good%20first%20issue%22%20no%3Aassignee redirect;
+          rewrite ^/help-wanted$     https://github.com/issues?q=(org%3Akubernetes%20OR%20org%3Akubernetes-sigs%20OR%20org%3Akubernetes-csi%20OR%20org%3Akubernetes-client)%20is%3Aopen%20is%3Aissue%20label%3A%22help%20wanted%22%20no%3Aassignee redirect;
           rewrite ^/needs-ok-to-test$ https://github.com/pulls?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Apr+label%3Aneeds-ok-to-test+label%3A%22cncf-cla%3A+yes%22+-label%3Aneeds-rebase redirect;
           rewrite ^/oncall$          https://storage.googleapis.com/test-infra-oncall/oncall.html redirect;
           rewrite ^/oncall-hotlist$  https://github.com/kubernetes/test-infra/search?q=label%3Akind%2Foncall-hotlist+is%3Aopen&type=Issues redirect;

--- a/apps/k8s-io/test.py
+++ b/apps/k8s-io/test.py
@@ -175,9 +175,9 @@ class RedirTest(HTTPTestCase):
             self.assert_temp_redirect(base + 'github-labels',
                 'https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md')
             self.assert_temp_redirect(base + 'good-first-issue',
-                'https://github.com/issues?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22+no%3Aassignee')
+                'https://github.com/issues?q=(org%3Akubernetes%20OR%20org%3Akubernetes-sigs%20OR%20org%3Akubernetes-csi%20OR%20org%3Akubernetes-client)%20is%3Aopen%20is%3Aissue%20label%3A%22good%20first%20issue%22%20no%3Aassignee')
             self.assert_temp_redirect(base + 'help-wanted',
-                'https://github.com/issues?q=org%3Akubernetes+org%3Akubernetes-sigs+org%3Akubernetes-csi+org%3Akubernetes-client+is%3Aopen+is%3Aissue+label%3A%22help+wanted%22+no%3Aassignee')
+                'https://github.com/issues?q=(org%3Akubernetes%20OR%20org%3Akubernetes-sigs%20OR%20org%3Akubernetes-csi%20OR%20org%3Akubernetes-client)%20is%3Aopen%20is%3Aissue%20label%3A%22help%20wanted%22%20no%3Aassignee')
             self.assert_temp_redirect(
                 base + 'oncall',
                 'https://storage.googleapis.com/test-infra-oncall/oncall.html')


### PR DESCRIPTION
Fixes https://github.com/kubernetes/community/issues/8452.

https://go.k8s.io/help-wanted and https://go.k8s.io/good-first-issue don't show any issues at this moment because the search filters include multiple org keywords without OR. We can see the issues by adding OR. Please take a look at the screenshot on the issue.