### PR TITLE
fix argocd-differ

### DIFF
--- a/.github/workflows/argocd-diff.yaml
+++ b/.github/workflows/argocd-diff.yaml
@@ -28,15 +28,26 @@ jobs:
 
       - name: Generate Diff
         run: |
+          # Kustomize and Helm don't work by default with argocd-diff, so we need to amend argocd a bit
+          kind create cluster
+          helm repo add argo https://argoproj.github.io/argo-helm
+          helm upgrade --install argocd argo/argo-cd --version 9.3.4 --create-namespace --namespace argocd-diff-preview \
+            --set config.params."kustomize\.buildOptions"="--load-restrictor LoadRestrictionsNone --enable-alpha-plugins"
+          kubectl apply -n argocd-diff-preview -f pull-request/kubernetes/gke-utility/argocd/clusters.yaml || true # ignore errors from missing ES
+          kubectl apply -n argocd-diff-preview -f pull-request/kubernetes/gke-utility/argocd/clusters-diff.yaml # ES based clusters
+
           docker run \
             --network=host \
+            -v ~/.kube:/root/.kube \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v $(pwd)/main:/base-branch \
             -v $(pwd)/pull-request:/target-branch \
             -v $(pwd)/output:/output \
             -e TARGET_BRANCH=refs/pull/${{ github.event.number }}/merge \
             -e REPO=${{ github.repository }} \
-            dagandersen/argocd-diff-preview:v0.1.19
+            dagandersen/argocd-diff-preview:v0.1.21 \
+            --argocd-namespace=argocd-diff-preview \
+            --create-cluster=false
 
       - name: Upload artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f #v6.0.0
@@ -57,5 +68,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.K8S_INFRA_CI_BOT_PR_TOKEN }}
         run: |
-          gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body-file output/diff.md --edit-last || \
-          gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body-file output/diff.md
+          gh pr comment ${{ github.event.number }} --repo ${{ github.repository }} --body-file output/diff.md --edit-last --create-if-none

--- a/kubernetes/eks-prow-build/datadog/values.yaml
+++ b/kubernetes/eks-prow-build/datadog/values.yaml
@@ -7,6 +7,7 @@ datadog:
   logs:
     enabled: true
     containerCollectAll: true
+    autoMultiLineDetection: true
   prometheusScrape:
     enabled: true
     serviceEndpoints: true
@@ -24,6 +25,9 @@ datadog:
       uncompressedLayersSupport: true
     host:
       enabled: true
+  apm:
+    instrumentation:
+      skipKPITelemetry: true # https://github.com/DataDog/helm-charts/issues/1395
   operator:
     enabled: false
   kubernetesResourcesLabelsAsTags:

--- a/kubernetes/gke-utility/argocd/clusters-diff.yaml
+++ b/kubernetes/gke-utility/argocd/clusters-diff.yaml
@@ -1,0 +1,51 @@
+# This file is used by the argocd-diff github actions workflow, never add it kustomization.yaml
+# The IBM clusters are loaded via ExternalSecrets which the ephemeral argocd-diff-preview cluster
+# cannot access. Therefore we create the same clusters with server set to localhost:8080
+# and random username/password so it appears as a valid cluster and we can generate the appsets
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ibm-ppc64le
+  labels:
+    name: ibm-ppc64le
+    argocd.argoproj.io/secret-type: cluster
+    clusterType: prow
+    environment: prod
+    prowNamespace: test-pods
+    cloud: ibm
+type: Opaque
+stringData:
+  name: ibm-ppc64le
+  server: http://localhost:8080
+  config: |
+    {
+      "username": "foobar",
+      "password": "string",
+      "tlsClientConfig": {
+        "insecure": true
+      }
+    }
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ibm-s390x
+  labels:
+    name: ibm-s390x
+    argocd.argoproj.io/secret-type: cluster
+    clusterType: prow
+    environment: prod
+    prowNamespace: test-pods
+    cloud: ibm
+type: Opaque
+stringData:
+  name: ibm-s390x
+  server: http://localhost:8080
+  config: |
+    {
+      "username": "foobar",
+      "password": "string",
+      "tlsClientConfig": {
+        "insecure": true
+      }
+    }


### PR DESCRIPTION
So our argocd-diff-preview hasn't been working correctly for a few reasons:
- The bundled argocd in the docker image doesn't allow kustomize with helm so I had to fix that with a modified argocd install
- `Generated 0 applications from 9 ApplicationSets for branch: main (branch: main)` this happened because we generate applications from appsets that require the clusters to be added, which is why we apply the clusters.yaml and the differ works correctly.
- The IBM clusters pull their credentials from Secret Manager so I substituted them with dummy cluster credentials but same labels and name.