### PR TITLE
Promote cpa images: v1.10.3 and v0.8.10

### DIFF
--- a/registry.k8s.io/images/k8s-staging-cpa/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-cpa/images.yaml
@@ -9,6 +9,7 @@
     "sha256:7a155604bfa165e1c8a0959d0134ecf4e6151c859355e9256a1d11973faf4ea5": ["v1.8.8-rc.1"]
     "sha256:2c2863bd990298d2aa01c12c3ac76698a5691cf389b419884e62e90407e82cfc": ["v1.8.9"]
     "sha256:8f3b4e4beb62a9a5ad1ff96712129996e614d1fe7c57739c9816545ecea6f8b6": ["v1.9.0"]
+    "sha256:a4d0ab78d5e2ec356c981f361a5ff7012b21ad353b4a980e1ca30c11dda6564b": ["v1.10.3"]
 - name: cluster-proportional-autoscaler-amd64
   dmap:
     "sha256:e310b7e60ed5dabcf9945fb86ee049bafde69b01ac0b9eb647c2b96c273e18d8": ["1.8.2"]
@@ -36,6 +37,7 @@
 - name: cpvpa
   dmap:
     "sha256:f6c85b45bb5e8ce6077855425bdd03e93d41926dbf6b751af64ab1ea41e1755b": ["v0.8.4"]
+    "sha256:ef244168d16a061fd7c90ef5b7cc3b10760f195be3dae365493838335ceda14a": ["v0.8.10"]
 - name: cpvpa-amd64
   dmap:
     "sha256:627e119c876fa41e61d34a1f216a46d74a20ab6ed13392970011df8d9c25e621": ["v0.8.4"]


### PR DESCRIPTION
Ref https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/issues/262, we are cutting a new release for both CPA and CPVA:
- https://github.com/kubernetes-sigs/cluster-proportional-autoscaler/releases/tag/v1.10.3
- https://github.com/kubernetes-sigs/cluster-proportional-vertical-autoscaler/releases/tag/v0.8.10

/assign @bowei @thockin 