### PR TITLE
Promote dra-example-driver v0.2.0 image and chart

### DIFF
--- a/registry.k8s.io/images/k8s-staging-dra-example-driver/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-dra-example-driver/images.yaml
@@ -1,6 +1,8 @@
 - name: charts/dra-example-driver
   dmap:
     "sha256:ab5cd9fd898b2ff79bea030520170a7feb579ff463dce9758775f7cce7d7231f": ["0.1.3"]
+    "sha256:50b42caf7663c386e195c0b769004d73131daa9fa62b298db8dcbab8c0c3edd1": ["0.2.0"]
 - name: dra-example-driver
   dmap:
     "sha256:50358e27c213a483c23d15f1cd9ea47cf59ae706cbf7e6dc56d38db8fbf7ec05": ["v0.1.0"]
+    "sha256:6fd370402b8f54e0b57b251414f1692a9252f1e6edaf1fc3305b8ba66bf12e99": ["v0.2.0"]


### PR DESCRIPTION
This PR promotes the v0.2.0 artifacts for the dra-example-driver:
- https://console.cloud.google.com/artifacts/docker/k8s-staging-images/us-central1/dra-example-driver/charts%2Fdra-example-driver/sha256:50b42caf7663c386e195c0b769004d73131daa9fa62b298db8dcbab8c0c3edd1?invt=Ab6q7w&project=k8s-staging-images
- https://console.cloud.google.com/artifacts/docker/k8s-staging-images/us-central1/dra-example-driver/dra-example-driver/sha256:6fd370402b8f54e0b57b251414f1692a9252f1e6edaf1fc3305b8ba66bf12e99?invt=Ab6q7w&project=k8s-staging-images

/assign @bart0sh 