### PR TITLE
Replace lon04 DC with new region in boskos on ibm ppc64le

### DIFF
--- a/kubernetes/ibm-ppc64le/prow/boskos-resources-configmap.yaml
+++ b/kubernetes/ibm-ppc64le/prow/boskos-resources-configmap.yaml
@@ -3,10 +3,10 @@ data:
   config: |
     resources:
     - names:
-      - k8s-boskos-powervs-lon04
-      - k8s-boskos-powervs-lon04-01
-      - k8s-boskos-powervs-lon04-02
-      - k8s-boskos-powervs-lon04-03
+      - k8s-boskos-powervs-eu-de-1-01
+      - k8s-boskos-powervs-eu-de-1-02
+      - k8s-boskos-powervs-eu-de-2-01
+      - k8s-boskos-powervs-eu-de-2-02
       - k8s-boskos-powervs-lon06
       - k8s-boskos-powervs-lon06-01
       - k8s-boskos-powervs-lon06-02


### PR DESCRIPTION
Removing old workspaces in `lon04` zone and adding a new ones in `eu-du-1 and `eu-du-2` which is stable on IBM PowerVS.