### PR TITLE
Adding matzew for mcp-lifecycle operator 

### DIFF
--- a/registry.k8s.io/images/k8s-staging-mcp-lifecycle-operator/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-mcp-lifecycle-operator/OWNERS
@@ -2,6 +2,7 @@
 
 approvers:
   - ArangoGutierrez
+  - matzew
   - mikebrow
   - mrunalp
   - soltysh


### PR DESCRIPTION
I am working on the mcp-lifecycle-operator project: https://github.com/kubernetes-sigs/mcp-lifecycle-operator/commits?author=matzew

Also I am member of the sig-apps: https://github.com/kubernetes/org/blob/main/config/kubernetes-sigs/org.yaml#L569 

I'd like to add myself to the `OWNERS` file of the image staging folder.
