### PR TITLE
Fix ibmcloud-secret-rotator CLI to apply --region before instance

### DIFF
--- a/kubernetes/ibm-s390x/helm/external-secrets.yaml
+++ b/kubernetes/ibm-s390x/helm/external-secrets.yaml
@@ -94,7 +94,11 @@ extraObjects:
                   set -o pipefail
 
                   go install sigs.k8s.io/provider-ibmcloud-test-infra/secret-manager@71ef4d8
-                  secret-manager rotate --instance-id 0664d47c-fe42-423f-930d-69570443cd15 --region eu-de --labels rotate:true --confirm
+                  secret-manager rotate \
+                    --region eu-de \
+                    --instance-id 0664d47c-fe42-423f-930d-69570443cd15 \
+                    --labels rotate:true \
+                    --confirm
                 env:
                 - name: IBMCLOUD_ENV_FILE
                   value: "/home/.ibmcloud/api-key"


### PR DESCRIPTION
This change fixes an issue where the ibmcloud-secret-rotator CronJob was attempting to contact the us-south Secrets Manager endpoint, even though the Secrets Manager instance is provisioned in eu-de, causing repeated DNS resolution failures.