### PR TITLE
Bump the probes image 0.0.7

### DIFF
--- a/registry.k8s.io/images/k8s-staging-perf-tests/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-perf-tests/images.yaml
@@ -46,7 +46,7 @@
     "sha256:1f7b520b759677f56a50c76372f9728099bd5375b5949b6f2fbafa5fdc8c2698": [ "2.55" ]
 - name: probes
   dmap:
-    "sha256:5f86f184607a48ea1b3578b3134f13ed482f12c32d05820667c977fb04e75a9c": [ "v0.0.7" ]
+    "sha256:1c962f8db30e2e52040f4be3ebf00d5634c2939e3efb76c12a5e51ade0040d40": [ "v0.0.8" ]
 - name: pushgateway
   dmap:
     "sha256:f74ff5b7ad0b8fb60c24b77eaeab025d659e46ec15f32430adb976544305c01f": [ "v1.4.2" ]

--- a/registry.k8s.io/images/k8s-staging-perf-tests/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-perf-tests/images.yaml
@@ -46,7 +46,7 @@
     "sha256:1f7b520b759677f56a50c76372f9728099bd5375b5949b6f2fbafa5fdc8c2698": [ "2.55" ]
 - name: probes
   dmap:
-    "sha256:e61dcd4cd12b8cfcfc7e74732db8fba6b8a1c2957f41f1880c57f89e14c70d31": [ "v0.0.7" ]
+    "sha256:5f86f184607a48ea1b3578b3134f13ed482f12c32d05820667c977fb04e75a9c": [ "v0.0.7" ]
 - name: pushgateway
   dmap:
     "sha256:f74ff5b7ad0b8fb60c24b77eaeab025d659e46ec15f32430adb976544305c01f": [ "v1.4.2" ]

--- a/registry.k8s.io/images/k8s-staging-perf-tests/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-perf-tests/images.yaml
@@ -47,7 +47,7 @@
 - name: probes
   dmap:
     "sha256:e61dcd4cd12b8cfcfc7e74732db8fba6b8a1c2957f41f1880c57f89e14c70d31": [ "v0.0.7" ]
-    "sha256:1c962f8db30e2e52040f4be3ebf00d5634c2939e3efb76c12a5e51ade0040d40": [ "v0.0.8" ]
+    "sha256:cd5e5f6345bc5012424da752c713713a22eb0e1c5fb68474c493e6b6516fd8d7": [ "v0.0.8" ]
 - name: pushgateway
   dmap:
     "sha256:f74ff5b7ad0b8fb60c24b77eaeab025d659e46ec15f32430adb976544305c01f": [ "v1.4.2" ]

--- a/registry.k8s.io/images/k8s-staging-perf-tests/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-perf-tests/images.yaml
@@ -46,6 +46,7 @@
     "sha256:1f7b520b759677f56a50c76372f9728099bd5375b5949b6f2fbafa5fdc8c2698": [ "2.55" ]
 - name: probes
   dmap:
+    "sha256:e61dcd4cd12b8cfcfc7e74732db8fba6b8a1c2957f41f1880c57f89e14c70d31": [ "v0.0.7" ]
     "sha256:1c962f8db30e2e52040f4be3ebf00d5634c2939e3efb76c12a5e51ade0040d40": [ "v0.0.8" ]
 - name: pushgateway
   dmap:


### PR DESCRIPTION
**What this PR does / why we need it:**
Bump the image to introduce changes from https://github.com/kubernetes/perf-tests/pull/3630, which introduce errorLogger and latencyLogger as well as flags enable-error-logging and enable-latency-logging to DNS propagation Prober.

**Special notes for your reviewer:**
```
gcrane digest gcr.io/k8s-staging-perf-tests/probes:v0.0.8 sha256:cd5e5f6345bc5012424da752c713713a22eb0e1c5fb68474c493e6b6516fd8d7
```
(Update on 27th August) I updated the digest as gcrane output a new one.

**If you are promoting an image, please make sure you have done the following:**

- [x]  I have verified the digest with [gcrane](https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md) and added it as a comment to the PR or in the body.
- [ ]  I'm promoting a multi-arch image that matches all the [supported](https://github.com/kubernetes/sig-release/tree/master/release-engineering/platforms) platforms of Kubernetes.
- [x]  I'm not promoting a tag that resolves to latest or moving tags as these are not supported
- [x]  registry.k8s.io is an immutable registry and I'll need to cut a new release if the digest is wrong.