### PR TITLE
groups: fix reconciliation for SIG UI groups

### DIFF
--- a/groups/sig-ui/groups.yaml
+++ b/groups/sig-ui/groups.yaml
@@ -1,4 +1,4 @@
-teams:
+groups:
   - email-id: sig-ui-leads@kubernetes.io
     name: sig-ui-leads
     description: |-


### PR DESCRIPTION
Follow-up of:
  - https://github.com/kubernetes/k8s.io/pull/8350

Look like we are using the wrong key.