### PR TITLE
Remove alvaroaleman from sig-testing leads

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -113,7 +113,6 @@ aliases:
     - xing-yang
   sig-testing-leads:
     - BenTheElder
-    - alvaroaleman
     - aojea
     - cjwagner
     - jbpratt


### PR DESCRIPTION
Ref
https://groups.google.com/g/kubernetes-sig-testing/c/qnZYgiDQzEM/m/NQh71udtAAAJ, I missed removing myself here previously.