### PR TITLE
Ingress NGINX: Promote Controller v1.12.3.

### DIFF
--- a/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -85,6 +85,7 @@
     "sha256:e6b8de175acda6ca913891f0f727bca4527e797d52688cbe9fec9040d6f6b6fa": ["v1.12.0"]
     "sha256:d2fbc4ec70d8aa2050dd91a91506e998765e86c96f32cffb56c503c9c34eed5b": ["v1.12.1"]
     "sha256:03497ee984628e95eca9b2279e3f3a3c1685dd48635479e627d219f00c8eefa9": ["v1.12.2"]
+    "sha256:ac444cd9515af325ba577b596fe4f27a34be1aa330538e8b317ad9d6c8fb94ee": ["v1.12.3"]
 
 # Ingress NGINX: Controller (chroot)
 - name: controller-chroot
@@ -136,6 +137,7 @@
     "sha256:87c88e1c38a6c8d4483c8f70b69e2cca49853bb3ec3124b9b1be648edf139af3": ["v1.12.0"]
     "sha256:90155c86548e0bb95b3abf1971cd687d8f5d43f340cfca0ad3484e2b8351096e": ["v1.12.1"]
     "sha256:a697e2bfa419768315250d079ccbbca45f6099c60057769702b912d20897a574": ["v1.12.2"]
+    "sha256:d830fba93e9e0f5ef1462f5fe8a7cd7b167178b79e6c10c041c7da19f1ac66ab": ["v1.12.3"]
 
 # Ingress NGINX: CFSSL
 - name: cfssl


### PR DESCRIPTION
Commit: https://github.com/kubernetes/ingress-nginx/commit/8d1208bd75b8ad0fe78f1f35c3176331a2042427
Job: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-ingress-nginx-controller/1930117264065957888
Build: https://storage.googleapis.com/kubernetes-ci-logs/logs/post-ingress-nginx-controller/1930117264065957888/artifacts/build.log