### PR TITLE
Update s390x ExternalSecret to use dedicated GCP secret

### DIFF
--- a/kubernetes/ibm-s390x/helm/external-secrets.yaml
+++ b/kubernetes/ibm-s390x/helm/external-secrets.yaml
@@ -18,17 +18,17 @@ extraObjects:
           auth:
             secretRef:
               secretApiKeySecretRef:
-                name: ibm-sm-apikey
+                name: ibm-sm-s390x-apikey
                 key: API_KEY
                 namespace: external-secrets
   - apiVersion: external-secrets.io/v1beta1
     kind: ExternalSecret
     metadata:
-      name: ibm-sm-apikey
+      name: ibm-sm-s390x-apikey
     spec:
       data:
         - remoteRef:
-            key: ibm-sm-apikey
+            key: ibm-sm-s390x-apikey
           secretKey: API_KEY
       secretStoreRef:
         kind: ClusterSecretStore
@@ -94,14 +94,14 @@ extraObjects:
                   set -o pipefail
 
                   go install sigs.k8s.io/provider-ibmcloud-test-infra/secret-manager@71ef4d8
-                  secret-manager rotate --instance-id 0664d47c-fe42-423f-930d-69570443cd1 --labels rotate:true --confirm
+                  secret-manager rotate --instance-id 0664d47c-fe42-423f-930d-69570443cd15 --labels rotate:true --confirm
                 env:
                 - name: IBMCLOUD_ENV_FILE
                   value: "/home/.ibmcloud/api-key"
                 volumeMounts:
                 - name: credentials
                   mountPath: /home/.ibmcloud
-              restartPolicy: OnFailure
+              restartPolicy: Never
               volumes:
               - name: credentials
                 secret:


### PR DESCRIPTION
This PR updates the s390x cluster ExternalSecret configuration to use a dedicated GCP Secret Manager secret (`ibm-sm-s390x-apikey`)