### PR TITLE
External secret to push ppc64le test artifacts to IBM COS

### DIFF
--- a/kubernetes/ibm-ppc64le/prow/secrets.yaml
+++ b/kubernetes/ibm-ppc64le/prow/secrets.yaml
@@ -72,3 +72,21 @@ spec:
     - secretKey: api-key
       remoteRef:
         key: iam_credentials/51518fbd-1667-f811-99ba-72688fd6c703
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: k8s-ppc-artifacts-svc-creds
+  namespace: test-pods
+spec:
+  refreshInterval: 60m
+  secretStoreRef:
+    name: secretstore-ibm-k8s
+    kind: ClusterSecretStore
+  target:
+    name: k8s-ppc-artifacts-svc-creds
+    creationPolicy: Owner
+  data:
+    - secretKey: service-credentials
+      remoteRef:
+        key: service_credentials/c26bce27-59db-1577-e630-3c7fc13f4dee


### PR DESCRIPTION
Need this secret to push [kubetest2-tf](https://github.com/kubernetes-sigs/provider-ibmcloud-test-infra/tree/main/kubetest2-tf) IBM kubetest2 deployer and Terraform related binaries to IBM COS and use them in the https://testgrid.k8s.io/ibm-ppc64le-e2e jobs when needed.