### PR TITLE
groups/sig-cl: remove neolit123 from capv alerts

### DIFF
--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -267,7 +267,6 @@ groups:
       - naadir.jeewa@broadcom.com
       - cilliancapi@gmail.com
       - sagar.muchhal@broadcom.com
-      - neolit123@gmail.com
 
   - email-id: k8s-infra-staging-cluster-api@kubernetes.io
     name: k8s-infra-staging-cluster-api


### PR DESCRIPTION
remove myself from the alert group for the capv provider.

note, the capv testgrid is quite red:
https://testgrid.k8s.io/vmware-cluster-api-provider-vsphere#periodic-e2e-govmomi-release-1-13
