### PR TITLE
Fix canary NS delegations for k8s.dev and kubernetes.dev

### DIFF
--- a/dns/zone-configs/k8s.dev._1_canary.yaml
+++ b/dns/zone-configs/k8s.dev._1_canary.yaml
@@ -2,7 +2,7 @@
 canary:
   type: NS
   values:
-  - ns-cloud-a1.googledomains.com.
-  - ns-cloud-a2.googledomains.com.
-  - ns-cloud-a3.googledomains.com.
-  - ns-cloud-a4.googledomains.com.
+  - ns-cloud-d1.googledomains.com.
+  - ns-cloud-d2.googledomains.com.
+  - ns-cloud-d3.googledomains.com.
+  - ns-cloud-d4.googledomains.com.

--- a/dns/zone-configs/kubernetes.dev._1_canary.yaml
+++ b/dns/zone-configs/kubernetes.dev._1_canary.yaml
@@ -2,7 +2,7 @@
 canary:
   type: NS
   values:
-  - ns-cloud-b1.googledomains.com.
-  - ns-cloud-b2.googledomains.com.
-  - ns-cloud-b3.googledomains.com.
-  - ns-cloud-b4.googledomains.com.
+  - ns-cloud-c1.googledomains.com.
+  - ns-cloud-c2.googledomains.com.
+  - ns-cloud-c3.googledomains.com.
+  - ns-cloud-c4.googledomains.com.


### PR DESCRIPTION
## Summary

Corrects the NS delegation records for canary subdomains to match the actual Google Cloud DNS nameservers assigned to the canary zones.

## Changes

- `dns/zone-configs/k8s.dev._1_canary.yaml`: Update canary NS from ns-cloud-a* → ns-cloud-d*
- `dns/zone-configs/kubernetes.dev._1_canary.yaml`: Update canary NS from ns-cloud-b* → ns-cloud-c*

## Context

The canary NS records in the zone config files didn't match the actual nameservers assigned to the canary zones in the `kubernetes-public` GCP project. This mismatch prevented DNS queries from reaching the canary zones where verification TXT records are stored, blocking enterprise domain verification for these two domains.

## Verification

After deployment:
- `dig canary.k8s.dev NS` should return ns-cloud-d{1-4}.googledomains.com
- `dig canary.kubernetes.dev NS` should return ns-cloud-c{1-4}.googledomains.com
- Verification TXT records should be queryable from public DNS

🤖 Generated with [Claude Code](https://claude.com/claude-code)