### PR TITLE
disable auth for utility grafana

### DIFF
--- a/kubernetes/gke-utility/helm/monitoring.yaml
+++ b/kubernetes/gke-utility/helm/monitoring.yaml
@@ -51,6 +51,10 @@ grafana:
     auth.anonymous:
       enabled: true
       org_role: Viewer
+    auth.basic:
+      enabled: false
+    auth:
+      disable_login_form: true
 
 alertmanager:
   enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:
Disables auth for gke utility monitoring.

cc @ameukam 