### PR TITLE
switch mimir to cluster type labels

### DIFF
--- a/kubernetes/apps/mimir.yaml
+++ b/kubernetes/apps/mimir.yaml
@@ -10,11 +10,8 @@ spec:
   generators:
     - clusters:
         selector:
-          matchExpressions:
-            - key: name
-              operator: In
-              values:
-                - utility
+          matchLabels:
+            clusterType: 'utility'
   template:
     metadata:
       name: 'mimir-{{ .name }}'


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR switches mimir applicationSet to use the match Label selector, matching the utility cluster type. Should fix mimir missing deployment.

cc @ameukam 
