### PR TITLE
k8s-infra-staging-sig-security@: Remove nested groups, use direct group membership.

### DIFF
--- a/groups/sig-security/groups.yaml
+++ b/groups/sig-security/groups.yaml
@@ -80,9 +80,13 @@ groups:
     description: |-
       Private list for GCP project access.
 
-      Aliased to cve-feed-maintainers@kubernetes.io for ease of maintainence.
+      Needs to be manually synchronized with cve-feed-maintainers@kubernetes.io
+      due to lack of support for nested groups.
     settings:
       WhoCanPostMessage: "ANYONE_CAN_POST"
       ReconcileMembers: "true"
     members:
-      - cve-feed-maintainers@kubernetes.io
+      - ian@coldwater.io
+      - tabitha.c.sable@gmail.com
+      - cailyn.codes@gmail.com
+      - mahe.tardy@gmail.com


### PR DESCRIPTION
It seems that google cloud does not support nested groups in the way we were trying to use them. Let's list out the group memberships directly, to see if this makes the project appear in the users' google cloud console.