### PR TITLE
Ingress NGINX: Promote Chart v4.13.1.

### DIFF
--- a/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -376,6 +376,7 @@
 - name: charts/ingress-nginx
   dmap:
     "sha256:e5927c7d7a113f288c1ed5e45ee48b7d208ee5d125c9a830e86e35e92f5fb032": ["v4.12.5"]
+    "sha256:1d936cee5b433a84f69065b90ec15abfb01eb78645af9926754c1fb2fa3d8c92": ["v4.13.1"]
 
 #
 # The following images have been renamed or are no longer maintained.


### PR DESCRIPTION
Commit: https://github.com/kubernetes/ingress-nginx/commit/3bb5d0c12e6146dac70cc0c4d70740cf2f1d010e
Job: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-ingress-nginx-chart/1955232584652820480
Build: https://storage.googleapis.com/kubernetes-ci-logs/logs/post-ingress-nginx-chart/1955232584652820480/artifacts/build.log