### PR TITLE
fix broken redirector service

### DIFF
--- a/apps/k8s-io/README.md
+++ b/apps/k8s-io/README.md
@@ -14,7 +14,6 @@ Vanity URL(s)
 | CI logs | https://ci-test.k8s.io | https://ci-test.kubernetes.io |
 | Git repo | https://code.k8s.io | https://code.kubernetes.io |
 | Search Git repo | https://cs.k8s.io | https://cs.kubernetes.io |
-| Downloads | https://dl.k8s.io | https://dl.kubernetes.io |
 | Documentation | https://docs.k8s.io | https://docs.kubernetes.io |
 | Kubernetes examples | https://examples.k8s.io | https://examples.kubernetes.io |
 | Features repo | https://feature.k8s.io <br> https://features.k8s.io |  https://feature.kubernetes.io <br> https://features.kubernetes.io |

--- a/apps/k8s-io/certificate-prod.yaml
+++ b/apps/k8s-io/certificate-prod.yaml
@@ -20,8 +20,6 @@ spec:
   - code.kubernetes.io
   - conduct.k8s.io
   - conduct.kubernetes.io
-  - dl.k8s.io
-  - dl.kubernetes.io
   - docs.k8s.io
   - docs.kubernetes.io
   - examples.k8s.io

--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -162,7 +162,6 @@ data:
         listen 80;
 
         rewrite ^/$         https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/ redirect;
-        rewrite ^/(.*)?$    https://packages.cloud.google.com/apt/$1 redirect;
       }
 
       server {
@@ -170,7 +169,6 @@ data:
         listen 80;
 
         rewrite ^/$         https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/ redirect;
-        rewrite ^/(.*)?$    https://packages.cloud.google.com/yum/$1 redirect;
       }
 
       server {
@@ -215,12 +213,6 @@ data:
         listen 80;
 
         rewrite ^/(.*)?$    https://github.com/kubernetes/community/tree/master/committee-code-of-conduct/$1 redirect;
-      }
-      server {
-        server_name dl.kubernetes.io;
-        listen 80;
-
-        rewrite ^/(.*)?$    https://dl.k8s.io/$1 redirect;
       }
       server {
         server_name docs.k8s.io docs.kubernetes.io;

--- a/apps/k8s-io/test.py
+++ b/apps/k8s-io/test.py
@@ -218,14 +218,10 @@ class RedirTest(HTTPTestCase):
     def test_yum(self):
         for base in ('yum.k8s.io', 'yum.kubernetes.io'):
             self.assert_temp_redirect(base, 'https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/')
-            self.assert_temp_redirect(base + '/$id',
-                'https://packages.cloud.google.com/yum/$id', id=rand_num())
 
     def test_apt(self):
         for base in ('apt.k8s.io', 'apt.kubernetes.io'):
             self.assert_temp_redirect(base, 'https://kubernetes.io/blog/2023/08/31/legacy-package-repository-deprecation/')
-            self.assert_temp_redirect(base + '/$id',
-                'https://packages.cloud.google.com/apt/$id', id=rand_num())
 
     def test_packages(self):
         for base in ('packages.k8s.io', 'packages.kubernetes.io', 'pkgs.k8s.io', 'pkgs.kubernetes.io'):
@@ -277,37 +273,6 @@ class RedirTest(HTTPTestCase):
             self.assert_temp_redirect(base + '/$path',
                 'https://github.com/kubernetes/community/tree/master/committee-code-of-conduct/$path',
                 path=path)
-
-    def test_dl(self):
-        for base in ('dl.k8s.io', 'dl.kubernetes.io'):
-            # Valid release version numbers
-            for extra in ('', '-alpha.$rc_ver', '-beta.$rc_ver', '-rc.$rc_ver'):
-                self.assert_temp_redirect(
-                    base + '/v$major_ver.$minor_ver.$patch_ver' + extra + '/$path',
-                    'https://cdn.dl.k8s.io/release/v$major_ver.$minor_ver.$patch_ver' + extra + '/$path',
-                    major_ver=rand_num(), minor_ver=rand_num(), patch_ver=rand_num(), rc_ver=rand_num(), path=rand_num())
-            # Not a release version
-            self.assert_temp_redirect(
-                base + '/v8/engine',
-                'https://cdn.dl.k8s.io/v8/engine')
-            # Not a valid release version (gamma)
-            self.assert_temp_redirect(
-                base + '/v1.2.3-gamma.4/kubernetes.tar.gz',
-                'https://cdn.dl.k8s.io/v1.2.3-gamma.4/kubernetes.tar.gz')
-            # A few /ci/ tests
-            self.assert_temp_redirect(
-                base + '/ci/v$ver/$path',
-                'https://storage.googleapis.com/k8s-release-dev/ci/v$ver/$path',
-                ver=rand_num(), path=rand_num())
-            self.assert_temp_redirect(
-                base + '/ci/latest-$ver.txt',
-                'https://storage.googleapis.com/k8s-release-dev/ci/latest-$ver.txt',
-                ver=rand_num())
-            # Base case
-            self.assert_temp_redirect(
-                base + '/$path',
-                'https://cdn.dl.k8s.io/$path',
-                path=rand_num())
 
     def test_docs(self):
         for base in ('docs.k8s.io', 'docs.kubernetes.io'):

--- a/dns/zone-configs/kubernetes.io._0_base.yaml
+++ b/dns/zone-configs/kubernetes.io._0_base.yaml
@@ -90,9 +90,6 @@ apt:
 yum:
   type: CNAME
   value: yum.k8s.io.
-dl:
-  type: CNAME
-  value: redirect.k8s.io.
 rel:
   type: CNAME
   value: rel.k8s.io.


### PR DESCRIPTION
In #9112, I forgot to remove dl.k8s.io and dl.kubernetes.io from the ManagedCertificate and it broke cert-renewal.
Fixes: https://github.com/kubernetes/k8s.io/issues/9389

This has been fixed, but we have a few changes we'll apply:
- Serve pkgs.k8s.io entirely from AWS Cloudfront, it will be much faster and eliminates an unnecessary hop.
- Migrate this service to use Gateway API + Managed Certificates with wildcards.
- Revisit the list of redirects and eliminate what we don't need. Also, we don't need every k8s.io domain be served at kubernetes.io. I'm not sure why we did, but we should cut it down.

