### PR TITLE
Add mailing list to WG WAS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -195,6 +195,11 @@ aliases:
   wg-structured-logging-leads:
     - mengjiao-liu
     - pohly
+  wg-workload-aware-scheduling-leads:
+    - helayoty
+    - andreyvelich
+    - mm4tt
+    - kannon92
   committee-code-of-conduct:
     - AnaMMedina21
     - endocrimes

--- a/groups/groups.yaml
+++ b/groups/groups.yaml
@@ -63,6 +63,7 @@ groups:
       - wg-node-lifecycle-leads@kubernetes.io
       - wg-serving-leads@kubernetes.io
       - wg-checkpoint-restore-leads@kubernetes.io
+      - wg-workload-aware-scheduling-leads@kubernetes.io
       - caniszczyk@linuxfoundation.org
       - cncf-speakers@linuxfoundation.org
       - community@kubernetes.io

--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -382,4 +382,8 @@ restrictions:
     allowedGroups:
       - "^wg-structured-logging@kubernetes.io$"
       - "^wg-structured-logging-leads@kubernetes.io$"
+  - path: "wg-workload-aware-scheduling/groups.yaml"
+    allowedGroups:
+      - "^wg-workload-aware-scheduling@kubernetes.io$"
+      - "^wg-workload-aware-scheduling-leads@kubernetes.io$"
   - path: "**/*" # prevent any other file from containing anything

--- a/groups/wg-workload-aware-scheduling/OWNERS
+++ b/groups/wg-workload-aware-scheduling/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- wg-workload-aware-scheduling-leads
+reviewers:
+- wg-workload-aware-scheduling-leads
+
+labels:
+- wg/workload-aware-scheduling

--- a/groups/wg-workload-aware-scheduling/groups.yaml
+++ b/groups/wg-workload-aware-scheduling/groups.yaml
@@ -1,0 +1,38 @@
+groups:
+  #
+  # Mailing lists
+  #
+  # Each group here represents a mailing list for the WG or its subprojects,
+  # and is not intended to govern access to infrastructure
+  #
+  - email-id: wg-workload-aware-scheduling-leads@kubernetes.io
+    name: wg-workload-aware-scheduling-leads
+    description: |-
+      WG workload-aware scheduling Organizers
+    settings:
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      ReconcileMembers: "true"
+    owners:
+      - hebaelayoty@gmail.com
+      - andrey.velichkevich@gmail.com
+      - mmatejczyk@google.com
+      - kehannon@redhat.com
+
+  - email-id: wg-workload-aware-scheduling@kubernetes.io
+    name: wg-workload-aware-scheduling
+    description: |-
+      Public mailing list for WG workload-aware-scheduling
+    settings:
+      WhoCanJoin: "ANYONE_CAN_JOIN"
+      WhoCanViewGroup: "ANYONE_CAN_VIEW"
+      WhoCanDiscoverGroup: "ANYONE_CAN_DISCOVER"
+      WhoCanPostMessage: "ANYONE_CAN_POST"
+      MessageModerationLevel: "MODERATE_NON_MEMBERS"
+      ReconcileMembers: "false"
+    owners:
+      - hebaelayoty@gmail.com
+      - andrey.velichkevich@gmail.com
+      - mmatejczyk@google.com
+      - kehannon@redhat.com
+    members:
+      - wg-workload-aware-scheduling-leads@kubernetes.io


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add wg-workload-aware-scheduling@kubernetes.io and wg-workload-aware-scheduling-leads@kubernetes.io mailing lists groups.
- Update leads@kubernetes.io mailing list members with the new wg

**Special notes for your reviewer**:
Ref: https://github.com/kubernetes/community/pull/8970
