### PR TITLE
promote headlamp images

### DIFF
--- a/registry.k8s.io/images/k8s-staging-headlamp/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-headlamp/images.yaml
@@ -1,0 +1,4 @@
+- name: headlamp
+  dmap:
+    "sha256:b44a0e59de1b59dcda21357a9d8e2b093fea7148b31b4c6fcb36ef96fa80d006": ["v0.41.0"]
+    "sha256:f11b1cdc8cc9a67d18fce307022d98174865ae18ba61d679b8551b7a3dc022ad": ["v0.42.0"]


### PR DESCRIPTION
- **Promote headlamp v0.41.0 and v0.42.0 images**

**What this PR does / why we need it**:

First time we are promoting Headlamp's images to the official kubernetes registry.

**Special notes for your reviewer**:

**If you are promoting an image, please make sure you have done the following:**

- [x] I have verified the digest with [gcrane](https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md) and added it as a comment to the PR or in the body.

- [ ] I'm promoting a multi-arch image that matches all the [supported](https://github.com/kubernetes/sig-release/tree/master/release-engineering/platforms) platforms of Kubernetes.

- [x] I'm not promoting a tag that resolves to latest or moving tags as these are not supported

- [x] registry.k8s.io is an immutable registry and I'll need to cut a new release if the digest is wrong.
