### PR TITLE
Add new workspace to boskos on ibm ppc64le

### DIFF
--- a/kubernetes/ibm-ppc64le/prow/boskos-resources-configmap.yaml
+++ b/kubernetes/ibm-ppc64le/prow/boskos-resources-configmap.yaml
@@ -7,11 +7,8 @@ data:
       - k8s-boskos-powervs-lon04-01
       - k8s-boskos-powervs-lon04-02
       - k8s-boskos-powervs-lon06
-      - k8s-boskos-powervs-sao01
+      - k8s-boskos-powervs-lon06-01
       - k8s-boskos-powervs-syd04
-      - k8s-boskos-powervs-syd05
-      - k8s-boskos-powervs-syd05-01
-      - k8s-boskos-powervs-tok04
       state: dirty
       type: powervs
 kind: ConfigMap


### PR DESCRIPTION
Removing old workspaces and adding a new one which is stable on IBM PowerVS.