### PR TITLE
Fix sig-multicluster groups config

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -154,7 +154,7 @@ restrictions:
       - "^sig-instrumentation-leads@kubernetes.io$"
   - path: "sig-multicluster/groups.yaml"
     allowedGroups:
-      - "^k8s-infra-staging-cluster-inventory-api@kubernetes.io$"
+      - "^k8s-infra-staging-cluster-inv-api@kubernetes.io$"
       - "^sig-multicluster@kubernetes.io$"
       - "^sig-multicluster-leads@kubernetes.io$"
   - path: "sig-network/groups.yaml"

--- a/groups/sig-multicluster/groups.yaml
+++ b/groups/sig-multicluster/groups.yaml
@@ -1,4 +1,4 @@
-teams:
+groups:
   - email-id: sig-multicluster-leads@kubernetes.io
     name: sig-multicluster-leads
     description: |-

--- a/groups/sig-multicluster/groups.yaml
+++ b/groups/sig-multicluster/groups.yaml
@@ -33,8 +33,8 @@ teams:
       MembersCanPostAsTheGroup: "false"
       ReconcileMembers: "false"
 
-  - email-id: k8s-infra-staging-cluster-inventory-api@kubernetes.io
-    name: k8s-infra-staging-cluster-inventory-api
+  - email-id: k8s-infra-staging-cluster-inv-api@kubernetes.io
+    name: k8s-infra-staging-cluster-inv-api
     description: |-
       ACL for staging cluster-inventory-api artifacts in GCP project.
     settings:


### PR DESCRIPTION
Fix the `groups/sig-multicluster/groups.yaml` config so it is actually reconciled by the Google Groups automation.

This PR also shortens the new staging access group from `k8s-infra-staging-cluster-inventory-api@kubernetes.io` to `k8s-infra-staging-cluster-inv-api@kubernetes.io`, because staging access groups must keep the project-name suffix within the 18 character limit.
