### PR TITLE
chore: changes for CAPA maintainers

### DIFF
--- a/registry.k8s.io/images/k8s-staging-cluster-api-aws/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-cluster-api-aws/OWNERS
@@ -2,12 +2,13 @@
 
 approvers:
 - richardcase
-- Ankitasw
 - dlipovetsky
 - nrb
 - AndiDog
+- damdo
 
 emeritus_approvers:
+- Ankitasw
 - chuckha
 - detiber
 - ncdc


### PR DESCRIPTION
Changes to the maintainers list for CAPA.

https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5760