### PR TITLE
Onboard `resource-state-metrics`

### DIFF
--- a/infra/gcp/terraform/k8s-staging-images/registries.tf
+++ b/infra/gcp/terraform/k8s-staging-images/registries.tf
@@ -51,6 +51,7 @@ locals {
     mcp-lifecycle-operator          = "group:k8s-infra-staging-mcp-lifecycle-op@kubernetes.io"
     minikube                        = "group:k8s-infra-staging-minikube@kubernetes.io"
     node-readiness-controller       = "group:k8s-infra-staging-nrc@kubernetes.io"
+    resource-state-metrics          = "group:k8s-infra-staging-resource-state-met@kubernetes.io"
     gateway-api-inference-extension = "group:sig-apps-leads@kubernetes.io"
     secrets-store-sync              = "group:k8s-infra-staging-secrets-store-sync@kubernetes.io"
     test-infra                      = "group:k8s-infra-staging-test-infra@kubernetes.io"

--- a/registry.k8s.io/images/k8s-staging-resource-state-metrics/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-resource-state-metrics/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- dgrisonnet
+- mrueg
+- rexagod

--- a/registry.k8s.io/images/k8s-staging-resource-state-metrics/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-resource-state-metrics/images.yaml
@@ -1,0 +1,2 @@
+- name: resource-state-metrics
+  dmap: {}


### PR DESCRIPTION

**What this PR does / why we need it**: Onboard `kubernetes-sigs/resource-state-metrics` to `k8s.io` to setup image promotions. There's a 18-char limit on the project name in the mailing identifier, so `resource-state-metrics` was truncated from the end.

**Special notes for your reviewer**: More information on `kubernetes-sigs/resource-state-metrics` can be found in https://github.com/kubernetes/enhancements/pull/4811.


