### PR TITLE
Update resource group and secret references for s390x

### DIFF
--- a/infra/ibmcloud/terraform/k8s-s390x-conformance/main.tf
+++ b/infra/ibmcloud/terraform/k8s-s390x-conformance/main.tf
@@ -24,13 +24,14 @@ module "iam_custom_role" {
 module "service_ids" {
   depends_on        = [module.iam_custom_role]
   source            = "./modules/iam/service_ids"
-  resource_group_id = module.resource_group.conformance_resource_group_id
+  resource_group_id = module.resource_group.build_resource_group_id
 }
 
 module "iam_access_groups" {
-  depends_on        = [module.iam_custom_role]
-  source            = "./modules/iam/access_groups"
-  resource_group_id = module.resource_group.conformance_resource_group_id
+  depends_on                = [module.iam_custom_role]
+  source                    = "./modules/iam/access_groups"
+  resource_group_id         = module.resource_group.conformance_resource_group_id
+  project_resource_group_id = module.resource_group.build_resource_group_id
 }
 
 module "secrets_manager" {

--- a/infra/ibmcloud/terraform/k8s-s390x-conformance/modules/iam/access_groups/access_groups.tf
+++ b/infra/ibmcloud/terraform/k8s-s390x-conformance/modules/iam/access_groups/access_groups.tf
@@ -55,6 +55,6 @@ resource "ibm_iam_access_group_policy" "secret_rotator" {
 
   resources {
     service           = "secrets-manager"
-    resource_group_id = var.resource_group_id
+    resource_group_id = var.project_resource_group_id
   }
 }

--- a/infra/ibmcloud/terraform/k8s-s390x-conformance/modules/iam/access_groups/variables.tf
+++ b/infra/ibmcloud/terraform/k8s-s390x-conformance/modules/iam/access_groups/variables.tf
@@ -15,3 +15,4 @@ limitations under the License.
 */
 
 variable "resource_group_id" {}
+variable "project_resource_group_id" {}

--- a/infra/ibmcloud/terraform/k8s-s390x-conformance/modules/resource_group/outputs.tf
+++ b/infra/ibmcloud/terraform/k8s-s390x-conformance/modules/resource_group/outputs.tf
@@ -16,3 +16,6 @@ limitations under the License.
 output "conformance_resource_group_id" {
   value = ibm_resource_group.conformance_resource_group.id
 }
+output "build_resource_group_id" {
+  value = data.ibm_resource_group.build_resource_group.id
+}

--- a/infra/ibmcloud/terraform/k8s-s390x-conformance/modules/resource_group/resource_group.tf
+++ b/infra/ibmcloud/terraform/k8s-s390x-conformance/modules/resource_group/resource_group.tf
@@ -16,3 +16,6 @@ limitations under the License.
 resource "ibm_resource_group" "conformance_resource_group" {
   name = "rg-conformance-test"
 }
+data "ibm_resource_group" "build_resource_group" {
+  name = "rg-build-cluster"
+}

--- a/infra/ibmcloud/terraform/k8s-s390x-conformance/modules/secrets_manager/secret_manager.tf
+++ b/infra/ibmcloud/terraform/k8s-s390x-conformance/modules/secrets_manager/secret_manager.tf
@@ -63,8 +63,8 @@ resource "ibm_sm_iam_credentials_secret" "secret_rotator" {
     unit        = "day"
   }
 
-  //The time-to-live (TTL) or lease duration of generated secret 86400seconds = 24hrs
-  ttl = "86400"
+  //The time-to-live (TTL) or lease duration of generated secret 91800seconds = 25.5hrs
+  ttl = "91800"
 }
 
 # RSA key of size 4096 bits

--- a/kubernetes/ibm-s390x/helm/external-secrets.yaml
+++ b/kubernetes/ibm-s390x/helm/external-secrets.yaml
@@ -67,7 +67,7 @@ extraObjects:
       data:
         - secretKey: api-key
           remoteRef:
-            key: iam_credentials/a2f576a8-e609-105f-e586-20b6706f2215
+            key: iam_credentials/c371e272-b356-419c-ad52-ec173b32bbe5
   - apiVersion: batch/v1
     kind: CronJob
     metadata:

--- a/kubernetes/ibm-s390x/prow/secrets.yaml
+++ b/kubernetes/ibm-s390x/prow/secrets.yaml
@@ -36,7 +36,7 @@ spec:
   data:
     - secretKey: key
       remoteRef:
-        key: iam_credentials/8d0c5130-2b8e-68f7-45b1-eeb54d36fe47
+        key: iam_credentials/1e0c0a43-37a3-ca93-278f-6385a7c80bd7
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
@@ -54,7 +54,7 @@ spec:
   data:
     - secretKey: ssh-privatekey
       remoteRef:
-        key: 9bf7242a-f493-7a86-61f3-4c75a1b73022
+        key: a0216616-bef4-8752-32be-c69a4f4bf87b
 ---
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
@@ -72,4 +72,4 @@ spec:
   data:
     - secretKey: api-key
       remoteRef:
-        key: iam_credentials/7e61f6ee-3d8d-f53b-70e7-c274e0dde72d
+        key: iam_credentials/8f0e235f-6aed-5497-47c3-38aaa964d268


### PR DESCRIPTION
Added build resource group outputs and data source, updated IAM access group policy to use project resource group, and changed TTL for secret rotator. Updated secret keys in helm and prow manifests to reference updated keys