### PR TITLE
monitoring: include DinD child containers in prow:job usage rules

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/kubelet/prow-rules.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/kubelet/prow-rules.yaml
@@ -107,9 +107,14 @@ spec:
 
     # total memory used by a Prow job
     # {namespace="...",pod="...",node="...",pod_ip="1.2.3.4",phase="...",org="...",repo="...",type="...",name="...",id="<UUID>"} [bytes]
+    # Uses the pod-level cgroup (container="") rather than the "test" container,
+    # so jobs that run their real work in sibling containers (e.g.
+    # preset-dind-enabled pods where dockerd spawns build containers like
+    # kube-cross) are counted. The pod cgroup metric naturally aggregates all
+    # descendant container cgroups.
     - record: prow:job:memory_working_set_bytes
       expr: |
-        sum by (namespace, pod, node, pod_ip) (container_memory_working_set_bytes{container="test"}) *
+        sum by (namespace, pod, node, pod_ip) (container_memory_working_set_bytes{container="",pod!=""}) *
           on(namespace, pod)
           group_left(org, repo, type, name, id, node, pod_ip, phase)
           prow:job
@@ -134,9 +139,11 @@ spec:
 
     # total CPU used by a Prow job
     # {namespace="...",pod="...",node="...",pod_ip="1.2.3.4",phase="...",org="...",repo="...",type="...",name="...",id="<UUID>"} [seconds]
+    # See note on prow:job:memory_working_set_bytes above: container="" picks
+    # the pod-level cgroup so DinD-spawned sibling containers are included.
     - record: prow:job:cpu_usage_seconds_rate:1m
       expr: |
-        sum by (namespace, pod, node, pod_ip) (rate(container_cpu_usage_seconds_total{container="test"}[1m])) *
+        sum by (namespace, pod, node, pod_ip) (rate(container_cpu_usage_seconds_total{container="",pod!=""}[1m])) *
           on(namespace, pod)
           group_left(org, repo, type, name, id, node, pod_ip, phase)
           prow:job

--- a/kubernetes/gke-prow-build/monitoring/rules.yaml
+++ b/kubernetes/gke-prow-build/monitoring/rules.yaml
@@ -106,9 +106,14 @@ spec:
 
     # total memory used by a Prow job
     # {namespace="...",pod="...",node="...",pod_ip="1.2.3.4",phase="...",org="...",repo="...",type="...",name="...",id="<UUID>"} [bytes]
+    # Uses the pod-level cgroup (container="") rather than the "test" container,
+    # so jobs that run their real work in sibling containers (e.g.
+    # preset-dind-enabled pods where dockerd spawns build containers like
+    # kube-cross) are counted. The pod cgroup metric naturally aggregates all
+    # descendant container cgroups.
     - record: prow:job:memory_working_set_bytes
       expr: |
-        sum by (namespace, pod, node, pod_ip) (container_memory_working_set_bytes{container="test"}) *
+        sum by (namespace, pod, node, pod_ip) (container_memory_working_set_bytes{container="",pod!=""}) *
           on(namespace, pod)
           group_left(org, repo, type, name, id, node, pod_ip, phase)
           prow:job
@@ -133,9 +138,11 @@ spec:
 
     # total CPU used by a Prow job
     # {namespace="...",pod="...",node="...",pod_ip="1.2.3.4",phase="...",org="...",repo="...",type="...",name="...",id="<UUID>"} [seconds]
+    # See note on prow:job:memory_working_set_bytes above: container="" picks
+    # the pod-level cgroup so DinD-spawned sibling containers are included.
     - record: prow:job:cpu_usage_seconds_rate:1m
       expr: |
-        sum by (namespace, pod, node, pod_ip) (rate(container_cpu_usage_seconds_total{container="test"}[1m])) *
+        sum by (namespace, pod, node, pod_ip) (rate(container_cpu_usage_seconds_total{container="",pod!=""}[1m])) *
           on(namespace, pod)
           group_left(org, repo, type, name, id, node, pod_ip, phase)
           prow:job


### PR DESCRIPTION
For preset-dind-enabled jobs like ci-kubernetes-build the actual work (go compile via kube-cross) runs in containers dockerd spawns inside the pod, not in the `test` container. Switch the usage rules to the pod cgroup (container="") so those siblings are counted.

The resource_requests / resource_limits rules continue to filter on container="test" — those are per-container values.

Applies the same change to the AWS prow-build-cluster mirror.

**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If you are promoting an image, please make sure you have done the following:**

- [ ] I have verified the digest with [gcrane](https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md) and added it as a comment to the PR or in the body.

- [ ] I'm promoting a multi-arch image that matches all the [supported](https://github.com/kubernetes/sig-release/tree/master/release-engineering/platforms) platforms of Kubernetes.

- [ ] I'm not promoting a tag that resolves to latest or moving tags as these are not supported

- [ ] registry.k8s.io is an immutable registry and I'll need to cut a new release if the digest is wrong.
