### PR TITLE
Add SIGNATURE_UPSTREAM_ENDPOINT and update archeio digest

### DIFF
--- a/infra/gcp/terraform/modules/oci-proxy/main.tf
+++ b/infra/gcp/terraform/modules/oci-proxy/main.tf
@@ -31,6 +31,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }
@@ -49,6 +53,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }
@@ -67,6 +75,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }
@@ -85,6 +97,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }
@@ -103,6 +119,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }
@@ -121,6 +141,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }
@@ -139,6 +163,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }
@@ -157,6 +185,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }
@@ -175,6 +207,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }
@@ -193,6 +229,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }
@@ -211,6 +251,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }
@@ -229,6 +273,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }
@@ -247,6 +295,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }
@@ -265,6 +317,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }
@@ -282,6 +338,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }
@@ -300,6 +360,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }
@@ -318,6 +382,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }
@@ -336,6 +404,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }
@@ -354,6 +426,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }
@@ -372,6 +448,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }
@@ -390,6 +470,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }
@@ -408,6 +492,10 @@ locals {
         {
           name  = "UPSTREAM_REGISTRY_PATH",
           value = "k8s-artifacts-prod/images"
+        },
+        {
+          name  = "SIGNATURE_UPSTREAM_ENDPOINT",
+          value = "https://us-central1-docker.pkg.dev"
         }
       ]
     }

--- a/infra/gcp/terraform/modules/oci-proxy/variables.tf
+++ b/infra/gcp/terraform/modules/oci-proxy/variables.tf
@@ -17,8 +17,8 @@ limitations under the License.
 // this one is overridden to the latest image in staging typically
 variable "digest" {
   type = string
-  # v0.5.0
-  default  = "sha256:d91229530a784c0569adf7192978f64c9371e906ed726cc3061aa98c2706bdce"
+  # v0.6.1
+  default  = "sha256:ce45b6103aafee8786c40974362b8819b29bb3cdc4fbdf8b69ce496e33e05fe9"
   nullable = false
 }
 // these should all be explicitly set for both prod and staging


### PR DESCRIPTION
Updates the archeio image digest to `v0.6.1` (includes signature routing support) and configures all 22 Cloud Run instances with `SIGNATURE_UPSTREAM_ENDPOINT=https://us-central1-docker.pkg.dev`. This makes archeio redirect cosign signature and attestation requests (`.sig`/`.att` manifest tags) to the canonical us-central1 Artifact Registry backend instead of the per-region backend, so signatures only need to exist in one place.

Depends on:
- kubernetes/registry.k8s.io#321 (archeio signature routing support, merged)

Ref: kubernetes-sigs/promo-tools#1762