### PR TITLE
Create cve-feed-maintainers@kubernetes.io

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -243,6 +243,8 @@ restrictions:
   - path: "sig-security/groups.yaml"
     allowedGroups:
       - "^security-tooling-private@kubernetes.io$"
+      - "^cve-feed-maintainers@kubernetes.io$"
+      - "^k8s-infra-staging-sig-security@kubernetes.io$"
       - "^sig-security@kubernetes.io$"
       - "^sig-security-leads@kubernetes.io$"
   - path: "sig-storage/groups.yaml"

--- a/groups/sig-security/groups.yaml
+++ b/groups/sig-security/groups.yaml
@@ -57,3 +57,32 @@ groups:
     members:
       - security-release-team@kubernetes.io
       - eric.smalling@gmail.com
+
+  - email-id: cve-feed-maintainers@kubernetes.io
+    name: cve-feed-maintainers
+    description: |-
+      Private list for operational notifications about the CVE feed automation.
+
+      Membership is restricted to the SIG Security Leads,
+      SIG Security Tooling Lead, and others who maintain the CVE feed.
+    settings:
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      ReconcileMembers: "true"
+    owners:
+      - ian@coldwater.io
+      - tabitha.c.sable@gmail.com
+      - cailyn.codes@gmail.com
+    members:
+      - mahe.tardy@gmail.com
+
+  - email-id: k8s-infra-staging-sig-security@kubernetes.io
+    name: k8s-infra-staging-sig-security
+    description: |-
+      Private list for GCP project access.
+
+      Aliased to cve-feed-maintainers@kubernetes.io for ease of maintainence.
+    settings:
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      ReconcileMembers: "true"
+    members:
+      - cve-feed-maintainers@kubernetes.io


### PR DESCRIPTION
For progress on https://github.com/kubernetes/sig-security/issues/149

New list will receive errors from CVE feed calculation prow job, and be used to control access to GCP project for cloud build.