### PR TITLE
k8s-infra-gcp-gcve-admins: remove invalid mail for chrischdi

### DIFF
--- a/groups/sig-k8s-infra/groups.yaml
+++ b/groups/sig-k8s-infra/groups.yaml
@@ -561,7 +561,6 @@ groups:
       ReconcileMembers: "true"
     members:
       - sig-k8s-infra-leads@kubernetes.io
-      - christian.schlotter@broadcom.com
       - christi.schlotter@gmail.com
       - fabrizio.pandini@broadcom.com
       - sabari.murugesan@broadcom.com


### PR DESCRIPTION
I moved companies ant this mail is invalid now.

My community/private mail is still on the list.