### PR TITLE
kubespray: create staging image registry access group

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -113,6 +113,7 @@ restrictions:
       - "^k8s-infra-staging-etcd-manager@kubernetes.io$"
       - "^k8s-infra-staging-kops@kubernetes.io$"
       - "^k8s-infra-staging-kubeadm@kubernetes.io$"
+      - "^k8s-infra-staging-kubespray@kubernetes.io$"
       - "^sig-cluster-lifecycle-kubespray-alerts@kubernetes.io$"
       - "^k8s-infra-staging-scl-image-builder@kubernetes.io$"
       - "^sig-cluster-lifecycle-cluster-api-vsphere-alerts@kubernetes.io$"

--- a/groups/sig-cluster-lifecycle/groups.yaml
+++ b/groups/sig-cluster-lifecycle/groups.yaml
@@ -466,6 +466,18 @@ groups:
       - fabrizio.pandini@gmail.com
       - neolit123@gmail.com
 
+  - email-id: k8s-infra-staging-kubespray@kubernetes.io
+    name: k8s-infra-staging-kubespray
+    description: |-
+      ACL for staging Kubespray CI/test images
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - kay.yan@daocloud.io
+      - mg@max.gautier.name
+      - tico88612@gmail.com
+      - 2t.antoine@gmail.com
+
   - email-id: sig-cluster-lifecycle-kubespray-alerts@kubernetes.io
     name: sig-cluster-lifecycle-kubespray-alerts
     description: |-


### PR DESCRIPTION
**What this PR does / why we need it**:

Creates the Google group `k8s-infra-staging-kubespray@kubernetes.io` for managing access to the future Kubespray staging image registry.

This is split out from kubernetes/k8s.io#9521 based on reviewer feedback.

Related work:

- kubernetes/k8s.io#9521
- kubernetes-sigs/kubespray#12383

**Special notes for your reviewer**:

For the initial membership, I used the existing Kubespray alerts group membership as a starting point. Please let me know if this should use a different maintainer set.

**If you are promoting an image, please make sure you have done the following:**

- [ ] I have verified the digest with [gcrane](https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md) and added it as a comment to the PR or in the body.

- [ ] I'm promoting a multi-arch image that matches all the [supported](https://github.com/kubernetes/sig-release/tree/master/release-engineering/platforms) platforms of Kubernetes.

- [ ] I'm not promoting a tag that resolves to latest or moving tags as these are not supported

- [ ] registry.k8s.io is an immutable registry and I'll need to cut a new release if the digest is wrong.
