### PR TITLE
Update release team groups for v1.35

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -301,6 +301,7 @@ groups:
       - kat.cosgrove@gmail.com
       - mudrinic.mare@gmail.com
       - saschagrunert@gmail.com
+      - drewhagendev@gmail.com # v1.35 Release Lead
 
   - email-id: sig-release@kubernetes.io
     name: sig-release


### PR DESCRIPTION
Updates the following groups for v1.35 release team:

- `k8s-infra-release-viewers@kubernetes.io`
- `release-comms@kubernetes.io`
- `release-managers@kubernetes.io`
- `release-team@kubernetes.io`
- `release-team-shadows@kubernetes.io`
- `k8s-infra-staging-tg-exporter@kubernetes.io`
- `release-team-enhancements@kubernetes.io`

Ref: [kubernetes/sig-release#2852](https://github.com/kubernetes/sig-release/issues/2852)

cc: @katcosgrove @justaugustus