### PR TITLE
add guicassolato@gmail.com as signet group owner

### DIFF
--- a/groups/sig-network/groups.yaml
+++ b/groups/sig-network/groups.yaml
@@ -27,8 +27,8 @@ groups:
       - antonio.ojea.garcia@gmail.com
       - bowei@google.com
       - danwinship@redhat.com
+      - guicassolato@gmail.com
       - michael.zappa@gmail.com
-      - sutt@redhat.com
       - thockin@google.com
     settings:
       AllowWebPosting: "true"
@@ -46,8 +46,8 @@ groups:
       - antonio.ojea.garcia@gmail.com
       - bowei@google.com
       - danwinship@redhat.com
+      - guicassolato@gmail.com
       - michael.zappa@gmail.com
-      - sutt@redhat.com
       - thockin@google.com
     settings:
       WhoCanJoin: "ANYONE_CAN_JOIN"


### PR DESCRIPTION
- Adds guicassolato@gmail.com to both sig-network leads and general discussion group owners.
- Removes sutt@redhat.com from both sig-network leads and general discussion group owners.