### PR TITLE
Update owners and staging repo ACL for dra-driver-cpu

### DIFF
--- a/groups/sig-node/groups.yaml
+++ b/groups/sig-node/groups.yaml
@@ -156,6 +156,8 @@ groups:
       - klueska@gmail.com
       - patrick.ohly@intel.com
       - pkrishn@google.com
+      - fromani@redhat.com
+      - sig-node-leads@kubernetes.io
 
   - email-id: k8s-infra-staging-nrc@kubernetes.io
     name: k8s-infra-staging-nrc

--- a/registry.k8s.io/images/k8s-staging-dra-driver-cpu/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-dra-driver-cpu/OWNERS
@@ -4,6 +4,9 @@ approvers:
 - johnbelamaric
 - klueska
 - pohly
+- ffromani
+- pravk03
+- sig-node-leads
 labels:
 - wg/device-management
 - sig/node


### PR DESCRIPTION
Owners updated based on https://github.com/kubernetes-sigs/dra-driver-cpu/blob/main/OWNERS 