### PR TITLE
Added sreeram-venkitesh to k8s-infra-release-editors

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -55,6 +55,7 @@ groups:
       - pal.nabarun95@gmail.com
       - saschagrunert@gmail.com
       - satyampsoni@gmail.com
+      - sreeramvenkitesh@gmail.com
 
   - email-id: k8s-infra-release-viewers@kubernetes.io
     name: k8s-infra-release-viewers


### PR DESCRIPTION
As a requirement stated on the release engineering [handbook](https://github.com/kubernetes/sig-release/blob/master/release-engineering/handbooks/k8s-release-cut.md) for the branch management shadows for the 1.35 cycle.

CC: @neoaggelos @drewhagen 