### PR TITLE
use a bot token instead of the workflow token

### DIFF
--- a/.github/workflows/argocd-diff.yaml
+++ b/.github/workflows/argocd-diff.yaml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -37,8 +36,8 @@ jobs:
             dagandersen/argocd-diff-preview:v0.1.19
 
       - name: Post diff as comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.K8S_INFRA_CI_BOT_PR_TOKEN }}
         run: |
           gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body-file output/diff.md --edit-last || \
           gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body-file output/diff.md
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The actions workflow I merged earlier in #8906 doesn't work because sig-contribex block write permissions for Actions. xref: https://github.com/kubernetes/org/issues/5126

I generated a fine-grained PR write-only token for @k8s-infra-ci-robot and added it as a secret to this repo for actions to use. 

Actions errors: https://github.com/kubernetes/k8s.io/actions/runs/20486128939