### PR TITLE
setup kps for prow consolidated monitoring

### DIFF
--- a/kubernetes/apps/monitoring.yaml
+++ b/kubernetes/apps/monitoring.yaml
@@ -49,3 +49,52 @@ spec:
         managedNamespaceMetadata:
           labels:
             istio-injection: enabled
+
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: monitoring
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+spec:
+  goTemplate: true
+  generators:
+    - clusters:
+        selector:
+          matchLabels:
+            clusterType: 'utility'
+  template:
+    metadata:
+      name: 'monitoring-{{ .name }}'
+      annotations:
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
+    spec:
+      destination:
+        namespace: monitoring
+        server: "{{ .server }}"
+      project: default
+      sources:
+        - chart: kube-prometheus-stack
+          repoURL: https://prometheus-community.github.io/helm-charts
+          targetRevision: 80.10.0
+          helm:
+            releaseName: monitoring
+            valueFiles:
+              - $values/kubernetes/{{ .name }}/helm/monitoring.yaml
+        - repoURL: https://github.com/kubernetes/k8s.io
+          targetRevision: main
+          ref: values
+        - path: kubernetes/{{ .name }}/monitoring/
+          repoURL: https://github.com/kubernetes/k8s.io
+          targetRevision: main
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+          - ServerSideApply=true
+        managedNamespaceMetadata:
+          labels:
+            istio-injection: enabled

--- a/kubernetes/gke-utility/helm/mimir.yaml
+++ b/kubernetes/gke-utility/helm/mimir.yaml
@@ -166,4 +166,3 @@ store_gateway:
       cpu: 1
       memory: 1.5Gi
   topologySpreadConstraints: {}
-

--- a/kubernetes/gke-utility/helm/monitoring.yaml
+++ b/kubernetes/gke-utility/helm/monitoring.yaml
@@ -35,7 +35,7 @@ kube-state-metrics:
     - deployments=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance]
 
 nodeExporter:
-  enabled: true
+  enabled: false
 
 prometheus:
   prometheusSpec:

--- a/kubernetes/gke-utility/helm/monitoring.yaml
+++ b/kubernetes/gke-utility/helm/monitoring.yaml
@@ -1,0 +1,85 @@
+grafana:
+  enabled: true
+  defaultDashboardsEnabled: false
+  admin:
+    existingSecret: grafana-credentials
+    userKey: username
+    passwordKey: password
+  service:
+    type: ClusterIP
+  sidecar:
+    dashboards:
+      enabled: true
+    datasources:
+      enabled: true
+  persistence:
+    enabled: true
+    storageClassName: hyperdisk-balanced
+    size: 30Gi
+  grafana.ini:
+    analytics:
+      reporting_enabled: false
+      check_for_updates: true
+    server:
+      root_url: https://monitoring.prow.k8s.io
+    auth.anonymous:
+      enabled: true
+      org_role: Viewer
+
+alertmanager:
+  enabled: false
+
+kube-state-metrics:
+  metricLabelsAllowlist:
+    - pods=[*]
+    - deployments=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance]
+
+nodeExporter:
+  enabled: true
+
+prometheus:
+  prometheusSpec:
+    retention: 24h
+    resources:
+      requests:
+        cpu: 1
+        memory: 4Gi
+      limits:
+        cpu: 2
+        memory: 8Gi
+    persistentVolumeClaimRetentionPolicy:
+      whenDeleted: Retain
+      whenScaled: Retain
+    storageSpec:
+      volumeClaimTemplate:
+        spec:
+          storageClassName: hyperdisk-balanced
+          resources:
+            requests:
+              storage: 50Gi
+    serviceMonitorSelectorNilUsesHelmValues: false
+    podMonitorSelectorNilUsesHelmValues: false
+    ruleSelectorNilUsesHelmValues: false
+    probeSelectorNilUsesHelmValues: false
+    scrapeConfigSelectorNilUsesHelmValues: false
+    externalLabels:
+      cluster: gke-utility
+      cloud: gcp
+    remoteWrite:
+      - url: http://mimir-gateway.mimir.svc.cluster.local/api/v1/push
+        basicAuth:
+          username:
+            name: mimir-credentials
+            key: username
+          password:
+            name: mimir-credentials
+            key: password
+        headers:
+          X-Scope-OrgID: prow
+
+coreDns:
+  enabled: false
+kubeControllerManager:
+  enabled: false
+kubeScheduler:
+  enabled: false

--- a/kubernetes/gke-utility/helm/monitoring.yaml
+++ b/kubernetes/gke-utility/helm/monitoring.yaml
@@ -83,3 +83,11 @@ kubeControllerManager:
   enabled: false
 kubeScheduler:
   enabled: false
+kubeApiServer:
+  enabled: false
+kubeEtcd:
+  enabled: false
+kubeProxy:
+  enabled: false
+kubelet:
+  enabled: false

--- a/kubernetes/gke-utility/istio-system/auth-policy.yaml
+++ b/kubernetes/gke-utility/istio-system/auth-policy.yaml
@@ -15,7 +15,6 @@ spec:
     - operation:
         hosts:
         - argo.k8s.io
-        - monitoring.prow.k8s.io
     # we want to force auth to atlantis.k8s.io/* except /events
     - operation:
         hosts:

--- a/kubernetes/gke-utility/monitoring/httproute.yaml
+++ b/kubernetes/gke-utility/monitoring/httproute.yaml
@@ -1,0 +1,20 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: grafana
+  namespace: monitoring
+spec:
+  parentRefs:
+    - name: istio-ingressgateway
+      namespace: istio-system
+      sectionName: https
+  hostnames:
+    - monitoring.prow.k8s.io
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: monitoring-grafana
+          port: 80

--- a/kubernetes/gke-utility/monitoring/kustomization.yaml
+++ b/kubernetes/gke-utility/monitoring/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: monitoring
+resources:
+  - secrets.yaml
+  - httproute.yaml

--- a/kubernetes/gke-utility/monitoring/secrets.yaml
+++ b/kubernetes/gke-utility/monitoring/secrets.yaml
@@ -1,0 +1,29 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: grafana-credentials
+spec:
+  dataFrom:
+    - extract:
+        key: grafana-credentials
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: k8s-infra-prow
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: mimir-credentials
+spec:
+  data:
+    - secretKey: username
+      remoteRef:
+        key: mimir-credentials
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: mimir-credentials
+        property: password
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: k8s-infra-prow


### PR DESCRIPTION
**What this PR does / why we need it**:
- This PR adds an empty Grafana + Prometheus install on gke-utility for consolidated prow monitoring. 
- Prometheus remote-writes to the in-cluster Mimir gateway. 
- Removed monitoring.prow.k8s.io from oauth2-proxy auth-policy for public access.
part of #8351 

cc @ameukam 

