### PR TITLE
Update kops-discovery probes to use HTTPS scheme

### DIFF
--- a/kubernetes/gke-utility/kops-discovery/deployment.yaml
+++ b/kubernetes/gke-utility/kops-discovery/deployment.yaml
@@ -58,17 +58,22 @@ spec:
             capabilities:
               drop:
                 - ALL
-          # Note: kops discovery server has no health endpoints, using TCP probe
+          # Note: kops discovery server has no health endpoints.
+          # Using httpGet with HTTPS scheme to perform a proper TLS handshake
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /
               port: 8443
+              scheme: HTTPS
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /
               port: 8443
+              scheme: HTTPS
             initialDelaySeconds: 5
             periodSeconds: 5
             timeoutSeconds: 3


### PR DESCRIPTION
This replaces the tcpSocket probes with httpGet probes using the HTTPS scheme. fix the error saw in the discovery pod:

```bash
http: TLS handshake error from 10.250.227.1:49662: EOF
```