### PR TITLE
create new staging dl for node-readiness-controller

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -185,6 +185,7 @@ restrictions:
       - "^k8s-infra-staging-kmm@kubernetes.io$"
       - "^k8s-infra-staging-nfd@kubernetes.io$"
       - "^k8s-infra-staging-npd@kubernetes.io$"
+      - "^k8s-infra-staging-nrc@kubernetes.io$"
       - "^k8s-infra-staging-sp-operator@kubernetes.io$"
       - "^k8s-infra-staging-dra-example-driver@kubernetes.io$"
   - path: "sig-release/groups.yaml"

--- a/groups/sig-node/groups.yaml
+++ b/groups/sig-node/groups.yaml
@@ -157,6 +157,17 @@ groups:
       - patrick.ohly@intel.com
       - pkrishn@google.com
 
+  - email-id: k8s-infra-staging-nrc@kubernetes.io
+    name: k8s-infra-staging-nrc
+    description: |-
+      ACL for pushing node-readiness-controller (nrc) artifacts
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - ajaysundar.k@gmail.com
+      - sig-node-leads@kubernetes.io
+      - timallclair@gmail.com
+
   #
   # k8s-infra gcs write access
   #


### PR DESCRIPTION
Addresses https://github.com/kubernetes/k8s.io/pull/8832#issuecomment-3610938732

adds a new dl, required for the staging registry creation for node-readiness-controller project.

ref: https://github.com/kubernetes-sigs/node-readiness-controller/issues/20