### PR TITLE
Update boskso resources on ibm-ppc64le cluster

### DIFF
--- a/kubernetes/ibm-ppc64le/prow/boskos-resources-configmap.yaml
+++ b/kubernetes/ibm-ppc64le/prow/boskos-resources-configmap.yaml
@@ -5,6 +5,8 @@ data:
     - names:
       - k8s-boskos-powervs-lon04
       - k8s-boskos-powervs-lon06
+      - k8s-boskos-powervs-osa21-01
+      - k8s-boskos-powervs-osa21-02
       - k8s-boskos-powervs-sao01
       - k8s-boskos-powervs-syd04
       - k8s-boskos-powervs-syd05


### PR DESCRIPTION
This PR adds 2 new workspaces as leases for Boskos.
