### PR TITLE
Add google group entry for `resource-state-metrics`

### DIFF
--- a/groups/restrictions.yaml
+++ b/groups/restrictions.yaml
@@ -151,6 +151,7 @@ restrictions:
       - "^k8s-infra-staging-kube-state-metrics@kubernetes.io$"
       - "^k8s-infra-staging-metrics-server@kubernetes.io$"
       - "^k8s-infra-staging-prometheus-adapter@kubernetes.io$"
+      - "^k8s-infra-staging-resource-state-met@kubernetes.io$"
       - "^sig-instrumentation@kubernetes.io$"
       - "^sig-instrumentation-leads@kubernetes.io$"
   - path: "sig-multicluster/groups.yaml"

--- a/groups/sig-instrumentation/groups.yaml
+++ b/groups/sig-instrumentation/groups.yaml
@@ -83,6 +83,17 @@ groups:
       - pszczesniak@google.com
       - fbranczyk@gmail.com
 
+  - email-id: k8s-infra-staging-resource-state-met@kubernetes.io
+    name: k8s-infra-staging-resource-state-met
+    description: |-
+      ACL for resource-state-metrics
+    settings:
+      ReconcileMembers: "true"
+    members:
+      - contact@rueg.eu
+      - dgrisonn@redhat.com
+      - rexagod@gmail.com
+
   - email-id: k8s-infra-staging-prometheus-adapter@kubernetes.io
     name: k8s-infra-staging-prometheus-adapter
     description: |-


### PR DESCRIPTION


**What this PR does / why we need it**: Adds a google group entry for RSM.

NOTE: There's a 18-char limit on the project name in the mailing identifier, so `resource-state-metrics` was truncated from the end.

