### PR TITLE
Add daniel chan to release editors for release cuts

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -44,6 +44,7 @@ groups:
       - ameukam@gmail.com
       - cicih@google.com
       - ctadeu@gmail.com
+      - danieljoshuachan@gmail.com
       - drewhagendev@gmail.com
       - gveronicalg@gmail.com
       - jameswangel@gmail.com


### PR DESCRIPTION
Update groups.yaml to add myself to release editors, to satisfy the prereq for cutting k8s releases.
source: [Cutting a Release > Prereq > Access to GCP](https://github.com/mbianchidev/sig-release/blob/master/release-engineering/handbooks/k8s-release-cut.md)

CC @neoaggelos (as my release management "sponsor")

@jimangel @xmudrii 