### PR TITLE
Promote e2e-test-images: node-perf/pytorch-wide-deep:1.0.0

### DIFF
--- a/registry.k8s.io/images/k8s-staging-e2e-test-images/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-e2e-test-images/images.yaml
@@ -129,6 +129,9 @@
     "sha256:d5d5822ef70f81db66c1271662e1b9d4556fb267ac7ae09dee5d91aa10736431": ["1.1"]
     "sha256:44d13eac1e70b9494b9ef8eee2932c80863a01812cdcc1dfff5d1d43d97a6816": ["1.2"]
     "sha256:91ab3b5ee22441c99370944e2e2cb32670db62db433611b4e3780bdee6a8e5a1": ["1.3"]
+- name: node-perf/pytorch-wide-deep
+  dmap:
+    "sha256:b56f2be85afe0c248e900d26f393f7cd6ac16a370c17dcfe2f6bc7bd51ca4e72": ["1.0.0"]
 - name: nonewprivs
   dmap:
     "sha256:553fcda2222ccea7cd534c8da34b709feb768d6389eb7333444b13f296bd168f": ["1.1"]


### PR DESCRIPTION
Image digest obtained via:
```
$ crane digest gcr.io/k8s-staging-e2e-test-images/node-perf/pytorch-wide-deep:1.0.0
sha256:b56f2be85afe0c248e900d26f393f7cd6ac16a370c17dcfe2f6bc7bd51ca4e72
```

Build URL:
https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-kubernetes-push-e2e-node-perf-pytorch-wide-deep-test-images/2014348705729089536