### PR TITLE
deploy artifacts.k8s.io to fastly

### DIFF
--- a/dns/zone-configs/k8s.dev._0_base.yaml
+++ b/dns/zone-configs/k8s.dev._0_base.yaml
@@ -8,6 +8,19 @@ www:
   type: CNAME
   value: kubernetes-contributor.netlify.app.
 
+artifacts:
+  - type: A
+    values:
+      - 151.101.1.91
+      - 151.101.65.91
+      - 151.101.129.91
+      - 151.101.193.91
+  - type: AAAA
+    values:
+      - 2a04:4e42::347
+      - 2a04:4e42:200::347
+      - 2a04:4e42:400::347
+      - 2a04:4e42:600::347
 dl:
   - type: A
     values:
@@ -21,6 +34,9 @@ dl:
       - 2a04:4e42:200::347
       - 2a04:4e42:400::347
       - 2a04:4e42:600::347
+_acme-challenge.artifacts:
+  type: CNAME
+  value: cy71vyk1da78pss707.fastly-validations.com.
 _acme-challenge.dl:
   type: CNAME
   value: zsmu1n0ec6lb2wtmt8.fastly-validations.com.

--- a/infra/fastly/terraform/README.md
+++ b/infra/fastly/terraform/README.md
@@ -1,19 +1,21 @@
 We have several endpoints that we serve via Fastly.
 
+- dl.k8s.io - Servers our kubernetes release assets from our prod release bucket
+- artifacts.k8s.io - Servers non kubernetes assets from GCS
+- dl.k8s.dev - Servers our release assets from our staging release bucket
+
+dl.k8s.dev main purpose is to test CDN changes and then apply it to dl.k8s.io
+
 
 Traffic Flow Diagram
 
-Legacy Approach:
-
-dl.k8s.io -> cdn.dl.k8s.io -> Fastly CDN -> GCS Bucket
-
-Updated Approach
-
-dl.k8s.dev -> Fastly CDN -> GCS Bucket
+dl.k8s.io -> Fastly CDN -> GCS Bucket
 
 Services List:
 
 |Address|Environment| Service ID |
 |---|---|---|
-| cdn.dl.k8s.io | Production | myOKWFV3A3TGNBOXkU5kk2 |
+| dl.k8s.io | Production | myOKWFV3A3TGNBOXkU5kk2 |
+| artifacts.k8s.io | Production |
 | dl.k8s.dev | Staging | UylsgjQtU5Y9hKw2Ue11j8 |
+| artifacts.k8s.dev | Staging | jgz1yYCC4yqh1ZoGhU8Nih |

--- a/infra/fastly/terraform/artifacts.k8s.dev/data.tf
+++ b/infra/fastly/terraform/artifacts.k8s.dev/data.tf
@@ -1,0 +1,35 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+data "google_secret_manager_secret_version_access" "datadog_api_key" {
+  secret  = "datadog_fastly_logs_streaming"
+  project = "k8s-infra-releases-prod"
+}
+
+data "google_secret_manager_secret_version_access" "gcs_reader_access_key" {
+  secret  = "fastly_reader_sa_access_key"
+  project = "k8s-infra-releases-prod"
+}
+
+data "google_secret_manager_secret_version_access" "gcs_reader_secret_key" {
+  secret  = "fastly_reader_sa_secret_key"
+  project = "k8s-infra-releases-prod"
+}
+
+data "google_secret_manager_secret_version_access" "fastly_api_key" {
+  secret  = "fastly-api-key"
+  project = "k8s-infra-prow"
+}

