### PR TITLE
create gcs buckets for mimir long term storage

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow/buckets.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/buckets.tf
@@ -202,44 +202,11 @@ module "prow_security_bucket" {
 }
 
 
-module "mimir_blocks_bucket" {
+module "mimir_bucket" {
   source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
   version = "~> 11.1"
 
-  name       = "k8s-infra-prow-mimir-blocks"
-  project_id = module.project.project_id
-  location   = "us-central1"
-
-  iam_members = [
-    {
-      role   = "roles/storage.objectUser"
-      member = "principal://iam.googleapis.com/projects/16065310909/locations/global/workloadIdentityPools/k8s-infra-prow.svc.id.goog/subject/ns/mimir/sa/mimir"
-    },
-  ]
-}
-
-
-module "mimir_ruler_bucket" {
-  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
-  version = "~> 11.1"
-
-  name       = "k8s-infra-prow-mimir-ruler"
-  project_id = module.project.project_id
-  location   = "us-central1"
-
-  iam_members = [
-    {
-      role   = "roles/storage.objectUser"
-      member = "principal://iam.googleapis.com/projects/16065310909/locations/global/workloadIdentityPools/k8s-infra-prow.svc.id.goog/subject/ns/mimir/sa/mimir"
-    },
-  ]
-}
-
-module "mimir_alertmanager_bucket" {
-  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
-  version = "~> 11.1"
-
-  name       = "k8s-infra-prow-mimir-alertmanager"
+  name       = "k8s-infra-prow-mimir"
   project_id = module.project.project_id
   location   = "us-central1"
 

--- a/infra/gcp/terraform/k8s-infra-prow/buckets.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/buckets.tf
@@ -200,3 +200,53 @@ module "prow_security_bucket" {
     },
   ]
 }
+
+
+module "mimir_blocks_bucket" {
+  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
+  version = "~> 11.1"
+
+  name       = "k8s-infra-prow-mimir-blocks"
+  project_id = module.project.project_id
+  location   = "us-central1"
+
+  iam_members = [
+    {
+      role   = "roles/storage.objectUser"
+      member = "principal://iam.googleapis.com/projects/16065310909/locations/global/workloadIdentityPools/k8s-infra-prow.svc.id.goog/subject/ns/mimir/sa/mimir"
+    },
+  ]
+}
+
+
+module "mimir_ruler_bucket" {
+  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
+  version = "~> 11.1"
+
+  name       = "k8s-infra-prow-mimir-ruler"
+  project_id = module.project.project_id
+  location   = "us-central1"
+
+  iam_members = [
+    {
+      role   = "roles/storage.objectUser"
+      member = "principal://iam.googleapis.com/projects/16065310909/locations/global/workloadIdentityPools/k8s-infra-prow.svc.id.goog/subject/ns/mimir/sa/mimir"
+    },
+  ]
+}
+
+module "mimir_alertmanager_bucket" {
+  source  = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
+  version = "~> 11.1"
+
+  name       = "k8s-infra-prow-mimir-alertmanager"
+  project_id = module.project.project_id
+  location   = "us-central1"
+
+  iam_members = [
+    {
+      role   = "roles/storage.objectUser"
+      member = "principal://iam.googleapis.com/projects/16065310909/locations/global/workloadIdentityPools/k8s-infra-prow.svc.id.goog/subject/ns/mimir/sa/mimir"
+    },
+  ]
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR creates 3 GCS buckets for mimir long term storage. This is part of #8351.

cc @ameukam @upodroid 

**Special notes for your reviewer**:

**If you are promoting an image, please make sure you have done the following:**

- [ ] I have verified the digest with [gcrane](https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md) and added it as a comment to the PR or in the body.

- [ ] I'm promoting a multi-arch image that matches all the [supported](https://github.com/kubernetes/sig-release/tree/master/release-engineering/platforms) platforms of Kubernetes.

- [ ] I'm not promoting a tag that resolves to latest or moving tags as these are not supported

- [ ] registry.k8s.io is an immutable registry and I'll need to cut a new release if the digest is wrong.
