### PR TITLE
promote secrets-store-sync controller:v0.0.2

### DIFF
--- a/registry.k8s.io/images/k8s-staging-secrets-store-sync/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-secrets-store-sync/images.yaml
@@ -1,3 +1,3 @@
 - name: controller
   dmap:
-    "sha256:d44dde20a1cf7b83ceb8638d00ad2823648946f12cb01fbc42065f49e257b7ea": [ "v0.0.1" ]
+    "sha256:399febaa4c537111589a8a52dea7d1ec4cecce8c3d1010729e875a2e305a2f07": [ "v0.0.2" ]


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

```
++ docker manifest push --purge gcr.io/k8s-staging-secrets-store-sync/controller:v0.0.2
sha256:399febaa4c537111589a8a52dea7d1ec4cecce8c3d1010729e875a2e305a2f07
```

Build - https://console.cloud.google.com/cloud-build/builds;region=global/6a32deba-3822-4dce-b8ec-70c9771c1d61?inv=1&invt=Ab3Ajw&project=k8s-staging-images

Generated by running -
```
➜ registry.k8s.io/images/k8s-staging-secrets-store-sync/generate.sh > registry.k8s.io/images/k8s-staging-secrets-store-sync/images.yaml
```

/assign @enj