### PR TITLE
Remote write config to eks and gcp monitoring setup

### DIFF
--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/prometheus-main/mimir-credentials.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/prometheus-main/mimir-credentials.yaml
@@ -1,20 +1,12 @@
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: grafana-credentials
-spec:
-  dataFrom:
-  - extract:
-      key: grafana-credentials
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: k8s-infra-prow-build
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
   name: mimir-credentials
+  namespace: monitoring
 spec:
+  target:
+    name: mimir-credentials
+    creationPolicy: Owner
   data:
     - secretKey: username
       remoteRef:

--- a/infra/aws/terraform/prow-build-cluster/resources/monitoring/prometheus-main/prometheus.yaml
+++ b/infra/aws/terraform/prow-build-cluster/resources/monitoring/prometheus-main/prometheus.yaml
@@ -51,3 +51,17 @@ spec:
     key: node-group
     operator: Equal
     value: stable
+  externalLabels:
+    cluster: eks-prow-build
+    cloud: aws
+  remoteWrite:
+    - url: https://mimir.prow.k8s.io/api/v1/push
+      basicAuth:
+        username:
+          name: mimir-credentials
+          key: username
+        password:
+          name: mimir-credentials
+          key: password
+      headers:
+        X-Scope-OrgID: prow

--- a/kubernetes/gke-prow-build/helm/monitoring.yaml
+++ b/kubernetes/gke-prow-build/helm/monitoring.yaml
@@ -57,6 +57,20 @@ prometheus:
     ruleSelectorNilUsesHelmValues: false
     probeSelectorNilUsesHelmValues: false
     scrapeConfigSelectorNilUsesHelmValues: false
+    externalLabels:
+      cluster: gke-prow-build
+      cloud: gcp
+    remoteWrite:
+      - url: https://mimir.prow.k8s.io/api/v1/push
+        basicAuth:
+          username:
+            name: mimir-credentials
+            key: username
+          password:
+            name: mimir-credentials
+            key: password
+        headers:
+          X-Scope-OrgID: prow
 # These endpoints aren't scrapable on GKE
 coreDns:
   enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a remoteWrite block to the Prometheus configuration in both the EKS and GKE monitoring stacks:

- Targets mimir push api.
- Authenticates via Basic Auth using the existing mimir-credentials secret.
- Sends the X-Scope-OrgID: prow tenant header required by Mimir (using the same tenant for both clouds to allow metrics from both stacks to land in a single tenant).
- Adds two external labels: Used to distinguish metrics from different cloud providers in the tenant.

Part of #8351 

cc @ameukam @upodroid 

**Special notes for your reviewer**:

**If you are promoting an image, please make sure you have done the following:**

- [ ] I have verified the digest with [gcrane](https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md) and added it as a comment to the PR or in the body.

- [ ] I'm promoting a multi-arch image that matches all the [supported](https://github.com/kubernetes/sig-release/tree/master/release-engineering/platforms) platforms of Kubernetes.

- [ ] I'm not promoting a tag that resolves to latest or moving tags as these are not supported

- [ ] registry.k8s.io is an immutable registry and I'll need to cut a new release if the digest is wrong.
