### PR TITLE
switch artifacts.k8s.io to Fastly

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -117,27 +117,26 @@ _acme-challenge.auth:
   type: TXT
   value: -4bYksesL3_5_RAceZwCCgcRtrsErNj1sWCCnDtwMcU
 
-# artifacts.k8s.io is for the (under development) binary artifact serving.
-# The IP points to a GCLB in front of CloudRun in the k8s-infra-porche-prod project.
+# DNS configuration for Fastly service artifacts.k8s.io
+# Reach out to sig-k8s-infra-leads@kubernetes.io for any issue
 artifacts:
-  type: A
-  ttl: 300 # short TTL in case of need to rollback
-  values:
-  - 34.110.216.12
-
-# DNS challenge for issuing (transition) TLS certificate
+  - type: A
+    values:
+      - 151.101.1.91
+      - 151.101.65.91
+      - 151.101.129.91
+      - 151.101.193.91
+  - type: AAAA
+    values:
+      - 2a04:4e42::347
+      - 2a04:4e42:200::347
+      - 2a04:4e42:400::347
+      - 2a04:4e42:600::347
 _acme-challenge.artifacts:
   type: CNAME
-  value: c72842dd-afa6-4ce7-b722-546baf89701f.5.authorize.certificatemanager.goog.
+  value: 6hc5e8ju4k04k7upt8.fastly-validations.com.
 
-# Sandbox artifacts redirector service.
-artifacts-sandbox:
-  - type: A
-    value: 34.110.218.166
-  - type: AAAA
-    value: "2600:1901:0:3b54::"
-
-# DNS configuration for Fastly service cdn.dl.k8s.io
+# DNS configuration for Fastly service dl.k8s.io
 # Reach out to sig-k8s-infra-leads@kubernetes.io for any issue
 dl:
   - type: A

--- a/infra/fastly/terraform/cdn/vcl/binaries.vcl
+++ b/infra/fastly/terraform/cdn/vcl/binaries.vcl
@@ -154,6 +154,7 @@ sub vcl_deliver {
   unset resp.http.x-goog-generation;
   unset resp.http.x-goog-hash;
   unset resp.http.x-goog-meta-goog-reserved-file-mtime;
+  unset resp.http.x-goog-meta-sha256;
   unset resp.http.x-goog-metageneration;
   unset resp.http.x-goog-storage-class;
   unset resp.http.x-goog-stored-content-encoding;


### PR DESCRIPTION
Verified successfully, and the certificate for artifacts.k8s.io has already been pre-provisioned(I manually patched the CNAME record last week).

/hold


```
 mahamed  Mac  ~  1  $  curl https://artifacts.k8s.io/binaries/kops/1.35.0-alpha.1/linux/amd64/kops.sha256 -IL
HTTP/2 307
content-type: text/html; charset=utf-8
location: https://storage.googleapis.com/k8s-artifacts-prod/binaries/kops/1.35.0-alpha.1/linux/amd64/kops.sha256
x-cloud-trace-context: b08ec4957ae96d4285b70f5780e0b80a;o=1
date: Mon, 13 Apr 2026 20:35:02 GMT
server: Google Frontend
via: 1.1 google
alt-svc: h3=":443"; ma=2592000

HTTP/2 200
content-type: text/plain; charset=utf-8
x-guploader-uploadid: AMNfjG0LUUcq-uKf7BnwYchAR3BxvgSC1Jw6iimVtaOOqYq8eaVrFtYCjtO4XCUL-dxvWZw
expires: Mon, 13 Apr 2026 21:35:03 GMT
date: Mon, 13 Apr 2026 20:35:03 GMT
cache-control: public, max-age=3600
last-modified: Mon, 01 Dec 2025 15:39:18 GMT
etag: "761e0a209ef65bb33825029256d2a704"
x-goog-generation: 1764603558301845
x-goog-metageneration: 1
x-goog-stored-content-encoding: identity
x-goog-stored-content-length: 65
x-goog-hash: crc32c=oCMRJw==
x-goog-hash: md5=dh4KIJ72W7M4JQKSVtKnBA==
x-goog-storage-class: STANDARD
accept-ranges: bytes
content-length: 65
server: UploadServer
alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000

 mahamed  Mac  ~  1  $  curl -H "Fastly-Debug: 1" https://artifacts.k8s.dev/binaries/kops/1.35.0-alpha.1/linux/amd64/kops.sha256 -IL
HTTP/2 200
last-modified: Mon, 01 Dec 2025 15:39:18 GMT
etag: "761e0a209ef65bb33825029256d2a704"
surrogate-key: F9798112697DCA6D87193C5A043DC24DDC3C4E14F4B05AAB338A4EA2D732EDF6
cache-control: public, max-age=86400
content-type: text/plain; charset=UTF-8
accept-ranges: bytes
date: Mon, 13 Apr 2026 20:35:05 GMT
via: 1.1 varnish
age: 44
fastly-debug-path: (D cache-mrs10566-MRS 1776112506) (F cache-mrs10522-MRS 1776112461) (D cache-chi-klot8100079-CHI 1776112461) (F cache-chi-klot8100079-CHI 1776112461)
fastly-debug-ttl: (H cache-mrs10566-MRS - - 44) (M cache-chi-klot8100079-CHI - - 0)
fastly-debug-digest: a832b1fb7eddbc4dca0ff21a056cebf7d1d2cc2a35d9f24e3f662255abfd7227
x-served-by: cache-mrs10566-MRS
x-cache: HIT
x-cache-hits: 1
access-control-allow-origin: *
alt-svc: h3=":443";ma=86400,h3-29=":443";ma=86400,h3-27=":443";ma=86400
content-length: 65
```