### PR TITLE
Removed defunct distributor

### DIFF
--- a/groups/committee-security-response/groups.yaml
+++ b/groups/committee-security-response/groups.yaml
@@ -49,7 +49,6 @@ groups:
       - kubernetes-security@huawei.com
       - kubernetes-security@service.aliyun.com
       - kube-security@microsoft.com
-      - kubernetes-security@weave.works
       - mke-security@mesosphere.com
       - release-managers-private@kubernetes.io
       - secalert@redhat.com


### PR DESCRIPTION
Weaveworks is gone, and their domain `weave.works` now points to a Thai gambling site. 