### PR TITLE
Add agentic net project name to the locals.registries list

### DIFF
--- a/infra/gcp/terraform/k8s-staging-images/registries.tf
+++ b/infra/gcp/terraform/k8s-staging-images/registries.tf
@@ -17,6 +17,7 @@ limitations under the License.
 locals {
   // The groups have to be created before applying this terraform code
   registries = {
+    agentic-net                     = "group:k8s-infra-staging-agentic-net@kubernetes.io"
     agent-sandbox                   = "group:k8s-infra-staging-agent-sandbox@kubernetes.io"
     aws-encryption-provider         = "group:k8s-infra-staging-provider-aws@kubernetes.io"
     charts                          = "group:k8s-infra-release-admins@kubernetes.io"


### PR DESCRIPTION
- The sig project: https://github.com/kubernetes-sigs/kube-agentic-networking
- Followed instruction from https://github.com/kubernetes/k8s.io/blob/main/registry.k8s.io/README.md#creating-staging-repos