### PR TITLE
groups: add stlaz to secrets-store-sync-controller group

### DIFF
--- a/groups/sig-auth/groups.yaml
+++ b/groups/sig-auth/groups.yaml
@@ -110,6 +110,7 @@ groups:
     members:
       - anish.ramasekar@gmail.com
       - i@monis.app
+      - standalaz@gmail.com
 
   #
   # k8s-infra gcs write access


### PR DESCRIPTION
I believe this might be necessary so that I can finish releasing new version of the controller as per https://github.com/kubernetes-sigs/secrets-store-sync-controller/pull/191

/cc @enj @aramase 