### PR TITLE
strip the url prefix when accessing kops ci bucket

### DIFF
--- a/.atlantis.yaml
+++ b/.atlantis.yaml
@@ -18,3 +18,27 @@ projects:
     branch: /main/
     dir: infra/aws/terraform/macos
     workflow: aws
+  - dir: infra/fastly/terraform/cdn # Skip planning this dir
+    branch: /main/
+    autoplan:
+      enabled: false
+  - dir: infra/fastly/terraform/dl.k8s.io
+    branch: /main/
+    when_modified:
+      - "**/*"
+      - "../cdn/**/*"
+  - dir: infra/fastly/terraform/dl.k8s.dev
+    branch: /main/
+    when_modified:
+      - "**/*"
+      - "../cdn/**/*"
+  - dir: infra/fastly/terraform/artifacts.k8s.io
+    branch: /main/
+    when_modified:
+      - "**/*"
+      - "../cdn/**/*"
+  - dir: infra/fastly/terraform/artifacts.k8s.dev
+    branch: /main/
+    when_modified:
+      - "**/*"
+      - "../cdn/**/*"

--- a/infra/fastly/terraform/cdn/vcl/binaries.vcl
+++ b/infra/fastly/terraform/cdn/vcl/binaries.vcl
@@ -35,6 +35,8 @@ sub vcl_recv {
 %{~ if length(setintersection([for bucket in bucket_configs : bucket.name], ["k8s-release-dev","k8s-staging-kops"])) == 2 ~}
   # Route /ci/kops/* requests to the k8s-staging-kops backend
   if (req.url.path ~ "^/ci/kops/") {
+    # We want to send the request to the root of the bucket
+    set req.url = regsub(req.url, "^/ci/kops", "");
     set req.backend = F_k8s_staging_kops;
     set req.http.X-Backend-Name = "k8s_staging_kops";
   # Route /ci/* requests to the k8s-release-dev backend


### PR DESCRIPTION
I fixed the following bug

```
 mahamed  DIAPLT128  ~  1  $  curl https://dl.k8s.dev/ci/kops/latest.txt
<?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: k8s-staging-kops/ci/kops/latest.txt</Details></Error>
 mahamed  DIAPLT128  ~  1  $  curl https://dl.k8s.dev/ci/kops/latest.txt
v1.35.0-beta.1-727-g641316eca94f40
```