### PR TITLE
Update CNAME entry for kube-agentic-networking website

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -573,7 +573,7 @@ node-readiness-controller.sigs:
   type: CNAME
   value: node-readiness-controller.netlify.app.
 # https://github.com/kubernetes-sigs/kube-agentic-networking docs (@LiorLieberman, @david-martin, @yuzisun)
-agentic-networking.sigs:
+kube-agentic-networking.sigs:
   type: CNAME
   value: kube-agentic-networking.netlify.app.
 # https://github.com/kubernetes-sigs/dranet docs (@aojea)


### PR DESCRIPTION
Follow up on https://github.com/kubernetes/k8s.io/pull/8927
Netlify site is up at https://kube-agentic-networking.netlify.app/
Fixing the DNS entry to reflect that.

cc @LiorLieberman 