### PR TITLE
add cluster-inventory-api staging registry

### DIFF
--- a/infra/gcp/terraform/k8s-staging-images/registries.tf
+++ b/infra/gcp/terraform/k8s-staging-images/registries.tf
@@ -24,6 +24,7 @@ locals {
     cloud-provider-kind             = "group:k8s-infra-staging-kind@kubernetes.io"
     contributor-site                = "group:k8s-infra-staging-contributor-site@kubernetes.io"
     cluster-capacity                = "group:k8s-infra-staging-cluster-capacity@kubernetes.io"
+    cluster-inventory-api           = "group:k8s-infra-staging-cluster-inventory-api@kubernetes.io"
     dns                             = "group:k8s-infra-staging-dns@kubernetes.io"
     dra-driver-cpu                  = "group:k8s-infra-staging-dra-driver-cpu@kubernetes.io"
     dra-example-driver              = "group:k8s-infra-staging-dra-example-driver@kubernetes.io"

--- a/infra/gcp/terraform/k8s-staging-images/registries.tf
+++ b/infra/gcp/terraform/k8s-staging-images/registries.tf
@@ -24,7 +24,7 @@ locals {
     cloud-provider-kind             = "group:k8s-infra-staging-kind@kubernetes.io"
     contributor-site                = "group:k8s-infra-staging-contributor-site@kubernetes.io"
     cluster-capacity                = "group:k8s-infra-staging-cluster-capacity@kubernetes.io"
-    cluster-inventory-api           = "group:k8s-infra-staging-cluster-inventory-api@kubernetes.io"
+    cluster-inventory-api           = "group:k8s-infra-staging-cluster-inv-api@kubernetes.io"
     dns                             = "group:k8s-infra-staging-dns@kubernetes.io"
     dra-driver-cpu                  = "group:k8s-infra-staging-dra-driver-cpu@kubernetes.io"
     dra-example-driver              = "group:k8s-infra-staging-dra-example-driver@kubernetes.io"


### PR DESCRIPTION
We would like to host images for [cluster-inventory-api](https://github.com/kubernetes-sigs/cluster-inventory-api) in registry.k8s.io, see [kubernetes-sigs/cluster-inventory-api#34](https://github.com/kubernetes-sigs/cluster-inventory-api/issues/34).

Specifically, we plan to publish the official credential plugins of cluster-inventory-api ([`secretreader`](https://github.com/kubernetes-sigs/cluster-inventory-api/tree/main/plugins/secretreader/cmd/plugin) and [`kubeconfig-secretreader`](https://github.com/kubernetes-sigs/cluster-inventory-api/tree/main/plugins/kubeconfig-secretreader/cmd/plugin)) as OCI artifacts so that users can consume them via [Image Volume](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/).

/sig multicluster

Signed-off-by: kahirokunn <okinakahiro@gmail.com>
