### PR TITLE
CAPO: Sync owners from repo

### DIFF
--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -222,6 +222,8 @@ groups:
     members:
       - emacchi@redhat.com
       - lennart.jern@est.tech
+      - m.andre@redhat.com
+      - stephenfin@redhat.com
 
   - email-id: sig-cluster-lifecycle-cluster-api-openstack-alerts@kubernetes.io
     name: sig-cluster-lifecycle-cluster-api-openstack-alerts

--- a/registry.k8s.io/images/k8s-staging-capi-openstack/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-capi-openstack/OWNERS
@@ -1,9 +1,27 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- EmilienM
-- jichenjc
+- emilienm
 - lentzi90
-- mdbooth
-- seanschneeweiss
+- mandre
+- stephenfin
+
+reviewers:
+- bnallapeta
+- smoshiur1237
+
+emeritus_approvers:
+- ncdc
+- chaosaffe
+- chrigl
+- dims
+- gyliu513
+- Lion-Wei
+- m1093782566
+- sbueringer
+- hidekazuna
+- chrischdi
 - tobiasgiese
+- seanschneeweiss
+- jichenjc
+- mdbooth


### PR DESCRIPTION
For reference, the owners and aliases in CAPO:
- https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/main/OWNERS
- https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/main/OWNERS_ALIASES