### PR TITLE
promoting images for IGW v1.3.1 release

### DIFF
--- a/registry.k8s.io/images/k8s-staging-gateway-api-inference-extension/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-gateway-api-inference-extension/images.yaml
@@ -28,6 +28,7 @@
     "sha256:75f318ea38e91d6746920415742bb2619ef17e5f4a31d6e53841df261a2d0b7a": ["v1.3.0-rc.3"]
     "sha256:db269e6337456f787819b9f2b91dd159a38711bd68e6919b61ab286c19ff3fe8": ["v1.3.0"]
     "sha256:1f68b215770e8a5d0b2bf8e4027809c895660ba99ce406f7c0d50dcdbfb3996f": ["v1.3.1-rc.1"]
+    "sha256:5195d8d8a4db995c1fd1dd4f98592d36972a84772d3a3640de560ba2915ea8cd": ["v1.3.1"]
 - name: charts/body-based-routing
   dmap:
     "sha256:fd9ab40eca8ba8d283a2d40d23e36d78a9bae3a3147d6dc70d0df4d32645fa71": ["v0.3.0-rc.1"]
@@ -58,6 +59,7 @@
     "sha256:f3210434de7c153a0cf3f1a5b31176db59e8b9cac19c4a142a0ae6a298f0019a": ["v1.3.0-rc.3"]
     "sha256:7d5b5037454f85790ac93f2bdd13c5a3cbee8e582aa4f2e9c7a131ea885c7334": ["v1.3.0"]
     "sha256:f3ba294a0359462430c09aed3399269eecbc77bdc7b256ce0168c4099ef8434f": ["v1.3.1-rc.1"]
+    "sha256:aedc6a36cdf1bf34d41886c525275b26711ce15996affc39d4eb94cd1f0f2dc8": ["v1.3.1"]
 - name: epp
   dmap:
     "sha256:a40d7c85b6ea5e8e25188edb614308c54ec0b495682c4e3a481d01074fa2468e": ["v0.1.0-rc.1"]
@@ -92,6 +94,7 @@
     "sha256:d2f6633466b35154f39e81bcaac7e820ca017b8c21eb18368db0f54f5f385c54": ["v1.3.0-rc.3"]
     "sha256:ff65450cce15fa960cb62a2630f31bf00c3ad6f0217d6f79420eb215aa64f8ac": ["v1.3.0"]
     "sha256:067d6d3d3adddb88726bd9d7d441820d76bac3673c1ef934a30757a1fcf8fd5a": ["v1.3.1-rc.1"]
+    "sha256:3329615b99badc550a1c347c2d5460578e726623cc3a22eed3ea7622eb791152": ["v1.3.1"]
 - name: bbr
   dmap:
     "sha256:a54d537a6fb0a274c71ce559afdd1683e809fcc373edbdebe65707188ba75344": ["v0.3.0-rc.1"]
@@ -122,6 +125,9 @@
     "sha256:53d7eee1ec08d3de239614d1898fdbbde83fa234c30cefabdac48d7a3746d52a": ["v1.3.0-rc.3"]
     "sha256:f58f03aa1042b81780543e6d7036b063a30d7d32a3fae2f7153498a64e593e18": ["v1.3.0"]
     "sha256:339a6bae316ec9b2acb6c5dec94260659b2c1213e2628d39f95202922e9460bf": ["v1.3.1-rc.1"]
+    "sha256:81751c60b5fd142bd803db92d6526849cda4fa09b49d0e8c6190fdfa01a4c58e": ["v1.3.1"]
+
+## Deprecated, no new images will be added, but old ones will be kept.
 - name: lora-syncer
   dmap:
     "sha256:842bd19df19f9754639305647271414ec9fa6952bc07936e4edafb6a79062438": ["v0.3.0-rc.1"]


### PR DESCRIPTION
https://pantheon.corp.google.com/artifacts/docker/k8s-staging-images/us-central1/gateway-api-inference-extension?e=13802955&invt=AcGaWQ&mods=logs_tg_prod