--- a/infra/fastly/terraform/artifacts.k8s.dev/main.tf
+++ b/infra/fastly/terraform/artifacts.k8s.dev/main.tf
@@ -1,0 +1,32 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+module "cdn" {
+  source = "../cdn"
+  domain = "artifacts.k8s.dev"
+  datadog_config = {
+    token        = data.google_secret_manager_secret_version_access.datadog_api_key.secret_data,
+    service_name = "artifacts.k8s.dev",
+    env          = "staging",
+  }
+  gcs_access_key = data.google_secret_manager_secret_version_access.gcs_reader_access_key.secret_data
+  gcs_secret_key = data.google_secret_manager_secret_version_access.gcs_reader_secret_key.secret_data
+
+  bucket_configs = [
+    { name = "k8s-artifacts-prod", },
+  ]
+}

--- a/infra/fastly/terraform/artifacts.k8s.dev/provider.tf
+++ b/infra/fastly/terraform/artifacts.k8s.dev/provider.tf
@@ -1,0 +1,44 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This file defines:
+- Required provider versions
+- Storage backend details
+*/
+
+terraform {
+  required_version = "1.12.2"
+  backend "gcs" {
+    bucket = "k8s-infra-terraform"
+    prefix = "artifacts.k8s.dev"
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.8.0"
+    }
+    fastly = {
+      source = "fastly/fastly"
+    }
+  }
+}
+
+
+provider "fastly" {
+  api_key = data.google_secret_manager_secret_version_access.fastly_api_key.secret_data
+}

--- a/infra/fastly/terraform/artifacts.k8s.io/data.tf
+++ b/infra/fastly/terraform/artifacts.k8s.io/data.tf
@@ -1,0 +1,35 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+data "google_secret_manager_secret_version_access" "datadog_api_key" {
+  secret  = "datadog_fastly_logs_streaming"
+  project = "k8s-infra-releases-prod"
+}
+
+data "google_secret_manager_secret_version_access" "gcs_reader_access_key" {
+  secret  = "fastly_reader_sa_access_key"
+  project = "k8s-infra-releases-prod"
+}
+
+data "google_secret_manager_secret_version_access" "gcs_reader_secret_key" {
+  secret  = "fastly_reader_sa_secret_key"
+  project = "k8s-infra-releases-prod"
+}
+
+data "google_secret_manager_secret_version_access" "fastly_api_key" {
+  secret  = "fastly-api-key"
+  project = "k8s-infra-prow"
+}

--- a/infra/fastly/terraform/artifacts.k8s.io/main.tf
+++ b/infra/fastly/terraform/artifacts.k8s.io/main.tf
@@ -1,0 +1,32 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+module "cdn" {
+  source = "../cdn"
+  domain = "artifacts.k8s.io"
+  datadog_config = {
+    token        = data.google_secret_manager_secret_version_access.datadog_api_key.secret_data,
+    service_name = "artifacts.k8s.io",
+    env          = "prod",
+  }
+  gcs_access_key = data.google_secret_manager_secret_version_access.gcs_reader_access_key.secret_data
+  gcs_secret_key = data.google_secret_manager_secret_version_access.gcs_reader_secret_key.secret_data
+
+  bucket_configs = [
+    { name = "k8s-artifacts-prod", },
+  ]
+}

--- a/infra/fastly/terraform/artifacts.k8s.io/provider.tf
+++ b/infra/fastly/terraform/artifacts.k8s.io/provider.tf
@@ -1,0 +1,44 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This file defines:
+- Required provider versions
+- Storage backend details
+*/
+
+terraform {
+  required_version = "1.12.2"
+  backend "gcs" {
+    bucket = "k8s-infra-terraform"
+    prefix = "artifacts.k8s.io"
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.8.0"
+    }
+    fastly = {
+      source = "fastly/fastly"
+    }
+  }
+}
+
+
+provider "fastly" {
+  api_key = data.google_secret_manager_secret_version_access.fastly_api_key.secret_data
+}

