### PR TITLE
dns: add dra-driver-nvidia-gpu.sigs.k8s.io CNAME to Netlify

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -585,6 +585,10 @@ kube-agentic-networking.sigs:
 dranet.sigs:
   type: CNAME
   value: kubernetes-sigs.github.io.
+# https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu docs (@klueska, @jgehrcke, @dims)
+dra-driver-nvidia-gpu.sigs:
+  type: CNAME
+  value: kubernetes-sigs-dra-driver-nvidia-gpu.netlify.app.
 # https://github.com/kubernetes-sigs/kindnet docs (@aojea)
 kindnet.sigs:
   type: CNAME


### PR DESCRIPTION
Maps dra-driver-nvidia-gpu.sigs.k8s.io to the Netlify site that hosts the MkDocs-generated documentation for
https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu.