### PR TITLE
chore: add staging repo for kro

### DIFF
--- a/infra/gcp/infra.yaml
+++ b/infra/gcp/infra.yaml
@@ -353,6 +353,7 @@ infra:
       k8s-staging-kmm:
       k8s-staging-kops:
       k8s-staging-krm-functions:
+      k8s-staging-kro:
       k8s-staging-kube-state-metrics:
       k8s-staging-kubeadm:
       k8s-staging-kubebuilder:


### PR DESCRIPTION
KRO is now at https://github.com/kubernetes-sigs/kro
