### PR TITLE
Add kops discovery server to kustomization

### DIFF
--- a/kubernetes/apps/kustomization.yaml
+++ b/kubernetes/apps/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - datadog.yaml
   - external-secrets.yaml
   - cert-manager.yaml
+  - kops-discovery.yaml
   - kube-system.yaml
   - kyverno.yaml
   - prow.yaml


### PR DESCRIPTION
Follow-up of:
  - https://github.com/kubernetes/k8s.io/pull/9149
  
  Needed so ArgoCD can reconcile the kubernetes manifests