### PR TITLE
add infra and group for karpenter clusterapi

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -117,6 +117,7 @@ restrictions:
       - "^sig-cluster-lifecycle-kubespray-alerts@kubernetes.io$"
       - "^k8s-infra-staging-scl-image-builder@kubernetes.io$"
       - "^sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io$"
+      - "^k8s-infra-staging-karpenter-provider-cluster-api@kubernetes.io$"
   - path: "sig-contributor-experience/groups.yaml"
     allowedGroups:
       - "^community@kubernetes.io$"

--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -500,6 +500,22 @@ groups:
       - tico88612@gmail.com
       - 2t.antoine@gmail.com
 
+  - email-id: k8s-infra-staging-karpenter-provider-cluster-api@kubernetes.io
+    name: k8s-infra-staging-karpenter-provider-cluster-api
+    description: |-
+      ACL for staging karpenter provider cluster api artifacts.
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - msm@opbstudios.com
+      # SIG Cluster Lifecycle leads
+      - cecilerobertm@gmail.com
+      - fabrizio.pandini@gmail.com
+      - neolit123@gmail.com
+      - justinsb@google.com
+      - vince@prigna.com
+
+
   #
   # k8s-infra gcs write access
   #

--- a/infra/gcp/infra.yaml
+++ b/infra/gcp/infra.yaml
@@ -348,6 +348,7 @@ infra:
       k8s-staging-ingress-nginx:
       k8s-staging-ingressconformance:
       k8s-staging-jobset:
+      k8s-staging-karpenter-provider-cluster-api:
       k8s-staging-kas-network-proxy:
       k8s-staging-kind:
       k8s-staging-kmm:


### PR DESCRIPTION
This change adds an infra configuration for a staging repository and a google group for access control for the karpenter provider cluster api project. It adds the cluster lifecycle leads as additional members in the group.