### PR TITLE
apps: bump nginx

### DIFF
--- a/apps/k8s-io/deployment.yaml
+++ b/apps/k8s-io/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           # Map all keys to files.
       containers:
       - name: nginx
-        image: nginx:1.26-alpine@sha256:5b44a5ab8ab467854f2bf7b835a32f850f32eb414b749fbf7ed506b139cd8d6b
+        image: nginx:1.30.1-alpine@sha256:6525b050aa05151ca19ec7090851bc8c12006cffdae5187f3d28023402f44cfa
         resources:
           limits:
             cpu: 1


### PR DESCRIPTION
**What this PR does / why we need it**:

nginx 1.26 is affected by CVE-2024-7347 and CVE-2025-23419.
