### PR TITLE
Change sig-contribex-leads back to manager in zoom-moderators

### DIFF
--- a/groups/sig-contributor-experience/groups.yaml
+++ b/groups/sig-contributor-experience/groups.yaml
@@ -291,7 +291,8 @@ groups:
       ReconcileMembers: "true"
     owners:
       - contributors@kubernetes.io
+    managers:
+      - sig-contribex-leads@kubernetes.io
     members:
       - chadmcrowell@gmail.com
       - chris@chrisshort.net
-      - sig-contribex-leads@kubernetes.io


### PR DESCRIPTION
Technically a revert of #8782 

Let's see if we can make it a manager now that it is part of the group. Otherwise, we'll revert it again.

/assign @BenTheElder @chris-short 