### PR TITLE
Create multi-zone Boskos resources for parallel s390x jobs

### DIFF
--- a/infra/ibmcloud/terraform/k8s-s390x-conformance/README.md
+++ b/infra/ibmcloud/terraform/k8s-s390x-conformance/README.md
@@ -57,3 +57,15 @@ Terraform will display a plan of the actions it will take, and you'll be prompte
 ```
 terraform output
 ```
+
+### Boskos VPC resource pool
+
+The `boskos_resources` variable controls the VPC resources that back the s390x
+conformance Boskos pool. By default this creates three resources:
+
+- `k8s-s390x-test-vpc-eu-de-1` in `eu-de-1`.
+- `k8s-s390x-test-vpc-eu-de-2` in `eu-de-2`.
+- `k8s-s390x-test-vpc-eu-de-3` in `eu-de-3`.
+
+All VPC resources are created under the existing `rg-conformance-test` resource
+group.

--- a/infra/ibmcloud/terraform/k8s-s390x-conformance/main.tf
+++ b/infra/ibmcloud/terraform/k8s-s390x-conformance/main.tf
@@ -14,6 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+locals {
+  boskos_resources = {
+    for name, resource in var.boskos_resources : name => {
+      zone        = resource.zone
+      subnet_name = coalesce(resource.subnet_name, "${name}-subnet")
+    }
+  }
+
+  vpc_resource_group_id = module.resource_group.conformance_resource_group_id
+
+}
+
 module "resource_group" {
   source = "./modules/resource_group"
 }
@@ -43,10 +55,14 @@ module "secrets_manager" {
   secrets_manager_id                = var.secrets_manager_id
 }
 module "vpc" {
+  for_each = local.boskos_resources
+
   providers = {
     ibm = ibm.vpc
   }
   source            = "./modules/vpc"
-  zone              = var.zone
-  resource_group_id = module.resource_group.conformance_resource_group_id
+  name              = each.key
+  subnet_name       = each.value.subnet_name
+  zone              = each.value.zone
+  resource_group_id = local.vpc_resource_group_id
 }

--- a/infra/ibmcloud/terraform/k8s-s390x-conformance/modules/vpc/outputs.tf
+++ b/infra/ibmcloud/terraform/k8s-s390x-conformance/modules/vpc/outputs.tf
@@ -16,8 +16,14 @@ limitations under the License.
 output "vpc_id" {
   value = ibm_is_vpc.vpc.id
 }
+output "vpc_name" {
+  value = ibm_is_vpc.vpc.name
+}
 output "subnet_id" {
   value = ibm_is_subnet.subnet.id
+}
+output "subnet_name" {
+  value = ibm_is_subnet.subnet.name
 }
 output "crn" {
   value = ibm_is_vpc.vpc.crn

--- a/infra/ibmcloud/terraform/k8s-s390x-conformance/modules/vpc/variables.tf
+++ b/infra/ibmcloud/terraform/k8s-s390x-conformance/modules/vpc/variables.tf
@@ -13,5 +13,15 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-variable "resource_group_id" {}
-variable "zone" {}
+variable "name" {
+  type = string
+}
+variable "resource_group_id" {
+  type = string
+}
+variable "subnet_name" {
+  type = string
+}
+variable "zone" {
+  type = string
+}

--- a/infra/ibmcloud/terraform/k8s-s390x-conformance/modules/vpc/vpc.tf
+++ b/infra/ibmcloud/terraform/k8s-s390x-conformance/modules/vpc/vpc.tf
@@ -15,13 +15,13 @@ limitations under the License.
 */
 # VPC
 resource "ibm_is_vpc" "vpc" {
-  name           = "k8s-s390x-test-vpc"
+  name           = var.name
   resource_group = var.resource_group_id
 }
 
 # Subnet
 resource "ibm_is_subnet" "subnet" {
-  name                     = "k8s-s390x-test-subnet"
+  name                     = var.subnet_name
   vpc                      = ibm_is_vpc.vpc.id
   zone                     = var.zone
   resource_group           = var.resource_group_id

--- a/infra/ibmcloud/terraform/k8s-s390x-conformance/outputs.tf
+++ b/infra/ibmcloud/terraform/k8s-s390x-conformance/outputs.tf
@@ -21,3 +21,33 @@ output "boskos_janitor_api_key_id" {
 output "secret_rotator_api_key_id" {
   value = module.secrets_manager.k8s_secret_rotator_id
 }
+
+output "boskos_resource_names" {
+  value = sort(keys(local.boskos_resources))
+}
+
+output "boskos_resource_userdata" {
+  value = {
+    for name, resource in local.boskos_resources : name => {
+      "region"         = var.region
+      "resource-group" = local.vpc_resource_group_id
+      "subnet-id"      = module.vpc[name].subnet_id
+      "subnet-name"    = module.vpc[name].subnet_name
+      "vpc-id"         = module.vpc[name].vpc_id
+      "vpc-name"       = module.vpc[name].vpc_name
+      "zone"           = resource.zone
+    }
+  }
+}
+
+output "boskos_resources_yaml" {
+  value = yamlencode({
+    resources = [
+      {
+        names = sort(keys(local.boskos_resources))
+        state = "free"
+        type  = "vpc-service"
+      }
+    ]
+  })
+}

--- a/infra/ibmcloud/terraform/k8s-s390x-conformance/variables.tf
+++ b/infra/ibmcloud/terraform/k8s-s390x-conformance/variables.tf
@@ -34,6 +34,27 @@ variable "region" {
   description = "IBM Cloud region"
   default     = "eu-de"
 }
+variable "boskos_resources" {
+  description = "Boskos VPC resources to create."
+  type = map(object({
+    zone        = string
+    subnet_name = optional(string)
+  }))
+  default = {
+    k8s-s390x-test-vpc-eu-de-1 = {
+      zone        = "eu-de-1"
+      subnet_name = "k8s-s390x-test-subnet-eu-de-1"
+    }
+    k8s-s390x-test-vpc-eu-de-2 = {
+      zone        = "eu-de-2"
+      subnet_name = "k8s-s390x-test-subnet-eu-de-2"
+    }
+    k8s-s390x-test-vpc-eu-de-3 = {
+      zone        = "eu-de-3"
+      subnet_name = "k8s-s390x-test-subnet-eu-de-3"
+    }
+  }
+}
 variable "secrets_manager_id" {
   type        = string
   description = "The instance ID of your secrets manager"

--- a/kubernetes/ibm-s390x/prow/boskos-resources-configmap.yaml
+++ b/kubernetes/ibm-s390x/prow/boskos-resources-configmap.yaml
@@ -3,7 +3,9 @@ data:
   config: |
     resources:
     - names:
-      - k8s-s390x-test-vpc
+      - k8s-s390x-test-vpc-eu-de-1
+      - k8s-s390x-test-vpc-eu-de-2
+      - k8s-s390x-test-vpc-eu-de-3
       state: free
       type: vpc-service
 kind: ConfigMap


### PR DESCRIPTION
## Summary

This PR expands the boskos resource pool from one VPC to three zone-specific VPCs.

Each s390x  job can lease a separate boskos VPC resource, allowing multiple s390x conformance jobs to run concurrently

## Changes

- Create VPC and subnet resources in:
  - `eu-de-1`
  - `eu-de-2`
  - `eu-de-3`


## Expected Result

Up to three s390x conformance jobs can lease independent VPC resources and run in parallel, subject to available Boskos resources.

## Testing

- Verified the Terraform configuration changes.
- Confirmed that the Boskos ConfigMap contains all three zone-specific VPC resource names.