### PR TITLE
Update Kubernetes election officers email list for 2026

### DIFF
--- a/groups/committee-steering/groups.yaml
+++ b/groups/committee-steering/groups.yaml
@@ -97,6 +97,6 @@ groups:
       MembersCanPostAsTheGroup: "true"
       ReconcileMembers: "true"
     owners:
-      - cblecker@gmail.com
-      - sreeramvenkitesh@gmail.com
       - ninapolshakova@gmail.com
+      - rlejano@gmail.com
+      - sreeramvenkitesh@gmail.com


### PR DESCRIPTION
Update elections@kubernetes.io email list with 2026 election officers, see https://github.com/kubernetes/community/blob/main/elections/steering/2026/README.md#officers
/cc @npolshakova @sreeram-venkitesh 