### PR TITLE
prow-build: use hyperdisk-balanced disks for prometheus

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/monitoring/prometheus-main/prometheus.yaml
+++ b/infra/gcp/terraform/k8s-infra-prow-build/prow-build/resources/monitoring/prometheus-main/prometheus.yaml
@@ -42,7 +42,7 @@ spec:
   storage:
     volumeClaimTemplate:
       spec:
-        storageClassName: standard-rwo
+        storageClassName: hyperdisk-balanced
         resources:
           requests:
             storage: 300Gi


### PR DESCRIPTION
The `pd-balanced` disks that we have been using for Prometheus in the GKE Prow build cluster are not available with the C4 instances that we migrated to: https://cloud.google.com/compute/docs/machine-resource#machine_type_comparison

This PR addresses this by migrating to the Hyperdisk Balanced disks that are supported on the C4 instances. This change has been already reconciled manually.

/assign @BenTheElder 