### PR TITLE
Bump boskos-ibmcloud-janitor version

### DIFF
--- a/kubernetes/ibm-ppc64le/prow/boskos-janitor.yaml
+++ b/kubernetes/ibm-ppc64le/prow/boskos-janitor.yaml
@@ -17,7 +17,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: boskos-ibmcloud-janitor
-          image: gcr.io/k8s-staging-boskos/ibmcloud-janitor-boskos:v20250514-3796008
+          image: gcr.io/k8s-staging-boskos/ibmcloud-janitor-boskos:v20250612-df45126
           args:
             - --boskos-url=http://boskos.test-pods.svc.cluster.local.
             - --resource-type=powervs


### PR DESCRIPTION
This PR bumps the ibmcloud janitor version to the latest one available.