### PR TITLE
Add ClusterSecretStore for IBM provider's Secrets Manager

### DIFF
--- a/kubernetes/ibm-s390x/helm/external-secrets.yaml
+++ b/kubernetes/ibm-s390x/helm/external-secrets.yaml
@@ -7,32 +7,32 @@ extraObjects:
       provider:
         gcpsm:
           projectID: k8s-infra-prow-build
-  # - apiVersion: external-secrets.io/v1beta1
-  #   kind: ClusterSecretStore
-  #   metadata:
-  #     name: secretstore-ibm-k8s
-  #   spec:
-  #     provider:
-  #       ibm:
-  #         serviceUrl: "https://3297fd32-6322-45e2-af3f-00b1a5af3565.us-south.secrets-manager.appdomain.cloud"
-  #         auth:
-  #           secretRef:
-  #             secretApiKeySecretRef:
-  #               name: ibm-sm-apikey
-  #               key: API_KEY
-  #               namespace: external-secrets
-  # - apiVersion: external-secrets.io/v1beta1
-  #   kind: ExternalSecret
-  #   metadata:
-  #     name: ibm-sm-apikey
-  #   spec:
-  #     data:
-  #       - remoteRef:
-  #           key: ibm-sm-apikey
-  #         secretKey: API_KEY
-  #     secretStoreRef:
-  #       kind: ClusterSecretStore
-  #       name: k8s-infra-prow-build
+  - apiVersion: external-secrets.io/v1beta1
+    kind: ClusterSecretStore
+    metadata:
+      name: secretstore-ibm-k8s
+    spec:
+      provider:
+        ibm:
+          serviceUrl: "https://0664d47c-fe42-423f-930d-69570443cd15.eu-de.secrets-manager.appdomain.cloud"
+          auth:
+            secretRef:
+              secretApiKeySecretRef:
+                name: ibm-sm-apikey
+                key: API_KEY
+                namespace: external-secrets
+  - apiVersion: external-secrets.io/v1beta1
+    kind: ExternalSecret
+    metadata:
+      name: ibm-sm-apikey
+    spec:
+      data:
+        - remoteRef:
+            key: ibm-sm-apikey
+          secretKey: API_KEY
+      secretStoreRef:
+        kind: ClusterSecretStore
+        name: k8s-infra-prow-build
   - apiVersion: v1
     kind: ConfigMap
     metadata:
@@ -52,60 +52,60 @@ extraObjects:
             }
           }
         }
-  # - apiVersion: external-secrets.io/v1beta1
-  #   kind: ExternalSecret
-  #   metadata:
-  #     name: secret-rotator-api-key
-  #   spec:
-  #     refreshInterval: 60m
-  #     secretStoreRef:
-  #       name: secretstore-ibm-k8s
-  #       kind: ClusterSecretStore
-  #     target:
-  #       name: secret-rotator-api-key
-  #       creationPolicy: Owner
-  #     data:
-  #       - secretKey: api-key
-  #         remoteRef:
-  #           key: iam_credentials/2067d245-e61c-11b2-2c5a-b2be281ea4b8
-  # - apiVersion: batch/v1
-  #   kind: CronJob
-  #   metadata:
-  #     name: ibmcloud-secret-rotator
-  #     labels:
-  #       app: ibmcloud-secret-rotator
-  #   spec:
-  #     schedule: "0 */2 * * *"
-  #     jobTemplate:
-  #       spec:
-  #         template:
-  #           spec:
-  #             containers:
-  #             - name: rotator-container
-  #               image: public.ecr.aws/docker/library/golang:1.24
-  #               imagePullPolicy: Always
-  #               command:
-  #               - /bin/bash
-  #               args:
-  #               - -c
-  #               - |
-  #                 set -o errexit
-  #                 set -o nounset
-  #                 set -o pipefail
+  - apiVersion: external-secrets.io/v1beta1
+    kind: ExternalSecret
+    metadata:
+      name: secret-rotator-api-key
+    spec:
+      refreshInterval: 60m
+      secretStoreRef:
+        name: secretstore-ibm-k8s
+        kind: ClusterSecretStore
+      target:
+        name: secret-rotator-api-key
+        creationPolicy: Owner
+      data:
+        - secretKey: api-key
+          remoteRef:
+            key: iam_credentials/a2f576a8-e609-105f-e586-20b6706f2215
+  - apiVersion: batch/v1
+    kind: CronJob
+    metadata:
+      name: ibmcloud-secret-rotator
+      labels:
+        app: ibmcloud-secret-rotator
+    spec:
+      schedule: "0 */2 * * *"
+      jobTemplate:
+        spec:
+          template:
+            spec:
+              containers:
+              - name: rotator-container
+                image: public.ecr.aws/docker/library/golang:1.24
+                imagePullPolicy: Always
+                command:
+                - /bin/bash
+                args:
+                - -c
+                - |
+                  set -o errexit
+                  set -o nounset
+                  set -o pipefail
 
