### PR TITLE
GCP: switch buckets for the prod registry

### DIFF
--- a/infra/gcp/terraform/k8s-infra-oci-proxy-prod/provider.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy-prod/provider.tf
@@ -29,11 +29,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.84.0"
+      version = "~> 6.50.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.84.0"
+      version = "~> 6.50.0"
     }
   }
 }

--- a/infra/gcp/terraform/k8s-infra-oci-proxy/provider.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy/provider.tf
@@ -29,11 +29,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.84.0"
+      version = "~> 6.50.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.84.0"
+      version = "~> 6.50.0"
     }
   }
 }

--- a/infra/gcp/terraform/modules/monitoring/uptime-alert/versions.tf
+++ b/infra/gcp/terraform/modules/monitoring/uptime-alert/versions.tf
@@ -20,11 +20,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.84.0"
+      version = "~> 6.50.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.84.0"
+      version = "~> 6.50.0"
     }
   }
 }

--- a/infra/gcp/terraform/modules/oci-proxy/main.tf
+++ b/infra/gcp/terraform/modules/oci-proxy/main.tf
@@ -237,8 +237,8 @@ locals {
       environment_variables = [
         {
           name = "DEFAULT_AWS_BASE_URL",
-          // AWS eu-central-1 is Frankfurt
-          value = "https://prod-registry-k8s-io-eu-central-1.s3.dualstack.eu-central-1.amazonaws.com",
+          // AWS eu-south-1 is Milan
+          value = "https://prod-registry-k8s-io-eu-south-1.s3.dualstack.eu-south-1.amazonaws.com",
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -255,8 +255,8 @@ locals {
       environment_variables = [
         {
           name = "DEFAULT_AWS_BASE_URL",
-          // AWS eu-west-1 is in Ireland
-          value = "https://prod-registry-k8s-io-eu-west-1.s3.dualstack.eu-west-1.amazonaws.com",
+          // AWS eu-west-3 is in Paris
+          value = "https://prod-registry-k8s-io-eu-west-3.s3.dualstack.eu-west-3.amazonaws.com",
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",


### PR DESCRIPTION
Switch S3 buckets for the Paris and Milan regions to ensure in-region
traffic for OCI clients located in those regions.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>