### PR TITLE
Replace fra04(eu-de-1) DC with new region in boskos on ibm ppc64le

### DIFF
--- a/kubernetes/ibm-ppc64le/prow/boskos-resources-configmap.yaml
+++ b/kubernetes/ibm-ppc64le/prow/boskos-resources-configmap.yaml
@@ -3,9 +3,9 @@ data:
   config: |
     resources:
     - names:
-      - k8s-boskos-powervs-eu-de-1-01
-      - k8s-boskos-powervs-eu-de-1-02
-      - k8s-boskos-powervs-eu-de-1-03
+      - k8s-boskos-powervs-wdc06-01
+      - k8s-boskos-powervs-wdc06-02
+      - k8s-boskos-powervs-wdc06-03
       - k8s-boskos-powervs-eu-de-2-01
       - k8s-boskos-powervs-eu-de-2-02
       - k8s-boskos-powervs-eu-de-2-03


### PR DESCRIPTION
**What this PR does / why we need it**:
Removing old workspaces in `eu-de-1(fra04)` zone and adding a new ones in `wdc06`.

https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-e2e-ppc64le-default/2071594725248339968/build-log.txt

SSH failure:
```
Error: remote-exec provisioner error

  with null_resource.wait-for-workers-completes[0],
  on main.tf line 74, in resource "null_resource" "wait-for-workers-completes":
  74:   provisioner "remote-exec" {

timeout - last error: dial tcp 161.156.22.10:22: i/o timeout
```

https://storage.googleapis.com/kubernetes-ci-logs/logs/ci-kubernetes-ppc64le-conformance-latest/2071775916282875904/build-log.txt
```

TASK [install-k8s : kubeadm join worker nodes] *********************************
skipping: [161.156.147.54]
[ERROR]: Task failed: Module failed: non-zero return code
Origin: /home/prow/go/src/github.com/kubernetes-sigs/provider-ibmcloud-test-infra/conformance-1782784996/roles/install-k8s/tasks/main.yml:142:3

140   register: kubernetes_join_command_result
141
142 - name: kubeadm join worker nodes
      ^ column 3

fatal: [161.156.147.50]: FAILED! => {"changed": true, "cmd": ["kubeadm", "join", "192.168.218.54:992", "--token", "uy2fqe.k0dkeh75v90g1fee", "--discovery-token-ca-cert-hash", "sha256:f858d4c1ba0cdee73348104617af7e8cc6c4a8544c4e6b8d38a3677240100b34"], "delta": "0:05:00.190058", "end": "2026-06-30 02:22:24.587073", "msg": "non-zero return code", "rc": 1, "start": "2026-06-30 02:17:24.397015", "stderr": "\t[WARNING Hostname]: hostname \"conformance-1782784996-worker-1\" could not be reached\n\t[WARNING Hostname]: hostname \"conformance-1782784996-worker-1\": lookup conformance-1782784996-worker-1 on 8.8.4.4:53: no such host\nerror: error execution phase preflight: couldn't validate the identity of the API Server: failed to request the cluster-info ConfigMap: Get \"https://192.168.218.54:992/api/v1/namespaces/kube-public/configmaps/cluster-info?timeout=10s\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)\nTo see the stack trace of this error execute with --v=5 or higher", "stderr_lines": ["\t[WARNING Hostname]: hostname \"conformance-1782784996-worker-1\" could not be reached", "\t[WARNING Hostname]: hostname \"conformance-1782784996-worker-1\": lookup conformance-1782784996-worker-1 on 8.8.4.4:53: no such host", "error: error execution phase preflight: couldn't validate the identity of the API Server: failed to request the cluster-info ConfigMap: Get \"https://192.168.218.54:992/api/v1/namespaces/kube-public/configmaps/cluster-info?timeout=10s\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)", "To see the stack trace of this error execute with --v=5 or higher"], "stdout": "[preflight] Running pre-flight checks", "stdout_lines": ["[preflight] Running pre-flight checks"]}
fatal: [161.156.147.51]: FAILED! => {"changed": true, "cmd": ["kubeadm", "join", "192.168.218.54:992", "--token", "uy2fqe.k0dkeh75v90g1fee", "--discovery-token-ca-cert-hash", "sha256:f858d4c1ba0cdee73348104617af7e8cc6c4a8544c4e6b8d38a3677240100b34"], "delta": "0:05:00.193956", "end": "2026-06-30 02:22:26.718715", "msg": "non-zero return code", "rc": 1, "start": "2026-06-30 02:17:26.524759", "stderr": "\t[WARNING Hostname]: hostname \"conformance-1782784996-worker-0\" could not be reached\n\t[WARNING Hostname]: hostname \"conformance-1782784996-worker-0\": lookup conformance-1782784996-worker-0 on 8.8.4.4:53: no such host\nerror: error execution phase preflight: couldn't validate the identity of the API Server: failed to request the cluster-info ConfigMap: Get \"https://192.168.218.54:992/api/v1/namespaces/kube-public/configmaps/cluster-info?timeout=10s\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)\nTo see the stack trace of this error execute with --v=5 or higher", "stderr_lines": ["\t[WARNING Hostname]: hostname \"conformance-1782784996-worker-0\" could not be reached", "\t[WARNING Hostname]: hostname \"conformance-1782784996-worker-0\": lookup conformance-1782784996-worker-0 on 8.8.4.4:53: no such host", "error: error execution phase preflight: couldn't validate the identity of the API Server: failed to request the cluster-info ConfigMap: Get \"https://192.168.218.54:992/api/v1/namespaces/kube-public/configmaps/cluster-info?timeout=10s\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)", "To see the stack trace of this error execute with --v=5 or higher"], "stdout": "[preflight] Running pre-flight checks", "stdout_lines": ["[preflight] Running pre-flight checks"]}
```
