### PR TITLE
AWS: Use c7a.8xlarge for kOps CI cluster

### DIFF
--- a/infra/aws/terraform/kops-infra-ci/eks.tf
+++ b/infra/aws/terraform/kops-infra-ci/eks.tf
@@ -91,7 +91,7 @@ module "eks" {
       }
 
       capacity_type  = "ON_DEMAND"
-      instance_types = ["c7a.4xlarge"]
+      instance_types = ["c7a.8xlarge"]
       ami_type       = "BOTTLEROCKET_x86_64"
 
       ebs_optimized     = true


### PR DESCRIPTION
/cc @ameukam 