### PR TITLE
slack-infra: migrate images to registry.k8s.io and fix slack-welcomer container name

### DIFF
--- a/apps/slack-infra/resources/slack-moderator/deployment.yaml
+++ b/apps/slack-infra/resources/slack-moderator/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-moderator
-        image: gcr.io/k8s-staging-slack-infra/slack-moderator:v20210223-8525eb3
+        image: registry.k8s.io/slack-infra/slack-moderator:v20230228-2b433f6
         args:
           - --config-path=/etc/slack-moderator/config.json
         ports:

--- a/apps/slack-infra/resources/slack-moderator/deployment.yaml
+++ b/apps/slack-infra/resources/slack-moderator/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-moderator
-        image: registry.k8s.io/slack-infra/slack-moderator:v20230228-2b433f6
+        image: registry.k8s.io/slack-infra/slack-moderator:v20260709-3c87798
         args:
           - --config-path=/etc/slack-moderator/config.json
         ports:

--- a/apps/slack-infra/resources/slack-post-message/deployment.yaml
+++ b/apps/slack-infra/resources/slack-post-message/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-post-message
-        image: gcr.io/k8s-staging-slack-infra/slack-post-message:v20210223-8525eb3
+        image: registry.k8s.io/slack-infra/slack-post-message:v20210223-8525eb3
         args:
           - --config-path=/etc/slack-post-message/config.json
         ports:

--- a/apps/slack-infra/resources/slack-post-message/deployment.yaml
+++ b/apps/slack-infra/resources/slack-post-message/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-post-message
-        image: registry.k8s.io/slack-infra/slack-post-message:v20210223-8525eb3
+        image: registry.k8s.io/slack-infra/slack-post-message:v20260709-3c87798
         args:
           - --config-path=/etc/slack-post-message/config.json
         ports:

--- a/apps/slack-infra/resources/slack-welcomer/deployment.yaml
+++ b/apps/slack-infra/resources/slack-welcomer/deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: slack-welcomer
-        image: registry.k8s.io/slack-infra/slack-welcomer:v20230228-2b433f6
+        image: registry.k8s.io/slack-infra/slack-welcomer:v20260709-3c87798
         args:
           - --config-path=/etc/slack-welcomer/config.json
           - --message-path=/etc/welcome-message/welcome.md

--- a/apps/slack-infra/resources/slack-welcomer/deployment.yaml
+++ b/apps/slack-infra/resources/slack-welcomer/deployment.yaml
@@ -15,8 +15,8 @@ spec:
         app: slack-welcomer
     spec:
       containers:
-      - name: slack-moderator
-        image: gcr.io/k8s-staging-slack-infra/slack-welcomer:v20220304-82143f8@sha256:ee2858f2292d8a1fa91b0a85d6b941d82d7540cda1e65739a9957da6eea3f52e
+      - name: slack-welcomer
+        image: registry.k8s.io/slack-infra/slack-welcomer:v20230228-2b433f6
         args:
           - --config-path=/etc/slack-welcomer/config.json
           - --message-path=/etc/welcome-message/welcome.md


### PR DESCRIPTION
Migrates slack-welcomer, slack-moderator and slack-post-message deployments from the deprecated gcr.io/k8s-staging-slack-infra registry to registry.k8s.io. Also fixes the slack-welcomer container name which was incorrectly labeled as slack-moderator. Images are already promoted in registry.k8s.io/images/k8s-staging-slack-infra/images.yaml — not promoting new images, only migrating existing ones.

/sig k8s-infra
/cc @upodroid @ameukam