### PR TITLE
Ingress NGINX: Promote NGINX v2.1.1.

### DIFF
--- a/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -252,6 +252,7 @@
     "sha256:d150d220752ed7479a1a1400be69bcca7bf5bf4b49d0d48890927f086eef5e2d": ["v2.0.2"]
     "sha256:d9e8c4a1dd38159904f09adc8f54255b228a1100e0d9cf602dd82b93ba1eb347": ["v2.0.3"]
     "sha256:a3e7e64c25cd5e1e4fb752b2a52452ab915d0bf980fdbdfe861fbfbe743d3e88": ["v2.1.0"]
+    "sha256:248a0d3e77c244b5a5478ecf3163b1d8d8baf7a517aef46006d5b09c6f0bcf76": ["v2.1.1"]
 
 # Ingress NGINX: Test Runner
 - name: e2e-test-runner


### PR DESCRIPTION
Commit: https://github.com/kubernetes/ingress-nginx/commit/974ca67915475496764a72682971319fe0bf805f
Job: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-ingress-nginx-nginx/1927233854804856832
Build: https://storage.googleapis.com/kubernetes-ci-logs/logs/post-ingress-nginx-nginx/1927233854804856832/artifacts/build.log