### PR TITLE
Add inference-perf mailing list

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -224,6 +224,7 @@ restrictions:
       - "^k8s-infra-staging-perf-tests@kubernetes.io$"
       - "^sig-scalability@kubernetes.io$"
       - "^sig-scalability-leads@kubernetes.io$"
+      - "^k8s-infra-staging-inference-perf@kubernetes.io$"
   - path: "sig-scheduling/groups.yaml"
     allowedGroups:
       - "^k8s-infra-staging-descheduler@kubernetes.io$"

--- a/groups/sig-scalability/groups.yaml
+++ b/groups/sig-scalability/groups.yaml
@@ -29,6 +29,17 @@ groups:
     members:
       - k8s-infra-sig-scalability-oncall@kubernetes.io
 
+  - email-id: k8s-infra-staging-inference-perf@kubernetes.io
+    name: k8s-infra-staging-inference-perf
+    description: |-
+      ACL for inference-perf artifacts
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - achandrasekar@google.com
+      - jkramberger@google.com
+      - sachin.mathew31@gmail.com
+
   #
   # k8s-infra gcs write access
   #


### PR DESCRIPTION
Adds k8s-infra-staging-inference-perf@kubernetes.io for inference-perf artifacts in registry.k8s.io.

https://github.com/kubernetes-sigs/inference-perf