### PR TITLE
Revert changing sig-contribex-leads back to manager in zoom-moderators

### DIFF
--- a/groups/sig-contributor-experience/groups.yaml
+++ b/groups/sig-contributor-experience/groups.yaml
@@ -291,8 +291,7 @@ groups:
       ReconcileMembers: "true"
     owners:
       - contributors@kubernetes.io
-    managers:
-      - sig-contribex-leads@kubernetes.io
     members:
       - chadmcrowell@gmail.com
       - chris@chrisshort.net
+      - sig-contribex-leads@kubernetes.io


### PR DESCRIPTION
This is a revert of #8783 because it appears that other Google Groups cannot be managers/owners (we get the same error as in #8782).

/assign @BenTheElder @chris-short 