### PR TITLE
AWS: Add private subnets the kOps CI cluster

### DIFF
--- a/infra/aws/terraform/kops-infra-ci/locals.tf
+++ b/infra/aws/terraform/kops-infra-ci/locals.tf
@@ -29,8 +29,10 @@ locals {
     "k8s.io/cluster-autoscaler/enabled"               = true
   }
 
-  partition       = cidrsubnets(aws_vpc_ipam_preview_next_cidr.main.cidr, 2, 2, 2)
+  partition       = cidrsubnets(aws_vpc_ipam_preview_next_cidr.main.cidr, 2, 2, 2, 2)
   azs             = slice(data.aws_availability_zones.available.names, 0, 3)
-  private_subnets = cidrsubnets(local.partition[0], 2, 2, 2)
+  private_subnets1 = cidrsubnets(local.partition[0], 2, 2, 2, 2)
+  private_subnets2 = cidrsubnets(local.partition[2], 2, 2, 2, 2)
+  private_subnets3 = cidrsubnets(local.partition[3], 2, 2, 2, 2)
   public_subnets  = cidrsubnets(local.partition[1], 2, 2, 2)
 }

--- a/infra/aws/terraform/kops-infra-ci/vpc.tf
+++ b/infra/aws/terraform/kops-infra-ci/vpc.tf
@@ -74,7 +74,7 @@ module "vpc" {
   ipv4_ipam_pool_id = aws_vpc_ipam_pool.main.id
 
   azs             = local.azs
-  private_subnets = local.private_subnets
+  private_subnets = concat(local.private_subnets1, local.private_subnets2, local.private_subnets3)
   public_subnets  = local.public_subnets
 
   enable_nat_gateway     = true


### PR DESCRIPTION
This should give us 4x more IPs for the kOps EKS cluster.

/cc @ameukam @justinsb 