### PR TITLE
etcd: Promote v3.7.0-rc.0 image

### DIFF
--- a/registry.k8s.io/images/k8s-staging-etcd/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-etcd/images.yaml
@@ -665,6 +665,7 @@
     "sha256:d774b2880ea996efe999eb22a69ad5aa37b340c461a25c5cf98376d674a678db": ["v3.6.11-ppc64le"]
     "sha256:8a41ef030edbf0160042812a217bdcdd8147f454a1f6925b4f6898d6c1189633": ["v3.6.11-s390x"]
     "sha256:b121286da5bfd4de3596e436e449da44e5a31314a6eb19780a6fc477410c8dfa": ["v3.7.0-beta.0", "3.7.0-beta.0-0"]
+    "sha256:55c8761e3cc7ce64077bf6c9ac582785daf0fa7a0ad7ea432c68d6a190751ea7": ["v3.7.0-rc.0", "3.7.0-rc.0-0"]
 - name: etcd-empty-dir-cleanup
   dmap:
     "sha256:f805272b4422efa92e20789295c343ed26ff36ddc4f70eeb5d7890d6b758b0fc": ["3.4.7.0"]


### PR DESCRIPTION
Promote v3.7.0-rc.0 etcd image

This PR promotes the `etcd` image version `v3.7.0-rc.0` to `registry.k8s.io`.

Staging image: `gcr.io/etcd-development/etcd:v3.7.0-rc.0`
Digest: `sha256:55c8761e3cc7ce64077bf6c9ac582785daf0fa7a0ad7ea432c68d6a190751ea7`

### Crane Verification

```bash
$ crane digest gcr.io/etcd-development/etcd:v3.7.0-rc.0
sha256:55c8761e3cc7ce64077bf6c9ac582785daf0fa7a0ad7ea432c68d6a190751ea7
```

<details>
<summary>crane manifest output</summary>

```json
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 3858,
         "digest": "sha256:0e69e4e29b61a0e78da5167a3bdd8479210da5ed9445007cde296420aea0d2e1",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 3858,
         "digest": "sha256:293eb370c534e3f1049e9c2260aa8bc3b69d5e0a42d81b735f7a8e6cb7eb96f6",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 3858,
         "digest": "sha256:cf9496ab5347d481f66dcda106278fb344d9b30d2cfa6a181cb52edad3531c67",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 3858,
         "digest": "sha256:6771570e0e3f4d42ff83a3f7d89e44474cd4f1494a57464c7756365ee300611a",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      }
   ]
}
```
</details>
