### PR TITLE
switch to hyperdisk-balanced for ghproxy in prow-build-trusted

### DIFF
--- a/kubernetes/gke-prow-build-trusted/prow/ghproxy.yaml
+++ b/kubernetes/gke-prow-build-trusted/prow/ghproxy.yaml
@@ -61,4 +61,4 @@ spec:
   resources:
     requests:
       storage: 100Gi
-  storageClassName: standard-rwo
+  storageClassName: hyperdisk-balanced

--- a/kubernetes/gke-prow-build-trusted/prow/hyperdisk-sc.yaml
+++ b/kubernetes/gke-prow-build-trusted/prow/hyperdisk-sc.yaml
@@ -1,0 +1,11 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: hyperdisk-balanced
+provisioner: pd.csi.storage.gke.io
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  type: hyperdisk-balanced
+  provisioned-throughput-on-create: "250Mi"
+  provisioned-iops-on-create: "7000"


### PR DESCRIPTION
we need to use a disk type compatible with the nodes

see previously 4702c302431380cdab598c996970e6e214dd1d7e