### PR TITLE
Move from bit.ly URLs to rel.k8s.io for the release team

### DIFF
--- a/apps/k8s-io/README.md
+++ b/apps/k8s-io/README.md
@@ -35,8 +35,9 @@ Vanity URL(s)
 
 NOTE: please see k8s.io/k8s.io/configmap-nginx.yaml for `server` definitions
 
-Redirections
-====
+# Redirections
+
+## go.k8s.io Redirects
 - https://go.k8s.io/api-review
 - https://go.k8s.io/bot-commands
 - https://go.k8s.io/calendar
@@ -66,6 +67,23 @@ Redirections
     - https://go.k8s.io/contact/sig-contributor-experience
     - https://go.k8s.io/contact/wg-lts
     - https://go.k8s.io/contact/committee-steering
+
+## rel.k8s.io Redirects
+
+### Direct Redirects
+- https://rel.k8s.io/ → https://github.com/kubernetes/kubernetes/releases
+- https://rel.k8s.io/k8s-release-cal → https://calendar.google.com/calendar/embed?src=kipmnllvl17vl9m98jen6ujcrs%40group.calendar.google.com
+- https://rel.k8s.io/k8s-sig-release-videos → https://youtube.com/playlist?list=PL69nYSiGNLP3QKkOsDsO6A0Y1rhgP84iZ&si=Mi095CYuJuz8LjN-
+
+### Version-specific Redirects
+
+Example:
+- https://rel.k8s.io/vXYY/releasemtg
+- https://rel.k8s.io/vXYY/retro
+- https://rel.k8s.io/v1XYY/contacts (Note: Access is restricted through Google Authorization)
+
+For all release versions, URLs follow this pattern:
+- https://rel.k8s.io/vXYY/{keyword} → https://github.com/kubernetes/sig-release/tree/master/releases/release-X.YY/links.md#{keyword}
 
 
 NOTE: please see configmap-nginx.yaml for rewrite rules.

--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -345,9 +345,11 @@ data:
         server_name releases.k8s.io rel.k8s.io releases.kubernetes.io rel.kubernetes.io;
         listen 80;
 
-        location / {
-          rewrite ^/$                  https://github.com/kubernetes/kubernetes/releases redirect;
-          rewrite ^/([^/]*)(/.*)?$     https://github.com/kubernetes/kubernetes/tree/$1$2 redirect;
+          rewrite ^/$                               https://github.com/kubernetes/kubernetes/releases redirect;
+          rewrite ^/k8s-release-cal                 https://calendar.google.com/calendar/embed?src=kipmnllvl17vl9m98jen6ujcrs%40group.calendar.google.com redirect;
+          rewrite ^/k8s-sig-release-videos          https://youtube.com/playlist?list=PL69nYSiGNLP3QKkOsDsO6A0Y1rhgP84iZ&si=Mi095CYuJuz8LjN- redirect;
+          rewrite ^/v([0-9])([0-9]+)/([a-zA-Z]+)$   https://github.com/kubernetes/sig-release/tree/master/releases/release-$1.$2/links.md#$3 redirect;
+          rewrite ^/([^/]*)(/.*)?$                  https://github.com/kubernetes/kubernetes/tree/$1$2 redirect;
         }
       }
 


### PR DESCRIPTION
Bit ly has started adding ads between redirects, so we're moving away from bit ly. 

Context: https://kubernetes.slack.com/archives/C2C40FMNF/p1739462854147559

/cc @BenTheElder @katcosgrove @fsmunoz @neoaggelos 