### PR TITLE
Increase TTL for prow_secret to 12 hours

### DIFF
--- a/infra/ibmcloud/terraform/k8s-power-conformance/modules/secrets_manager/secrets_manager.tf
+++ b/infra/ibmcloud/terraform/k8s-power-conformance/modules/secrets_manager/secrets_manager.tf
@@ -34,8 +34,8 @@ resource "ibm_sm_iam_credentials_secret" "prow_secret" {
   access_groups = [var.pvs_access_group_id]
   labels        = ["rotate:true"]
 
-  //The time-to-live (TTL) or lease duration of generated secret 14400seconds = 4hrs
-  ttl = "21600"
+  //The time-to-live (TTL) or lease duration of generated secret 43200seconds = 12hrs
+  ttl = "43200"
 }
 
 resource "ibm_sm_iam_credentials_secret" "janitor_secret" {


### PR DESCRIPTION
Updated the TTL for the `ibm_sm_iam_credentials_secret` prow_secret resource from `14400` seconds (4 hours) to `43200` seconds (12 hours) to extend the lease duration of generated secrets
Ref Job: https://testgrid.k8s.io/ibm-s390x-k8s#ci-kubernetes-s390x-conformance-latest-kubetest2