### PR TITLE
Ingress NGINX: Promote Chart v4.13.2.

### DIFF
--- a/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-ingress-nginx/images.yaml
@@ -391,6 +391,7 @@
   dmap:
     "sha256:e5927c7d7a113f288c1ed5e45ee48b7d208ee5d125c9a830e86e35e92f5fb032": ["v4.12.5"]
     "sha256:1d936cee5b433a84f69065b90ec15abfb01eb78645af9926754c1fb2fa3d8c92": ["v4.13.1"]
+    "sha256:1f5d40f230e5ef7091521b2113c122a6831268b122249b781ea54f72c8bff2a1": ["v4.13.2"]
 
 #
 # The following images have been renamed or are no longer maintained.


### PR DESCRIPTION
Commit: https://github.com/kubernetes/ingress-nginx/commit/8f39a704d8a9b76a7167f2892d684ec3eb656c01
Job: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-ingress-nginx-chart/1961483303009652736
Build: https://storage.googleapis.com/kubernetes-ci-logs/logs/post-ingress-nginx-chart/1961483303009652736/artifacts/build.log

/cc @strongjz