### PR TITLE
Scrape Boskos gke metrics into Datadog via Prometheus Annotation

### DIFF
--- a/kubernetes/gke-prow-build/prow/boskos.yaml
+++ b/kubernetes/gke-prow-build/prow/boskos.yaml
@@ -54,6 +54,20 @@ spec:
       labels:
         app: boskos
       namespace: test-pods
+      annotations:
+        ad.datadoghq.com/boskos.checks: |
+          {
+            "openmetrics": {
+              "init_config": {},
+              "instances": [
+                {
+                  "openmetrics_endpoint": "http://%%host%%:9090/metrics",
+                  "namespace": "boskos",
+                  "metrics": ["boskos_resources"]
+                }
+              ]
+            }
+          }
     spec:
       serviceAccountName: boskos
       terminationGracePeriodSeconds: 30

--- a/kubernetes/gke-prow-build/prow/boskos.yaml
+++ b/kubernetes/gke-prow-build/prow/boskos.yaml
@@ -55,19 +55,9 @@ spec:
         app: boskos
       namespace: test-pods
       annotations:
-        ad.datadoghq.com/boskos.checks: |
-          {
-            "openmetrics": {
-              "init_config": {},
-              "instances": [
-                {
-                  "openmetrics_endpoint": "http://%%host%%:9090/metrics",
-                  "namespace": "boskos",
-                  "metrics": ["boskos_resources"]
-                }
-              ]
-            }
-          }
+        prometheus.io/scrape: "true"                                                                                                                                                
+        prometheus.io/port: "9090"                                                                                                                                                  
+        prometheus.io/path: "/metrics" 
     spec:
       serviceAccountName: boskos
       terminationGracePeriodSeconds: 30

--- a/kubernetes/gke-prow-build/prow/boskos.yaml
+++ b/kubernetes/gke-prow-build/prow/boskos.yaml
@@ -55,9 +55,9 @@ spec:
         app: boskos
       namespace: test-pods
       annotations:
-        prometheus.io/scrape: "true"                                                                                                                                                
-        prometheus.io/port: "9090"                                                                                                                                                  
-        prometheus.io/path: "/metrics" 
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
     spec:
       serviceAccountName: boskos
       terminationGracePeriodSeconds: 30
@@ -108,4 +108,3 @@ spec:
     targetPort: 9090
   loadBalancerIP: 35.225.208.117 # k8s-infra-prow-build/boskos-metrics
   type: LoadBalancer
-  

--- a/kubernetes/gke-prow-build/prow/boskos.yaml
+++ b/kubernetes/gke-prow-build/prow/boskos.yaml
@@ -108,3 +108,4 @@ spec:
     targetPort: 9090
   loadBalancerIP: 35.225.208.117 # k8s-infra-prow-build/boskos-metrics
   type: LoadBalancer
+  


### PR DESCRIPTION
This PR adds Prometheus scrape annotations to the Boskos pod to enable monitoring of GKE Boskos metrics in Datadog.