### PR TITLE
promote dranet image

### DIFF
--- a/registry.k8s.io/images/k8s-staging-networking/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-networking/images.yaml
@@ -1,3 +1,6 @@
+- name: dranet
+  dmap:
+    "sha256:3248d8a520584100a5e87a2b92039591ea3b83a5492cc3e2d881b20d3b18ada6": ["stable", "v1.0.1"]
 - name: ip-masq-agent
   dmap:
     "sha256:ea696f45c75fde5d2239b457520bbf2f71465467136d4238e4549d8464b61848": ["v2.12.0"]


### PR DESCRIPTION
```
crane digest gcr.io/k8s-staging-networking/dranet:stable
sha256:3248d8a520584100a5e87a2b92039591ea3b83a5492cc3e2d881b20d3b18ada6

```

copied from current Google registry

```
crane copy ghcr.io/google/dranet:v1.0.1 gcr.io/k8s-staging-networking/dranet:stable
2025/12/15 05:41:14 Copying from ghcr.io/google/dranet:v1.0.1 to gcr.io/k8s-staging-networking/dranet:stable
2025/12/15 05:41:16 existing manifest: sha256:9d70a069b3856122ed0ed4f366da1ed6a3daa01646ed73c7eda47ce491446009
2025/12/15 05:41:16 existing manifest: sha256:530743660578e020d2d64585eaabf093fb001c837cb410d2d1371906b7f97a39
2025/12/15 05:41:16 existing manifest: sha256:f3007157b128c27fbae2faa2fbb1c25d3841458f658e7b984ff543e08dfa722c
2025/12/15 05:41:17 existing manifest: sha256:3e30e2dc0619808835f65c84345b2c92938a54f8a9a859befe580bce6fd80b56
2025/12/15 05:41:17 gcr.io/k8s-staging-networking/dranet:stable: digest: sha256:3248d8a520584100a5e87a2b92039591ea3b83a5492cc3e2d881b20d3b18ada6 size: 1609

```

/assign @gauravkghildiyal @michaelasp 