### PR TITLE
Add v1.36 docs shadows to release-team, release-team-shadows

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -351,9 +351,13 @@ groups:
       - rytswd@gmail.com # v1.36 Release Lead
     members:
       - chadmcrowell@gmail.com # v1.36 Communications Lead
+      - diane.todea@gmail.com # v1.36 Docs Shadow
+      - emile.savard.21@gmail.com # v1.36 Docs Shadow
       - gmail@yudocaa.in # v1.36 Docs Lead
       - j@mickey.dev # v1.36 Enhancements Lead
       - prajyotparab19@gmail.com # v1.36 Release Signal Lead
+      - singh1203.ss@gmail.com # v1.36 Docs Shadow
+      - tusharmittalworkm@gmail.com # v1.36 Docs Shadow
 
   - email-id: release-team-shadows@kubernetes.io
     name: release-team-shadows
@@ -376,12 +380,16 @@ groups:
     members:
       - agustina.barbetta@gmail.com # v1.36 Release Lead Shadow
       - chadmcrowell@gmail.com # v1.36 Communications Lead
+      - diane.todea@gmail.com # v1.36 Docs Shadow
+      - emile.savard.21@gmail.com # v1.36 Docs Shadow
       - gmail@yudocaa.in # v1.36 Docs Lead
       - j@mickey.dev # v1.36 Enhancements Lead
       - jenny.shu@solo.io # v1.36 Release Lead Shadow
       - prajyotparab19@gmail.com # v1.36 Release Signal Lead
       - rawat.dipesh@gmail.com # v1.36 Release Lead Shadow
       - rayandas91@gmail.com # v1.36 Release Lead Shadow
+      - singh1203.ss@gmail.com # v1.36 Docs Shadow
+      - tusharmittalworkm@gmail.com # v1.36 Docs Shadow
 
   # RBAC groups:
   # - grant access to the `namespace-user` role for a single namespace on the `aaa` cluster


### PR DESCRIPTION
This PR adds the new onboarding docs shadows to relevant google-groups.