--- a/infra/fastly/terraform/cdn/services.tf
+++ b/infra/fastly/terraform/cdn/services.tf
@@ -110,9 +110,11 @@ resource "fastly_service_vcl" "this" {
   }
 
   vcl {
-    name    = "Main"
-    content = file("${path.module}/vcl/binaries.vcl")
-    main    = true
+    name = "Main"
+    content = templatefile("${path.module}/vcl/binaries.vcl", {
+      bucket_configs = var.bucket_configs
+    })
+    main = true
   }
 
   product_enablement {
@@ -129,8 +131,8 @@ resource "fastly_service_vcl" "this" {
   force_destroy = true
 }
 
-# resource "fastly_tls_subscription" "this" {
-#   domains               = [var.domain]
-#   common_name           = var.domain
-#   certificate_authority = "lets-encrypt"
-# }
+resource "fastly_tls_subscription" "this" {
+  domains               = [var.domain]
+  common_name           = var.domain
+  certificate_authority = "lets-encrypt"
+}

--- a/infra/fastly/terraform/cdn/vcl/binaries.vcl
+++ b/infra/fastly/terraform/cdn/vcl/binaries.vcl
@@ -17,28 +17,32 @@ sub vcl_recv {
     set req.url = "/index.html";
   }
 
+%{~ if length([for bucket in bucket_configs : bucket.name if bucket.release_bucket]) > 0 ~}
   # Rewrite /vX.Y.Z* paths to /release/vX.Y.Z* for the origin
   if (req.url.path ~ "^/v[0-9]+\.[0-9]+\.[0-9]+") {
     set req.url = "/release" req.url;
   }
+%{ endif ~}
 
   #FASTLY recv
 
+%{~ if length([for bucket in bucket_configs : bucket.name if bucket.release_bucket]) > 0 ~}
   # Set the default backend to release bucket
   set req.backend = F_k8s_release;
   set req.http.X-Backend-Name = "k8s_release";
+%{ endif ~}
   
+%{~ if length(setintersection([for bucket in bucket_configs : bucket.name], ["k8s-release-dev","k8s-staging-kops"])) == 2 ~}
+  # Route /ci/kops/* requests to the k8s-staging-kops backend
+  if (req.url.path ~ "^/ci/kops/") {
+    set req.backend = F_k8s_staging_kops;
+    set req.http.X-Backend-Name = "k8s_staging_kops";
   # Route /ci/* requests to the k8s-release-dev backend
-  if (req.url.path ~ "^/ci/") {
+  } else if (req.url.path ~ "^/ci/") {
     set req.backend = F_k8s_release_dev;
     set req.http.X-Backend-Name = "k8s_release_dev";
   }
-
-  # Route /kops/* requests to the k8s-staging-kops backend
-  if (req.url.path ~ "^/kops/") {
-    set req.backend = F_k8s_staging_kops;
-    set req.http.X-Backend-Name = "k8s_staging_kops";
-  }
+%{ endif ~}
 
   # don't bother doing a cache lookup for a request type that isn't cacheable
   if (req.method != "HEAD" && req.method != "GET" && req.method != "FASTLYPURGE") {
@@ -70,17 +74,14 @@ sub vcl_fetch {
     set beresp.stale_while_revalidate = 3600s; # 1 hour
   }
 
-  # Never cache txt files served from the CI or kops backend
-  if (req.backend == F_k8s_release_dev && req.url.ext == "txt") {
-    set beresp.cacheable = false;
-    set beresp.ttl = 0s;
-    return (pass);
-  }
+%{~ if contains([for bucket in bucket_configs : bucket.name], "k8s-staging-kops") ~}
+  # Never cache txt files served from the kops backend
   if (req.backend == F_k8s_staging_kops && req.url.ext == "txt") {
     set beresp.cacheable = false;
     set beresp.ttl = 0s;
     return (pass);
   }
+%{ endif ~}
 
   #FASTLY fetch
   if ((beresp.status == 500 || beresp.status == 503) && req.restarts < 1 && (req.method == "GET" || req.method == "HEAD")) {
@@ -113,6 +114,12 @@ sub vcl_fetch {
   # Set the final headers sent to the edge PoPs and Clients
   set beresp.ttl = 24h;
   set beresp.http.Cache-Control = "public, max-age=86400";
+
+  # We have various text files with incorrect Content-Type headers set because GCS
+  # doesn't know how to handle them
+  if (req.url.ext ~ "^(sha256|sha512|cert)$" || req.url.path ~ "/(SHA256SUMS|SHA512SUMS)$") {
+    set beresp.http.Content-Type = "text/plain; charset=UTF-8";
+  }
 
   return(deliver);
 }
@@ -170,13 +177,26 @@ sub vcl_deliver {
 
 sub vcl_miss {
   if(req.backend.is_origin) {
-    if (req.http.X-Backend-Name == "k8s_release_dev") {
-      call set_google_auth_header_k8s_release_dev;
-    } else if (req.http.X-Backend-Name == "k8s_staging_kops") {
-      call set_google_auth_header_k8s_staging_kops;
-    } else {
+%{ if length([for bucket in bucket_configs : bucket.name if bucket.release_bucket]) > 0 ~}
+    if (req.http.X-Backend-Name == "k8s_release") {
       call set_google_auth_header_k8s_release;
     }
+%{ endif ~}
+%{ if contains([for bucket in bucket_configs : bucket.name], "k8s-staging-kops") ~}
+    if (req.http.X-Backend-Name == "k8s_staging_kops") {
+      call set_google_auth_header_k8s_staging_kops;
+    }
+%{ endif ~}
+%{ if contains([for bucket in bucket_configs : bucket.name], "k8s-release-dev") ~}
+    if (req.http.X-Backend-Name == "k8s_release_dev") {
+      call set_google_auth_header_k8s_release_dev;
+    }
+%{ endif ~}
+%{ if contains([for bucket in bucket_configs : bucket.name], "k8s-artifacts-prod") ~}
+    if (req.http.X-Backend-Name == "k8s_artifacts_prod") {
+      call set_google_auth_header_k8s_artifacts_prod;
+    }
+%{ endif ~}
   }
   #FASTLY miss
   return(fetch);
@@ -217,13 +237,26 @@ sub vcl_error {
 
 sub vcl_pass {
   if(req.backend.is_origin) {
-    if (req.http.X-Backend-Name == "k8s_release_dev") {
-      call set_google_auth_header_k8s_release_dev;
-    } else if (req.http.X-Backend-Name == "k8s_staging_kops") {
-      call set_google_auth_header_k8s_staging_kops;
-    } else {
+%{ if length([for bucket in bucket_configs : bucket.name if bucket.release_bucket]) > 0 ~}
+    if (req.http.X-Backend-Name == "k8s_release") {
       call set_google_auth_header_k8s_release;
     }
+%{ endif ~}
+%{ if contains([for bucket in bucket_configs : bucket.name], "k8s-staging-kops") ~}
+    if (req.http.X-Backend-Name == "k8s_staging_kops") {
+      call set_google_auth_header_k8s_staging_kops;
+    }
+%{ endif ~}
+%{ if contains([for bucket in bucket_configs : bucket.name], "k8s-release-dev") ~}
+    if (req.http.X-Backend-Name == "k8s_release_dev") {
+      call set_google_auth_header_k8s_release_dev;
+    }
+%{ endif ~}
+%{ if contains([for bucket in bucket_configs : bucket.name], "k8s-artifacts-prod") ~}
+    if (req.http.X-Backend-Name == "k8s_artifacts_prod") {
+      call set_google_auth_header_k8s_artifacts_prod;
+    }
+%{ endif ~}
   }
   #FASTLY pass
 }


### PR DESCRIPTION
This PR enables hosting artifacts.k8s.io entirely on Fastly and allows us to make gs://k8s-artifacts-prod private and decommission porche.

I amended the binaries.vcl so we can use a common fastly config between artifacts.k8s.io and dl.k8s.io.

I'll make the DNS changes in a follow up PR.

