### PR TITLE
Add elieserr to k8s-infra-release-editors

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -46,6 +46,7 @@ groups:
       - ctadeu@gmail.com
       - danieljoshuachan@gmail.com
       - drewhagendev@gmail.com
+      - elieser.pereiraa@gmail.com
       - gveronicalg@gmail.com
       - jameswangel@gmail.com
       - jeremy.r.rickard@gmail.com


### PR DESCRIPTION
As a requirement stated on the release engineering [hadbook](https://github.com/kubernetes/sig-release/blob/master/release-engineering/handbooks/k8s-release-cut.md) for the branch management shadows for the 1.35 cycle. 
cc: @neoaggelos 