### PR TITLE
sig-cluster-lifecycle: add damdo to CAPA

### DIFF
--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -299,10 +299,10 @@ groups:
       ReconcileMembers: "true"
     members:
       - richmcase@gmail.com
-      - ankita.swamy20@gmail.com
       - daniel.lipovetsky@gmail.com
       - andreas.sommer87@googlemail.com
       - nolan@nbrubaker.com
+      - damiano.donati@gmail.com
 
   - email-id: sig-cluster-lifecycle-cluster-api-aws-alerts@kubernetes.io
     name: sig-cluster-lifecycle-cluster-api-aws-alerts
@@ -317,10 +317,10 @@ groups:
       ReconcileMembers: "false"
     owners:
       - richmcase@gmail.com
-      - ankita.swamy20@gmail.com
       - daniel.lipovetsky@gmail.com
       - andreas.sommer87@googlemail.com
       - nolan@nbrubaker.com
+      - damiano.donati@gmail.com
 
   - email-id: k8s-infra-staging-cluster-api-do@kubernetes.io
     name: k8s-infra-staging-cluster-api-do


### PR DESCRIPTION
Following up from https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/5760
Adding myself in the CAPA groups