### PR TITLE
Move boskos pods to prefer being scheduled on infra nodes

### DIFF
--- a/kubernetes/ibm-ppc64le/prow/boskos-janitor.yaml
+++ b/kubernetes/ibm-ppc64le/prow/boskos-janitor.yaml
@@ -15,6 +15,21 @@ spec:
         app: boskos-ibmcloud-janitor
     spec:
       terminationGracePeriodSeconds: 300
+      tolerations:
+        - effect: NoSchedule
+          key: infra
+          operator: Equal
+          value: "true"
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: role
+                    operator: In
+                    values:
+                      - infra
       containers:
         - name: boskos-ibmcloud-janitor
           image: gcr.io/k8s-staging-boskos/ibmcloud-janitor-boskos:v20260519-f0a76c5

--- a/kubernetes/ibm-ppc64le/prow/boskos-reaper.yaml
+++ b/kubernetes/ibm-ppc64le/prow/boskos-reaper.yaml
@@ -15,6 +15,21 @@ spec:
         app: boskos-reaper
     spec:
       terminationGracePeriodSeconds: 30
+      tolerations:
+        - effect: NoSchedule
+          key: infra
+          operator: Equal
+          value: "true"
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: role
+                    operator: In
+                    values:
+                      - infra
       containers:
         - name: boskos-reaper
           image: gcr.io/k8s-staging-boskos/reaper:v20260519-f0a76c5

--- a/kubernetes/ibm-ppc64le/prow/boskos.yaml
+++ b/kubernetes/ibm-ppc64le/prow/boskos.yaml
@@ -61,6 +61,21 @@ spec:
     spec:
       serviceAccountName: boskos
       terminationGracePeriodSeconds: 30
+      tolerations:
+        - effect: NoSchedule
+          key: infra
+          operator: Equal
+          value: "true"
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              preference:
+                matchExpressions:
+                  - key: role
+                    operator: In
+                    values:
+                      - infra
       containers:
         - name: boskos
           image: gcr.io/k8s-staging-boskos/boskos:v20260519-f0a76c5


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows the boskos pods to be deployed to the dedicated `infra` nodes, which host other critical deployments tied to the `ppc64le` build cluster. This frees up the compute nodes from hosting the build cluster infrastructure related pods.

**Special notes for your reviewer**:


**If you are promoting an image, please make sure you have done the following:**

- [ ] I have verified the digest with [gcrane](https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md) and added it as a comment to the PR or in the body.

- [ ] I'm promoting a multi-arch image that matches all the [supported](https://github.com/kubernetes/sig-release/tree/master/release-engineering/platforms) platforms of Kubernetes.

- [ ] I'm not promoting a tag that resolves to latest or moving tags as these are not supported

- [ ] registry.k8s.io is an immutable registry and I'll need to cut a new release if the digest is wrong.
