### PR TITLE
add chad as zoom admin

### DIFF
--- a/groups/sig-contributor-experience/groups.yaml
+++ b/groups/sig-contributor-experience/groups.yaml
@@ -140,6 +140,7 @@ groups:
       - jberkus@redhat.com
       - marky.r.jackson@gmail.com
       - chris@chrisshort.net
+      - chadmcrowell@gmail.com
 
   - email-id: sig-contribex@kubernetes.io
     name: sig-contribex


### PR DESCRIPTION
This request adds Chad to the moderators@ mail group; see Community issue https://github.com/kubernetes/community/issues/8670

Chad is becoming a Zoom Admin and is already a YouTube Admin.