### PR TITLE
AWS: add tags to kOps CI Cluster

### DIFF
--- a/infra/aws/terraform/kops-infra-ci/eks.tf
+++ b/infra/aws/terraform/kops-infra-ci/eks.tf
@@ -169,6 +169,10 @@ resource "aws_eks_pod_identity_association" "kops_prow_build" {
   namespace       = "test-pods"
   service_account = "prowjob-default-sa"
   role_arn        = aws_iam_role.eks_pod_identity_role.arn
+
+  tags = merge(var.tags, var.janitor_tags, {
+    "region" = data.aws_region.current.region
+  })
 }
 
 
@@ -190,7 +194,9 @@ module "vpc_cni_irsa" {
     }
   }
 
-  tags = var.tags
+  tags = merge(var.tags, var.janitor_tags, {
+    "region" = data.aws_region.current.region
+  })
 }
 
 module "ebs_csi_irsa" {
@@ -208,7 +214,9 @@ module "ebs_csi_irsa" {
     }
   }
 
-  tags = var.tags
+  tags = merge(var.tags, var.janitor_tags, {
+    "region" = data.aws_region.current.region
+  })
 }
 
 module "cluster_autoscaler_irsa_role" {
@@ -227,5 +235,7 @@ module "cluster_autoscaler_irsa_role" {
     }
   }
 
-  tags = var.tags
+  tags = merge(var.tags, var.janitor_tags, {
+    "region" = data.aws_region.current.region
+  })
 }

--- a/infra/aws/terraform/kops-infra-ci/iam.tf
+++ b/infra/aws/terraform/kops-infra-ci/iam.tf
@@ -52,6 +52,10 @@ resource "aws_iam_role" "google_prow_trust_role" {
   description          = ""
   max_session_duration = 43200
   assume_role_policy   = data.aws_iam_policy_document.google_prow_trust_policy.json
+
+  tags = merge(var.tags, var.janitor_tags, {
+    "region" = data.aws_region.current.region
+  })
 }
 
 
