### PR TITLE
AWS: Bump kOps CI cluster to 1.30

### DIFF
--- a/infra/aws/terraform/kops-infra-ci/eks.tf
+++ b/infra/aws/terraform/kops-infra-ci/eks.tf
@@ -17,7 +17,7 @@ limitations under the License.
 module "eks" {
   providers = { aws = aws.kops-infra-ci }
   source    = "terraform-aws-modules/eks/aws"
-  version   = "20.10.0"
+  version   = "20.37.2"
 
   cluster_name                   = local.cluster_name
   cluster_version                = var.eks_version

--- a/infra/aws/terraform/kops-infra-ci/variables.tf
+++ b/infra/aws/terraform/kops-infra-ci/variables.tf
@@ -16,7 +16,7 @@ limitations under the License.
 
 variable "eks_version" {
   type    = string
-  default = "1.29"
+  default = "1.30"
 }
 
 variable "tags" {


### PR DESCRIPTION
Also bump the EKS terraform module