### PR TITLE
Add bowei@google.com as an owner in groups.yaml

### DIFF
--- a/groups/sig-network/groups.yaml
+++ b/groups/sig-network/groups.yaml
@@ -25,6 +25,7 @@ groups:
       sig-network leads
     owners:
       - antonio.ojea.garcia@gmail.com
+      - bowei@google.com
       - danwinship@redhat.com
       - michael.zappa@gmail.com
       - sutt@redhat.com
@@ -43,6 +44,7 @@ groups:
       SIG network general discussion group
     owners:
       - antonio.ojea.garcia@gmail.com
+      - bowei@google.com
       - danwinship@redhat.com
       - michael.zappa@gmail.com
       - sutt@redhat.com


### PR DESCRIPTION
Added bowei@google.com as an owner to both sig-network leads and general discussion groups.