### PR TITLE
Update CNAME from etcd.netlify.com to etcd.netlify.app

### DIFF
--- a/dns/zone-configs/etcd.io._0_base.yaml
+++ b/dns/zone-configs/etcd.io._0_base.yaml
@@ -26,7 +26,7 @@ _gh-kubernetes-e:
 
 www:
   - type: CNAME
-    value: etcd.netlify.com.
+    value: etcd.netlify.app.
 
 mail:
   - type: CNAME


### PR DESCRIPTION
Hi, while looking into https://github.com/kubernetes/sig-security/issues/172, I noticed a minor discrepancy in the etcd.io DNS config. 

etcd.netlify.com will return a 404 as Netlify deprecated automatic redirects from `*.netlify.com` sites to `*.netlify.app` sites in late March 2024. [Details here](https://answers.netlify.com/t/deprecating-automatic-com-redirects/115442). Also from that link is this quote:
> If you’re using a CNAME linked to subdomain.netlify.com, generally, you’ll wanna update that to be for your .app domain, but it will continue to work for DNS.

So it's important to note that name resolution still works fine and this PR doesn't necessarily *fix* anything. Rather, this change aligns with the pattern used across all other Netlify sites referenced in this repo and follows the vendor's recommendation.