### PR TITLE
promote etcd 3.6.1-1 image

### DIFF
--- a/registry.k8s.io/images/k8s-staging-etcd/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-etcd/images.yaml
@@ -33,6 +33,7 @@
     "sha256:0f59a43c4278255aae07b3e97506d3880aff23c6da7e37e117b4b12651e048ad": ["3.6.0-rc.4-0"]
     "sha256:56e65847a2a2735f7847507896f28ecf4662d74fe1cba1da7c66fe63914b4fd1": ["3.6.0-rc.5-0"]
     "sha256:3ecb80f64e038e0474cbc29c852ab8a25d6c22065bedfa98f40167af5fb988d7": ["3.6.1-0"]
+    "sha256:fb788a010edcde4099eefc96e6b8c085e5deb6afbd4b38c612d9841ebc0ccb1c": ["3.6.1-1"]
 - name: etcd-empty-dir-cleanup
   dmap:
     "sha256:f805272b4422efa92e20789295c343ed26ff36ddc4f70eeb5d7890d6b758b0fc": ["3.4.7.0"]


### PR DESCRIPTION
```
docker manifest push --purge gcr.io/k8s-staging-etcd/etcd:3.6.1-1
sha256:fb788a010edcde4099eefc96e6b8c085e5deb6afbd4b38c612d9841ebc0ccb1c
```

https://storage.googleapis.com/kubernetes-ci-logs/logs/post-kubernetes-push-image-etcd/1936084350009348096/build-log.txt

After: https://github.com/kubernetes/kubernetes/pull/132395 & https://github.com/kubernetes/kubernetes/pull/132410

/assign @ArkaSaha30 @ahrtr