### PR TITLE
groups: drop setting for a staging group

### DIFF
--- a/groups/sig-ui/groups.yaml
+++ b/groups/sig-ui/groups.yaml
@@ -39,9 +39,8 @@ teams:
     name: k8s-infra-staging-headlamp
     description: |-
       ACL for staging Headlamp
+    settings:
+      ReconcileMembers: "true"
     members:
       - me@joaquimrocha.com
       - renesd@gmail.com
-    settings:
-      WhoCanPostMessage: "ANYONE_CAN_POST"
-      ReconcileMembers: "true"


### PR DESCRIPTION
Allow publishing is not required for Google groups using for staging repos.