### PR TITLE
Update OWNERS file for approvers and reviewers

### DIFF
--- a/registry.k8s.io/images/k8s-staging-cluster-api-gcp/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-cluster-api-gcp/OWNERS
@@ -5,13 +5,15 @@ approvers:
 - cpanato
 - dims
 - justinsb
-- richardcase
+- damdo
+- salasberryfin
 
 reviewers:
 - cpanato
 - dims
 - justinsb
-- richardcase
+- damdo
+- salasberryfin
 
 emeritus_approvers:
 - vincepri


### PR DESCRIPTION
Removed 'richardcase' from approvers and reviewers, added 'damdo' and 'salasberryfin'.

Syncs up diff in : https://github.com/kubernetes-sigs/cluster-api-provider-gcp/blob/3b04ea41ec30a86132446f3b067b16e2f9e699cc/OWNERS_ALIASES#L22-L26

/assign @richardcase @cpanato 