### PR TITLE
Add k8s-infra-staging-cluster-inventory-api group

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -154,6 +154,7 @@ restrictions:
       - "^sig-instrumentation-leads@kubernetes.io$"
   - path: "sig-multicluster/groups.yaml"
     allowedGroups:
+      - "^k8s-infra-staging-cluster-inventory-api@kubernetes.io$"
       - "^sig-multicluster@kubernetes.io$"
       - "^sig-multicluster-leads@kubernetes.io$"
   - path: "sig-network/groups.yaml"

--- a/groups/sig-multicluster/groups.yaml
+++ b/groups/sig-multicluster/groups.yaml
@@ -32,3 +32,16 @@ teams:
       WhoCanModerateContent: "OWNERS_AND_MANAGERS"
       MembersCanPostAsTheGroup: "false"
       ReconcileMembers: "false"
+
+  - email-id: k8s-infra-staging-cluster-inventory-api@kubernetes.io
+    name: k8s-infra-staging-cluster-inventory-api
+    description: |-
+      ACL for staging cluster-inventory-api artifacts in GCP project.
+    settings:
+      ReconcileMembers: "true"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+    members:
+      - okinakahiro@gmail.com
+      - gothicqiujian@gmail.com
+      - ming@redhat.com
+      - skitt@redhat.com


### PR DESCRIPTION
Add a Google Group `k8s-infra-staging-cluster-inventory-api@kubernetes.io` for SIG Multicluster to manage the staging artifacts of [cluster-inventory-api](https://github.com/kubernetes-sigs/cluster-inventory-api).

This group will own the OCI artifacts to be published to the `cluster-inventory-api` staging registry, which is added in a follow-up PR.

/sig multicluster

Signed-off-by: kahirokunn <okinakahiro@gmail.com>
