### PR TITLE
create observability project and access

### DIFF
--- a/infra/gcp/terraform/k8s-infra-observability/main.tf
+++ b/infra/gcp/terraform/k8s-infra-observability/main.tf
@@ -1,0 +1,74 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This file defines:
+- GCP project for centralized observability infrastructure
+- Required APIs
+- IAM bindings for admin and viewer groups
+*/
+
+locals {
+  project_id = "k8s-infra-observability"
+}
+
+data "google_billing_account" "account" {
+  billing_account = "018801-93540E-22A20E"
+}
+
+data "google_organization" "org" {
+  domain = "kubernetes.io"
+}
+
+// Create the observability project
+resource "google_project" "project" {
+  name            = local.project_id
+  project_id      = local.project_id
+  org_id          = data.google_organization.org.org_id
+  billing_account = data.google_billing_account.account.id
+}
+
+// Enable required GCP APIs
+resource "google_project_service" "services" {
+  project = google_project.project.id
+
+  for_each = toset([
+    "cloudresourcemanager.googleapis.com",
+    "compute.googleapis.com",
+    "container.googleapis.com",
+    "iam.googleapis.com",
+    "logging.googleapis.com",
+    "monitoring.googleapis.com",
+    "servicenetworking.googleapis.com",
+    "storage.googleapis.com",
+  ])
+
+  service = each.key
+}
+
+// Owner access for admins 
+resource "google_project_iam_member" "admins" {
+  project = google_project.project.id
+  role    = "roles/owner"
+  member  = "group:k8s-infra-observability-admins@kubernetes.io"
+}
+
+// Viewer access
+resource "google_project_iam_member" "viewers" {
+  project = google_project.project.id
+  role    = "roles/viewer"
+  member  = "group:k8s-infra-observability-viewers@kubernetes.io"
+}

--- a/infra/gcp/terraform/k8s-infra-observability/provider.tf
+++ b/infra/gcp/terraform/k8s-infra-observability/provider.tf
@@ -1,0 +1,33 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  backend "gcs" {
+    bucket = "k8s-infra-tf-state"
+    prefix = "k8s-infra-observability"
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.7.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 7.7.0"
+    }
+  }
+}

--- a/infra/gcp/terraform/k8s-infra-observability/versions.tf
+++ b/infra/gcp/terraform/k8s-infra-observability/versions.tf
@@ -1,0 +1,19 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  required_version = "~> 1.6"
+}


### PR DESCRIPTION
## What this PR does

  Creates the GCP project `k8s-infra-observability` for centralized observability infrastructure.

  ### Resources Created
  - GCP project under kubernetes.io organization
  - APIs enabled for GKE, storage, monitoring
  - IAM bindings for admin and viewer groups

  ### Prerequisites
  - PR #8942 (groups) must be merged first
  - Groups must be synced before this can apply

  ## Why

  Second step toward centralized observability. This project will host:
  - Dedicated GKE cluster for Mimir/Grafana
  - GCS bucket for long-term metrics storage

  See #8351 for full context.

  /sig k8s-infra
  /depends-on https://github.com/kubernetes/k8s.io/pull/8942
cc: @ameukam 
