### PR TITLE
patch a few bugs in ArgoCD and bump ESO

### DIFF
--- a/.github/workflows/argocd-diff.yaml
+++ b/.github/workflows/argocd-diff.yaml
@@ -1,21 +1,27 @@
 name: Argo CD Diff Preview
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - 'kubernetes/**' # All Kubernetes manifests owned by ArgoCD live here
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout the PR
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           path: pull-request
+          ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: actions/checkout@v4
+      - name: Checkout out kubernetes/k8s.io main branch
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           ref: main
           path: main
@@ -32,6 +38,21 @@ jobs:
             -e REPO=${{ github.repository }} \
             dagandersen/argocd-diff-preview:v0.1.19
 
+      - name: Upload artifact
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f #v6.0.0
+        with:
+          name: diff-md
+          path: output/diff.md
+
+  comment:
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: diff-md
+          path: output
       - name: Post diff as comment
         env:
           GH_TOKEN: ${{ secrets.K8S_INFRA_CI_BOT_PR_TOKEN }}

--- a/kubernetes/apps/external-secrets.yaml
+++ b/kubernetes/apps/external-secrets.yaml
@@ -22,7 +22,7 @@ spec:
       sources:
         - chart: external-secrets
           repoURL: "https://charts.external-secrets.io"
-          targetRevision: 1.0.0
+          targetRevision: 1.2.0
           helm:
             releaseName: external-secrets
             parameters:
@@ -30,6 +30,8 @@ spec:
                 value: "true"
               - name: serviceAccount.name
                 value: external-secrets
+              - name: crds.annotations.argocd\.argoproj\.io/sync-options
+                value: ServerSideApply=true
             valueFiles:
               - $values/kubernetes/{{ .name }}/helm/external-secrets.yaml
         - repoURL: "https://github.com/kubernetes/k8s.io.git"

--- a/kubernetes/apps/kube-system.yaml
+++ b/kubernetes/apps/kube-system.yaml
@@ -13,7 +13,9 @@ spec:
             - key: name
               operator: NotIn
               values:
+                - gke-aaa
                 - gke-prow
+                - gke-utility
   template:
     metadata:
       name: 'kube-system-{{ .name }}'

--- a/kubernetes/gke-prow/prow/crds/prowjob-crd.yaml
+++ b/kubernetes/gke-prow/prow/crds/prowjob-crd.yaml
@@ -9,7 +9,6 @@ metadata:
   creationTimestamp: null
   name: prowjobs.prow.k8s.io
 spec:
-  preserveUnknownFields: false
   group: prow.k8s.io
   names:
     kind: ProwJob

--- a/kubernetes/gke-utility/argocd/clusters.yaml
+++ b/kubernetes/gke-utility/argocd/clusters.yaml
@@ -3,6 +3,7 @@ kind: Secret
 metadata:
   name: gke-prow
   labels:
+    name: gke-prow
     argocd.argoproj.io/secret-type: cluster
     clusterType: prow
     environment: prod
@@ -29,6 +30,7 @@ kind: Secret
 metadata:
   name: gke-prow-build
   labels:
+    name: gke-prow-build
     argocd.argoproj.io/secret-type: cluster
     clusterType: prow
     environment: prod
@@ -52,6 +54,7 @@ kind: Secret
 metadata:
   name: gke-prow-build-trusted
   labels:
+    name: gke-prow-build-trusted
     argocd.argoproj.io/secret-type: cluster
     clusterType: prow
     environment: prod
@@ -75,6 +78,7 @@ kind: Secret
 metadata:
   name: gke-aaa
   labels:
+    name: gke-aaa
     argocd.argoproj.io/secret-type: cluster
     clusterType: apps
     environment: prod
@@ -106,6 +110,7 @@ spec:
         config: "{{ .config }}"
       metadata:
         labels:
+          name: ibm-ppc64le
           argocd.argoproj.io/secret-type: cluster
           clusterType: prow
           environment: prod
@@ -133,6 +138,7 @@ spec:
         config: "{{ .config }}"
       metadata:
         labels:
+          name: ibm-s390x
           argocd.argoproj.io/secret-type: cluster
           clusterType: prow
           environment: prod
@@ -151,6 +157,7 @@ kind: Secret
 metadata:
   name: eks-prow-kops
   labels:
+    name: eks-prow-kops
     argocd.argoproj.io/secret-type: cluster
     clusterType: prow
     environment: prod
@@ -175,6 +182,7 @@ kind: Secret
 metadata:
   name: eks-prow-build
   labels:
+    name: eks-prow-build
     argocd.argoproj.io/secret-type: cluster
     clusterType: prow
     environment: prod

--- a/kubernetes/gke-utility/helm/external-secrets.yaml
+++ b/kubernetes/gke-utility/helm/external-secrets.yaml
@@ -7,6 +7,14 @@ extraObjects:
       provider:
         gcpsm:
           projectID: k8s-infra-prow
+ -  apiVersion: external-secrets.io/v1
+    kind: ClusterSecretStore
+    metadata:
+      name: k8s-infra-prow-build
+    spec:
+      provider:
+        gcpsm:
+          projectID: k8s-infra-prow-build
  -  apiVersion: monitoring.googleapis.com/v1
     kind: PodMonitoring
     metadata:


### PR DESCRIPTION
Patching a few bugs in our manifests:
- Bumping ESO to the latest version, also the CRDs are huge so the CRDs need to use SSA
- The appset generator doesn't filter by name so you need to use the label name and then filter by that label key.
- `preserveUnknownFields: false` in the prow CRD is causing a permadiff so I removed that as well