### PR TITLE
promote kube-network-policies v1.0.0

### DIFF
--- a/registry.k8s.io/images/k8s-staging-networking/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-networking/images.yaml
@@ -51,6 +51,9 @@
     "sha256:b64448f2424c8c45a98102b80a2a050e7573ece120808106689c2324bf1fe842": ["v1.0.0"]
 - name: kube-network-policies
   dmap:
+    "sha256:d117e82e72f2cef7bf0a92070f6566fca0b4290eaee0d4a95a42f0d965292fa3": ["v1.0.0-iptracker"]
+    "sha256:bfc918b89829fa589192566cd64ddc26957b9a0b32cfc81ece543c06ad1f7734": ["v1.0.0-npa-v1alpha2"]
+    "sha256:1e3e79625828c8fdc9a579e3e587abaaadbb0eed317abc6912badb1b92f76135": ["v1.0.0"]
     "sha256:659319ad358df6d1bd4f1c4904530e7809b45a061a62a9d7ddcf9ecdb088d7ea": ["v0.9.2-iptracker"]
     "sha256:b88ed0965ee9f0be15806b4fa6bc607fb82f3513de8371ed2ace864f1c44ba5d": ["v0.9.2-npa-v1alpha2"]
     "sha256:df8407f91e71e0252dfaa95a9d71b48bd39f64a3ae5320e42d623c09695a4bee": ["v0.9.2"]


### PR DESCRIPTION
$ crane digest gcr.io/k8s-staging-networking/kube-network-policies:v20251105-d97bacf sha256:1e3e79625828c8fdc9a579e3e587abaaadbb0eed317abc6912badb1b92f76135 $ crane digest gcr.io/k8s-staging-networking/kube-network-policies:v20251105-d97bacf-npa-v1alpha2 sha256:bfc918b89829fa589192566cd64ddc26957b9a0b32cfc81ece543c06ad1f7734 $ crane digest gcr.io/k8s-staging-networking/kube-network-policies:v20251105-d97bacf-iptracker sha256:d117e82e72f2cef7bf0a92070f6566fca0b4290eaee0d4a95a42f0d965292fa3

commit d97bacf42a9de59c86afaadf3a29f9b538c31930 (HEAD -> main, tag: v1.0.0,

Fixes: https://github.com/kubernetes-sigs/kube-network-policies/issues/307