### PR TITLE
update slack-infra deployments to use registry.k8s.io images

### DIFF
--- a/apps/slack-infra/resources/slack-event-log/deployment.yaml
+++ b/apps/slack-infra/resources/slack-event-log/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-event-log
-        image: gcr.io/k8s-staging-slack-infra/slack-event-log:v20210223-8525eb3
+        image: registry.k8s.io/slack-infra/slack-event-log:v20260709-3c87798
         args:
           - --config-path=/etc/slack-event-log/config.json
         ports:

--- a/apps/slack-infra/resources/slack-moderator-words/deployment.yaml
+++ b/apps/slack-infra/resources/slack-moderator-words/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-moderator-words
-        image: gcr.io/k8s-staging-slack-infra/slack-moderator-words:v20230228-2b433f6@sha256:a946cee92f8f97f1ae2599ea924af0cec489a9179bc0e4d753b6699d7eac7b6c
+        image: registry.k8s.io/slack-infra/slack-moderator-words:v20260709-3c87798
         args:
           - --config-path=/etc/slack-moderator-words/config.json
           - --filter-config-path=/etc/filters/filters.yaml

--- a/apps/slack-infra/resources/slack-moderator/deployment.yaml
+++ b/apps/slack-infra/resources/slack-moderator/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-moderator
-        image: gcr.io/k8s-staging-slack-infra/slack-moderator:v20210223-8525eb3
+        image: registry.k8s.io/slack-infra/slack-moderator:v20260709-3c87798
         args:
           - --config-path=/etc/slack-moderator/config.json
         ports:

--- a/apps/slack-infra/resources/slack-welcomer/deployment.yaml
+++ b/apps/slack-infra/resources/slack-welcomer/deployment.yaml
@@ -15,8 +15,8 @@ spec:
         app: slack-welcomer
     spec:
       containers:
-      - name: slack-moderator
-        image: gcr.io/k8s-staging-slack-infra/slack-welcomer:v20220304-82143f8@sha256:ee2858f2292d8a1fa91b0a85d6b941d82d7540cda1e65739a9957da6eea3f52e
+      - name: slack-welcomer
+        image: registry.k8s.io/slack-infra/slack-welcomer:v20260709-3c87798
         args:
           - --config-path=/etc/slack-welcomer/config.json
           - --message-path=/etc/welcome-message/welcome.md


### PR DESCRIPTION
This pull request updates slack-infra deployments to use registry.k8s.io images.
Split from PR #9213.