### PR TITLE
Ingress NGINX: Promote Test Runner v2.2.1.

### DIFF
--- a/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -280,6 +280,7 @@
     "sha256:a3e7e64c25cd5e1e4fb752b2a52452ab915d0bf980fdbdfe861fbfbe743d3e88": ["v2.1.0"]
     "sha256:248a0d3e77c244b5a5478ecf3163b1d8d8baf7a517aef46006d5b09c6f0bcf76": ["v2.1.1"]
     "sha256:cf02a924bf423dcefc236f5da1a4e6d7a2638c8fc79df09fae4bbc87d859208d": ["v2.2.0"]
+    "sha256:abb708465e9ac3252f295d1ae5b2c6e1b227f4f7d12144534e63fc3897908727": ["v2.2.1"]
 
 # Ingress NGINX: Test Runner
 - name: e2e-test-runner


### PR DESCRIPTION
Commit: https://github.com/kubernetes/ingress-nginx/commit/617b31084bf0e4cd3c8daae694b409b3b5c4d777
Job: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-ingress-nginx-nginx/1952372965316235264
Build: https://storage.googleapis.com/kubernetes-ci-logs/logs/post-ingress-nginx-nginx/1952372965316235264/artifacts/build.log