### PR TITLE
kubernetes/gke-utility: expose kops-discovery via HTTPRoute

### DIFF
--- a/kubernetes/gke-utility/istio-system/gateway.yaml
+++ b/kubernetes/gke-utility/istio-system/gateway.yaml
@@ -21,6 +21,8 @@ spec:
       mode: Terminate
       certificateRefs:
       - name: k8s-io-wild-cert
+      - name: kops-discovery-cert
+        namespace: kops-discovery
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/kubernetes/gke-utility/kops-discovery/certificate.yaml
+++ b/kubernetes/gke-utility/kops-discovery/certificate.yaml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kops-discovery
+spec:
+  secretName: kops-discovery-cert
+  issuerRef:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+  dnsNames:
+  - discovery.kops.k8s.io

--- a/kubernetes/gke-utility/kops-discovery/deployment.yaml
+++ b/kubernetes/gke-utility/kops-discovery/deployment.yaml
@@ -25,12 +25,22 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+      volumes:
+        - name: tls
+          secret:
+            secretName: kops-discovery-cert
       containers:
         - name: discovery-server
           image: registry.k8s.io/kops/discovery-server:1.35.0-beta.1
           args:
             - --listen=:8443
             - --storage=memory
+            - --tls-cert=/tls/tls.crt
+            - --tls-key=/tls/tls.key
+          volumeMounts:
+            - name: tls
+              mountPath: /tls
+              readOnly: true
           ports:
             - name: https
               containerPort: 8443

--- a/kubernetes/gke-utility/kops-discovery/httproute.yaml
+++ b/kubernetes/gke-utility/kops-discovery/httproute.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kops-discovery
+spec:
+  parentRefs:
+  - name: istio-ingressgateway
+    namespace: istio-system
+    sectionName: https
+  hostnames:
+  - discovery.kops.k8s.io
+  rules:
+  - matches:
+    - path:
+        value: /
+    backendRefs:
+    - name: kops-discovery
+      port: 443

--- a/kubernetes/gke-utility/kops-discovery/kustomization.yaml
+++ b/kubernetes/gke-utility/kops-discovery/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - rbac.yaml
   - deployment.yaml
   - service.yaml
+  - certificate.yaml
+  - httproute.yaml


### PR DESCRIPTION
Add HTTPRoute for discovery.kops.k8s.io attached to the existing istio-ingressgateway in the utility cluster.