### PR TITLE
add toleration for stable node-group taint to datadog agent

### DIFF
--- a/kubernetes/eks-prow-build/datadog/values.yaml
+++ b/kubernetes/eks-prow-build/datadog/values.yaml
@@ -47,3 +47,7 @@ agents:
       operator: Equal
       value: arm64
       effect: NoSchedule
+    - key: node-group
+      operator: Equal
+      value: stable
+      effect: NoSchedule

--- a/kubernetes/eks-prow-build/datadog/values.yaml
+++ b/kubernetes/eks-prow-build/datadog/values.yaml
@@ -43,11 +43,4 @@ clusterAgent:
   tokenExistingSecret: datadog-secret
 agents:
   tolerations: # datadog supports arm64
-    - key: kubernetes.io/arch
-      operator: Equal
-      value: arm64
-      effect: NoSchedule
-    - key: node-group
-      operator: Equal
-      value: stable
-      effect: NoSchedule
+      operator: Exists

--- a/kubernetes/eks-prow-build/datadog/values.yaml
+++ b/kubernetes/eks-prow-build/datadog/values.yaml
@@ -42,5 +42,5 @@ datadog:
 clusterAgent:
   tokenExistingSecret: datadog-secret
 agents:
-  tolerations: # datadog supports arm64
+  tolerations: # tolerate all taints
       operator: Exists


### PR DESCRIPTION
Boskos metrics aren't reaching Datadog on eks-prow-build because Boskos is pinned to the stable node group (tainted node-group=stable:NoSchedule), but the Datadog agent DaemonSet doesn't tolerate that taint. This adds the toleration so the agent can schedule on those nodes and collect metrics.

cc @upodroid 