### PR TITLE
Promote pets/zookeeper-installer:1.7 image

### DIFF
--- a/registry.k8s.io/images/k8s-staging-e2e-test-images/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-e2e-test-images/images.yaml
@@ -147,6 +147,7 @@
 - name: pets/zookeeper-installer
   dmap:
     "sha256:8cc5701cf3d0882cb2b7cd85cf1cdabb63294e5495c2329b67727008c42e44ee": ["1.5"]
+    "sha256:93f1ff7469dfd1de4833ad0983fb5df995e4864c3d1580acbfb42d5e93b25536": ["1.7"]
 - name: redis
   dmap:
     "sha256:faf766493fd9cc93bee4bf64c85d452af2f7b9d5febee52a55bbebfaf46d45e2": ["5.0.5-alpine"]


### PR DESCRIPTION
Promote the zookeeper-installer image version 1.7 from staging to production registry.

```
$ crane digest gcr.io/k8s-staging-e2e-test-images/pets/zookeeper-installer:1.7
sha256:93f1ff7469dfd1de4833ad0983fb5df995e4864c3d1580acbfb42d5e93b25536
```

CI job that created the image:
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-kubernetes-push-e2e-pets-zookeeper-installer-test-images/2013722608284995584