### PR TITLE
Bump kyverno to v3.4.3

### DIFF
--- a/kubernetes/apps/kyverno.yaml
+++ b/kubernetes/apps/kyverno.yaml
@@ -20,7 +20,7 @@ spec:
       sources:
         - chart: kyverno
           repoURL: "https://kyverno.github.io/kyverno"
-          targetRevision: 3.3.7
+          targetRevision: 3.4.3
           helm:
             releaseName: kyverno
             valueFiles:


### PR DESCRIPTION
- Bump kyverno to v3.4.3
- v3.4.3 charts are mapped to 1.14.3 release, which includes multi-arch image fix (s390x/ppc64le).