### PR TITLE
Update s390x cluster URLs to new endpoint

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow/iam.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/iam.tf
@@ -175,12 +175,12 @@ resource "google_iam_workload_identity_pool_provider" "ppc64le" {
 }
 
 data "http" "s390x_issuer" {
-  url      = "https://d7b2a019-eu-de.lb.appdomain.cloud:6443/.well-known/openid-configuration"
+  url      = "https://b9100f68-eu-de.lb.appdomain.cloud:6443/.well-known/openid-configuration"
   insecure = true
 }
 
 data "http" "s390x_jwks" {
-  url      = "https://d7b2a019-eu-de.lb.appdomain.cloud:6443/openid/v1/jwks"
+  url      = "https://b9100f68-eu-de.lb.appdomain.cloud:6443/openid/v1/jwks"
   insecure = true
 }
 

--- a/kubernetes/gke-utility/argocd/clusters.yaml
+++ b/kubernetes/gke-utility/argocd/clusters.yaml
@@ -129,7 +129,7 @@ spec:
       engineVersion: v2
       data:
         name: ibm-s390x
-        server: https://d7b2a019-eu-de.lb.appdomain.cloud:6443
+        server: https://b9100f68-eu-de.lb.appdomain.cloud:6443
         config: "{{ .config }}"
       metadata:
         labels:


### PR DESCRIPTION
Changed s390x cluster URLs in Terraform and ArgoCD configs from `d7b2a019` to `b9100f68`. This updates the issuer and server endpoints to reflect the new cluster address.