### PR TITLE
fix arm64 nodepool for kind

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/main.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/main.tf
@@ -137,7 +137,7 @@ module "prow_build_nodepool_c4d_highmem_8_localssd" {
   ]
   name            = "pool7"
   initial_count   = 1
-  min_count       = 1
+  min_count       = 10
   max_count       = 80
   machine_type    = "c4d-highmem-8-lssd" # has 2 local ssd disks attached
   disk_size_gb    = 100
@@ -199,7 +199,6 @@ module "prow_build_nodepool_c4a_highmem_8_localssd" {
   initial_count = 1
   min_count     = 1
   max_count     = 10
-  image_type    = "UBUNTU_CONTAINERD"
   machine_type  = "c4a-highmem-8-lssd" # has 2 local ssd disks attached
   disk_size_gb  = 100
   disk_type     = "hyperdisk-balanced"


### PR DESCRIPTION
/cc @ameukam @aojea @BenTheElder 

The kernel bug appeared in the kind jobs on arm64 nodes so I changed their os too.

c4d is in preview so I'm forcing the nodepool to always run atleast 10 nodes of this type per zone. Looking at the nodepool size metrics, it has consistently stayed above 20 per zone for weeks. The autoscaler seems to be preferring c4 pool over c4d pool, which isn't ideal.


<img width="1506" alt="image" src="https://github.com/user-attachments/assets/651ac025-c582-4c7c-9191-5eb2b39e83ca" />
