### PR TITLE
AWS: bump kOps CI cluster cluster

### DIFF
--- a/infra/aws/terraform/kops-infra-ci/terraform.tf
+++ b/infra/aws/terraform/kops-infra-ci/terraform.tf
@@ -19,15 +19,12 @@ terraform {
     bucket = "k8s-infra-kops-ci-tf-state"
     region = "us-east-2"
     key    = "kops-infra-ci/terraform.tfstate"
-    // TODO(ameukam): stop used hardcoded account id. Preferably use SSO user
-    role_arn     = "arn:aws:iam::808842816990:role/OrganizationAccountAccessRole"
-    session_name = "kops-infra-ci"
   }
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.16.0"
+      version = "~> 6.37.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/infra/aws/terraform/kops-infra-ci/variables.tf
+++ b/infra/aws/terraform/kops-infra-ci/variables.tf
@@ -16,7 +16,7 @@ limitations under the License.
 
 variable "eks_version" {
   type    = string
-  default = "1.30"
+  default = "1.31"
 }
 
 variable "tags" {


### PR DESCRIPTION
 - Bump eks_version from 1.30 to 1.31
 - Upgrade AWS provider to ~> 6.37.0
 - Remove hardcoded role_arn/session_name from S3 backend to allow local runs