### PR TITLE
Removed weave.works addresses

### DIFF
--- a/groups/sig-network/groups.yaml
+++ b/groups/sig-network/groups.yaml
@@ -263,7 +263,6 @@ groups:
     members:
       - k8s-infra-release-editors@kubernetes.io
       - brucema19901024@gmail.com
-      - bryan@weave.works
       - cdc@redhat.com
       - dcbw@redhat.com
       - grosenhouse@pivotal.io


### PR DESCRIPTION
Weaveworks is gone, and their domain `weave.works` now points to a Thai gambling site.

