### PR TITLE
docs: update gcp infra terraform docs

### DIFF
--- a/infra/gcp/terraform/boskos/README.md
+++ b/infra/gcp/terraform/boskos/README.md
@@ -1,3 +1,71 @@
 # Boskos Terraform Module
 
-This folder defines the configuration of all the boskos projects.
+This terraform directory defines the configuration of all the boskos projects.
+
+
+This directory creates and manages 160+ GCP projects used by Boskos for ephemeral end-to-end test isolation.
+
+## What This Manages
+
+- `Boskos` **GCP folder** : This is under the `kubernetes.io` organization.
+- **160 standard E2E projects**: `k8s-infra-e2e-boskos-001` through `k8s-infra-e2e-boskos-160`.
+- **30 scale E2E projects**: `k8s-infra-e2e-boskos-scale-01` through `k8s-infra-e2e-boskos-scale-30`.
+- **10 GPU E2E projects**: `k8s-infra-e2e-boskos-gpu-01` through `k8s-infra-e2e-boskos-gpu-10`.
+- **6 special boskos projects**: This is used for debugging, ingress, node-e2e, scale-5k testing.
+- **Artifact Registry**: Used in each project (Docker format, 7-day cleanup, public read)
+- **SSH keys**: Used for accessing Prow on each project's compute metadata.
+
+## Project Configuration
+
+Each Boskos project gets the following APIs enabled:
+
+- `artifactregistry.googleapis.com`
+- `cloudbuild.googleapis.com`
+- `cloudkms.googleapis.com`
+- `cloudresourcemanager.googleapis.com`
+- `cloudscheduler.googleapis.com`
+- `compute.googleapis.com`
+- `container.googleapis.com`
+- `file.googleapis.com`
+- `logging.googleapis.com`
+- `monitoring.googleapis.com`
+- `secretmanager.googleapis.com`
+- `cloudasset.googleapis.com`
+
+
+## Terraform Documentation
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 1.10.5 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 6.26.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | 6.26.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | 6.26.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_artifact_registry"></a> [artifact\_registry](#module\_artifact\_registry) | GoogleCloudPlatform/artifact-registry/google | ~> 0.3 |
+| <a name="module_folder_iam"></a> [folder\_iam](#module\_folder\_iam) | terraform-google-modules/iam/google//modules/folders_iam | ~> 8.1 |
+| <a name="module_project"></a> [project](#module\_project) | terraform-google-modules/project-factory/google | ~> 18.0 |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_compute_project_metadata.default](https://registry.terraform.io/providers/hashicorp/google/6.26.0/docs/resources/compute_project_metadata) | resource |
+| [google_folder.boskos](https://registry.terraform.io/providers/hashicorp/google/6.26.0/docs/resources/folder) | resource |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.

--- a/infra/gcp/terraform/boskos/README.md
+++ b/infra/gcp/terraform/boskos/README.md
@@ -8,10 +8,7 @@ This directory creates and manages 160+ GCP projects used by Boskos for ephemera
 ## What This Manages
 
 - `Boskos` **GCP folder** : This is under the `kubernetes.io` organization.
-- **160 standard E2E projects**: `k8s-infra-e2e-boskos-001` through `k8s-infra-e2e-boskos-160`.
-- **30 scale E2E projects**: `k8s-infra-e2e-boskos-scale-01` through `k8s-infra-e2e-boskos-scale-30`.
-- **10 GPU E2E projects**: `k8s-infra-e2e-boskos-gpu-01` through `k8s-infra-e2e-boskos-gpu-10`.
-- **6 special boskos projects**: This is used for debugging, ingress, node-e2e, scale-5k testing.
+- **E2E projects**: Manages GCP projects used for several E2E tests.
 - **Artifact Registry**: Used in each project (Docker format, 7-day cleanup, public read)
 - **SSH keys**: Used for accessing Prow on each project's compute metadata.
 

--- a/infra/gcp/terraform/k8s-infra-prow-build-trusted/README.md
+++ b/infra/gcp/terraform/k8s-infra-prow-build-trusted/README.md
@@ -1,0 +1,60 @@
+# k8s-infra-prow-build-trusted
+
+This directory creates a smaller, dedicated GKE cluster for sensitive CI operations, Cloud Build triggers for staging projects, image promotion, jobs that require GitHub tokens, registry credentials, or other secrets.
+
+## What This Manages
+
+- **GCP Project** (`k8s-infra-prow-build-trusted`): via the `gke-project` module.
+- **GKE cluster** (`prow-build-trusted`): via the `gke-cluster` module, production cluster on the `REGULAR` release channel.
+- **Single node pool** (`trusted-pool2`): c4-highmem-8 (1–6 nodes, UBUNTU_CONTAINERD).
+- **Service accounts**: Workload Identity-bound SAs for `gcb-builder`, `prow-deployer`, `k8s-cve-feed`, `k8s-keps`, `k8s-metrics`, `k8s-triage`, `k8s-testgrid-config-updater`, `kubernetes-external-secrets`, and the default `prow-build-trusted` pod SA.
+- **Secret Manager secrets**: GitHub tokens, cluster kubeconfigs (EKS, Kops), registry credentials (Quay.io), service accounts, Slack auth, Snyk token, and more, with group-based admin bindings.
+- **External IPs**: Static addresses for external-secrets and ghproxy metrics scraping.
+- **Project-level IAM**: Authoritative bindings for cluster admin and secret access.
+
+
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.6 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.31.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 6.31.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 6.31.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_iam"></a> [iam](#module\_iam) | terraform-google-modules/iam/google//modules/projects_iam | ~> 8.1 |
+| <a name="module_project"></a> [project](#module\_project) | ../modules/gke-project | n/a |
+| <a name="module_prow_build_cluster"></a> [prow\_build\_cluster](#module\_prow\_build\_cluster) | ../modules/gke-cluster | n/a |
+| <a name="module_prow_build_nodepool2"></a> [prow\_build\_nodepool2](#module\_prow\_build\_nodepool2) | ../modules/gke-nodepool | n/a |
+| <a name="module_workload_identity_service_accounts"></a> [workload\_identity\_service\_accounts](#module\_workload\_identity\_service\_accounts) | ../modules/workload-identity-service-account | n/a |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_compute_address.ghproxy_metrics_address](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+| [google_compute_address.kubernetes_external_secrets_metrics_address](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+| [google_project_iam_member.k8s_infra_prow_oncall](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_secret_manager_secret.build_cluster_secrets](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
+| [google_secret_manager_secret_iam_binding.build_cluster_secret_admins](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_binding) | resource |
+| [google_secret_manager_secret_iam_member.k8s_prow_kes_sa_role_accessor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_secret_manager_secret_iam_member.k8s_prow_kes_sa_role_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_organization.org](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/organization) | data source |
+| [google_secret_manager_secret.capdo_quayio_registry_secret](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/secret_manager_secret) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.

--- a/infra/gcp/terraform/k8s-infra-prow-build/README.md
+++ b/infra/gcp/terraform/k8s-infra-prow-build/README.md
@@ -1,0 +1,78 @@
+# k8s-infra-prow-build
+
+This directory creates the GCP project and GKE cluster where Prow dispatches the majority of CI test jobs.
+
+## What This Manages
+
+- **GCP Project** (`k8s-infra-prow-build`): via the `gke-project` module.
+- **GKE cluster** (`prow-build`): via the `gke-cluster` module, production cluster on the REGULAR release channel.
+- **Three node pools** via the `gke-nodepool` module:
+  - `pool7`: c4d-highmem-8-lssd (10–250 nodes, preferred pool).
+  - `pool6`: c4-highmem-8-lssd (1–250 nodes, overflow/nested-virt, tainted `spare=true:PreferNoSchedule`).
+  - `pool7-arm64`: c4a-highmem-8-lssd (3–100 nodes, ARM64 workloads).
+- **Workload Identity Federation pools**: Cross-cloud authentication for EKS, Kops, and AKS build clusters.
+- **VPC peering**: With GCVE (`broadcom-451918`) for vSphere testing.
+- **Service accounts**: Workload Identity-bound SAs for `prow-build`, `boskos-janitor`, and `kubernetes-external-secrets`.
+- **Scale test resources**: Dedicated SA and Secret Manager secret for 5k scale test cache pulling.
+- **Secret Manager secrets**: CI secrets (SSH keys, service account credentials, Lambda AI API key) with group-based admin bindings.
+- **External IPs**: Static addresses for Boskos metrics, external-secrets metrics, and Grafana ingress.
+- **Monitoring dashboards**: Cloud Monitoring dashboards loaded from JSON definitions.
+
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.6 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 7.7.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 7.7.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 7.7.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_iam"></a> [iam](#module\_iam) | terraform-google-modules/iam/google//modules/projects_iam | ~> 8.1 |
+| <a name="module_project"></a> [project](#module\_project) | ../modules/gke-project | n/a |
+| <a name="module_prow_build_cluster"></a> [prow\_build\_cluster](#module\_prow\_build\_cluster) | ../modules/gke-cluster | n/a |
+| <a name="module_prow_build_nodepool_c4_highmem_8_localssd"></a> [prow\_build\_nodepool\_c4\_highmem\_8\_localssd](#module\_prow\_build\_nodepool\_c4\_highmem\_8\_localssd) | ../modules/gke-nodepool | n/a |
+| <a name="module_prow_build_nodepool_c4a_highmem_8_localssd"></a> [prow\_build\_nodepool\_c4a\_highmem\_8\_localssd](#module\_prow\_build\_nodepool\_c4a\_highmem\_8\_localssd) | ../modules/gke-nodepool | n/a |
+| <a name="module_prow_build_nodepool_c4d_highmem_8_localssd"></a> [prow\_build\_nodepool\_c4d\_highmem\_8\_localssd](#module\_prow\_build\_nodepool\_c4d\_highmem\_8\_localssd) | ../modules/gke-nodepool | n/a |
+| <a name="module_workload_identity_service_accounts"></a> [workload\_identity\_service\_accounts](#module\_workload\_identity\_service\_accounts) | ../modules/workload-identity-service-account | n/a |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_compute_address.boskos_metrics](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+| [google_compute_address.kubernetes_external_secrets_metrics](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+| [google_compute_global_address.grafana_ingress](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
+| [google_iam_workload_identity_pool.aks_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool) | resource |
+| [google_iam_workload_identity_pool.eks_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool) | resource |
+| [google_iam_workload_identity_pool_provider.aks_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool_provider) | resource |
+| [google_iam_workload_identity_pool_provider.eks_cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool_provider) | resource |
+| [google_iam_workload_identity_pool_provider.eks_kops](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool_provider) | resource |
+| [google_monitoring_dashboard.dashboards](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_dashboard) | resource |
+| [google_project_iam_member.k8s_infra_prow_oncall](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.k8s_infra_prow_viewers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_secret_manager_secret.build_cluster_secrets](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
+| [google_secret_manager_secret.scale_cache_key](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
+| [google_secret_manager_secret_iam_binding.build_cluster_secret_admins](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_binding) | resource |
+| [google_secret_manager_secret_version.scale_cache_key](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
+| [google_service_account.scale_cache](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_key.scale_cache](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_key) | resource |
+| [google_vmwareengine_network_peering.gvce_peering](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/vmwareengine_network_peering) | resource |
+| [google_iam_role.prow_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/iam_role) | data source |
+| [google_organization.org](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/organization) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.

--- a/infra/gcp/terraform/k8s-infra-prow-build/README.md
+++ b/infra/gcp/terraform/k8s-infra-prow-build/README.md
@@ -6,10 +6,7 @@ This directory creates the GCP project and GKE cluster where Prow dispatches the
 
 - **GCP Project** (`k8s-infra-prow-build`): via the `gke-project` module.
 - **GKE cluster** (`prow-build`): via the `gke-cluster` module, production cluster on the REGULAR release channel.
-- **Three node pools** via the `gke-nodepool` module:
-  - `pool7`: c4d-highmem-8-lssd (10–250 nodes, preferred pool).
-  - `pool6`: c4-highmem-8-lssd (1–250 nodes, overflow/nested-virt, tainted `spare=true:PreferNoSchedule`).
-  - `pool7-arm64`: c4a-highmem-8-lssd (3–100 nodes, ARM64 workloads).
+- **Node pools**: Setup via the `gke-nodepool` module.
 - **Workload Identity Federation pools**: Cross-cloud authentication for EKS, Kops, and AKS build clusters.
 - **VPC peering**: With GCVE (`broadcom-451918`) for vSphere testing.
 - **Service accounts**: Workload Identity-bound SAs for `prow-build`, `boskos-janitor`, and `kubernetes-external-secrets`.

--- a/infra/gcp/terraform/k8s-infra-prow/README.md
+++ b/infra/gcp/terraform/k8s-infra-prow/README.md
@@ -1,0 +1,94 @@
+# k8s-infra-prow
+
+This directory defines the GCP project and infrastructure for the Prow CI control plane. It provisions two GKE clusters, a shared VPC, static IP addresses, GCS buckets for CI and TestGrid data, TLS certificates, an Artifact Registry for Prow images, Workload Identity pools for external build clusters (IBM, AKS), and Pub/Sub for TestGrid and Kettle log ingestion.
+
+## What This Manages
+
+- **GCP Project** (`k8s-infra-prow`): The project that hosts the Prow control plane and utility clusters.
+- **Two GKE clusters**:
+  - `prow`: runs the CI control plane (hook, deck, tide, sinker, crier, etc.).
+  - `utility`: runs support services (Atlantis, ArgoCD, Istio, cert-manager).
+- **VPC**: Dual-stack (IPv4/IPv6) network with Cloud NAT and secondary ranges for both clusters.
+- **Static IP addresses**: Global IPv4/IPv6 for Prow ingress, regional IPs for the utility cluster ingress, and NAT IPs.
+- **GCS buckets**:
+  - `kubernetes-ci-logs`: Public CI logs (90-day retention).
+  - `k8s-security-ci-logs`: Private CI logs for kubernetes-security org jobs (14-day retention).
+  - `k8s-testgrid-config` / `k8s-testgrid-config-external`: TestGrid configuration storage.
+  - `k8s-infra-prow-gcb`: Cloud Build artifacts (7-day retention).
+- **TLS certificates**: Managed certificates for `prow.k8s.io` and `*.prow.k8s.io`.
+- **Artifact Registry**: Docker repository for Prow container images (public read).
+- **Workload Identity pools**: Federation for IBM (ppc64le, s390x) and AKS external build clusters.
+- **Pub/Sub**: Topic on `kubernetes-ci-logs` for TestGrid and Kettle log ingestion.
+
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 1.10.5 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.45.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 6.45.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 6.45.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_gcb_bucket"></a> [gcb\_bucket](#module\_gcb\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | ~> 11.1 |
+| <a name="module_iam"></a> [iam](#module\_iam) | terraform-google-modules/iam/google//modules/projects_iam | ~> 7 |
+| <a name="module_nat"></a> [nat](#module\_nat) | terraform-google-modules/cloud-nat/google | ~> 5.0 |
+| <a name="module_project"></a> [project](#module\_project) | terraform-google-modules/project-factory/google | ~> 18.0 |
+| <a name="module_prow"></a> [prow](#module\_prow) | terraform-google-modules/kubernetes-engine/google//modules/beta-private-cluster | ~> 37.1 |
+| <a name="module_prow_bucket"></a> [prow\_bucket](#module\_prow\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | ~> 11.1 |
+| <a name="module_prow_security_bucket"></a> [prow\_security\_bucket](#module\_prow\_security\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | ~> 11.1 |
+| <a name="module_testgrid_config_bucket"></a> [testgrid\_config\_bucket](#module\_testgrid\_config\_bucket) | github.com/terraform-google-modules/terraform-google-cloud-storage//modules/simple_bucket | v11.1.2 |
+| <a name="module_testgrid_config_external_bucket"></a> [testgrid\_config\_external\_bucket](#module\_testgrid\_config\_external\_bucket) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | ~> 12.1 |
+| <a name="module_utility_cluster"></a> [utility\_cluster](#module\_utility\_cluster) | terraform-google-modules/kubernetes-engine/google//modules/beta-private-cluster | ~> 37.1 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-google-modules/network/google | ~> 11.1 |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_artifact_registry_repository.images](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository) | resource |
+| [google_artifact_registry_repository_iam_member.image_builder](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository_iam_member) | resource |
+| [google_artifact_registry_repository_iam_member.images](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/artifact_registry_repository_iam_member) | resource |
+| [google_certificate_manager_certificate.prow](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/certificate_manager_certificate) | resource |
+| [google_certificate_manager_certificate_map.prow](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/certificate_manager_certificate_map) | resource |
+| [google_certificate_manager_certificate_map_entry.prow](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/certificate_manager_certificate_map_entry) | resource |
+| [google_certificate_manager_dns_authorization.prow](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/certificate_manager_dns_authorization) | resource |
+| [google_compute_address.prow_nat](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+| [google_compute_address.utility_ingress](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_address) | resource |
+| [google_compute_global_address.prow](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
+| [google_iam_workload_identity_pool.ibm_clusters](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool) | resource |
+| [google_iam_workload_identity_pool_provider.ppc64le](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool_provider) | resource |
+| [google_iam_workload_identity_pool_provider.s390x](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool_provider) | resource |
+| [google_pubsub_topic.kubernetes_ci_logs_topic](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic) | resource |
+| [google_pubsub_topic_iam_binding.publish_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic_iam_binding) | resource |
+| [google_pubsub_topic_iam_binding.read_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/pubsub_topic_iam_binding) | resource |
+| [google_service_account.argocd](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account.gke_nodes](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account.image_builder](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account.prow](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_iam_binding.argocd](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
+| [google_service_account_iam_binding.prow](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
+| [google_service_account_iam_member.image_builder](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [google_storage_notification.notification](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_notification) | resource |
+| [google_storage_project_service_account.gcs_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/storage_project_service_account) | data source |
+| [http_http.ppc64le_issuer](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
+| [http_http.ppc64le_jwks](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
+| [http_http.s390x_issuer](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
+| [http_http.s390x_jwks](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+No outputs.

--- a/infra/gcp/terraform/k8s-infra-seed/README.md
+++ b/infra/gcp/terraform/k8s-infra-seed/README.md
@@ -1,9 +1,51 @@
-# k8s-infra-seed Terraform layer
+# k8s-infra-seed Terraform Layer
 
-This terraform layer manages the following infrastucture:
+This Terraform layer defines the k8s-infra-seed GCP project and the organization-level configuration for the `kubernetes.io` GCP org.
 
-1. The kubernetes.io GCP organization
-1. All org level configurations
-1. The k8s-infra-seed GCP project.
+## What it Manages
 
-It will eventually replace k8s-infra-kubernetes-io project.
+- **Organization-level IAM**: Authoritative bindings covering org admins, billing, folder management, org policy, auditing, security center, and more.
+- **Atlantis service account** (`atlantis@k8s-infra-seed.iam.gserviceaccount.com`): Identity used by Atlantis for all Terraform operations, with Workload Identity binding to the Prow cluster.
+- **Datadog service account** (`datadog@k8s-infra-seed.iam.gserviceaccount.com`): Monitoring integration with read-only org-level access and token creator bindings for Datadog's GCI pipeline.
+
+
+
+## Terraform Documentation
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | 1.10.5 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | 6.26.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | 6.26.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | 6.26.0 |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_iam"></a> [iam](#module\_iam) | terraform-google-modules/iam/google//modules/organizations_iam | ~> 8.1 |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_service_account.atlantis](https://registry.terraform.io/providers/hashicorp/google/6.26.0/docs/resources/service_account) | resource |
+| [google_service_account.datadog](https://registry.terraform.io/providers/hashicorp/google/6.26.0/docs/resources/service_account) | resource |
+| [google_service_account_iam_binding.atlantis](https://registry.terraform.io/providers/hashicorp/google/6.26.0/docs/resources/service_account_iam_binding) | resource |
+| [google_service_account_iam_binding.datadog](https://registry.terraform.io/providers/hashicorp/google/6.26.0/docs/resources/service_account_iam_binding) | resource |
+| [google_organization.org](https://registry.terraform.io/providers/hashicorp/google/6.26.0/docs/data-sources/organization) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_seed_project_id"></a> [seed\_project\_id](#input\_seed\_project\_id) | The ID of the seed project. | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.

--- a/infra/gcp/terraform/modules/gke-cluster/README.md
+++ b/infra/gcp/terraform/modules/gke-cluster/README.md
@@ -14,3 +14,70 @@ If this is a "prod" cluster:
 
 [`gke-project`]: /infra/gcp/terraform/modules/gke-project
 [`gke-nodepool`]: /infra/gcp/terraform/modules/gke-nodepool
+
+
+## Usage
+
+```hcl
+module "prow_build_cluster" {
+  source             = "../modules/gke-cluster"
+  project_name       = module.project.project_id
+  cluster_name       = "prow-build"
+  cluster_location   = "us-central1"
+  bigquery_location  = "US"
+  is_prod_cluster    = "true"
+  release_channel    = "REGULAR"
+}
+```
+
+## Terraform Documentation
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >=6.31.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >=6.31.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >=6.31.0 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >=6.31.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google-beta_google_container_cluster.prod_cluster](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_cluster) | resource |
+| [google-beta_google_container_cluster.test_cluster](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_cluster) | resource |
+| [google_bigquery_dataset.prod_usage_metering](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_dataset) | resource |
+| [google_bigquery_dataset.test_usage_metering](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/bigquery_dataset) | resource |
+| [google_project_iam_member.cluster_node_sa_logging](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.cluster_node_sa_monitoring_metricwriter](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.cluster_node_sa_monitoring_viewer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_service_account.cluster_node_sa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_bigquery_location"></a> [bigquery\_location](#input\_bigquery\_location) | The bigquery specific location where the dataset should be created | `string` | n/a | yes |
+| <a name="input_cloud_shell_access"></a> [cloud\_shell\_access](#input\_cloud\_shell\_access) | Control plane access restricted to Google Cloud Shell | `bool` | `true` | no |
+| <a name="input_cluster_location"></a> [cluster\_location](#input\_cluster\_location) | The GCP location (region or zone) where the cluster should be created | `string` | n/a | yes |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster | `string` | n/a | yes |
+| <a name="input_dns_cache_enabled"></a> [dns\_cache\_enabled](#input\_dns\_cache\_enabled) | Whether the cluster has the NodeLocal DNSCache add-on enabled<br/><br/>  NOTE: changes to this value require node recreation to take effect (will happen during next maintenance window, or if gcloud command is used)<br/><br/>  More information available here: https://cloud.google.com/kubernetes-engine/docs/how-to/nodelocal-dns-cache | `string` | `"false"` | no |
+| <a name="input_enable_shielded_nodes"></a> [enable\_shielded\_nodes](#input\_enable\_shielded\_nodes) | Enable Shielded Nodes on all nodes in this cluster. | `bool` | `false` | no |
+| <a name="input_is_prod_cluster"></a> [is\_prod\_cluster](#input\_is\_prod\_cluster) | If this is not a prod cluster it's safe to delete resources on destroy | `string` | `"false"` | no |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | The name of the project in which to provision resources. | `string` | n/a | yes |
+| <a name="input_release_channel"></a> [release\_channel](#input\_release\_channel) | The release channel of this cluster. Accepted values are `UNSPECIFIED`, `RAPID`, `REGULAR` and `STABLE`.<br/><br/>  Setting a release channel overrides the 'min\_master\_version' option.<br/><br/>  More information about release channels can be found here : https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels. | `string` | `"UNSPECIFIED"` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_cluster"></a> [cluster](#output\_cluster) | The cluster |
+| <a name="output_cluster_node_sa"></a> [cluster\_node\_sa](#output\_cluster\_node\_sa) | The service\_account created for the cluster's nodes |

--- a/infra/gcp/terraform/modules/gke-nodepool/README.md
+++ b/infra/gcp/terraform/modules/gke-nodepool/README.md
@@ -9,3 +9,86 @@ It is assumed that the associated GKE cluster has been provisioned using the [`g
 
 [`gke-cluster`]: /infra/gcp/terraform/modules/gke-cluster
 [`gke-project`]: /infra/gcp/terraform/modules/gke-project
+
+
+## Usage
+
+```hcl
+module "prow_build_nodepool_c4_highmem_8_localssd" {
+  source       = "../modules/gke-nodepool"
+  project_name = module.project.project_id
+  cluster_name = module.prow_build_cluster.cluster.name
+  location     = module.prow_build_cluster.cluster.location
+  node_locations = [
+    "us-central1-a",
+    "us-central1-b",
+    "us-central1-c",
+    "us-central1-f",
+  ]
+  name                         = "pool6"
+  initial_count                = 1
+  min_count                    = 1
+  max_count                    = 250 # total across all zones
+  machine_type                 = "c4-highmem-8-lssd"
+  disk_size_gb                 = 100
+  disk_type                    = "hyperdisk-balanced"
+  enable_nested_virtualization = true
+  service_account              = module.prow_build_cluster.cluster_node_sa.email
+  taints = [
+    {
+      key    = "spare"
+      value  = "true"
+      effect = "PREFER_NO_SCHEDULE"
+    }
+  ]
+}
+```
+
+## Terraform Documentation
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >=6.31.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >=6.31.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >=6.31.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google-beta_google_container_node_pool.node_pool](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_container_node_pool) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster to attach this node\_pool to | `string` | n/a | yes |
+| <a name="input_disk_size_gb"></a> [disk\_size\_gb](#input\_disk\_size\_gb) | The disk\_size\_gb of this node\_pool | `string` | n/a | yes |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | The disk\_type of this node\_pool | `string` | n/a | yes |
+| <a name="input_enable_nested_virtualization"></a> [enable\_nested\_virtualization](#input\_enable\_nested\_virtualization) | Whether to enable nested virtualization on the node pool's VMs | `bool` | `false` | no |
+| <a name="input_ephemeral_local_ssd_count"></a> [ephemeral\_local\_ssd\_count](#input\_ephemeral\_local\_ssd\_count) | Number of local SSDs to provision for ephemeral storage. If 0, ephemeral storage is backed by boot disk | `string` | `0` | no |
+| <a name="input_image_type"></a> [image\_type](#input\_image\_type) | The image\_type of this node\_pool | `string` | `"COS_CONTAINERD"` | no |
+| <a name="input_initial_count"></a> [initial\_count](#input\_initial\_count) | The initial\_node\_count of this node\_pool | `string` | n/a | yes |
+| <a name="input_labels"></a> [labels](#input\_labels) | The labels to apply to this node\_pool | `map(string)` | `{}` | no |
+| <a name="input_location"></a> [location](#input\_location) | The GCP location (region or zone) where the node\_pool should be located | `string` | n/a | yes |
+| <a name="input_machine_type"></a> [machine\_type](#input\_machine\_type) | The machine\_type of this node\_pool | `string` | n/a | yes |
+| <a name="input_max_count"></a> [max\_count](#input\_max\_count) | The max\_node\_count of this node\_pool | `string` | n/a | yes |
+| <a name="input_min_count"></a> [min\_count](#input\_min\_count) | The min\_node\_count of this node\_pool | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | The name to use for this node\_pool | `string` | n/a | yes |
+| <a name="input_node_locations"></a> [node\_locations](#input\_node\_locations) | The GCP locations (regions or zones) where the node\_pool should be located | `list(any)` | `[]` | no |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | The name of the project in which to provision the node\_pool | `string` | n/a | yes |
+| <a name="input_service_account"></a> [service\_account](#input\_service\_account) | The email address of the GCP Service Account to be associated with nodes in this node\_pool | `string` | n/a | yes |
+| <a name="input_taints"></a> [taints](#input\_taints) | The taints to apply to this node\_pool upon creation (NOTE: changes will be ignored throughout lifecycle) | `list(object({ key = string, value = string, effect = string }))` | `[]` | no |
+
+## Outputs
+
+No outputs.

--- a/infra/gcp/terraform/modules/gke-project/README.md
+++ b/infra/gcp/terraform/modules/gke-project/README.md
@@ -12,3 +12,58 @@ that is intended to host a GKE cluster created by the [`gke-cluster`] module:
 [`gke-cluster`]: /infra/gcp/terraform/modules/gke-cluster
 [`gke-nodepool`]: /infra/gcp/terraform/modules/gke-nodepool
 [`ServiceAccountLister`]: /infra/gcp/roles/iam.serviceAccountLister.yaml
+
+## Usage
+
+```hcl
+module "project" {
+  source       = "../modules/gke-project"
+  project_id   = "k8s-infra-prow-build"
+  project_name = "k8s-infra-prow-build"
+}
+```
+
+
+## Terraform Documentation
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >=6.31.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >=6.31.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >=6.31.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_project.project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project) | resource |
+| [google_project_iam_member.cluster_admins](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.cluster_users](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_service.services](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_iam_role.service_account_lister](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/iam_role) | data source |
+| [google_organization.org](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/organization) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_cluster_admins_group"></a> [cluster\_admins\_group](#input\_cluster\_admins\_group) | The group to treat as cluster admins | `string` | `"k8s-infra-cluster-admins@kubernetes.io"` | no |
+| <a name="input_cluster_users_group"></a> [cluster\_users\_group](#input\_cluster\_users\_group) | The group to treat as cluster users | `string` | `"gke-security-groups@kubernetes.io"` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The id of the project, eg: my-awesome-project | `string` | n/a | yes |
+| <a name="input_project_name"></a> [project\_name](#input\_project\_name) | The display name of the project, eg: My Awesome Project | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_project_id"></a> [project\_id](#output\_project\_id) | The project\_id of the project that was created |
+| <a name="output_project_number"></a> [project\_number](#output\_project\_number) | Numeric identifier for the project |

--- a/infra/gcp/terraform/modules/oci-proxy/README.md
+++ b/infra/gcp/terraform/modules/oci-proxy/README.md
@@ -7,3 +7,82 @@ will be vetted in staging before manually rolling out to production.
 
 The only differences between staging and production are inputs variables
 to this module, such as domain and IP address.
+
+
+
+## What This Creates
+
+- **Cloud Run services**: Deployed in 10+ regions globally
+- **Global external HTTPS load balancer**: Deployed with Cloud Armor security policy
+- **Serverless NEGs**: Connects the load balancer to Cloud Run
+- **Cloud Armor**: Security policy for DDoS protection
+- **Monitoring**: Uptime checks and alert policies (via `monitoring/uptime-alert` submodule)
+- **Networking**: URL map, SSL certificates, forwarding rules
+
+
+
+
+## Terraform Documentation
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.3.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | n/a |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+| ---- | ------ | ------- |
+| <a name="module_alerts"></a> [alerts](#module\_alerts) | ../monitoring/uptime-alert | n/a |
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google-beta_google_compute_region_network_endpoint_group.default](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_compute_region_network_endpoint_group) | resource |
+| [google_certificate_manager_certificate.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/certificate_manager_certificate) | resource |
+| [google_certificate_manager_certificate_map.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/certificate_manager_certificate_map) | resource |
+| [google_certificate_manager_certificate_map_entry.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/certificate_manager_certificate_map_entry) | resource |
+| [google_certificate_manager_dns_authorization.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/certificate_manager_dns_authorization) | resource |
+| [google_cloud_run_service.oci-proxy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service) | resource |
+| [google_cloud_run_service_iam_member.allUsers](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service_iam_member) | resource |
+| [google_compute_backend_service.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_backend_service) | resource |
+| [google_compute_global_address.ipv4](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
+| [google_compute_global_address.ipv6](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_address) | resource |
+| [google_compute_global_forwarding_rule.http_ipv4](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
+| [google_compute_global_forwarding_rule.http_ipv6](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
+| [google_compute_global_forwarding_rule.https_ipv4](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
+| [google_compute_global_forwarding_rule.https_ipv6](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_global_forwarding_rule) | resource |
+| [google_compute_security_policy.cloud-armor](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_security_policy) | resource |
+| [google_compute_target_http_proxy.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_target_http_proxy) | resource |
+| [google_compute_target_https_proxy.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_target_https_proxy) | resource |
+| [google_compute_url_map.default](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_url_map) | resource |
+| [google_compute_url_map.https_redirect](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_url_map) | resource |
+| [google_monitoring_notification_channel.emails](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_notification_channel) | resource |
+| [google_project_iam_member.k8s_infra_oci_proxy_admins](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_service.project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service) | resource |
+| [google_service_account.oci-proxy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_digest"></a> [digest](#input\_digest) | this one is overridden to the latest image in staging typically | `string` | `"sha256:d91229530a784c0569adf7192978f64c9371e906ed726cc3061aa98c2706bdce"` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | these should all be explicitly set for both prod and staging | `string` | n/a | yes |
+| <a name="input_notification_channel_id"></a> [notification\_channel\_id](#input\_notification\_channel\_id) | n/a | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | n/a | `string` | n/a | yes |
+| <a name="input_service_account_name"></a> [service\_account\_name](#input\_service\_account\_name) | n/a | `string` | n/a | yes |
+| <a name="input_verbosity"></a> [verbosity](#input\_verbosity) | n/a | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_region_locations"></a> [region\_locations](#output\_region\_locations) | n/a |
+| <a name="output_service_account_id"></a> [service\_account\_id](#output\_service\_account\_id) | n/a |

--- a/infra/gcp/terraform/modules/workload-identity-service-account/README.md
+++ b/infra/gcp/terraform/modules/workload-identity-service-account/README.md
@@ -3,3 +3,72 @@
 This terraform module defines a GCP service account intended solely for use
 by pods running in GKE clusters in a given project, running as a given K8s
 service account in a given namespace.
+
+
+## What This Creates
+
+- **GCP service account** in the specified project
+- **Workload Identity binding**: Authoritative IAM policy binding the K8s SA to the GCP SA
+
+
+## Usage
+
+```hcl
+module "workload_identity_service_accounts" {
+  for_each                                = local.workload_identity_service_accounts
+  source                                  = "../modules/workload-identity-service-account"
+  project_id                              = module.project.project_id
+  name                                    = each.key
+  description                             = each.value.description
+  cluster_namespace                       = lookup(each.value, "cluster_namespace", local.pod_namespace)
+  project_roles                           = lookup(each.value, "project_roles", [])
+  additional_workload_identity_principals = lookup(each.value, "additional_workload_identity_principals", [])
+}
+
+```
+
+## Terraform Documentation
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >=6.31.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >=6.31.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | >=6.31.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [google_project_iam_member.project_roles](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_service_account.serviceaccount](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_iam_policy.serviceaccount_iam](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_policy) | resource |
+| [google_iam_policy.workload_identity](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/iam_policy) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_additional_workload_identity_principals"></a> [additional\_workload\_identity\_principals](#input\_additional\_workload\_identity\_principals) | A list of extra principals to grant WorkloadIdentityUser on the service account | `list(string)` | `[]` | no |
+| <a name="input_cluster_namespace"></a> [cluster\_namespace](#input\_cluster\_namespace) | The namespace of the kubernetes service account that will bind to the service account, eg: my-namespace | `string` | n/a | yes |
+| <a name="input_cluster_project_id"></a> [cluster\_project\_id](#input\_cluster\_project\_id) | The id of the project hosting clusters that will use the serviceaccount, eg: my-awesome-cluster-project (default: project\_id) | `string` | `""` | no |
+| <a name="input_cluster_serviceaccount_name"></a> [cluster\_serviceaccount\_name](#input\_cluster\_serviceaccount\_name) | The name of the kubernetes service account that will bind to the service account, eg: my-cluster-sa (default: name) | `string` | `""` | no |
+| <a name="input_description"></a> [description](#input\_description) | The description of the service account, eg: My Awesome Service Account (default: name) | `string` | `""` | no |
+| <a name="input_name"></a> [name](#input\_name) | The name of the serviceaccount, eg: my-awesome-sa | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The id of the project hosting the serviceaccount, eg: my-awesome-project | `string` | n/a | yes |
+| <a name="input_project_roles"></a> [project\_roles](#input\_project\_roles) | A list of roles to bind to the serviceaccount in its project, eg: [ "roles/bigquery.user" ] | `list(string)` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_email"></a> [email](#output\_email) | The email of the serviceaccount that was created |
+| <a name="output_iam_policy"></a> [iam\_policy](#output\_iam\_policy) | The serviceaccount iam\_policy |


### PR DESCRIPTION
This PR updates the documentation across `infra/gcp/terraform/` so each Terraform project/module has a self-contained description of its purpose, terraform inputs, outputs providers and resources.                   
                  
  Covered in this PR:                                                           
  - `infra/gcp/terraform/boskos/`
  - `infra/gcp/terraform/k8s-infra-seed/`      
  - `infra/gcp/terraform/modules/`
  - `infra/gcp/terraform/k8s-infra-prow/`
  - `k8s-infra-prow-build/`
  - `k8s-infra-prow-build-trusted/`