### PR TITLE
deploy new testgrid UI

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -247,6 +247,16 @@ hooks.prow:
   - type: AAAA
     ttl: 600 # this has needed to change in the past
     value: "2600:1901:0:b465::"
+testgrid.prow:
+  - type: A
+    value: 34.128.150.99
+  - type: AAAA
+    value: "2600:1901:0:b465::"
+testgrid-api.prow:
+  - type: A
+    value: 34.128.150.99
+  - type: AAAA
+    value: "2600:1901:0:b465::"
 # prow-certificates in k8s-infra-prow project
 _acme-challenge.prow:
   type: CNAME

--- a/kubernetes/gke-prow/prow/gateway.yaml
+++ b/kubernetes/gke-prow/prow/gateway.yaml
@@ -71,3 +71,33 @@ spec:
     - type: RequestRedirect
       requestRedirect:
         scheme: https
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: testgrid-ui
+spec:
+  parentRefs:
+  - name: prow
+    sectionName: https
+  hostnames:
+  - testgrid.prow.k8s.io
+  rules:
+  - backendRefs:
+    - name: testgrid-ui
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: testgrid-api
+spec:
+  parentRefs:
+  - name: prow
+    sectionName: https
+  hostnames:
+  - testgrid-api.prow.k8s.io
+  rules:
+  - backendRefs:
+    - name: testgrid-proxy
+      port: 80

--- a/kubernetes/gke-prow/prow/kustomization.yaml
+++ b/kubernetes/gke-prow/prow/kustomization.yaml
@@ -20,3 +20,4 @@ resources:
   - statusreconciler.yaml
   - tide.yaml
   - monitoring.yaml
+  - testgrid.yaml

--- a/kubernetes/gke-prow/prow/testgrid.yaml
+++ b/kubernetes/gke-prow/prow/testgrid.yaml
@@ -1,0 +1,174 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testgrid-api
+  labels:
+    app: testgrid
+    component: api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: testgrid
+      component: api
+  template:
+    metadata:
+      labels:
+        app: testgrid
+        component: api
+    spec:
+      serviceAccountName: testgrid-api
+      containers:
+      - name: testgrid-api
+        image: gcr.io/k8s-testgrid/api:v20251223-v0.0.175-2-g0e84967e
+        args:
+        - --allowed-origin=*
+        - --scope=gs://k8s-testgrid
+        - --port=8080
+        ports:
+        - name: http
+          containerPort: 8080
+        resources:
+          requests:
+            cpu: 200m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: testgrid-api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: testgrid-api
+spec:
+  selector:
+    app: testgrid
+    component: api
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testgrid-ui
+  labels:
+    app: testgrid
+    component: ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: testgrid
+      component: ui
+  template:
+    metadata:
+      labels:
+        app: testgrid
+        component: ui
+    spec:
+      serviceAccountName: testgrid-ui
+      containers:
+      - name: testgrid-ui
+        image: gcr.io/k8s-staging-test-infra/testgrid-ui:latest
+        ports:
+        - name: http
+          containerPort: 80
+        resources:
+          requests:
+            cpu: 200m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: testgrid-ui
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: testgrid-ui
+spec:
+  selector:
+    app: testgrid
+    component: ui
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: testgrid-proxy
+  labels:
+    app: testgrid-proxy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: testgrid-proxy
+  template:
+    metadata:
+      labels:
+        app: testgrid-proxy
+    spec:
+      containers:
+      - name: nginx
+        image: cgr.dev/chainguard/nginx
+        ports:
+        - name: http
+          containerPort: 80
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+          limits:
+            cpu: 250m
+            memory: 256Mi
+        volumeMounts:
+        - name: nginx-config
+          mountPath: /etc/nginx/conf.d/nginx.conf
+          subPath: nginx.conf
+      volumes:
+      - name: nginx-config
+        configMap:
+          name: nginx-proxy-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-proxy-config
+data:
+  nginx.conf: |
+    server {
+        listen 80;
+        server_name localhost;
+
+        location / {
+            proxy_pass http://testgrid-data.k8s.io/;
+        }
+    }
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: testgrid-proxy
+spec:
+  selector:
+    app: testgrid-proxy
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  type: ClusterIP


### PR DESCRIPTION
Fixes: #8740

I deployed the new testgrid UI, however it is broken.

Action Items:
- The testgrid API needs to be deployed via HTTPS. I copied over the prod manifest https://github.com/GoogleCloudPlatform/testgrid/blob/main/cluster/prod/api.yaml and deployed it in our cluster. However, we can't access the `k8s-testgrid` bucket. I would need the googlers to grant permission to our principal which is `principal://iam.googleapis.com/projects/16065310909/locations/global/workloadIdentityPools/k8s-infra-prow.svc.id.goog/subject/ns/default/sa/testgrid-api` or arrange transferring this bucket to the k8s-infra-prow project along with the testgrid deployment.
- Automate the image build pipeline. The image was manually built like this `docker build . --platform linux/amd64 -t gcr.io/k8s-staging-test-infra/testgrid-ui:latest --build-arg API_URL=https://testgrid-api.prow.k8s.io --push`
- Withdraw the testgrid-data.k8s.io endpoint and replace it with testgrid-api.prow.k8s.io


<img width="1496" height="729" alt="image" src="https://github.com/user-attachments/assets/7a8aee57-e225-499c-aeac-25c1f92cf750" />

@SohamChakraborty 
