### PR TITLE
fix: correct datadog agents.tolerations YAML to be a list

### DIFF
--- a/kubernetes/eks-prow-build/datadog/values.yaml
+++ b/kubernetes/eks-prow-build/datadog/values.yaml
@@ -42,5 +42,5 @@ datadog:
 clusterAgent:
   tokenExistingSecret: datadog-secret
 agents:
-  tolerations: # tolerate all taints
-      operator: Exists
+  tolerations:
+    - operator: Exists


### PR DESCRIPTION
Fix datadog agents.tolerations to be a list

```
agents:
  tolerations:
    - operator: Exists
```