### PR TITLE
add group for karpenter clusterapi

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -117,6 +117,7 @@ restrictions:
       - "^sig-cluster-lifecycle-kubespray-alerts@kubernetes.io$"
       - "^k8s-infra-staging-scl-image-builder@kubernetes.io$"
       - "^sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io$"
+      - "^karpenter-cluster-api-leads@kubernetes.io$"
   - path: "sig-contributor-experience/groups.yaml"
     allowedGroups:
       - "^community@kubernetes.io$"

--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -500,6 +500,16 @@ groups:
       - tico88612@gmail.com
       - 2t.antoine@gmail.com
 
+  - email-id: karpenter-cluster-api-leads@kubernetes.io
+    name: karpenter-cluster-api-leads
+    description: |-
+      ACL for staging karpenter provider cluster api artifacts.
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - msm@opbstudios.com
+      - macao@redhat.com
+
   #
   # k8s-infra gcs write access
   #


### PR DESCRIPTION
This change adds a google group for access control for the karpenter provider cluster api project. It adds the cluster lifecycle leads as additional members in the group.