### PR TITLE
bump datadog to 3.202.2

### DIFF
--- a/kubernetes/aks-prow-build/datadog/kustomization.yaml
+++ b/kubernetes/aks-prow-build/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.157.0
+    version: 3.202.2
     kubeVersion: "1.33"
     valuesFile: values.yaml
 

--- a/kubernetes/eks-prow-build/datadog/kustomization.yaml
+++ b/kubernetes/eks-prow-build/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.157.3
+    version: 3.202.2
     kubeVersion: "1.32"
     valuesFile: values.yaml
 

--- a/kubernetes/eks-prow-kops/datadog/kustomization.yaml
+++ b/kubernetes/eks-prow-kops/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.157.3
+    version: 3.202.2
     kubeVersion: "1.30"
     valuesFile: values.yaml
 

--- a/kubernetes/gke-aaa/datadog/kustomization.yaml
+++ b/kubernetes/gke-aaa/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.157.3
+    version: 3.202.2
     valuesFile: values.yaml
 
 resources:

--- a/kubernetes/gke-prow-build-trusted/datadog/kustomization.yaml
+++ b/kubernetes/gke-prow-build-trusted/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.157.3
+    version: 3.202.2
     valuesFile: values.yaml
 
 resources:

--- a/kubernetes/gke-prow-build/datadog/kustomization.yaml
+++ b/kubernetes/gke-prow-build/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.157.3
+    version: 3.202.2
     valuesFile: values.yaml
 
 resources:

--- a/kubernetes/gke-prow/datadog/kustomization.yaml
+++ b/kubernetes/gke-prow/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.157.3
+    version: 3.202.2
     valuesFile: values.yaml
 
 resources:

--- a/kubernetes/gke-utility/datadog/kustomization.yaml
+++ b/kubernetes/gke-utility/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.157.3
+    version: 3.202.2
     valuesFile: values.yaml
 
 resources:


### PR DESCRIPTION
We haven't bumped datadog in a while

@geewynn This should solve the missing prom metrics