### PR TITLE
fix a missing service account in filepromoter manifest

### DIFF
--- a/artifacts/filestores/k8s-staging-provider-gcp/filepromoter-manifest.yaml
+++ b/artifacts/filestores/k8s-staging-provider-gcp/filepromoter-manifest.yaml
@@ -3,3 +3,4 @@ filestores:
 - base: gs://k8s-staging-cloud-provider-gcp
   src: true
 - base: gs://k8s-artifacts-prod/binaries/cloud-provider-gcp/
+  service-account: k8s-infra-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
The file promotion failed because I missed a service account in #8886 

/cc @hakman 

```
mahamed@dev:/tmp$ curl https://artifacts.k8s.io/binaries/cloud-provider-gcp/v35.0.0/auth-provider-gcp/linux/amd64/auth-provider-gcp -IL
HTTP/2 307
content-type: text/html; charset=utf-8
location: https://storage.googleapis.com/k8s-artifacts-prod/binaries/cloud-provider-gcp/v35.0.0/auth-provider-gcp/linux/amd64/auth-provider-gcp
x-cloud-trace-context: eefea3258b0abb858946669533cabde5
date: Fri, 26 Dec 2025 18:27:08 GMT
server: Google Frontend
via: 1.1 google
alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000

HTTP/2 404
content-type: application/xml; charset=UTF-8
x-guploader-uploadid: AHVrFxOjp1jFww7GR0_K8mwwRNn9zEfjH2_2E-24YDHY6KXtSQF1LESRAcQRUgpIudTiFxAWlTgA1kI
content-length: 264
date: Fri, 26 Dec 2025 18:27:08 GMT
expires: Fri, 26 Dec 2025 18:27:08 GMT
cache-control: private, max-age=0
server: UploadServer
```