### PR TITLE
chore(kro): push kro image and chart to 0.5.0 based on previous rc

### DIFF
--- a/registry.k8s.io/images/k8s-staging-kro/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-kro/images.yaml
@@ -1,6 +1,6 @@
 - name: kro
   dmap:
-    "sha256:1abd0e5f7c2719162067eb478a647562c2a8d1580c6e9038a9eb28b7ec2e5f0f": ["v0.5.0-rc.1", "0.5.0-rc.1"]
+    "sha256:1abd0e5f7c2719162067eb478a647562c2a8d1580c6e9038a9eb28b7ec2e5f0f": ["v0.5.0-rc.1", "v0.5.0"]
 - name: charts/kro
   dmap:
-    "sha256:8de045ac83ec0f394142322fd2b810a9c89ae37ed1fdf6f5172b1d30a08b0d8d": ["v0.5.0-rc.1", "0.5.0-rc.1"]
+    "sha256:8de045ac83ec0f394142322fd2b810a9c89ae37ed1fdf6f5172b1d30a08b0d8d": ["v0.5.0-rc.1", "0.5.0-rc.1", "v0.5.0", "0.5.0"]


### PR DESCRIPTION
also adds a non prefixed version to the chart to stay semver compliant and allow tools with tools that only accept strict semver

contributes to https://github.com/kubernetes-sigs/kro/issues/696