### PR TITLE
Removed weave.works addresses

### DIFF
--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -425,9 +425,7 @@ groups:
     settings:
       ReconcileMembers: "true"
     members:
-      - daniel@weave.works
       - justinsb@google.com
-      - leigh@weave.works
       - luoh@vmware.com
       - timothysc@gmail.com
 


### PR DESCRIPTION
Weaveworks is gone, and their domain `weave.works` now points to a Thai gambling site.