### PR TITLE
promote csi-secrets-store driver:v1.5.3

### DIFF
--- a/registry.k8s.io/images/k8s-staging-csi-secrets-store/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-csi-secrets-store/images.yaml
@@ -45,6 +45,7 @@
     "sha256:beeae3f16f95b3469e92eff6de8dcc55b8b758a1b1cc45c1798ecb3636c2df0d": [ "v1.5.0" ]
     "sha256:a12109abc03034c761f8d6fcdbf15e75dadd4baa541e18ae7cf3d29d9bdb02c4": [ "v1.5.1" ]
     "sha256:82dc5f4aad8efb51b8a31de84d09c367f3ad723f37f8ff0b3c58c75496cebc47": [ "v1.5.2" ]
+    "sha256:f4bc29f1b2fd435a70db0c56f68d94ddd6e0e230236d87b0d689848406fa3710": [ "v1.5.3" ]
 - name: driver-crds
   dmap:
     "sha256:508f58321f8085877a8b8e7268e5a5efbca707ebe10e8c705124a5c9e1b5ceab": [ "v0.1.0" ]
@@ -80,3 +81,4 @@
     "sha256:c1377ad1a8db37203a7528f3f39a60f7fc101d60d2620dae03f2e1edd8d21cad": [ "v1.5.0" ]
     "sha256:ded62cc74900638c0e3d874edf2dc12b37c91b4c2a1a5a79d058f421ca799ec2": [ "v1.5.1" ]
     "sha256:fabcbd4458e175e8e00e627617cd0dfa122effb7726b1e9f75ad61f9a3c7832b": [ "v1.5.2" ]
+    "sha256:7691e591df749a7e9a1ebadf338a8e1ad7a1253f73c9a844fbdac79d059ffe03": [ "v1.5.3" ]


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

```
++ docker manifest push --purge gcr.io/k8s-staging-csi-secrets-store/driver:v1.5.3
sha256: f4bc29f1b2fd435a70db0c56f68d94ddd6e0e230236d87b0d689848406fa3710
```

```
++ docker manifest push --purge gcr.io/k8s-staging-csi-secrets-store/driver-crds:v1.5.3
sha256: 7691e591df749a7e9a1ebadf338a8e1ad7a1253f73c9a844fbdac79d059ffe03
```

Build - https://console.cloud.google.com/cloud-build/builds;region=global/2db8a4c0-263e-4661-ba9c-ddeeff4276af?inv=1&invt=Ab3nZA&project=k8s-staging-csi-secrets-store

Generated by running -
```
➜ registry.k8s.io/images/k8s-staging-csi-secrets-store/generate.sh > registry.k8s.io/images/k8s-staging-csi-secrets-store/images.yaml
```

Test run with the staging image: https://github.com/kubernetes-sigs/secrets-store-csi-driver/actions/runs/16498895628

/assign @stlaz 