### PR TITLE
view argocd diffs in PRs

### DIFF
--- a/.github/actions/argocd-diff.yaml
+++ b/.github/actions/argocd-diff.yaml
@@ -1,0 +1,44 @@
+name: Argo CD Diff Preview
+
+on:
+  pull_request:
+    paths:
+      - 'kubernetes/**' # All Kubernetes manifests owned by ArgoCD live here
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: pull-request
+
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          path: main
+
+      - name: Generate Diff
+        run: |
+          docker run \
+            --network=host \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v $(pwd)/main:/base-branch \
+            -v $(pwd)/pull-request:/target-branch \
+            -v $(pwd)/output:/output \
+            -e TARGET_BRANCH=refs/pull/${{ github.event.number }}/merge \
+            -e REPO=${{ github.repository }} \
+            dagandersen/argocd-diff-preview:v0.1.19
+
+      - name: Post diff as comment
+        run: |
+          gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body-file output/diff.md --edit-last || \
+          gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body-file output/diff.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/kubernetes/gke-prow-build/prow/kustomization.yaml
+++ b/kubernetes/gke-prow-build/prow/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
   - boskos-resources-configmap.yaml
   - boskos.yaml
   - build-serviceaccounts.yaml
-  - externalsecrets.yaml
+  - secrets.yaml
   - limit-range.yaml
   - monitoring.yaml
   - test-pods-poddisruptionbudget.yaml


### PR DESCRIPTION
Details: https://github.com/dag-andersen/argocd-diff-preview

I would like to see the diffs between a proposed change and the current code in main, especially when we are modifying helm charts, etc where the diff isn't clear from the change. It also validates the proposed changes and catches misconfigurations in kustomize, etc