### PR TITLE
AWS: bump kOps CI cluster

### DIFF
--- a/infra/aws/terraform/kops-infra-ci/data.tf
+++ b/infra/aws/terraform/kops-infra-ci/data.tf
@@ -28,3 +28,12 @@ data "aws_region" "current" {
 }
 
 data "aws_organizations_organization" "current" {}
+
+data "aws_iam_roles" "sso_admins" {
+  name_regex  = "AWSReservedSSO_AdministratorAccess_.*"
+  path_prefix = "/aws-reserved/sso.amazonaws.com/"
+}
+
+data "aws_eks_cluster_auth" "eks" {
+  name = module.eks.cluster_name
+}

--- a/infra/aws/terraform/kops-infra-ci/eks.tf
+++ b/infra/aws/terraform/kops-infra-ci/eks.tf
@@ -83,7 +83,7 @@ module "eks" {
 
       subnet_ids = module.vpc.private_subnets
 
-      min_size     = 3
+      min_size     = 10
       max_size     = 100
       desired_size = 3
 

--- a/infra/aws/terraform/kops-infra-ci/providers.tf
+++ b/infra/aws/terraform/kops-infra-ci/providers.tf
@@ -32,12 +32,5 @@ provider "aws" {
 provider "kubernetes" {
   host                   = module.eks.cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
-
-  # This requires the awscli to be installed locally where Terraform is executed.
-  exec {
-    api_version = "client.authentication.k8s.io/v1beta1"
-    command     = "aws"
-    # This requires the awscli to be installed locally where Terraform is executed
-    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
-  }
+  token                  = data.aws_eks_cluster_auth.eks.token
 }

--- a/infra/aws/terraform/kops-infra-ci/terraform.tf
+++ b/infra/aws/terraform/kops-infra-ci/terraform.tf
@@ -27,7 +27,12 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.58.0"
+      version = "~> 5.100.0"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+      version = "~> 2.38.0"
+
     }
   }
 }

--- a/infra/aws/terraform/kops-infra-ci/variables.tf
+++ b/infra/aws/terraform/kops-infra-ci/variables.tf
@@ -16,7 +16,7 @@ limitations under the License.
 
 variable "eks_version" {
   type    = string
-  default = "1.28"
+  default = "1.29"
 }
 
 variable "tags" {


### PR DESCRIPTION
The cluster was auto-upgraded to 1.29 but the EKS addons were not upgraded.
Also bumping the terraform provider to the latest patch and start to simply authentication.