### PR TITLE
add Nutanix to private disclosure mailing list

### DIFF
--- a/groups/committee-security-response/groups.yaml
+++ b/groups/committee-security-response/groups.yaml
@@ -65,6 +65,7 @@ groups:
       - security@ubuntu.com
       - VMware.psirt@broadcom.com
       - vulnerabilityreports@cloudfoundry.org
+      - psirt@nutanix.com
 
   - email-id: security@kubernetes.io
     name: security


### PR DESCRIPTION
This pull request adds a new email contact to the `groups/committee-security-response/groups.yaml` file. 

* [`groups/committee-security-response/groups.yaml`](diffhunk://#diff-c3f8a20d170143dedebee58165ae902343710a4b95f93a52205b9e9ee742b136R68): Added `psirt@nutanix.com` to the list of security response contacts.

following discution with @ritazh 