### PR TITLE
AWS: migrate kOps CI EKS cluster to use access entries

### DIFF
--- a/infra/aws/terraform/kops-infra-ci/data.tf
+++ b/infra/aws/terraform/kops-infra-ci/data.tf
@@ -34,6 +34,12 @@ data "aws_iam_roles" "sso_admins" {
   path_prefix = "/aws-reserved/sso.amazonaws.com/"
 }
 
+data "aws_eks_cluster" "eks" {
+  provider = aws.kops-infra-ci
+  name     = local.cluster_name
+}
+
 data "aws_eks_cluster_auth" "eks" {
-  name = module.eks.cluster_name
+  provider = aws.kops-infra-ci
+  name     = local.cluster_name
 }

--- a/infra/aws/terraform/kops-infra-ci/eks.tf
+++ b/infra/aws/terraform/kops-infra-ci/eks.tf
@@ -133,33 +133,23 @@ module "eks" {
     }
   }
 
+  access_entries = {
+    prow-eks-admin = {
+      principal_arn = "arn:aws:iam::468814281478:role/Prow-EKS-Admin"
+      policy_associations = {
+        cluster-admin = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = {
+            type = "cluster"
+          }
+        }
+      }
+    }
+  }
+
   tags = merge(var.tags, {
     "region" = data.aws_region.current.region
   })
-}
-
-//TODO(ameukam): Use access entries
-module "eks-auth" {
-  source  = "terraform-aws-modules/eks/aws//modules/aws-auth"
-  version = "~> 20.0"
-
-  manage_aws_auth_configmap = true
-
-  aws_auth_roles = [
-    {
-      rolearn  = "arn:aws:iam::468814281478:role/Prow-EKS-Admin"
-      username = "arn:aws:iam::468814281478:role/Prow-EKS-Admin"
-      groups   = ["system:masters"]
-    },
-  ]
-
-  aws_auth_users = [
-    {
-      userarn  = "arn:aws:iam::${data.aws_organizations_organization.current.id}:user/ameukam"
-      username = "ameukam"
-      groups   = ["system:masters"]
-    },
-  ]
 }
 
 resource "aws_eks_pod_identity_association" "kops_prow_build" {

--- a/infra/aws/terraform/kops-infra-ci/providers.tf
+++ b/infra/aws/terraform/kops-infra-ci/providers.tf
@@ -30,7 +30,7 @@ provider "aws" {
 }
 
 provider "kubernetes" {
-  host                   = module.eks.cluster_endpoint
-  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  host                   = data.aws_eks_cluster.eks.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.eks.certificate_authority[0].data)
   token                  = data.aws_eks_cluster_auth.eks.token
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Replace the deprecated module "eks-auth" (aws-auth ConfigMap approach, v20.x) with native EKS Access Entries via the module "eks" access_entries attribute (v21.x).

Issues fixed:
- Remove module "eks-auth" which was mixing v20.37.2 (aws-auth ConfigMap) with module "eks" at v21.20.0 (Access Entries), as noted in the TODO
- Add Prow-EKS-Admin IAM role as an EKS Access Entry with AmazonEKSClusterAdminPolicy

**Special notes for your reviewer**:

**If you are promoting an image, please make sure you have done the following:**

- [ ] I have verified the digest with [gcrane](https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md) and added it as a comment to the PR or in the body.

- [ ] I'm promoting a multi-arch image that matches all the [supported](https://github.com/kubernetes/sig-release/tree/master/release-engineering/platforms) platforms of Kubernetes.

- [ ] I'm not promoting a tag that resolves to latest or moving tags as these are not supported

- [ ] registry.k8s.io is an immutable registry and I'll need to cut a new release if the digest is wrong.
