### PR TITLE
bump datadog to 3.157.3

### DIFF
--- a/kubernetes/eks-prow-build/datadog/kustomization.yaml
+++ b/kubernetes/eks-prow-build/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.118.0
+    version: 3.157.3
     kubeVersion: "1.32"
     valuesFile: values.yaml
 

--- a/kubernetes/eks-prow-build/datadog/values.yaml
+++ b/kubernetes/eks-prow-build/datadog/values.yaml
@@ -24,6 +24,17 @@ datadog:
       uncompressedLayersSupport: true
     host:
       enabled: true
+  operator:
+    enabled: false
+  kubernetesResourcesLabelsAsTags:
+    nodes:
+      kubernetes.io/arch: kubernetes.io/arch
+    pods:
+      prow.k8s.io/refs.org: prow.k8s.io/refs.org
+      prow.k8s.io/refs.repo: prow.k8s.io/refs.repo
+      prow.k8s.io/type: prow.k8s.io/type
+      prow.k8s.io/job: prow.k8s.io/job
+      prow.k8s.io/id: prow.k8s.io/id
 clusterAgent:
   tokenExistingSecret: datadog-secret
 agents:

--- a/kubernetes/eks-prow-kops/datadog/kustomization.yaml
+++ b/kubernetes/eks-prow-kops/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.157.0
+    version: 3.157.3
     kubeVersion: "1.30"
     valuesFile: values.yaml
 

--- a/kubernetes/eks-prow-kops/datadog/values.yaml
+++ b/kubernetes/eks-prow-kops/datadog/values.yaml
@@ -27,6 +27,17 @@ datadog:
   apm:
     instrumentation:
       skipKPITelemetry: true # https://github.com/DataDog/helm-charts/issues/1395
+  operator:
+    enabled: false
+  kubernetesResourcesLabelsAsTags:
+    nodes:
+      kubernetes.io/arch: kubernetes.io/arch
+    pods:
+      prow.k8s.io/refs.org: prow.k8s.io/refs.org
+      prow.k8s.io/refs.repo: prow.k8s.io/refs.repo
+      prow.k8s.io/type: prow.k8s.io/type
+      prow.k8s.io/job: prow.k8s.io/job
+      prow.k8s.io/id: prow.k8s.io/id
 clusterAgent:
   tokenExistingSecret: datadog-secret
 agents:

--- a/kubernetes/gke-aaa/datadog/kustomization.yaml
+++ b/kubernetes/gke-aaa/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.118.0
+    version: 3.157.3
     valuesFile: values.yaml
 
 resources:

--- a/kubernetes/gke-aaa/datadog/values.yaml
+++ b/kubernetes/gke-aaa/datadog/values.yaml
@@ -30,6 +30,8 @@ datadog:
   apm:
     instrumentation:
       skipKPITelemetry: true # https://github.com/DataDog/helm-charts/issues/1395
+  operator:
+    enabled: false
 clusterAgent:
   tokenExistingSecret: datadog-secret
 agents:

--- a/kubernetes/gke-prow-build-trusted/datadog/kustomization.yaml
+++ b/kubernetes/gke-prow-build-trusted/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.135.4
+    version: 3.157.3
     valuesFile: values.yaml
 
 resources:

--- a/kubernetes/gke-prow-build-trusted/datadog/values.yaml
+++ b/kubernetes/gke-prow-build-trusted/datadog/values.yaml
@@ -27,6 +27,17 @@ datadog:
   apm:
     instrumentation:
       skipKPITelemetry: true # https://github.com/DataDog/helm-charts/issues/1395
+  operator:
+    enabled: false
+  kubernetesResourcesLabelsAsTags:
+    nodes:
+      kubernetes.io/arch: kubernetes.io/arch
+    pods:
+      prow.k8s.io/refs.org: prow.k8s.io/refs.org
+      prow.k8s.io/refs.repo: prow.k8s.io/refs.repo
+      prow.k8s.io/type: prow.k8s.io/type
+      prow.k8s.io/job: prow.k8s.io/job
+      prow.k8s.io/id: prow.k8s.io/id
 clusterAgent:
   tokenExistingSecret: datadog-secret
 agents:

--- a/kubernetes/gke-prow-build/datadog/kustomization.yaml
+++ b/kubernetes/gke-prow-build/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.135.4
+    version: 3.157.3
     valuesFile: values.yaml
 
 resources:

--- a/kubernetes/gke-prow-build/datadog/values.yaml
+++ b/kubernetes/gke-prow-build/datadog/values.yaml
@@ -30,6 +30,17 @@ datadog:
   apm:
     instrumentation:
       skipKPITelemetry: true # https://github.com/DataDog/helm-charts/issues/1395
+  operator:
+    enabled: false
+  kubernetesResourcesLabelsAsTags:
+    nodes:
+      kubernetes.io/arch: kubernetes.io/arch
+    pods:
+      prow.k8s.io/refs.org: prow.k8s.io/refs.org
+      prow.k8s.io/refs.repo: prow.k8s.io/refs.repo
+      prow.k8s.io/type: prow.k8s.io/type
+      prow.k8s.io/job: prow.k8s.io/job
+      prow.k8s.io/id: prow.k8s.io/id
 clusterAgent:
   tokenExistingSecret: datadog-secret
 agents:

--- a/kubernetes/gke-prow/datadog/kustomization.yaml
+++ b/kubernetes/gke-prow/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.135.4
+    version: 3.157.3
     valuesFile: values.yaml
 
 resources:

--- a/kubernetes/gke-prow/datadog/values.yaml
+++ b/kubernetes/gke-prow/datadog/values.yaml
@@ -30,6 +30,8 @@ datadog:
   apm:
     instrumentation:
       skipKPITelemetry: true # https://github.com/DataDog/helm-charts/issues/1395
+  operator:
+    enabled: false
 clusterAgent:
   tokenExistingSecret: datadog-secret
 agents:

--- a/kubernetes/gke-utility/datadog/kustomization.yaml
+++ b/kubernetes/gke-utility/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.135.4
+    version: 3.157.3
     valuesFile: values.yaml
 
 resources:

--- a/kubernetes/gke-utility/datadog/values.yaml
+++ b/kubernetes/gke-utility/datadog/values.yaml
@@ -30,6 +30,8 @@ datadog:
   apm:
     instrumentation:
       skipKPITelemetry: true # https://github.com/DataDog/helm-charts/issues/1395
+  operator:
+    enabled: false
 clusterAgent:
   tokenExistingSecret: datadog-secret
 agents:


### PR DESCRIPTION
Bumping datadog to the latest version and adding specific pod labels to the metrics to achieve parity with https://monitoring-gke.prow.k8s.io/d/96Q8oOOZk/builds?orgId=1&refresh=30s&var-org=kubernetes&var-repo=kubernetes&var-job=ci-kubernetes-unit&var-build=All&from=now-7d&to=now

Also, the chart installs the operator which we don't use, so I turned it off.

/cc @hakman