### PR TITLE
promote cloud-provider-kind v0.7.0

### DIFF
--- a/registry.k8s.io/images/k8s-staging-cloud-provider-kind/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-cloud-provider-kind/images.yaml
@@ -1,5 +1,6 @@
 - name: cloud-controller-manager
   dmap:
+    "sha256:59d395103583174dfd5c653e08391d21dc66ea759f70a234e3f0cc87b1adedcd": ["v0.7.0"]
     "sha256:99fe3b34abd66489362b772d0ad6e743bd41f646a272251937eb4f9277cd29f8": ["v0.6.0"]
     "sha256:302f1b050c951ebdb384db98f5bc028b84bae727cc7fdf07264b46d148a386bb": ["v0.5.0"]
     "sha256:cacb2da53a0d3b363bf53f11c9e0f714d7605471130a43ae7d1e161da0c3cbdb": ["v0.4.0"]


### PR DESCRIPTION

```
crane digest us-central1-docker.pkg.dev/k8s-staging-images/cloud-provider-kind/cloud-controller-manager:v20250709-bdf1655
sha256:59d395103583174dfd5c653e08391d21dc66ea759f70a234e3f0cc87b1adedcd
```

Fixes: https://github.com/kubernetes-sigs/cloud-provider-kind/issues/262

