### PR TITLE
Revert "per sascha's suggestion, adds drew to sig-release-leads"

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -301,7 +301,6 @@ groups:
       - kat.cosgrove@gmail.com
       - mudrinic.mare@gmail.com
       - saschagrunert@gmail.com
-      - drewhagendev@gmail.com # v1.35 Release Lead
 
   - email-id: sig-release@kubernetes.io
     name: sig-release


### PR DESCRIPTION
This reverts commit 8eb2a3b8feb74bc76ea390283d6993f88982a889.

Release Team leads do not require access to the SIG leads list. The initial request was around calendar access, which has been resolved.

cc: @drewhagen @kubernetes/sig-release-leads 
