### PR TITLE
Temporary change sig-contribex-leads to member in zoom-moderators

### DIFF
--- a/groups/sig-contributor-experience/groups.yaml
+++ b/groups/sig-contributor-experience/groups.yaml
@@ -291,8 +291,7 @@ groups:
       ReconcileMembers: "true"
     owners:
       - contributors@kubernetes.io
-    managers:
-      - sig-contribex-leads@kubernetes.io
     members:
       - chadmcrowell@gmail.com
       - chris@chrisshort.net
+      - sig-contribex-leads@kubernetes.io


### PR DESCRIPTION
The groups job is failing to reconcile the newly added `zoom-moderators` Google Group with the following error:

```
2025/11/19 16:27:34 unable to add sig-contribex-leads@kubernetes.io to "zoom-moderators@kubernetes.io" as MANAGER: googleapi: Error 400: Invalid Input: memberKey, invalid
```

I don't have much idea why is this the case, but some random thought that I have is that maybe you first have to add the user and then make it a manager. Or that groups can't be managers. But let's first try the former option and see if it helps.

/assign @BenTheElder @chris-short 