### PR TITLE
Add v1.36 Release Team members

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -350,15 +350,10 @@ groups:
       - rayandas91@gmail.com # v1.36 Release Lead Shadow
       - rytswd@gmail.com # v1.36 Release Lead
     members:
-      - agustina.barbetta@gmail.com # v1.36 Release Lead Shadow
       - chadmcrowell@gmail.com # v1.36 Communications Lead
       - gmail@yudocaa.in # v1.36 Docs Lead
       - j@mickey.dev # v1.36 Enhancements Lead
-      - jenny.shu@solo.io # v1.36 Release Lead Shadow
       - prajyotparab19@gmail.com # v1.36 Release Signal Lead
-      - rawat.dipesh@gmail.com # v1.36 Release Lead Shadow
-      - rayandas91@gmail.com # v1.36 Release Lead Shadow
-      - rytswd@gmail.com # v1.36 Release Lead
 
   - email-id: release-team-shadows@kubernetes.io
     name: release-team-shadows


### PR DESCRIPTION
As the shadow selection process is underway, this only adds the Release Lead, Release Lead Shadows, and Subteam Leads.