### PR TITLE
No Moderation on sig-node-ci group

### DIFF
--- a/groups/sig-node/groups.yaml
+++ b/groups/sig-node/groups.yaml
@@ -72,7 +72,7 @@ groups:
       WhoCanViewGroup: "ANYONE_CAN_VIEW"
       WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
       WhoCanPostMessage: "ANYONE_CAN_POST"
-      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      MessageModerationLevel: "MODERATE_NONE"
       WhoCanViewMembership: "ALL_MANAGERS_CAN_VIEW"
       WhoCanModerateMembers: "OWNERS_AND_MANAGERS"
       WhoCanModerateContent: "OWNERS_AND_MANAGERS"


### PR DESCRIPTION
Same as https://github.com/kubernetes/k8s.io/pull/8622/ but for sig-node-ci. Previous PR changed the wrong group.