### PR TITLE
GCP: delete N1 nodepools for the CI clusters

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/main.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/main.tf
@@ -60,28 +60,6 @@ module "prow_build_cluster" {
   cloud_shell_access = false
 }
 
-// The image/machine/disk match prow-build for consistency's sake
-module "prow_build_nodepool" {
-  source       = "../modules/gke-nodepool"
-  project_name = module.project.project_id
-  cluster_name = module.prow_build_cluster.cluster.name
-  location     = module.prow_build_cluster.cluster.location
-  name         = "trusted-pool1"
-  node_locations = [
-    "us-central1-a",
-    "us-central1-b",
-    "us-central1-f",
-  ]
-  initial_count   = 0
-  min_count       = 0
-  max_count       = 0
-  image_type      = "UBUNTU_CONTAINERD"
-  machine_type    = "n1-highmem-8"
-  disk_size_gb    = 200
-  disk_type       = "pd-ssd"
-  service_account = module.prow_build_cluster.cluster_node_sa.email
-}
-
 module "prow_build_nodepool2" {
   source       = "../modules/gke-nodepool"
   project_name = module.project.project_id

--- a/infra/gcp/terraform/k8s-infra-prow-build/main.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/main.tf
@@ -80,31 +80,6 @@ module "prow_build_cluster" {
   cloud_shell_access = false
 }
 
-# Why use UBUNTU_CONTAINERD for image_type?
-# - ipv6 jobs need an ipv6 stack; COS lacks one, so use UBUNTU
-# - k8s-prow-builds/prow cluster uses _CONTAINERD variant, keep parity
-module "prow_build_nodepool_n1_highmem_8_localssd" {
-  source       = "../modules/gke-nodepool"
-  project_name = module.project.project_id
-  cluster_name = module.prow_build_cluster.cluster.name
-  location     = module.prow_build_cluster.cluster.location
-  node_locations = [
-    "us-central1-b",
-    "us-central1-c",
-    "us-central1-f",
-  ]
-  name                      = "pool5"
-  initial_count             = 0
-  min_count                 = 0
-  max_count                 = 0
-  image_type                = "UBUNTU_CONTAINERD"
-  machine_type              = "n1-highmem-8"
-  disk_size_gb              = 100
-  disk_type                 = "pd-standard"
-  ephemeral_local_ssd_count = 2 # each is 375GB
-  service_account           = module.prow_build_cluster.cluster_node_sa.email
-}
-
 module "prow_build_nodepool_c4_highmem_8_localssd" {
   source       = "../modules/gke-nodepool"
   project_name = module.project.project_id


### PR DESCRIPTION
The node pools were reduced to 0 nodes

closes https://github.com/kubernetes/k8s.io/issues/2438