### PR TITLE
add a purge token for k8s build jobs

### DIFF
--- a/kubernetes/gke-prow-build/prow/secrets.yaml
+++ b/kubernetes/gke-prow-build/prow/secrets.yaml
@@ -181,3 +181,16 @@ spec:
   secretStoreRef:
     kind: ClusterSecretStore
     name: k8s-infra-prow-build
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: fastly-purge-token
+spec:
+  data:
+  - remoteRef:
+      key: fastly-purge-token
+    secretKey: token
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: k8s-infra-prow-build


### PR DESCRIPTION
@Verolop 

Required for https://github.com/kubernetes/test-infra/pull/36795

The token has purge + ro access.