### PR TITLE
Change memory default request from 1Gi to 128Mi for ibm-ppc64le prow components

### DIFF
--- a/kubernetes/ibm-ppc64le/prow/limit-range.yaml
+++ b/kubernetes/ibm-ppc64le/prow/limit-range.yaml
@@ -15,5 +15,5 @@ metadata:
 spec:
   limits:
   - defaultRequest:
-      memory: 1Gi
+      memory: 128Mi
     type: Container


### PR DESCRIPTION
The boskos-* pods consume far less memory than the requests, and the peak usage is seen to be at 40Mi, hence 128Mi will just be sufficient