### PR TITLE
Increase api request and limits for testgrid-api deployment

### DIFF
--- a/kubernetes/gke-prow/prow/testgrid.yaml
+++ b/kubernetes/gke-prow/prow/testgrid.yaml
@@ -29,7 +29,7 @@ spec:
         - name: http
           containerPort: 8080
         resources:
-          requests: 
+          requests:
             cpu: 1
             memory: 2Gi
           limits:

--- a/kubernetes/gke-prow/prow/testgrid.yaml
+++ b/kubernetes/gke-prow/prow/testgrid.yaml
@@ -29,12 +29,12 @@ spec:
         - name: http
           containerPort: 8080
         resources:
-          requests:
-            cpu: 200m
-            memory: 256Mi
+          requests: 
+            cpu: 1
+            memory: 2Gi
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: 2
+            memory: 4Gi
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
Increase resource request and limit to testgrid-api deployment.

Fixes: https://github.com/kubernetes-sigs/testgrid/issues/84