### PR TITLE
Promote Gateway API echo-basic test image

### DIFF
--- a/registry.k8s.io/images/k8s-staging-gateway-api/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-gateway-api/images.yaml
@@ -21,6 +21,7 @@
     "sha256:7e7558cf4eec0934dc1dc034e9a4be9a944720a3bc9b3991b109bc5923743e93": ["v1.4.0"]
     "sha256:fcbdfab85b3c4441e2fe8fdedd382904332ccb8253a5d51f6006c16903e7ae40": ["v1.5.0"]
     "sha256:1930f87f9a037f8acadc37e79185bb217614d9674304e3c1f6074aec8ff6b8dc": ["v1.5.1"]
+    "sha256:2bb1ec592aaff0bf80e270a5e20c73e2592ac01016a50c2e91560bf6cf29dca7": ["v1.6.0-dev.1"]
 - name: echo-advanced
   dmap:
     "sha256:96c3b75534386ca36c0c76ac8fdbe695f63f35bb3e0632537ffba9732c1f58c9": ["v1.4.0", "v1.5.0", "v1.5.1"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Promotes the `echo-basic` test image, this image is a required dependency to validate the changes introduced in https://github.com/kubernetes-sigs/gateway-api/pull/4817 in preparation for the Gateway API v1.6.x release.

**Special notes for your reviewer**:

**If you are promoting an image, please make sure you have done the following:**

- [x] I have verified the digest with [gcrane](https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md) and added it as a comment to the PR or in the body.

- [x] I'm promoting a multi-arch image that matches all the [supported](https://github.com/kubernetes/sig-release/tree/master/release-engineering/platforms) platforms of Kubernetes.

- [x] I'm not promoting a tag that resolves to latest or moving tags as these are not supported

- [x] registry.k8s.io is an immutable registry and I'll need to cut a new release if the digest is wrong.
