### PR TITLE
AWS: bump module and provider versions for kOps CI

### DIFF
--- a/infra/aws/terraform/kops-infra-ci/eks.tf
+++ b/infra/aws/terraform/kops-infra-ci/eks.tf
@@ -17,7 +17,7 @@ limitations under the License.
 module "eks" {
   providers = { aws = aws.kops-infra-ci }
   source    = "terraform-aws-modules/eks/aws"
-  version   = "21.3.2"
+  version   = "~> 21.20"
 
   name                   = local.cluster_name
   kubernetes_version     = var.eks_version
@@ -179,7 +179,7 @@ resource "aws_eks_pod_identity_association" "kops_prow_build" {
 module "vpc_cni_irsa" {
   providers = { aws = aws.kops-infra-ci }
   source    = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
-  version   = "~> 6.2.1"
+  version   = "~> 6.6"
 
   name                  = "vpc-cni-ipv4"
   attach_vpc_cni_policy = true
@@ -202,7 +202,7 @@ module "vpc_cni_irsa" {
 module "ebs_csi_irsa" {
   providers = { aws = aws.kops-infra-ci }
   source    = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
-  version   = "~> 6.2.1"
+  version   = "~> 6.6"
 
   name                  = "ebs-csi"
   attach_ebs_csi_policy = true
@@ -222,7 +222,7 @@ module "ebs_csi_irsa" {
 module "cluster_autoscaler_irsa_role" {
   providers = { aws = aws.kops-infra-ci }
   source    = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
-  version   = "~> 6.2.1"
+  version   = "~> 6.6"
 
   name                             = "cluster-autoscaler"
   attach_cluster_autoscaler_policy = true

--- a/infra/aws/terraform/kops-infra-ci/terraform.tf
+++ b/infra/aws/terraform/kops-infra-ci/terraform.tf
@@ -24,7 +24,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.37.0"
+      version = "~> 6.44"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/infra/aws/terraform/kops-infra-ci/vpc.tf
+++ b/infra/aws/terraform/kops-infra-ci/vpc.tf
@@ -66,7 +66,7 @@ module "vpc" {
   }
 
   source  = "terraform-aws-modules/vpc/aws"
-  version = "~> 6.4.0"
+  version = "~> 6.6"
 
   name = "${local.prefix}-vpc"
   cidr = aws_vpc_ipam_preview_next_cidr.main.cidr
@@ -113,7 +113,7 @@ module "vpc_endpoints" {
   }
 
   source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
-  version = "~> 6.4.0"
+  version = "~> 6.6"
 
   vpc_id = module.vpc.vpc_id
 
@@ -142,7 +142,7 @@ module "vpc_endpoints" {
       replace(service, ".", "_") =>
       {
         service             = service
-        subnet_ids          = module.vpc.private_subnets
+        subnet_ids          = slice(module.vpc.private_subnets, 0, length(local.azs))
         private_dns_enabled = true
         tags                = { Name = "${local.prefix}-${service}" }
       }


### PR DESCRIPTION
- eks/aws: 21.3.2 (exact pin) -> ~> 21.20
- iam/aws IRSA (3x): ~> 6.2.1 -> ~> 6.6
- vpc/aws: ~> 6.4.0 -> ~> 6.6
- hashicorp/aws provider: ~> 6.37.0 -> ~> 6.44