### PR TITLE
expand 5k scale pool

### DIFF
--- a/kubernetes/gke-prow-build/prow/boskos-resources-configmap.yaml
+++ b/kubernetes/gke-prow-build/prow/boskos-resources-configmap.yaml
@@ -211,10 +211,9 @@ data:
       type: scalability-project
     - names:
       - k8s-infra-e2e-scale-5k-project
-      # uncomment after the quotas have been bumped
-      # - k8s-infra-e2e-boskos-scale-28
-      # - k8s-infra-e2e-boskos-scale-29
-      # - k8s-infra-e2e-boskos-scale-30
+      - k8s-infra-e2e-boskos-scale-28
+      - k8s-infra-e2e-boskos-scale-29
+      - k8s-infra-e2e-boskos-scale-30
       state: dirty
       type: scalability-scale-project
     - names:


### PR DESCRIPTION
These gcp projects have had their quotas bumped and can run 5k nodes.

xref: #8602

/hold