### PR TITLE
Promote regression-issue-74839 to 1.4

### DIFF
--- a/registry.k8s.io/images/k8s-staging-e2e-test-images/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-e2e-test-images/images.yaml
@@ -151,6 +151,7 @@
 - name: regression-issue-74839
   dmap:
     "sha256:b4f1d8d61bdad84bd50442d161d5460e4019d53e989b64220fdbc62fc87d76bf": ["1.2"]
+    "sha256:55cf49aeaafe4b3e8ce90783e6bb59e5a8b1b6b41aaeced7d0b26562a149ffb0": ["1.4"]
 - name: resource-consumer
   dmap:
     "sha256:74e800780d7656d42fb0f28e153619044a826e5f532d1871cac4b7c4d66d946f": ["1.6"]


### PR DESCRIPTION
Follow-up PR of https://github.com/kubernetes/kubernetes/pull/134164 for promoting `regression-issue-74839` to 1.4.
The hash was pushed here: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-kubernetes-push-e2e-regression-issue-74839-test-images/1970066624035688448

Related to https://github.com/kubernetes/kubernetes/issues/134116