### PR TITLE
Bump git-sync to v4.7.0

### DIFF
--- a/registry.k8s.io/images/k8s-staging-git-sync/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-git-sync/images.yaml
@@ -1,5 +1,6 @@
 - name: git-sync
   dmap:
+    "sha256:d232fd13474ba1b46dba431af2b1411b9d9afacda55ae644d2a32e43975128dd": ["v4.7.0"]
     "sha256:228a26d5f55ac5ae9c51635812570ba0073e0b1e0bd8fc3a653a0523b918c092": ["v4.6.0"]
     "sha256:1df295fdab03031f932f2b7dae82fa19bd77334e2510c311bbdfc7e09ef49ece": ["v4.5.1"]
     "sha256:0e64aedb0d0ae0a3bab880349a5109b2a31891d646dd61e433ca36ed220dff1f": ["v4.5.0"]


### PR DESCRIPTION
**What this PR does / why we need it**: Publish a new git-sync version

**If you are promoting an image, please make sure you have done the following:**

- [X] I have verified the digest with [gcrane](https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md) and added it as a comment to the PR or in the body.

- [X] I'm promoting a multi-arch image that matches all the [supported](https://github.com/kubernetes/sig-release/tree/master/release-engineering/platforms) platforms of Kubernetes.

- [X] I'm not promoting a tag that resolves to latest or moving tags as these are not supported

- [X] registry.k8s.io is an immutable registry and I'll need to cut a new release if the digest is wrong.

Fixes https://github.com/kubernetes/git-sync/issues/984

Fixes https://github.com/kubernetes/git-sync/issues/985