### PR TITLE
promote gvisor image for minikube

### DIFF
--- a/registry.k8s.io/images/k8s-staging-minikube/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-minikube/images.yaml
@@ -3,4 +3,4 @@
     "sha256:57f19c6a0b6a78f180f0ed65b7d548602839f2a5379f1febf3bd7055e729f629": ["v1", "v2", "v11"]
 - name: gvisor
   dmap:
-    "sha256:2cc0438e89691ed5eab3fce6b68fce6982e5de189418ebfc97a0932cda9bc080": ["v3"]
+    "sha256:2cc0438e89691ed5eab3fce6b68fce6982e5de189418ebfc97a0932cda9bc080": ["v0.0.3"]


### PR DESCRIPTION
got the SHA from https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-minikube-gvisor-addon-image/2009434597758078976


closes https://github.com/kubernetes/minikube/issues/22404