### PR TITLE
node-readiness-controller: promote images to v0.1.0 tag

### DIFF
--- a/registry.k8s.io/images/k8s-staging-node-readiness-controller/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-node-readiness-controller/images.yaml
@@ -1,1 +1,6 @@
-# No images yet
+- name: node-readiness-controller
+  dmap:
+    "sha256:b9a70b7f08d0bfce70d6c1472e5d4906a656629586c792a76fd06663e0014b0d": ["v0.1.0"]
+- name: node-readiness-reporter
+  dmap:
+    "sha256:87d79a67d167a3c44ed554cac5df1162f3a1a9b844cfa90114bf817c9da4f208": ["v0.1.0"]


### PR DESCRIPTION
ref: https://github.com/kubernetes-sigs/node-readiness-controller/pull/76#discussion_r2681105143

cc: @ajaysundark 

/hold