### PR TITLE
fix: improve verifier dependency errors

### DIFF
--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -40,6 +40,11 @@ readonly shellcheck_cmd=(
     --source-path=SCRIPTDIR
 )
 
+if ! command -v shellcheck >/dev/null 2>&1; then
+    echo "shellcheck not found - please install shellcheck"
+    exit 1
+fi
+
 failed_files=()
 passed_files=()
 # calling shellcheck for each file takes longer, but:

--- a/hack/verify-yamllint.sh
+++ b/hack/verify-yamllint.sh
@@ -44,7 +44,7 @@ fi
 
 version=$(yamllint --version | awk '{ print $2 }')
 if [[ "${version}" != "${yamllint_version}" ]]; then
-  echo >/dev/stderr "ERROR: incorrect yamllint version '${version}' - please install with: ${pip} install ${pip_requirements}"
+  echo >/dev/stderr "ERROR: incorrect yamllint version '${version}' - please install with: ${pip} install -r ${pip_requirements}"
   exit 1
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Small devex cleanup for local verifiers.

- `verify-yamllint.sh` now suggests the right `pip3 install -r requirements.txt` command when the installed version is off.
- `verify-shellcheck.sh` now stops early if `shellcheck` is missing, instead of saying every shell script failed. noisy rn.

Repro:

```sh
bash hack/verify-yamllint.sh
bash hack/verify-shellcheck.sh
```

On my box this hits real local toolchain states: yamllint is `1.38.0` while repo pins `1.18.0`, and `shellcheck` is not installed. No cloud quota/API limit weirdness here, just host tools.

**Special notes for your reviewer**:

Checked related issues/PRs, found older merged verifier work but no open issue to link.

Verified:

```sh
bash -n hack/verify-yamllint.sh
bash -n hack/verify-shellcheck.sh
git diff --check
(cd groups && go test ./...)
(cd registry.k8s.io/manifests && go test ./...)
```

Image promotion checklist: n/a.