### PR TITLE
promote cloud-provider-kind v0.10.0

### DIFF
--- a/registry.k8s.io/images/k8s-staging-cloud-provider-kind/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-cloud-provider-kind/images.yaml
@@ -1,5 +1,6 @@
 - name: cloud-controller-manager
   dmap:
+    "sha256:dca2bf9c34ef2df549b81b5f286363521c7e473dbd3f232ebba1046436653f77": ["v0.10.0"]
     "sha256:4dc6fea7fcc986eeaf6b59d332599b125fc97f015fc87f7e2d2f9e0b1d5e6196": ["v0.9.0"]
     "sha256:5cf9f9a93d571f54f278567483e4225710e3948c6a1bf740b27cd47aa7de8380": ["v0.8.0"]
     "sha256:59d395103583174dfd5c653e08391d21dc66ea759f70a234e3f0cc87b1adedcd": ["v0.7.0"]


### PR DESCRIPTION
crane digest us-central1-docker.pkg.dev/k8s-staging-images/cloud-provider-kind/cloud-controller-manager:v20251129-4535525
sha256:dca2bf9c34ef2df549b81b5f286363521c7e473dbd3f232ebba1046436653f77


https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-cloud-provider-kind-image/1994762233007050752

/assign @BenTheElder @stmcginnis 