### PR TITLE
configure the workflow server-side instead of inrepo

### DIFF
--- a/.atlantis.yaml
+++ b/.atlantis.yaml
@@ -10,23 +10,3 @@ projects:
     branch: /main/
     dir: infra/aws/terraform/artifacts.k8s.io
     workflow: aws
-# For AWS, atlantis needs to assume a specific role in each account except the management account
-# so we read it from the folder that atlantis will work on
-workflows:
-  aws:
-    plan:
-      steps:
-        - init:
-            extra_args: ["--backend-config", "atlantis.config"]
-        - plan:
-            extra_args: ["-var-file", "atlantis.tfvars"]
-    apply:
-      steps:
-        - apply:
-            extra_args: ["-var-file", "atlantis.tfvars"]
-    import:
-      steps:
-        - init:
-            extra_args: ["--backend-config", "atlantis.config"]
-        - import:
-            extra_args: ["-var-file", "atlantis.tfvars"]

--- a/kubernetes/gke-utility/atlantis/atlantis.yaml
+++ b/kubernetes/gke-utility/atlantis/atlantis.yaml
@@ -11,4 +11,5 @@ hide-prev-plan-comments: true
 hide-unchanged-plan-comments: true
 checkout-strategy: merge
 emoji-reaction: eyes
+repo-config: /config/repos.yaml
 # default-tf-distribution: opentofu # uncomment when we start using opentofu

--- a/kubernetes/gke-utility/atlantis/kustomization.yaml
+++ b/kubernetes/gke-utility/atlantis/kustomization.yaml
@@ -15,6 +15,7 @@ configMapGenerator:
   - name: atlantis-config
     files:
       - atlantis.yaml
+      - repos.yaml
 
 patchesStrategicMerge:
   - |-

--- a/kubernetes/gke-utility/atlantis/repos.yaml
+++ b/kubernetes/gke-utility/atlantis/repos.yaml
@@ -1,0 +1,27 @@
+# https://www.runatlantis.io/docs/server-side-repo-config.html
+repos:
+  - id: github.com/kubernetes/k8s.io
+    branch: /main/
+    allow_custom_workflows: false # NO CUSTOM WORKLOADS CAN BE SPECIFIED IN THE REPOS
+    allowed_workflows: [aws]
+
+# For AWS, atlantis needs to assume a specific role in each account except the management account
+# so we read it from the folder that atlantis will work on
+workflows:
+  aws:
+    plan:
+      steps:
+        - init:
+            extra_args: ["-backend-config=atlantis.config"]
+        - plan:
+            extra_args: ["-var-file=atlantis.tfvars"]
+    apply:
+      steps:
+        - apply:
+            extra_args: ["-var-file=atlantis.tfvars"]
+    import:
+      steps:
+        - init:
+            extra_args: ["-backend-config=atlantis.config"]
+        - import:
+            extra_args: ["-var-file=atlantis.tfvars"]


### PR DESCRIPTION
The workflow changes I made in #8684 have no effect as atlantis by default doesn't allow repositories to specify custom workloads. We'll retain this secure behaviour and put the workflow definition server-side