### PR TITLE
Revert "Update boskos to v20250908-5e4ab72, prow to v20250903-f49c6158b and ghproxy as needed"

### DIFF
--- a/kubernetes/gke-prow-build-trusted/prow/ghproxy.yaml
+++ b/kubernetes/gke-prow-build-trusted/prow/ghproxy.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:v20250903-f49c6158b
+          image: us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:v20250823-25d79acb8
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/kubernetes/gke-prow-build/prow/boskos-janitor.yaml
+++ b/kubernetes/gke-prow-build/prow/boskos-janitor.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: boskos-janitor
       containers:
       - name: boskos-janitor
-        image: gcr.io/k8s-staging-boskos/janitor:v20250908-5e4ab72
+        image: gcr.io/k8s-staging-boskos/janitor:v20250612-e9e5322
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
         - --resource-type=gce-project,gpu-project,scalability-project,scalability-scale-project

--- a/kubernetes/gke-prow-build/prow/boskos-reaper.yaml
+++ b/kubernetes/gke-prow-build/prow/boskos-reaper.yaml
@@ -17,7 +17,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos-reaper
-        image: gcr.io/k8s-staging-boskos/reaper:v20250908-5e4ab72
+        image: gcr.io/k8s-staging-boskos/reaper:v20250612-e9e5322
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
         - --resource-type=gce-project,gpu-project,scalability-project,scalability-scale-project,gcve-vsphere-project

--- a/kubernetes/gke-prow-build/prow/boskos.yaml
+++ b/kubernetes/gke-prow-build/prow/boskos.yaml
@@ -59,7 +59,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos
-        image: gcr.io/k8s-staging-boskos/boskos:v20250908-5e4ab72
+        image: gcr.io/k8s-staging-boskos/boskos:v20250612-e9e5322
         args:
         - --config=/etc/config/config
         - --namespace=test-pods

--- a/kubernetes/gke-prow/prow/cherrypicker.yaml
+++ b/kubernetes/gke-prow/prow/cherrypicker.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: us-docker.pkg.dev/k8s-infra-prow/images/cherrypicker:v20250903-f49c6158b
+        image: us-docker.pkg.dev/k8s-infra-prow/images/cherrypicker:v20250823-25d79acb8
         imagePullPolicy: Always
         args:
         - --github-token-path=/etc/github/token

--- a/kubernetes/gke-prow/prow/crier.yaml
+++ b/kubernetes/gke-prow/prow/crier.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier
-          image: us-docker.pkg.dev/k8s-infra-prow/images/crier:v20250903-f49c6158b
+          image: us-docker.pkg.dev/k8s-infra-prow/images/crier:v20250823-25d79acb8
           args:
             - --blob-storage-workers=1
             - --config-path=/etc/config/config.yaml

--- a/kubernetes/gke-prow/prow/deck.yaml
+++ b/kubernetes/gke-prow/prow/deck.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: deck
-          image: us-docker.pkg.dev/k8s-infra-prow/images/deck:v20250903-f49c6158b
+          image: us-docker.pkg.dev/k8s-infra-prow/images/deck:v20250823-25d79acb8
           imagePullPolicy: Always
           ports:
             - name: http

--- a/kubernetes/gke-prow/prow/ghproxy.yaml
+++ b/kubernetes/gke-prow/prow/ghproxy.yaml
@@ -48,7 +48,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:v20250903-f49c6158b
+          image: us-docker.pkg.dev/k8s-infra-prow/images/ghproxy:v20250823-25d79acb8
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99

--- a/kubernetes/gke-prow/prow/hook.yaml
+++ b/kubernetes/gke-prow/prow/hook.yaml
@@ -37,7 +37,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook
-          image: us-docker.pkg.dev/k8s-infra-prow/images/hook:v20250903-f49c6158b
+          image: us-docker.pkg.dev/k8s-infra-prow/images/hook:v20250823-25d79acb8
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/kubernetes/gke-prow/prow/horologium.yaml
+++ b/kubernetes/gke-prow/prow/horologium.yaml
@@ -34,7 +34,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: us-docker.pkg.dev/k8s-infra-prow/images/horologium:v20250903-f49c6158b
+        image: us-docker.pkg.dev/k8s-infra-prow/images/horologium:v20250823-25d79acb8
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/kubernetes/gke-prow/prow/needs-rebase.yaml
+++ b/kubernetes/gke-prow/prow/needs-rebase.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: us-docker.pkg.dev/k8s-infra-prow/images/needs-rebase:v20250903-f49c6158b
+        image: us-docker.pkg.dev/k8s-infra-prow/images/needs-rebase:v20250823-25d79acb8
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/kubernetes/gke-prow/prow/pipeline.yaml
+++ b/kubernetes/gke-prow/prow/pipeline.yaml
@@ -18,7 +18,7 @@
 #       serviceAccountName: prow-pipeline
 #       containers:
 #       - name: pipeline
-#         image: us-docker.pkg.dev/k8s-infra-prow/images/pipeline:v20250903-f49c6158b
+#         image: us-docker.pkg.dev/k8s-infra-prow/images/pipeline:v20250823-25d79acb8
 #         args:
 #         - --all-contexts
 #         - --config=/etc/prow-config/config.yaml

