### PR TITLE
Update "rel.k8s.io/release-team-cal" shortlink to point to Kubernetes release calendar

### DIFF
--- a/apps/k8s-io/README.md
+++ b/apps/k8s-io/README.md
@@ -72,7 +72,7 @@ NOTE: please see k8s.io/k8s.io/configmap-nginx.yaml for `server` definitions
 
 ### Direct Redirects
 - https://rel.k8s.io/ → https://github.com/kubernetes/kubernetes/releases
-- https://rel.k8s.io/k8s-release-cal → https://calendar.google.com/calendar/embed?src=kipmnllvl17vl9m98jen6ujcrs%40group.calendar.google.com
+- https://rel.k8s.io/release-team-cal → https://calendar.google.com/calendar/embed?src=agst.us_b07popf7t4avmt4km7eq5tk5ao%40group.calendar.google.com
 - https://rel.k8s.io/k8s-sig-release-videos → https://youtube.com/playlist?list=PL69nYSiGNLP3QKkOsDsO6A0Y1rhgP84iZ&si=Mi095CYuJuz8LjN-
 
 ### Version-specific Redirects

--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -356,7 +356,7 @@ data:
 
         location / {
           rewrite ^/$                               https://github.com/kubernetes/kubernetes/releases redirect;
-          rewrite ^/k8s-release-cal                 https://calendar.google.com/calendar/embed?src=kipmnllvl17vl9m98jen6ujcrs%40group.calendar.google.com redirect;
+          rewrite ^/release-team-cal                https://calendar.google.com/calendar/embed?src=agst.us_b07popf7t4avmt4km7eq5tk5ao%40group.calendar.google.com redirect;
           rewrite ^/k8s-sig-release-videos          https://youtube.com/playlist?list=PL69nYSiGNLP3QKkOsDsO6A0Y1rhgP84iZ&si=Mi095CYuJuz8LjN- redirect;
           rewrite ^/v([0-9])([0-9]+)/([a-zA-Z]+)$   https://github.com/kubernetes/sig-release/tree/master/releases/release-$1.$2/links.md#$3 redirect;
           rewrite ^/([^/]*)(/.*)?$                  https://github.com/kubernetes/kubernetes/tree/$1$2 redirect;


### PR DESCRIPTION
### Description

This change updates the release calendar shortlink ( from `https://rel.k8s.io/k8s-release-cal` to `https://rel.k8s.io/release-team-cal`) so that it points to the Kubernetes v1.xx release team calendar, matching the original behavior of the bitly link.

- Old
https://bit.ly/k8s-release-cal  -> https://calendar.google.com/calendar/embed?src=agst.us_b07popf7t4avmt4km7eq5tk5ao%40group.calendar.google.com

- New (post this PR merge)
https://rel.k8s.io/release-team-cal -> https://calendar.google.com/calendar/embed?src=agst.us_b07popf7t4avmt4km7eq5tk5ao%40group.calendar.google.com

/cc @katcosgrove @fsmunoz @rytswd 