### PR TITLE
add karpenter config for arm64 nodepool

### DIFF
--- a/kubernetes/apps/kyverno.yaml
+++ b/kubernetes/apps/kyverno.yaml
@@ -16,6 +16,10 @@ spec:
               operator: In
               values:
                 - aks-prow-build
+    - clusters:
+        selector:
+          matchLabels:
+            cloud: eks
   template:
     metadata:
       name: "kyverno-{{ .name }}"

--- a/kubernetes/eks-prow-build/kube-system/nodepool.yaml
+++ b/kubernetes/eks-prow-build/kube-system/nodepool.yaml
@@ -45,3 +45,56 @@ spec:
     expireAfter: 720h
     budgets:
       - nodes: "20%" # Allowing rotating 20% of instances at any given time
+
+---
+apiVersion: karpenter.sh/v1beta1
+kind: NodePool
+metadata:
+  name: arm64-node
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        apiVersion: karpenter.k8s.aws/v1beta1
+        kind: EC2NodeClass
+        name: default
+      taints:
+        - key: kubernetes.io/arch
+          value: arm64
+          effect: NoSchedule
+
+      requirements:  # m7gd.2xlarge / m8gd.2xlarge arm64 non-spot
+        - key: topology.kubernetes.io/zone
+          operator: In
+          values: ["us-east-2a", "us-east-2b", "us-east-2c"]
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["arm64"]
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: NotIn
+          values: ["spot"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["m"]
+        - key: karpenter.k8s.aws/instance-family
+          operator: In
+          values: ["m7gd", "m8gd"]
+        - key: karpenter.k8s.aws/instance-size
+          operator: In
+          values: ["2xlarge"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["6"]
+
+  limits:
+    cpu: "1200" # 150 x m7gd.2xlarge (8 vCPUs)
+
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 30s
+    expireAfter: 720h
+    budgets:
+      - nodes: "20%" # Allowing rotating 20% of instances at any given time

--- a/kubernetes/eks-prow-build/prow/kyverno.yaml
+++ b/kubernetes/eks-prow-build/prow/kyverno.yaml
@@ -1,0 +1,36 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: add-arm64-toleration
+spec:
+  rules:
+    - name: add-toleration
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      preconditions:
+        any:
+          - key: '{{request.object.spec.nodeSelector."kubernetes.io/arch" || ""}}'
+            operator: Equals
+            value: arm64
+    - name: add-toleration-from-nodeaffinity
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      preconditions:
+        any:
+          - key: arm64
+            operator: In
+            value: '{{ request.object.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[].matchExpressions[?key==''kubernetes.io/arch''].values[] | [] || `[]` }}'
+      mutate:
+        patchStrategicMerge:
+          spec:
+            tolerations:
+              - key: kubernetes.io/arch
+                operator: Equal
+                value: arm64
+                effect: NoSchedule


### PR DESCRIPTION


This PR does the following:
- Adds a new Karpenter NodePool to support arm64 (Graviton) build nodes in the EKS prow-build-cluster
- Enables Kyverno on this EKS cluster by adding a cloud: eks generator to the existing ApplicationSet, plus an empty values file matching the IBM/AKS pattern.
- Adds a taint to the arm64 NodePool (kubernetes.io/arch=arm64:NoSchedule) so amd64-default workloads don't accidentally land there.
- Adds a Kyverno ClusterPolicy that injects the matching toleration when a pod has nodeSelector: kubernetes.io/arch: arm64.