### PR TITLE
groups: add new k8s-infra-staging-contributor-site DL under sig-contribex

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -133,6 +133,7 @@ restrictions:
       - "^k8s-infra-rbac-elekto@kubernetes.io$"
       - "^k8s-infra-rbac-slack-infra@kubernetes.io$"
       - "^k8s-infra-staging-slack-infra@kubernetes.io$"
+      - "^k8s-infra-staging-contributor-site@kubernetes.io$"
       - "^zoom-moderators@kubernetes.io$"
   - path: "sig-etcd/groups.yaml"
     allowedGroups:

--- a/groups/sig-contributor-experience/groups.yaml
+++ b/groups/sig-contributor-experience/groups.yaml
@@ -230,6 +230,16 @@ groups:
       - nikitaraghunath@gmail.com
       - rajula96reddy@gmail.com
 
+  - email-id: k8s-infra-staging-contributor-site@kubernetes.io
+    name: k8s-infra-staging-contributor-site
+    description: |-
+      ACL for contributor site artifacts
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - prajyotparab19@gmail.com
+      - sig-contribex-leads@kubernetes.io
+
   #
   # k8s-infra owners for sig-owned subprojects
   #


### PR DESCRIPTION
PR adds a new [k8s-infra-staging-contributor-site@kubernetes.io](mailto:k8s-infra-staging-contributor-site@kubernetes.io) mailing list.

required to support the solution outlined in kubernetes/contributor-site#565.