### PR TITLE
Update WG Checkpoint Restore mailing lists

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -178,9 +178,9 @@ aliases:
     - rthallisey
   wg-checkpoint-restore-leads:
     - adrianreber
+    - andreyvelich
     - haircommander
     - rst0git
-    - viktoriaas
   wg-policy-leads:
     - JimBugwadia
     - poonam-lamba

--- a/groups/wg-checkpoint-restore/groups.yaml
+++ b/groups/wg-checkpoint-restore/groups.yaml
@@ -18,9 +18,9 @@ groups:
       MessageModerationLevel: "MODERATE_NONE"
     owners:
       - areber@redhat.com
+      - andrey.velichkevich@gmail.com
       - pehunt@redhat.com
       - radostin@stoyanov.io
-      - viktoria.spisakovaa@gmail.com
 
   - email-id: wg-checkpoint-restore@kubernetes.io
     name: wg-checkpoint-restore
@@ -39,8 +39,8 @@ groups:
       ReconcileMembers: "false"
     owners:
       - areber@redhat.com
+      - andrey.velichkevich@gmail.com
       - pehunt@redhat.com
       - radostin@stoyanov.io
-      - viktoria.spisakovaa@gmail.com
     members:
       - wg-checkpoint-restore-leads@kubernetes.io


### PR DESCRIPTION
As a follow up on the update in https://github.com/kubernetes/community/pull/8927, this pull request adds @andreyvelich to the owners for `wg-checkpoint-restore-leads` and `wg-checkpoint-restore`