### PR TITLE
setup mimir on gke utility cluster

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -287,6 +287,11 @@ atlantis:
     value: 34.66.218.218
   - type: AAAA
     value: "2600:1900:4000:627b:8000::"
+mimir.prow:
+  - type: A
+    value: 34.66.218.218
+  - type: AAAA
+    value: "2600:1900:4000:627b:8000::"
 
 # kOps discovery service (https://github.com/kubernetes/kops/tree/master/discovery)
 discovery.kops:

--- a/kubernetes/apps/mimir.yaml
+++ b/kubernetes/apps/mimir.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: mimir
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+spec:
+  goTemplate: true
+  generators:
+    - clusters:
+        selector:
+          matchExpressions:
+            - key: name
+              operator: In
+              values:
+                - utility
+  template:
+    metadata:
+      name: 'mimir-{{ .name }}'
+      annotations:
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
+    spec:
+      destination:
+        namespace: mimir
+        server: "{{ .server }}"
+      project: default
+      sources:
+        - chart: mimir-distributed
+          repoURL: https://grafana.github.io/helm-charts
+          targetRevision: 5.5.1
+          helm:
+            releaseName: mimir
+            valueFiles:
+              - $values/kubernetes/{{ .name }}/helm/mimir.yaml
+        - repoURL: https://github.com/kubernetes/k8s.io
+          targetRevision: main
+          ref: values
+        - path: kubernetes/{{ .name }}/mimir/
+          repoURL: https://github.com/kubernetes/k8s.io
+          targetRevision: main
+      syncPolicy:
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+      managedNamespaceMetadata:
+          labels:
+            istio-injection: enabled

--- a/kubernetes/gke-utility/helm/mimir.yaml
+++ b/kubernetes/gke-utility/helm/mimir.yaml
@@ -1,0 +1,194 @@
+serviceAccount:
+  create: true
+  name: mimir
+
+nginx:
+  enabled: false
+
+minio:
+  enabled: false
+
+kafka:
+  enabled: false
+
+gateway:
+  enabled: true
+  replicas: 2
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 512Mi
+  nginx:
+    basicAuth:
+      enabled: true
+      existingSecret: mimir-credentials
+
+mimir:
+  structuredConfig:
+    ingest_storage:
+      enabled: false
+      kafka:
+        address: null
+        topic: null
+        auto_create_topic_default_partitions: null
+    distributor:
+      remote_timeout: null
+    ingester:
+      push_grpc_method_enabled: null
+    common:
+      storage:
+        backend: gcs
+        gcs:
+          bucket_name: k8s-infra-prow-mimir
+    blocks_storage:
+      backend: gcs
+      storage_prefix: blocks
+    ruler_storage:
+      backend: gcs
+      storage_prefix: ruler
+    alertmanager_storage:
+      backend: gcs
+      storage_prefix: alertmanager
+
+metaMonitoring:
+  serviceMonitor:
+    enabled: true
+
+alertmanager:
+  persistentVolume:
+    enabled: true
+  replicas: 2
+  resources:
+    limits:
+      cpu: 2
+      memory: 1.4Gi
+    requests:
+      cpu: 1
+      memory: 1Gi
+  statefulSet:
+    enabled: true
+
+compactor:
+  persistentVolume:
+    size: 20Gi
+  resources:
+    limits:
+      cpu: 4
+      memory: 2.1Gi
+    requests:
+      cpu: 1
+      memory: 1.5Gi
+
+distributor:
+  replicas: 2
+  resources:
+    limits:
+      cpu: 4
+      memory: 5.7Gi
+    requests:
+      cpu: 2
+      memory: 4Gi
+
+ingester:
+  persistentVolume:
+    size: 50Gi
+  replicas: 3
+  resources:
+    limits:
+      memory: 12Gi
+    requests:
+      cpu: 3.5
+      memory: 8Gi
+  topologySpreadConstraints: {}
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                  - ingester
+          topologyKey: "kubernetes.io/hostname"
+  zoneAwareReplication:
+    enabled: true
+    topologyKey: "kubernetes.io/zone"
+
+chunks-cache:
+  enabled: true
+  replicas: 3
+
+index-cache:
+  enabled: true
+  replicas: 3
+
+metadata-cache:
+  enabled: true
+  replicas: 3
+
+results-cache:
+  enabled: true
+  replicas: 3
+
+overrides_exporter:
+  replicas: 1
+  resources:
+    limits:
+      memory: 128Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+
+querier:
+  replicas: 1
+  resources:
+    limits:
+      memory: 5.6Gi
+    requests:
+      cpu: 2
+      memory: 4Gi
+
+query_frontend:
+  replicas: 1
+  resources:
+    limits:
+      memory: 2.8Gi
+    requests:
+      cpu: 2
+      memory: 2Gi
+
+ruler:
+  replicas: 1
+  resources:
+    limits:
+      memory: 2.8Gi
+    requests:
+      cpu: 1
+      memory: 2Gi
+
+store_gateway:
+  persistentVolume:
+    size: 10Gi
+  replicas: 3
+  resources:
+    limits:
+      memory: 2.1Gi
+    requests:
+      cpu: 1
+      memory: 1.5Gi
+  topologySpreadConstraints: {}
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                  - store-gateway
+          topologyKey: "kubernetes.io/hostname"
+  zoneAwareReplication:
+    enabled: true
+    topologyKey: "kubernetes.io/zone"

