### PR TITLE
Promote gateway-api-inference-extension v1.5.0 images

### DIFF
--- a/registry.k8s.io/images/k8s-staging-gateway-api-inference-extension/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-gateway-api-inference-extension/images.yaml
@@ -35,6 +35,7 @@
     "sha256:0647dc351018cd227d296cf5d7750ff02c1b57b98f69ee39865d0f03d64baad5": ["v1.4.0"]
     "sha256:5166d7647478d1f6516d2887077b74c55ba911ef5eda1b10f2fc93741a8d05f0": ["v1.5.0-rc.1"]
     "sha256:0a99ed8b64c4138af09626e7b39fdf3e9725f3675c64e8e0cd5badcf3ab09f08": ["v1.5.0-rc.2"]
+    "sha256:bc6b00e127fe93961c4788e99abc398efff7344cc427e3620deb2027191db197": ["v1.5.0"]
 - name: charts/body-based-routing
   dmap:
     "sha256:fd9ab40eca8ba8d283a2d40d23e36d78a9bae3a3147d6dc70d0df4d32645fa71": ["v0.3.0-rc.1"]
@@ -72,6 +73,7 @@
     "sha256:cf84642a33af245ed5b55180fa8af7a60aec748bef830b854cab7202090dff6b": ["v1.4.0"]
     "sha256:88bb8c03aee5222390cacbdd6bfd5a98019c9087e8b3430b0a24030cf4432051": ["v1.5.0-rc.1"]
     "sha256:0677c1424cf4f9263ae56b76dc86719eed5b3acffb3b1395de153b4845a5d49c": ["v1.5.0-rc.2"]
+    "sha256:518461ed5ddb7f0ec434858d520db835c21599f92fba80ab6383b0d6deef5515": ["v1.5.0"]
 - name: charts/standalone
   dmap:
     "sha256:a9efa0422cca0e692a463d3191c6865a406f424d8e39df7cb7a5d16bad912561": ["v1.4.0-rc.1"]
@@ -80,6 +82,7 @@
     "sha256:0aad26f61cac007903947f11567fa54d3be15d78dd7ef042ce25db4527a4ab72": ["v1.4.0"]
     "sha256:93603e8097239fd7f8b13139b039b17ba51d40da8ed1e0f11e3a7f03208aaade": ["v1.5.0-rc.1"]
     "sha256:fdd8517ed05652ec23353d9a45994fd04a8e18e654afcdcdb74bc26ca808f4f7": ["v1.5.0-rc.2"]
+    "sha256:cf5525592a23a4e95df22eafdc9338802cc43f01ebb1d9519a3f39d8f870b242": ["v1.5.0"]
 - name: epp
   dmap:
     "sha256:a40d7c85b6ea5e8e25188edb614308c54ec0b495682c4e3a481d01074fa2468e": ["v0.1.0-rc.1"]
@@ -121,6 +124,7 @@
     "sha256:77fc9c34f105e50d3c0db81afe7554c3304a30d7b290a452cf6b91c06887ecba": ["v1.4.0"]
     "sha256:47bb44d1518a750357fc04456e8b9cbb16d4e5f163c698de1e9a008b38d2b6d4": ["v1.5.0-rc.1"]
     "sha256:a544513519bd2c04ffffa62119230f056a8722a21ca7816cd9eb7b16a26b6356": ["v1.5.0-rc.2"]
+    "sha256:86c679b057298e68c6e65ff5603e92066d432e77b11f1f81f0a06399694810bc": ["v1.5.0"]
 - name: bbr
   dmap:
     "sha256:a54d537a6fb0a274c71ce559afdd1683e809fcc373edbdebe65707188ba75344": ["v0.3.0-rc.1"]
@@ -158,6 +162,7 @@
     "sha256:676e4fd5b60b50da01d05069435d51fd1481bf33e41b12ecfd9c3c4f5835b058": ["v1.4.0"]
     "sha256:b501df7a3c0a1905fbbe43c75a08c60aa75ec14620881c4a94ac0b950ad45261": ["v1.5.0-rc.1"]
     "sha256:5cee83483ccdb657f4beba70b4f772a1cf63c216ca3660d9a323842472606be6": ["v1.5.0-rc.2"]
+    "sha256:7b7fc8739fab501f0fc9f73bc6d5be8a27f135f570e1555fae6914494298a24d": ["v1.5.0"]
 - name: latency-prediction-server
   dmap:
     "sha256:cdee389374e3f3447e4e35c8953ee0904cbb3d289ba328a6d33273ecc9a37661": ["v1.4.0-rc.1"]
@@ -166,6 +171,7 @@
     "sha256:c18fe6359771c51fea3bf09c55fd061a9fb628861bd9acc152705368fe9fa736": ["v1.4.0"]
     "sha256:bd122c5ef72f8b2a6aa0431bfa9832dd8caf21f4be475dc1e1a97fb24209f8b1": ["v1.5.0-rc.1"]
     "sha256:829124f14b5b60b5c2f6d84e778880d7110af95c5e18aed5d78541f6ed1b6da1": ["v1.5.0-rc.2"]
+    "sha256:ffe1956f6fe1f3583b693baf71cd1e0fbd2fe8454329e168f81a3b6e9844673e": ["v1.5.0"]
 - name: latency-training-server
   dmap:
     "sha256:7f6adf446b592d12f968b2487b152d7fe43342d7f4bad51cfa0005d251abf21b": ["v1.4.0-rc.1"]
@@ -174,6 +180,7 @@
     "sha256:689e4e20e6f6d961f2728de5ec5510f4f374d898b3c34ca13ea27ee0f83373b9": ["v1.4.0"]
     "sha256:de524e28bc09a6d5262f6e6f4d09cccb04d8b7efb3087a73156425ebfe2e4221": ["v1.5.0-rc.1"]
     "sha256:ef1141fc035ecb9beebe346acd9d0ae779161a80b086f0c0a3b328080a30f16b": ["v1.5.0-rc.2"]
+    "sha256:3a86be5fec3fe43ddee4cae73247fe86eda0ca22f7076031d5b4ccbdb90e898e": ["v1.5.0"]
 
 ## Deprecated, no new images will be added, but old ones will be kept.
 - name: lora-syncer


### PR DESCRIPTION
Promote `gateway-api-inference-extension` images for `v1.5.0`.

Source tag: `v1.5.0`
Release tracker: kubernetes-sigs/gateway-api-inference-extension#2766