### PR TITLE
Enable autosync on mimir ApplicationSet

### DIFF
--- a/kubernetes/apps/mimir.yaml
+++ b/kubernetes/apps/mimir.yaml
@@ -40,6 +40,9 @@ spec:
           repoURL: https://github.com/kubernetes/k8s.io
           targetRevision: main
       syncPolicy:
+        automated:
+          selfHeal: true
+          prune: false
         syncOptions:
           - CreateNamespace=true
           - ServerSideApply=true


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enable automated sync with selfHeal for the Mimir ApplicationSet with auto-prune disabled to prevent data loss for git resource deletion.

cc @ameukam 