### PR TITLE
publish kindnet 1.0.0

### DIFF
--- a/registry.k8s.io/images/k8s-staging-networking/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-networking/images.yaml
@@ -43,6 +43,9 @@
 - name: ingress-gce-404-server-with-metrics-amd64
   dmap:
     "sha256:7eb7b3cee4d33c10c49893ad3c386232b86d4067de5251294d4c620d6e072b93": ["v1.10.11"]
+- name: kindnet
+  dmap:
+    "sha256:b64448f2424c8c45a98102b80a2a050e7573ece120808106689c2324bf1fe842": ["v1.0.0"]
 - name: kube-network-policies
   dmap:
     "sha256:659319ad358df6d1bd4f1c4904530e7809b45a061a62a9d7ddcf9ecdb088d7ea": ["v0.9.2-iptracker"]


### PR DESCRIPTION
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-kindnet-image/1978936709412294656

```
exporting to image
#29 pushing layers 4.5s done
#29 pushing manifest for gcr.io/k8s-staging-networking/kindnet:v20251016-cfb1bcc@sha256:b64448f2424c8c45a98102b80a2a050e7573ece120808106689c2324bf1fe842
#29 pushing manifest for gcr.io/k8s-staging-networking/kindnet:v20251016-cfb1bcc@sha256:b64448f2424c8c45a98102b80a2a050e7573ece120808106689c2324bf1fe842 3.3s done
#29 DONE 11.3s
Released image: gcr.io/k8s-staging-networking/kindnet:v20251016-cfb1bcc
```

/assign @BenTheElder 