### PR TITLE
eks-prow-build: schedule alertmanager on stable nodes

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/alertmanager-main/alertmanager.yaml
@@ -21,3 +21,10 @@ spec:
   replicas: 3
   alertmanagerConfiguration:
     name: main
+  nodeSelector:
+    node-group: stable
+  tolerations:
+  - effect: NoSchedule
+    key: node-group
+    operator: Equal
+    value: stable


### PR DESCRIPTION
Schedule the Alertmanager pods on the stable node group to free up some resources on the nodes used for CI (and to be able to better predict free resources on those nodes).

/assign @ameukam @dims 