@@ -79,6 +83,11 @@ resource "aws_iam_role" "eks_pod_identity_role" {
 
   name               = "EKSPodIdentityRole"
   assume_role_policy = data.aws_iam_policy_document.eks_pod_identity_policy.json
+
+
+  tags = merge(var.tags, var.janitor_tags, {
+    "region" = data.aws_region.current.region
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "eks_pod_identity_policy" {
@@ -103,7 +112,9 @@ module "ci_iam_group" {
     "arn:aws:iam::aws:policy/AdministratorAccess",
   ]
 
-  tags = var.tags
+  tags = merge(var.tags, var.janitor_tags, {
+    "region" = data.aws_region.current.region
+  })
 }
 
 module "kops_ci_user" {
@@ -118,5 +129,7 @@ module "kops_ci_user" {
   force_destroy           = true
   password_reset_required = false
 
-  tags = var.tags
+  tags = merge(var.tags, var.janitor_tags, {
+    "region" = data.aws_region.current.region
+  })
 }

--- a/infra/aws/terraform/kops-infra-ci/locals.tf
+++ b/infra/aws/terraform/kops-infra-ci/locals.tf
@@ -29,10 +29,10 @@ locals {
     "k8s.io/cluster-autoscaler/enabled"               = true
   }
 
-  partition       = cidrsubnets(aws_vpc_ipam_preview_next_cidr.main.cidr, 2, 2, 2, 2)
-  azs             = slice(data.aws_availability_zones.available.names, 0, 3)
+  partition        = cidrsubnets(aws_vpc_ipam_preview_next_cidr.main.cidr, 2, 2, 2, 2)
+  azs              = slice(data.aws_availability_zones.available.names, 0, 3)
   private_subnets1 = cidrsubnets(local.partition[0], 2, 2, 2, 2)
   private_subnets2 = cidrsubnets(local.partition[2], 2, 2, 2, 2)
   private_subnets3 = cidrsubnets(local.partition[3], 2, 2, 2, 2)
-  public_subnets  = cidrsubnets(local.partition[1], 2, 2, 2)
+  public_subnets   = cidrsubnets(local.partition[1], 2, 2, 2)
 }

--- a/infra/aws/terraform/kops-infra-ci/main.tf
+++ b/infra/aws/terraform/kops-infra-ci/main.tf
@@ -28,13 +28,20 @@ resource "aws_iam_openid_connect_provider" "google_prow_idp" {
     # GlobalSign root certificate (Google Managed Certficates)
     "08745487e891c19e3078c1f2a07e452950ef36f6"
   ]
+
+
+  tags = merge(var.tags, var.janitor_tags, {
+    "region" = data.aws_region.current.region
+  })
 }
 
 ## Used by kOps to store the state of the kOps created
 resource "aws_s3_bucket" "kops_state_store" {
   provider = aws.kops-infra-ci
   bucket   = "k8s-kops-ci-prow-state-store"
-  tags     = var.tags
+  tags = merge(var.tags, var.janitor_tags, {
+    "region" = data.aws_region.current.region
+  })
 }
 
 resource "aws_s3_bucket_ownership_controls" "kops_state_store" {
@@ -50,7 +57,9 @@ resource "aws_s3_bucket_ownership_controls" "kops_state_store" {
 resource "aws_s3_bucket" "kops_oidc_store" {
   provider = aws.kops-infra-ci
   bucket   = "k8s-kops-ci-prow"
-  tags     = var.tags
+  tags = merge(var.tags, var.janitor_tags, {
+    "region" = data.aws_region.current.region
+  })
 }
 
 resource "aws_s3_bucket_ownership_controls" "kops_oidc_store" {

--- a/infra/aws/terraform/kops-infra-ci/variables.tf
+++ b/infra/aws/terraform/kops-infra-ci/variables.tf
@@ -29,6 +29,13 @@ variable "tags" {
   }
 }
 
+variable "janitor_tags" {
+  type = map(string)
+  default = {
+    "Shared" = "Ignore"
+  }
+}
+
 variable "region" {
   type    = string
   default = "us-east-2"

--- a/infra/aws/terraform/kops-infra-ci/vpc.tf
+++ b/infra/aws/terraform/kops-infra-ci/vpc.tf
@@ -21,7 +21,7 @@ resource "aws_vpc_ipam" "main" {
     region_name = data.aws_region.current.region
   }
 
-  tags = merge(var.tags, {
+  tags = merge(var.tags, var.janitor_tags, {
     "region" = data.aws_region.current.region
   })
 }
@@ -41,7 +41,7 @@ resource "aws_vpc_ipam_pool" "main" {
   address_family = "ipv4"
   ipam_scope_id  = aws_vpc_ipam.main.private_default_scope_id
   locale         = data.aws_region.current.region
-  tags = merge(var.tags, {
+  tags = merge(var.tags, var.janitor_tags, {
     "region" = data.aws_region.current.region
   })
 }
@@ -98,7 +98,7 @@ module "vpc" {
     "kubernetes.io/role/internal-elb" = 1
   }
 
-  tags = merge(var.tags, {
+  tags = merge(var.tags, var.janitor_tags, {
     "region" = data.aws_region.current.region
   })
 }
@@ -148,7 +148,9 @@ module "vpc_endpoints" {
       }
   })
 
-  tags = var.tags
+  tags = merge(var.tags, var.janitor_tags, {
+    "region" = data.aws_region.current.region
+  })
 }
 
 // Required by kOps CI
@@ -157,5 +159,7 @@ resource "aws_route53_zone" "hosted_zone" {
 
   name = "tests-kops-aws.k8s.io"
 
-  tags = var.tags
+  tags = merge(var.tags, var.janitor_tags, {
+    "region" = data.aws_region.current.region
+  })
 }


### PR DESCRIPTION
Ensure the boskos janitor don't the CI cluster and resources needed for it.