### PR TITLE
Add drewhagen to release editors for release cuts

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -43,6 +43,7 @@ groups:
       - adolfo.garcia@uservers.net
       - cicih@google.com
       - ctadeu@gmail.com
+      - drewhagendev@gmail.com
       - gveronicalg@gmail.com
       - jameswangel@gmail.com
       - jeremy.r.rickard@gmail.com


### PR DESCRIPTION
Update groups.yaml to add myself to release editors, to satisfy the prereq for cutting k8s releases.
source: [Cutting a Release > Prereq > Access to GCP](https://github.com/mbianchidev/sig-release/blob/master/release-engineering/handbooks/k8s-release-cut.md)

CC @mbianchidev  (as my release management "sponsor")
+ @jimangel