### PR TITLE
add datadog prometheus annotations to eks and ibm boskos deployments

### DIFF
--- a/kubernetes/eks-prow-build/prow/boskos.yaml
+++ b/kubernetes/eks-prow-build/prow/boskos.yaml
@@ -35,6 +35,10 @@ spec:
       labels:
         app: boskos
       namespace: test-pods
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
     spec:
       serviceAccountName: boskos
       terminationGracePeriodSeconds: 30

--- a/kubernetes/ibm-ppc64le/prow/boskos.yaml
+++ b/kubernetes/ibm-ppc64le/prow/boskos.yaml
@@ -54,6 +54,10 @@ spec:
       labels:
         app: boskos
       namespace: test-pods
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
     spec:
       serviceAccountName: boskos
       terminationGracePeriodSeconds: 30

--- a/kubernetes/ibm-s390x/prow/boskos.yaml
+++ b/kubernetes/ibm-s390x/prow/boskos.yaml
@@ -54,6 +54,10 @@ spec:
       labels:
         app: boskos
       namespace: test-pods
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: "/metrics"
     spec:
       serviceAccountName: boskos
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
This PR adds Prometheus scrape annotations to the Boskos pod to enable monitoring of EKS and IBM Boskos metrics in Datadog.