### PR TITLE
Reduce refreshInterval for ibm jobs external secret prow-job-api-key

### DIFF
--- a/kubernetes/ibm-ppc64le/prow/secrets.yaml
+++ b/kubernetes/ibm-ppc64le/prow/secrets.yaml
@@ -25,7 +25,7 @@ metadata:
   name: prow-job-api-key
   namespace: test-pods
 spec:
-  refreshInterval: 60m
+  refreshInterval: 30m
   secretStoreRef:
     name: secretstore-ibm-k8s
     kind: ClusterSecretStore


### PR DESCRIPTION
Attempt to reduce failures of below kind:
```
Error: Error occured while configuring ibmpisession: "option UserAccount is required"
```
Please see https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/ci-kubernetes-e2e-ppc64le-default/1937238826258796544