### PR TITLE
Promote dra-driver-cpu v0.2.0

### DIFF
--- a/registry.k8s.io/images/k8s-staging-dra-driver-cpu/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-dra-driver-cpu/images.yaml
@@ -1,3 +1,7 @@
 - name: dra-driver-cpu
   dmap:
     "sha256:a74bef2b40dff4e0aeabe247bd6513152d013932749f8d32c0e39e5e8fb810af": ["v0.1.0"] # promote
+    "sha256:67e068207f67117d205545fc6dbf4342d6b214edab76396130f472c338c6c598": ["v0.2.0"]
+- name: charts/dra-driver-cpu
+  dmap:
+    "sha256:94541b171271761306559f4a030ce817929be153ddb2a431800abc4a68a5d728": ["0.2.0"]


### PR DESCRIPTION
**What this PR does / why we need it**:

Promote dra-driver-cpu image to v0.2.0
xref - https://github.com/kubernetes-sigs/dra-driver-cpu/pull/189 


**Special notes for your reviewer**:

**If you are promoting an image, please make sure you have done the following:**

- [x] I have verified the digest with [gcrane](https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md) and added it as a comment to the PR or in the body.

- [x] I'm promoting a multi-arch image that matches all the [supported](https://github.com/kubernetes/sig-release/tree/master/release-engineering/platforms) platforms of Kubernetes.

- [x] I'm not promoting a tag that resolves to latest or moving tags as these are not supported

- [x] registry.k8s.io is an immutable registry and I'll need to cut a new release if the digest is wrong.
