### PR TITLE
AWS: add access key for kops-ci-user

### DIFF
--- a/infra/aws/terraform/kops-infra-ci/iam.tf
+++ b/infra/aws/terraform/kops-infra-ci/iam.tf
@@ -111,6 +111,7 @@ module "kops_ci_user" {
 
   name                          = "kops-ci-user"
   create_iam_user_login_profile = false
+  create_iam_access_key = true
 
   force_destroy           = true
   password_reset_required = false


### PR DESCRIPTION
Related to:
  - https://github.com/kubernetes/k8s.io/issues/5127

Follow-up of:
  - https://github.com/kubernetes/k8s.io/pull/8536

Needed to add credentials to CI clusters for kOps E2E tests