### PR TITLE
Setup image promotion for cluster-inventory-api

### DIFF
--- a/registry.k8s.io/images/k8s-staging-cluster-inventory-api/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-cluster-inventory-api/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - mikeshng
+  - kahirokunn
+  - sig-multicluster-leads
+
+labels:
+  - sig/multicluster

--- a/registry.k8s.io/images/k8s-staging-cluster-inventory-api/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-cluster-inventory-api/images.yaml
@@ -1,0 +1,6 @@
+- name: secretreader
+  dmap:
+    "sha256:4e38ad3aa16c15de0edb688fda77b9a17a5d6d039063e87f0408031c8790470e": ["v0.1.2"]
+- name: kubeconfig-secretreader
+  dmap:
+    "sha256:ebe81cf81cdd85bf9c77a88a968a93c8bbb2b1dd9995005160014b8c1f58ee65": ["v0.1.2"]

--- a/registry.k8s.io/manifests/k8s-staging-cluster-inventory-api/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-cluster-inventory-api/promoter-manifest.yaml
@@ -1,0 +1,49 @@
+# google group for us-central1-docker.pkg.dev/k8s-staging-images/cluster-inventory-api is k8s-infra-staging-cluster-inv-api@kubernetes.io
+registries:
+  - name: us-central1-docker.pkg.dev/k8s-staging-images/cluster-inventory-api
+    src: true
+  - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia-northeast1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia-northeast2-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: australia-southeast1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-north1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-southwest1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-central1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-east1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-east4-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-east5-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-south1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-west1-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-west2-docker.pkg.dev/k8s-artifacts-prod/images/cluster-inventory-api
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+imagesPath: "../../images/k8s-staging-cluster-inventory-api/images.yaml"


### PR DESCRIPTION
This PR is a follow-up to the cluster-inventory-api staging setup work:

- https://github.com/kubernetes/k8s.io/pull/9385 added the SIG Multicluster Google Group for the staging artifacts.
- https://github.com/kubernetes/k8s.io/pull/9402 fixed the group reconciliation config and shortened the staging access group to `k8s-infra-staging-cluster-inv-api@kubernetes.io`.
- https://github.com/kubernetes/k8s.io/pull/9347 added the `cluster-inventory-api` Artifact Registry staging entry and applied the Terraform changes.

Thank you to the reviewers and approvers on those PRs for the guidance and follow-up. This PR continues that setup by adding the image promoter configuration for `cluster-inventory-api`.

Specifically, this PR:

- adds the image promotion OWNERS file for `k8s-staging-cluster-inventory-api`
- adds the first `v0.1.2` promotion entries for:
  - `secretreader`
  - `kubeconfig-secretreader`
- adds the thin promoter manifest for `us-central1-docker.pkg.dev/k8s-staging-images/cluster-inventory-api`, promoting into the standard `k8s-artifacts-prod/images/cluster-inventory-api` destinations

The staged artifacts are the official cluster-inventory-api credential plugins, published as OCI artifacts for consumption through Kubernetes Image Volumes.

/sig multicluster

Signed-off-by: kahirokunn <okinakahiro@gmail.com>
