### PR TITLE
Update TTL for prow_secret in secrets manager modules

### DIFF
--- a/infra/ibmcloud/terraform/k8s-power-conformance/modules/secrets_manager/secrets_manager.tf
+++ b/infra/ibmcloud/terraform/k8s-power-conformance/modules/secrets_manager/secrets_manager.tf
@@ -34,8 +34,8 @@ resource "ibm_sm_iam_credentials_secret" "prow_secret" {
   access_groups = [var.pvs_access_group_id]
   labels        = ["rotate:true"]
 
-  //The time-to-live (TTL) or lease duration of generated secret 43200seconds = 12hrs
-  ttl = "43200"
+  //The time-to-live (TTL) or lease duration of generated secret 21600seconds = 6hrs
+  ttl = "21600"
 }
 
 resource "ibm_sm_iam_credentials_secret" "janitor_secret" {

--- a/infra/ibmcloud/terraform/k8s-s390x-conformance/modules/secrets_manager/secret_manager.tf
+++ b/infra/ibmcloud/terraform/k8s-s390x-conformance/modules/secrets_manager/secret_manager.tf
@@ -32,8 +32,8 @@ resource "ibm_sm_iam_credentials_secret" "prow_secret" {
   access_groups = [var.vpc_build_cluster_access_group_id]
   labels        = ["rotate:true"]
 
-  //The time-to-live (TTL) or lease duration of generated secret 14400seconds = 4hrs
-  ttl = "14400"
+  //The time-to-live (TTL) or lease duration of generated secret 43200seconds = 12hrs
+  ttl = "43200"
 }
 resource "ibm_sm_iam_credentials_secret" "janitor_secret" {
   depends_on    = [ibm_sm_iam_credentials_configuration.sm_iam_credentials_configuration_instance]

--- a/kubernetes/ibm-s390x/helm/external-secrets.yaml
+++ b/kubernetes/ibm-s390x/helm/external-secrets.yaml
@@ -94,10 +94,12 @@ extraObjects:
                   set -o pipefail
 
                   go install sigs.k8s.io/provider-ibmcloud-test-infra/secret-manager@71ef4d8
-                  secret-manager rotate --instance-id 0664d47c-fe42-423f-930d-69570443cd15 --labels rotate:true --confirm
+                  secret-manager rotate --instance-id 0664d47c-fe42-423f-930d-69570443cd15 --region eu-de --labels rotate:true --confirm
                 env:
                 - name: IBMCLOUD_ENV_FILE
                   value: "/home/.ibmcloud/api-key"
+                - name: IBMCLOUD_REGION
+                  value: "eu-de"
                 volumeMounts:
                 - name: credentials
                   mountPath: /home/.ibmcloud


### PR DESCRIPTION
### Changes Made:
- k8s-s390x-conformance from 4hrs to 12hrs to better align with required secret rotation policies.
- Added `--region eu-de ` flag and IBMCLOUD_REGION=eu-de environment variable to ensure the CLI uses the correct regional endpoint.

### Reason for these changes:
While debugging recent failures in the `ibmcloud-secret-rotator` cronJob, noticed that the Secrets Manager CLI was defaulting to the `us-south` endpoint, even though the Secrets Manager instance is provisioned in `eu-de`

This resulted in DNS resolution failures like:
```
go: downloading github.com/go-playground/locales v0.14.1
Error: Get "https://0664d47c-fe42-423f-930d-69570443cd15.us-south.secrets-manager.appdomain.cloud/api/v2/secrets?limit=10&match_all_labels=rotate%3Atrue&secret_types=iam_credentials": dial tcp: lookup 0664d47c-fe42-423f-930d-69570443cd15.us-south.secrets-manager.appdomain.cloud on 10.96.0.10:53: no such host
```
the CronJob and Helm config already assume `eu-de`, but the CLI falls back to `us-south` unless explicitly specified.