### PR TITLE
Add new group for dra-driver-google-tpu

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -183,6 +183,7 @@ restrictions:
       - "^k8s-infra-staging-cri-tools@kubernetes.io$"
       - "^k8s-infra-staging-dra-driver-cpu@kubernetes.io$"
       - "^k8s-infra-staging-dra-driver-nvidia@kubernetes.io$"
+      - "^k8s-infra-staging-dra-driver-google@kubernetes.io$"
       - "^k8s-infra-staging-kmm@kubernetes.io$"
       - "^k8s-infra-staging-nfd@kubernetes.io$"
       - "^k8s-infra-staging-npd@kubernetes.io$"

--- a/groups/sig-node/groups.yaml
+++ b/groups/sig-node/groups.yaml
@@ -192,6 +192,18 @@ groups:
       - shivamerla@nvidia.com
       - sig-node-leads@kubernetes.io
 
+  - email-id: k8s-infra-staging-dra-driver-google@kubernetes.io
+    name: k8s-infra-staging-dra-driver-google
+    description: |-
+      ACL for pushing dra-driver-google artifacts
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - jbelamaric@google.com
+      - mortent@google.com
+      - troychiu@google.com
+      - sig-node-leads@kubernetes.io
+
   - email-id: k8s-infra-staging-nrc@kubernetes.io
     name: k8s-infra-staging-nrc
     description: |-


### PR DESCRIPTION
Following https://github.com/kubernetes/k8s.io/blob/main/registry.k8s.io/README.md to add new group for https://github.com/kubernetes-sigs/dra-driver-google-tpu

cc @mortent 