### PR TITLE
Update the v1.36 Docs shadows details with current members

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -361,11 +361,11 @@ groups:
       - rytswd@gmail.com # v1.36 Release Lead
     members:
       - amanshrivastava118@gmail.com # v1.36 Release Signal Shadow
+      - anshuman.tripathi305@gmail.com # v1.36 Docs Shadow
       - chadmcrowell@gmail.com # v1.36 Communications Lead
       - cst.grzn@gmail.com # v1.36 Release Signal Shadow
       - danieljoshuachan@gmail.com # v1.36 Communications Shadow
       - dhanisha.6@gmail.com # v1.36 Release Signal Shadow
-      - diane.todea@gmail.com # v1.36 Docs Shadow
       - drewhagendev@gmail.com # v1.36 BRM Shadow
       - emile.savard.21@gmail.com # v1.36 Docs Shadow
       - gmail@yudocaa.in # v1.36 Docs Lead
@@ -410,11 +410,11 @@ groups:
     members:
       - agustina.barbetta@gmail.com # v1.36 Release Lead Shadow
       - amanshrivastava118@gmail.com # v1.36 Release Signal Shadow
+      - anshuman.tripathi305@gmail.com # v1.36 Docs Shadow
       - chadmcrowell@gmail.com # v1.36 Communications Lead
       - cst.grzn@gmail.com # v1.36 Release Signal Shadow
       - danieljoshuachan@gmail.com # v1.36 Communications Shadow
       - dhanisha.6@gmail.com # v1.36 Release Signal Shadow
-      - diane.todea@gmail.com # v1.36 Docs Shadow
       - emile.savard.21@gmail.com # v1.36 Docs Shadow
       - gmail@yudocaa.in # v1.36 Docs Lead
       - j@mickey.dev # v1.36 Enhancements Lead


### PR DESCRIPTION
We've a change in the Docs Shadow team. This PR updates the release-team, release-team-shadows google groups to accomodate the current member details.