### PR TITLE
add single process oom kill kubeletconfig to GKE nodes

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow-build/iam.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/iam.tf
@@ -29,9 +29,19 @@ module "iam" {
       "serviceAccount:prow-control-plane@k8s-infra-prow.iam.gserviceaccount.com",
       "serviceAccount:prow-deployer@k8s-infra-prow-build-trusted.iam.gserviceaccount.com"
     ]
+    "roles/owner" = [
+      "group:k8s-infra-prow-oncall@kubernetes.io"
+    ]
+    "organizations/758905017065/roles/prow.viewer" = [
+      "group:k8s-infra-prow-viewers@kubernetes.io"
+    ]
+    "roles/viewer" = [
+      "group:k8s-infra-prow-viewers@kubernetes.io"
+    ]
     "roles/secretmanager.secretAccessor" = [
       "serviceAccount:kubernetes-external-secrets@k8s-infra-prow-build.iam.gserviceaccount.com",
       "principal://iam.googleapis.com/projects/${module.project.project_number}/locations/global/workloadIdentityPools/${module.project.project_id}.svc.id.goog/subject/ns/external-secrets/sa/external-secrets",
+      "principal://iam.googleapis.com/projects/180382678033/locations/global/workloadIdentityPools/k8s-infra-prow-build-trusted.svc.id.goog/subject/ns/external-secrets/sa/external-secrets",
     ]
   }
 }

--- a/infra/gcp/terraform/k8s-infra-prow-build/provider.tf
+++ b/infra/gcp/terraform/k8s-infra-prow-build/provider.tf
@@ -23,18 +23,18 @@ This file defines:
 terraform {
 
   backend "gcs" {
-    bucket = "k8s-infra-tf-prow-clusters"
-    prefix = "k8s-infra-prow-build/prow-build" // $project_name/$cluster_name
+    bucket = "k8s-infra-terraform"
+    prefix = "k8s-infra-prow-build"
   }
 
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.31.0"
+      version = "~> 6.50.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 6.31.0"
+      version = "~> 6.50.0"
     }
   }
 }

--- a/infra/gcp/terraform/modules/gke-cluster/versions.tf
+++ b/infra/gcp/terraform/modules/gke-cluster/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.31.0"
+      version = "~> 6.50.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 6.31.0"
+      version = "~> 6.50.0"
     }
   }
 }

--- a/infra/gcp/terraform/modules/gke-nodepool/versions.tf
+++ b/infra/gcp/terraform/modules/gke-nodepool/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.31.0"
+      version = "~> 6.50.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 6.31.0"
+      version = "~> 6.50.0"
     }
   }
 }

--- a/infra/gcp/terraform/modules/gke-project/versions.tf
+++ b/infra/gcp/terraform/modules/gke-project/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.31.0"
+      version = "~> 6.50.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 6.31.0"
+      version = "~> 6.50.0"
     }
   }
 }

--- a/infra/gcp/terraform/modules/workload-identity-service-account/versions.tf
+++ b/infra/gcp/terraform/modules/workload-identity-service-account/versions.tf
@@ -17,11 +17,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.31.0"
+      version = "~>6.50.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 6.31.0"
+      version = "~> 6.50.0"
     }
   }
 }


### PR DESCRIPTION
This PR is busy but it does the following

- use the gke project factory module instead of our custom module
- The current GKE cluster is route based so we can't use the gke module we [use](https://github.com/kubernetes/k8s.io/blob/main/infra/gcp/terraform/k8s-infra-prow/gke.tf) in k8s-infra-prow project.
- The single_process_oom_kill field hasn't made it to the GKE module [yet](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/tree/main/modules/gke-node-pool). Once it does, I'll mark the PR ready for review.

/cc @BenTheElder @ameukam 