### PR TITLE
configure prow to work with a github app and set sane resource limits

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -244,13 +244,6 @@ prow:
   - type: AAAA
     ttl: 600 # this has needed to change in the past
     value: "2600:1901:0:b465::"
-hooks.prow:
-  - type: A
-    ttl: 600 # this has needed to change in the past
-    value: 34.128.150.99
-  - type: AAAA
-    ttl: 600 # this has needed to change in the past
-    value: "2600:1901:0:b465::"
 testgrid.prow:
   - type: A
     value: 34.128.150.99

--- a/hack/autobump-config.yaml
+++ b/hack/autobump-config.yaml
@@ -19,10 +19,6 @@ prefixes:
     repo: "https://github.com/kubernetes-sigs/boskos"
     summarise: false
     consistentImages: true
-  - name: "ghproxy"
-    prefix: "us-docker.pkg.dev/k8s-infra-prow/images/ghproxy"
-    repo: "https://github.com/kubernetes-sigs/prow"
-    summarise: false
   - name: "prow"
     prefix: "us-docker.pkg.dev/k8s-infra-prow/images/"
     repo: "https://github.com/kubernetes-sigs/prow"

--- a/infra/gcp/terraform/k8s-infra-prow/buckets.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/buckets.tf
@@ -69,6 +69,10 @@ module "testgrid_config_bucket" {
       member = "serviceAccount:k8s-testgrid-config-updater@k8s-infra-prow-build-trusted.iam.gserviceaccount.com"
     },
     {
+      role   = "roles/storage.objectAdmin"
+      member = google_service_account.prow.member
+    },
+    {
       // Let K8s TestGrid canary read configs from this bucket. 
       role   = "roles/storage.objectViewer"
       member = "serviceAccount:testgrid-canary@k8s-testgrid.iam.gserviceaccount.com"

--- a/kubernetes/gke-prow/prow/cherrypicker.yaml
+++ b/kubernetes/gke-prow/prow/cherrypicker.yaml
@@ -45,6 +45,13 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --dry-run=false
+        resources:
+          requests:
+            cpu: 300m
+            memory: 2000Mi
+          limits:
+            cpu: 1000m
+            memory: 4000Mi
         ports:
           - name: http
             containerPort: 8888

--- a/kubernetes/gke-prow/prow/crier.yaml
+++ b/kubernetes/gke-prow/prow/crier.yaml
@@ -37,15 +37,28 @@ spec:
           args:
             - --blob-storage-workers=1
             - --config-path=/etc/config/config.yaml
+            - --github-app-id=$(GITHUB_APP_ID)
+            - --github-app-private-key-path=/etc/github/key.pem
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
-            - --github-token-path=/etc/github/oauth
             - --github-workers=5
             - --job-config-path=/etc/job-config
             - --kubernetes-blob-storage-workers=1
             - --slack-token-file=/etc/slack/token
             - --slack-workers=1
+          resources:
+            requests:
+              cpu: 100m
+              memory: 1000Mi
+            limits:
+              cpu: 1000m
+              memory: 4000Mi
           env:
+            - name: GITHUB_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: github-credentials
+                  key: app_id
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG
               value: "/etc/kubeconfig-k8s-infra-prow/kubeconfig:/etc/kubeconfig-k8s-infra-prow-build/kubeconfig:/etc/kubeconfig-k8s-infra-prow-build-trusted/kubeconfig:/etc/kubeconfig-k8s-infra-aks-prow-build/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig:/etc/kubeconfig-k8s-infra-kops-prow-build/kubeconfig:/etc/k8s-infra-ppc64le-prow-build-kubeconfig/kubeconfig:/etc/k8s-infra-s390x-prow-build-kubeconfig/kubeconfig"
@@ -99,7 +112,7 @@ spec:
             - name: job-config
               mountPath: /etc/job-config
               readOnly: true
-            - name: oauth
+            - name: github
               mountPath: /etc/github
               readOnly: true
             - name: slack
@@ -120,9 +133,12 @@ spec:
         - name: job-config
           configMap:
             name: job-config
-        - name: oauth
+        - name: github
           secret:
-            secretName: oauth-token
+            secretName: github-credentials
+            items:
+              - key: app_private_key
+                path: key.pem
         - name: slack
           secret:
             secretName: slack-token

--- a/kubernetes/gke-prow/prow/deck.yaml
+++ b/kubernetes/gke-prow/prow/deck.yaml
@@ -54,13 +54,26 @@ spec:
             - --job-config-path=/etc/job-config
             - --spyglass=true
             - --rerun-creates-job
-            - --github-token-path=/etc/github/oauth
+            - --github-app-id=$(GITHUB_APP_ID)
+            - --github-app-private-key-path=/etc/github/key.pem
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
-            - --github-oauth-config-file=/etc/githuboauth/secret
+            - --github-oauth-config-file=/etc/github/oauth-config.yaml
             - --cookie-secret=/etc/cookie/secret
             - --plugin-config=/etc/plugins/plugins.yaml
+          resources:
+            requests:
+              cpu: 1000m
+              memory: 2000Mi
+            limits:
+              cpu: 2000m
+              memory: 5000Mi
           env:
+            - name: GITHUB_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: github-credentials
+                  key: app_id
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG
               value: "/etc/kubeconfig-k8s-infra-prow/kubeconfig:/etc/kubeconfig-k8s-infra-prow-build/kubeconfig:/etc/kubeconfig-k8s-infra-prow-build-trusted/kubeconfig:/etc/kubeconfig-k8s-infra-aks-prow-build/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig:/etc/kubeconfig-k8s-infra-kops-prow-build/kubeconfig:/etc/k8s-infra-ppc64le-prow-build-kubeconfig/kubeconfig:/etc/k8s-infra-s390x-prow-build-kubeconfig/kubeconfig"
@@ -81,9 +94,6 @@ spec:
             - name: AZURE_FEDERATED_TOKEN_FILE
               value: "/var/run/secrets/azure-token/serviceaccount/token"
           volumeMounts:
-            - name: oauth-config
-              mountPath: /etc/githuboauth
-              readOnly: true
             - name: cookie-secret
               mountPath: /etc/cookie
               readOnly: true
@@ -117,7 +127,7 @@ spec:
             - name: job-config
               mountPath: /etc/job-config
               readOnly: true
-            - name: oauth-token
+            - name: github
               mountPath: /etc/github
               readOnly: true
             - name: plugins
@@ -145,12 +155,14 @@ spec:
             periodSeconds: 3
             timeoutSeconds: 600
       volumes:
-        - name: oauth-config
+        - name: github
           secret:
-            secretName: github-oauth-config
-        - name: oauth-token
-          secret:
-            secretName: oauth-token
+            secretName: github-credentials
+            items:
+              - key: app_private_key
+                path: key.pem
+              - key: oauth_config
+                path: oauth-config.yaml
         - name: cookie-secret
           secret:
             secretName: cookie

--- a/kubernetes/gke-prow/prow/external-secrets.yaml
+++ b/kubernetes/gke-prow/prow/external-secrets.yaml
@@ -93,12 +93,11 @@ spec:
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: oauth-token
+  name: github-credentials
 spec:
-  data:
-    - remoteRef:
-        key: oauth-token
-      secretKey: oauth
+  dataFrom:
+  - extract:
+      key: github-credentials
   secretStoreRef:
     kind: ClusterSecretStore
     name: k8s-infra-prow
@@ -125,19 +124,6 @@ spec:
     - remoteRef:
         key: hmac-token
       secretKey: hmac
-  secretStoreRef:
-    kind: ClusterSecretStore
-    name: k8s-infra-prow
----
-apiVersion: external-secrets.io/v1
-kind: ExternalSecret
-metadata:
-  name: github-oauth-config
-spec:
-  data:
-    - remoteRef:
-        key: github-oauth-config
-      secretKey: secret
   secretStoreRef:
     kind: ClusterSecretStore
     name: k8s-infra-prow

--- a/kubernetes/gke-prow/prow/gateway.yaml
+++ b/kubernetes/gke-prow/prow/gateway.yaml
@@ -46,21 +46,6 @@ spec:
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: prow-hooks
-spec:
-  parentRefs:
-  - name: prow
-    sectionName: https
-  hostnames:
-  - hooks.prow.k8s.io
-  rules:
-  - backendRefs:
-    - name: hook
-      port: 8888
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
   name: https-redirect
 spec:
   parentRefs:

--- a/kubernetes/gke-prow/prow/ghproxy.yaml
+++ b/kubernetes/gke-prow/prow/ghproxy.yaml
@@ -52,8 +52,14 @@ spec:
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=99
-            - --push-gateway=pushgateway
             - --serve-metrics=true
+          resources:
+            requests:
+              cpu: 100m
+              memory: 500Mi
+            limits:
+              cpu: 300m
+              memory: 2000Mi
           ports:
             - name: main
               containerPort: 8888

--- a/kubernetes/gke-prow/prow/hook.yaml
+++ b/kubernetes/gke-prow/prow/hook.yaml
@@ -42,13 +42,26 @@ spec:
           args:
             - --dry-run=false
             - --slack-token-file=/etc/slack/token
+            - --github-app-id=$(GITHUB_APP_ID)
+            - --github-app-private-key-path=/etc/github/key.pem
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
-            - --github-token-path=/etc/github/oauth
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config
           # - --webhook-path=/
+          resources:
+            requests:
+              cpu: 100m
+              memory: 3000Mi
+            limits:
+              cpu: 1000m
+              memory: 6000Mi
           env:
+            - name: GITHUB_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: github-credentials
+                  key: app_id
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG
               value: "/etc/kubeconfig-k8s-infra-prow/kubeconfig:/etc/kubeconfig-k8s-infra-prow-build/kubeconfig:/etc/kubeconfig-k8s-infra-prow-build-trusted/kubeconfig:/etc/kubeconfig-k8s-infra-aks-prow-build/kubeconfig:/etc/kubeconfig-eks-prow-build-cluster/kubeconfig:/etc/kubeconfig-k8s-infra-kops-prow-build/kubeconfig:/etc/k8s-infra-ppc64le-prow-build-kubeconfig/kubeconfig:/etc/k8s-infra-s390x-prow-build-kubeconfig/kubeconfig"
@@ -79,7 +92,7 @@ spec:
             - name: hmac
               mountPath: /etc/webhook
               readOnly: true
-            - name: oauth
+            - name: github
               mountPath: /etc/github
               readOnly: true
             - name: config
@@ -149,9 +162,12 @@ spec:
         - name: hmac
           secret:
             secretName: hmac-token
-        - name: oauth
+        - name: github
           secret:
-            secretName: oauth-token
+            secretName: github-credentials
+            items:
+              - key: app_private_key
+                path: key.pem
         - name: config
           configMap:
             name: config

--- a/kubernetes/gke-prow/prow/horologium.yaml
+++ b/kubernetes/gke-prow/prow/horologium.yaml
@@ -49,6 +49,13 @@ spec:
         - name: job-config
           mountPath: /etc/job-config
           readOnly: true
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1500Mi
+          limits:
+            cpu: 500m
+            memory: 3000Mi
       volumes:
       - name: config
         configMap:

--- a/kubernetes/gke-prow/prow/needs-rebase.yaml
+++ b/kubernetes/gke-prow/prow/needs-rebase.yaml
@@ -36,10 +36,24 @@ spec:
         imagePullPolicy: Always
         args:
         - --dry-run=false
+        - --github-app-id=$(GITHUB_APP_ID)
+        - --github-app-private-key-path=/etc/github/key.pem
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
-        - --github-token-path=/etc/github/oauth
-        - --update-period=6h
+        - --update-period=3h
+        resources:
+          requests:
+            cpu: 100m
+            memory: 500Mi
+          limits:
+            cpu: 200m
+            memory: 1000Mi
+        env:
+          - name: GITHUB_APP_ID
+            valueFrom:
+              secretKeyRef:
+                name: github-credentials
+                key: app_id
         ports:
           - name: http
             containerPort: 8888
@@ -47,7 +61,7 @@ spec:
         - name: hmac
           mountPath: /etc/webhook
           readOnly: true
-        - name: oauth
+        - name: github
           mountPath: /etc/github
           readOnly: true
         - name: plugins
@@ -57,9 +71,12 @@ spec:
       - name: hmac
         secret:
           secretName: hmac-token
-      - name: oauth
+      - name: github
         secret:
-          secretName: oauth-token
+          secretName: github-credentials
+          items:
+            - key: app_private_key
+              path: key.pem
       - name: plugins
         configMap:
           name: plugins

--- a/kubernetes/gke-prow/prow/prow-controller-manager.yaml
+++ b/kubernetes/gke-prow/prow/prow-controller-manager.yaml
@@ -43,6 +43,13 @@ spec:
             - --dry-run=false
             - --enable-controller=plank
             - --job-config-path=/etc/job-config
+          resources:
+            requests:
+              cpu: 300m
+              memory: 2000Mi
+            limits:
+              cpu: 1000m
+              memory: 4000Mi
           env:
             # Use KUBECONFIG envvar rather than --kubeconfig flag in order to provide multiple configs to merge.
             - name: KUBECONFIG

--- a/kubernetes/gke-prow/prow/sinker.yaml
+++ b/kubernetes/gke-prow/prow/sinker.yaml
@@ -43,6 +43,13 @@ spec:
               value: "d1aa7522-0959-442e-80ee-8c4f7fb4c184"
             - name: AZURE_FEDERATED_TOKEN_FILE
               value: "/var/run/secrets/azure-token/serviceaccount/token"
+          resources:
+            requests:
+              cpu: 100m
+              memory: 2000Mi
+            limits:
+              cpu: 1000m
+              memory: 4000Mi
           ports:
             - name: metrics
               containerPort: 9090

--- a/kubernetes/gke-prow/prow/statusreconciler.yaml
+++ b/kubernetes/gke-prow/prow/statusreconciler.yaml
@@ -39,13 +39,27 @@ spec:
         - --continue-on-error=true
         - --plugin-config=/etc/plugins/plugins.yaml
         - --config-path=/etc/config/config.yaml
-        - --github-token-path=/etc/github/oauth
+        - --github-app-id=$(GITHUB_APP_ID)
+        - --github-app-private-key-path=/etc/github/cert
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --job-config-path=/etc/job-config
         - --denylist=kubernetes/kubernetes
+        resources:
+          requests:
+            cpu: 100m
+            memory: 500Mi
+          limits:
+            cpu: 300m
+            memory: 1000Mi
+        env:
+          - name: GITHUB_APP_ID
+            valueFrom:
+              secretKeyRef:
+                name: github-credentials
+                key: app_id
         volumeMounts:
-        - name: oauth
+        - name: github
           mountPath: /etc/github
           readOnly: true
         - name: config
@@ -58,9 +72,12 @@ spec:
           mountPath: /etc/plugins
           readOnly: true
       volumes:
-      - name: oauth
+      - name: github
         secret:
-          secretName: oauth-token
+          secretName: github-credentials
+          items:
+            - key: app_private_key
+              path: key.pem
       - name: config
         configMap:
           name: config

--- a/kubernetes/gke-prow/prow/tide.yaml
+++ b/kubernetes/gke-prow/prow/tide.yaml
@@ -37,20 +37,34 @@ spec:
         image: us-docker.pkg.dev/k8s-infra-prow/images/tide:v20260617-37d12bec7
         args:
         - --dry-run=false
+        - --github-app-id=$(GITHUB_APP_ID)
+        - --github-app-private-key-path=/etc/github/key.pem
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
-        - --github-token-path=/etc/github/oauth
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --history-uri=gs://kubernetes-ci-logs/tide-history.json
         - --status-path=gs://kubernetes-ci-logs/tide-status-checkpoint.yaml
+        resources:
+          requests:
+            cpu: 300m
+            memory: 2000Mi
+          limits:
+            cpu: 1000m
+            memory: 4000Mi
+        env:
+          - name: GITHUB_APP_ID
+            valueFrom:
+              secretKeyRef:
+                name: github-credentials
+                key: app_id
         ports:
         - name: http
           containerPort: 8888
         - name: metrics
           containerPort: 9090
         volumeMounts:
-        - name: oauth
+        - name: github
           mountPath: /etc/github
           readOnly: true
         - name: config
@@ -60,9 +74,12 @@ spec:
           mountPath: /etc/job-config
           readOnly: true
       volumes:
-      - name: oauth
+      - name: github
         secret:
-          secretName: oauth-token
+          secretName: github-credentials
+          items:
+            - key: app_private_key
+              path: key.pem
       - name: config
         configMap:
           name: config


### PR DESCRIPTION
I temporarily disabled ArgoCD autosync and applied the changes manually, I'm observing the performance of the new resource limits before merging.

Fixes: https://github.com/kubernetes/org/issues/6449



All the components except the cherrypicker are using the GitHub app.

The secret in GCP SM looks like this:

```json
{
  "app_id": "REDACTED",
  "app_client_id": "REDACTED",
  "app_private_key": "REDACTED",
  "oauth_config": "client_id: REDACTED\nclient_secret: REDACTED\nredirect_url: https://prow.k8s.io/github-login/redirect\nfinal_redirect_url: https://prow.k8s.io/pr\n"
}
```