### PR TITLE
Update boskos resource type and state for s390x

### DIFF
--- a/kubernetes/ibm-s390x/prow/boskos-janitor.yaml
+++ b/kubernetes/ibm-s390x/prow/boskos-janitor.yaml
@@ -20,7 +20,7 @@ spec:
           image: gcr.io/k8s-staging-boskos/ibmcloud-janitor-boskos:v20250922-14f95fc
           args:
             - --boskos-url=http://boskos.test-pods.svc.cluster.local.
-            - --resource-type=powervs
+            - --resource-type=vpc-service
             - --ignore-api-key=true
             - --account-id=efa47ec6fd45473a9e1fd6b7b8363f5c
           env:

--- a/kubernetes/ibm-s390x/prow/boskos-reaper.yaml
+++ b/kubernetes/ibm-s390x/prow/boskos-reaper.yaml
@@ -20,4 +20,4 @@ spec:
           image: gcr.io/k8s-staging-boskos/reaper:v20250922-14f95fc
           args:
             - --boskos-url=http://boskos.test-pods.svc.cluster.local.
-            - --resource-type=powervs
+            - --resource-type=vpc-service

--- a/kubernetes/ibm-s390x/prow/boskos-resources-configmap.yaml
+++ b/kubernetes/ibm-s390x/prow/boskos-resources-configmap.yaml
@@ -4,7 +4,7 @@ data:
     resources:
     - names:
       - k8s-s390x-test-vpc
-      state: dirty
+      state: free
       type: vpc-service
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
Changed boskos resource type to `vpc-service` in janitor and reaper configs. Updated resource state to `free` in boskos-resources-configmap for `k8s-s390x-test-vpc`.