-  #                 go install sigs.k8s.io/provider-ibmcloud-test-infra/secret-manager@71ef4d8
-  #                 secret-manager rotate --instance-id 3297fd32-6322-45e2-af3f-00b1a5af3565 --labels rotate:true --confirm
-  #               env:
-  #               - name: IBMCLOUD_ENV_FILE
-  #                 value: "/home/.ibmcloud/api-key"
-  #               volumeMounts:
-  #               - name: credentials
-  #                 mountPath: /home/.ibmcloud
-  #             restartPolicy: OnFailure
-  #             volumes:
-  #             - name: credentials
-  #               secret:
-  #                 secretName: secret-rotator-api-key
+                  go install sigs.k8s.io/provider-ibmcloud-test-infra/secret-manager@71ef4d8
+                  secret-manager rotate --instance-id 0664d47c-fe42-423f-930d-69570443cd1 --labels rotate:true --confirm
+                env:
+                - name: IBMCLOUD_ENV_FILE
+                  value: "/home/.ibmcloud/api-key"
+                volumeMounts:
+                - name: credentials
+                  mountPath: /home/.ibmcloud
+              restartPolicy: OnFailure
+              volumes:
+              - name: credentials
+                secret:
+                  secretName: secret-rotator-api-key
 
 extraVolumes:
   - name: google-iam-token

--- a/kubernetes/ibm-s390x/prow/secrets.yaml
+++ b/kubernetes/ibm-s390x/prow/secrets.yaml
@@ -19,57 +19,57 @@ stringData:
       }
     }
 
-# ---
-# apiVersion: external-secrets.io/v1beta1
-# kind: ExternalSecret
-# metadata:
-#   name: prow-job-api-key
-#   namespace: test-pods
-# spec:
-#   refreshInterval: 30m
-#   secretStoreRef:
-#     name: secretstore-ibm-k8s
-#     kind: ClusterSecretStore
-#   target:
-#     name: prow-job-api-key
-#     creationPolicy: Owner
-#   data:
-#     - secretKey: key
-#       remoteRef:
-#         key: iam_credentials/32412dc3-aa99-d54d-4b9b-7b33a8c741a3
-# ---
-# apiVersion: external-secrets.io/v1beta1
-# kind: ExternalSecret
-# metadata:
-#   name: prow-job-ssh-private-key
-#   namespace: test-pods
-# spec:
-#   refreshInterval: 60m
-#   secretStoreRef:
-#     name: secretstore-ibm-k8s
-#     kind: ClusterSecretStore
-#   target:
-#     name: prow-job-ssh-private-key
-#     creationPolicy: Owner
-#   data:
-#     - secretKey: ssh-privatekey
-#       remoteRef:
-#         key: 72d8039f-6cfc-1bbf-ba8e-d85985b42ee0
-# ---
-# apiVersion: external-secrets.io/v1beta1
-# kind: ExternalSecret
-# metadata:
-#   name: boskos-janitor-api-key
-#   namespace: test-pods
-# spec:
-#   refreshInterval: 60m
-#   secretStoreRef:
-#     name: secretstore-ibm-k8s
-#     kind: ClusterSecretStore
-#   target:
-#     name: boskos-janitor-api-key
-#     creationPolicy: Owner
-#   data:
-#     - secretKey: api-key
-#       remoteRef:
-#         key: iam_credentials/51518fbd-1667-f811-99ba-72688fd6c703
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: prow-job-api-key
+  namespace: test-pods
+spec:
+  refreshInterval: 30m
+  secretStoreRef:
+    name: secretstore-ibm-k8s
+    kind: ClusterSecretStore
+  target:
+    name: prow-job-api-key
+    creationPolicy: Owner
+  data:
+    - secretKey: key
+      remoteRef:
+        key: iam_credentials/8d0c5130-2b8e-68f7-45b1-eeb54d36fe47
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: prow-job-ssh-private-key
+  namespace: test-pods
+spec:
+  refreshInterval: 60m
+  secretStoreRef:
+    name: secretstore-ibm-k8s
+    kind: ClusterSecretStore
+  target:
+    name: prow-job-ssh-private-key
+    creationPolicy: Owner
+  data:
+    - secretKey: ssh-privatekey
+      remoteRef:
+        key: 9bf7242a-f493-7a86-61f3-4c75a1b73022
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: boskos-janitor-api-key
+  namespace: test-pods
+spec:
+  refreshInterval: 60m
+  secretStoreRef:
+    name: secretstore-ibm-k8s
+    kind: ClusterSecretStore
+  target:
+    name: boskos-janitor-api-key
+    creationPolicy: Owner
+  data:
+    - secretKey: api-key
+      remoteRef:
+        key: iam_credentials/7e61f6ee-3d8d-f53b-70e7-c274e0dde72d


### PR DESCRIPTION
This ClusterSecretStore is to fetch the secrets from Secrets Manager in IBM Cloud provider.
This would be deployed on IBM's s390x build cluster added by [PR #8412](https://github.com/kubernetes/k8s.io/pull/8412)