### PR TITLE
reduce the boskos sweep attempts to 2

### DIFF
--- a/kubernetes/eks-prow-build/prow/boskos-janitor.yaml
+++ b/kubernetes/eks-prow-build/prow/boskos-janitor.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     app: aws-boskos-janitor
 spec:
-  replicas: 2 # 2 distributed janitor instances
+  replicas: 4 # 4 distributed janitor instances
   selector:
     matchLabels:
       app: aws-boskos-janitor
@@ -36,6 +36,7 @@ spec:
             - --boskos-url=http://boskos.test-pods.svc.cluster.local.
             - --resource-type=aws-account
             - --exclude-tags=Boskos=Ignore
+            - --sweep-count=2
           resources:
             requests:
               cpu: 500m


### PR DESCRIPTION
We added more resources to boskos to sweep and the cleanup is taking too long. I bumped the replicas to 4 and we sweep every region twice instead of 5 times.

You can see the improvement [here](https://monitoring-eks.prow.k8s.io/d/wSrfvNxWz/boskos-resource-usage?orgId=1&from=now-7d&to=now).