--- a/kubernetes/gke-utility/helm/mimir.yaml
+++ b/kubernetes/gke-utility/helm/mimir.yaml
@@ -102,19 +102,6 @@ ingester:
       cpu: 3.5
       memory: 8Gi
   topologySpreadConstraints: {}
-  affinity:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/component
-                operator: In
-                values:
-                  - ingester
-          topologyKey: "kubernetes.io/hostname"
-  zoneAwareReplication:
-    enabled: true
-    topologyKey: "kubernetes.io/zone"
 
 chunks-cache:
   enabled: true
@@ -179,16 +166,4 @@ store_gateway:
       cpu: 1
       memory: 1.5Gi
   topologySpreadConstraints: {}
-  affinity:
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - labelSelector:
-            matchExpressions:
-              - key: app.kubernetes.io/component
-                operator: In
-                values:
-                  - store-gateway
-          topologyKey: "kubernetes.io/hostname"
-  zoneAwareReplication:
-    enabled: true
-    topologyKey: "kubernetes.io/zone"
+

--- a/kubernetes/gke-utility/mimir/external-secrets.yaml
+++ b/kubernetes/gke-utility/mimir/external-secrets.yaml
@@ -1,0 +1,14 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mimir-credentials
+  namespace: mimir
+spec:
+  data:
+    - secretKey: .htpasswd
+      remoteRef:
+        key: mimir-credentials
+        property: htpasswd
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: k8s-infra-prow

--- a/kubernetes/gke-utility/mimir/httproute.yaml
+++ b/kubernetes/gke-utility/mimir/httproute.yaml
@@ -1,0 +1,20 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mimir
+  namespace: mimir
+spec:
+  parentRefs:
+    - name: istio-ingressgateway
+      namespace: istio-system
+      sectionName: https
+  hostnames:
+    - mimir.prow.k8s.io
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: mimir-gateway
+          port: 80

--- a/kubernetes/gke-utility/mimir/kustomization.yaml
+++ b/kubernetes/gke-utility/mimir/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: mimir
+resources:
+  - external-secrets.yaml
+  - httproute.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
Part of #8351 

This PR:
 - Adds Mimir deployment using argocd application set referecing gke utility cluster. 
 - Adds Mimir helm values file based on mimir small helm value example. [mimir-small.yaml](https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/small.yaml) 
 - Adds Gateway-API HTTPRoute for `mimir.prow.k8s.io` with path-based routing to distributor, query-frontend, alertmanager, and ruler.
 - Adds mimir.prow.k8s.io A and AAAA records.
 - Adds mimir.prow.k8s.io to the oauth2-proxy AuthorizationPolicy.
 - Adds htpasswd-based basic auth for mimir endpoints.

cc @ameukam @upodroid 

**Special notes for your reviewer**:

**If you are promoting an image, please make sure you have done the following:**

- [ ] I have verified the digest with [gcrane](https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md) and added it as a comment to the PR or in the body.

- [ ] I'm promoting a multi-arch image that matches all the [supported](https://github.com/kubernetes/sig-release/tree/master/release-engineering/platforms) platforms of Kubernetes.

- [ ] I'm not promoting a tag that resolves to latest or moving tags as these are not supported

- [ ] registry.k8s.io is an immutable registry and I'll need to cut a new release if the digest is wrong.
