### PR TITLE
promote secrets-store-sync controller:v0.0.3

### DIFF
--- a/registry.k8s.io/images/k8s-staging-secrets-store-sync/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-secrets-store-sync/images.yaml
@@ -1,3 +1,4 @@
 - name: controller
   dmap:
     "sha256:399febaa4c537111589a8a52dea7d1ec4cecce8c3d1010729e875a2e305a2f07": [ "v0.0.2" ]
+    "sha256:15768ff940ba7744d9994f8abde9ceb3ec3c5c6a024cb1256feb4d1b17c6b9f5": [ "v0.0.3" ]


### PR DESCRIPTION
Change generated by `registry.k8s.io/images/k8s-staging-secrets-store-sync/generate.sh`

Link to a green E2E Provider test: https://github.com/kubernetes-sigs/secrets-store-sync-controller/actions/runs/22406230869

/cc aramase enj