### PR TITLE
Rename group for all NVIDIA accelerator related projects as dra-driver-nvidia

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -181,7 +181,7 @@ restrictions:
       - "^k8s-infra-push-cri-tools@kubernetes.io$"
       - "^k8s-infra-staging-cri-tools@kubernetes.io$"
       - "^k8s-infra-staging-dra-driver-cpu@kubernetes.io$"
-      - "^k8s-infra-staging-nv-dra-driver-gpu@kubernetes.io$"
+      - "^k8s-infra-staging-dra-driver-nvidia@kubernetes.io$"
       - "^k8s-infra-staging-kmm@kubernetes.io$"
       - "^k8s-infra-staging-nfd@kubernetes.io$"
       - "^k8s-infra-staging-npd@kubernetes.io$"

--- a/groups/sig-node/groups.yaml
+++ b/groups/sig-node/groups.yaml
@@ -180,15 +180,16 @@ groups:
       - fromani@redhat.com
       - sig-node-leads@kubernetes.io
 
-  - email-id: k8s-infra-staging-nv-dra-driver-gpu@kubernetes.io
-    name: k8s-infra-staging-nv-dra-driver-gpu
+  - email-id: k8s-infra-staging-dra-driver-nvidia@kubernetes.io
+    name: k8s-infra-staging-dra-driver-nvidia
     description: |-
-      ACL for pushing nv-dra-driver-gpu artifacts
+      ACL for pushing dra-driver-nvidia artifacts
     settings:
       ReconcileMembers: "true"
     members:
       - davanum@gmail.com
       - klueska@gmail.com
+      - shivamerla@nvidia.com
       - sig-node-leads@kubernetes.io
 
   - email-id: k8s-infra-staging-nrc@kubernetes.io


### PR DESCRIPTION
Following the proposal of https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/issues/988 this change will create a single group called `dra-driver-nvidia` for all NVIDIA accelerator types and all images will share the same registry.