### PR TITLE
Add davanum@gmail.com to k8s-infra-prow-viewers

### DIFF
--- a/groups/sig-testing/groups.yaml
+++ b/groups/sig-testing/groups.yaml
@@ -187,6 +187,7 @@ groups:
     - neolit123@gmail.com
     - philjohnson96@gmail.com
     - elieser.pereiraa@gmail.com
+    - davanum@gmail.com
     - sig-testing-leads@kubernetes.io
 
   #


### PR DESCRIPTION
Adding myself to the `k8s-infra-prow-viewers` group for view access to resources used by prow.k8s.io (build clusters and e2e projects). This is a self-service, non-privileged read-only group per the comment in the file.

/sig testing