--- a/kubernetes/gke-prow/prow/prow-controller-manager.yaml
+++ b/kubernetes/gke-prow/prow/prow-controller-manager.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
         - name: prow-controller-manager
-          image: us-docker.pkg.dev/k8s-infra-prow/images/prow-controller-manager:v20250903-f49c6158b
+          image: us-docker.pkg.dev/k8s-infra-prow/images/prow-controller-manager:v20250823-25d79acb8
           args:
             - --config-path=/etc/config/config.yaml
             - --dry-run=false

--- a/kubernetes/gke-prow/prow/sinker.yaml
+++ b/kubernetes/gke-prow/prow/sinker.yaml
@@ -22,7 +22,7 @@ spec:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config
             - --dry-run=false
-          image: us-docker.pkg.dev/k8s-infra-prow/images/sinker:v20250903-f49c6158b
+          image: us-docker.pkg.dev/k8s-infra-prow/images/sinker:v20250823-25d79acb8
           env:
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG

--- a/kubernetes/gke-prow/prow/statusreconciler.yaml
+++ b/kubernetes/gke-prow/prow/statusreconciler.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: us-docker.pkg.dev/k8s-infra-prow/images/status-reconciler:v20250903-f49c6158b
+        image: us-docker.pkg.dev/k8s-infra-prow/images/status-reconciler:v20250823-25d79acb8
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/kubernetes/gke-prow/prow/tide.yaml
+++ b/kubernetes/gke-prow/prow/tide.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: us-docker.pkg.dev/k8s-infra-prow/images/tide:v20250903-f49c6158b
+        image: us-docker.pkg.dev/k8s-infra-prow/images/tide:v20250823-25d79acb8
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/kubernetes/ibm-ppc64le/prow/boskos-janitor.yaml
+++ b/kubernetes/ibm-ppc64le/prow/boskos-janitor.yaml
@@ -17,7 +17,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: boskos-ibmcloud-janitor
-          image: gcr.io/k8s-staging-boskos/ibmcloud-janitor-boskos:v20250908-5e4ab72
+          image: gcr.io/k8s-staging-boskos/ibmcloud-janitor-boskos:v20250612-e9e5322
           args:
             - --boskos-url=http://boskos.test-pods.svc.cluster.local.
             - --resource-type=powervs

--- a/kubernetes/ibm-ppc64le/prow/boskos-reaper.yaml
+++ b/kubernetes/ibm-ppc64le/prow/boskos-reaper.yaml
@@ -17,7 +17,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: boskos-reaper
-          image: gcr.io/k8s-staging-boskos/reaper:v20250908-5e4ab72
+          image: gcr.io/k8s-staging-boskos/reaper:v20250612-e9e5322
           args:
             - --boskos-url=http://boskos.test-pods.svc.cluster.local.
             - --resource-type=powervs

--- a/kubernetes/ibm-ppc64le/prow/boskos.yaml
+++ b/kubernetes/ibm-ppc64le/prow/boskos.yaml
@@ -59,7 +59,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: boskos
-          image: gcr.io/k8s-staging-boskos/boskos:v20250908-5e4ab72
+          image: gcr.io/k8s-staging-boskos/boskos:v20250612-e9e5322
           args:
             - --config=/etc/config/config
             - --namespace=test-pods

--- a/kubernetes/ibm-s390x/prow/boskos-janitor.yaml
+++ b/kubernetes/ibm-s390x/prow/boskos-janitor.yaml
@@ -17,7 +17,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
         - name: boskos-ibmcloud-janitor
-          image: gcr.io/k8s-staging-boskos/ibmcloud-janitor-boskos:v20250908-5e4ab72
+          image: gcr.io/k8s-staging-boskos/ibmcloud-janitor-boskos:v20250612-e9e5322
           args:
             - --boskos-url=http://boskos.test-pods.svc.cluster.local.
             - --resource-type=powervs

--- a/kubernetes/ibm-s390x/prow/boskos-reaper.yaml
+++ b/kubernetes/ibm-s390x/prow/boskos-reaper.yaml
@@ -17,7 +17,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: boskos-reaper
-          image: gcr.io/k8s-staging-boskos/reaper:v20250908-5e4ab72
+          image: gcr.io/k8s-staging-boskos/reaper:v20250612-e9e5322
           args:
             - --boskos-url=http://boskos.test-pods.svc.cluster.local.
             - --resource-type=powervs

--- a/kubernetes/ibm-s390x/prow/boskos.yaml
+++ b/kubernetes/ibm-s390x/prow/boskos.yaml
@@ -59,7 +59,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: boskos
-          image: gcr.io/k8s-staging-boskos/boskos:v20250908-5e4ab72
+          image: gcr.io/k8s-staging-boskos/boskos:v20250612-e9e5322
           args:
             - --config=/etc/config/config
             - --namespace=test-pods


### PR DESCRIPTION
Reverts kubernetes/k8s.io#8467

fixes https://github.com/kubernetes/kubernetes/issues/134115 until boskos can be rolled forward safely

cc @dims @kubernetes/sig-k8s-infra-leads 