### PR TITLE
Enable image registry for Gateway API conformance images

### DIFF
--- a/groups/sig-network/groups.yaml
+++ b/groups/sig-network/groups.yaml
@@ -134,9 +134,8 @@ groups:
     members:
       - antonio.ojea.garcia@gmail.com
       - bowei@google.com
-      - cmluciano@us.ibm.com
-      - daneyonhansen@gmail.com
-      - harrybagdi@gmail.com
+      - nick@isovalent.com
+      - ricardo.katz@gmail.com
       - robertjscott@google.com
       - thockin@google.com
 

--- a/infra/gcp/terraform/k8s-staging-images/registries.tf
+++ b/infra/gcp/terraform/k8s-staging-images/registries.tf
@@ -33,6 +33,7 @@ locals {
     etcd                            = "group:k8s-infra-staging-etcd@kubernetes.io"
     etcd-manager                    = "group:k8s-infra-staging-etcd-manager@kubernetes.io"
     gateway-api                     = "group:k8s-infra-staging-gateway-api@kubernetes.io"
+    gateway-api-conformance-images  = "group:k8s-infra-staging-gateway-api@kubernetes.io"
     headlamp                        = "group:k8s-infra-staging-headlamp@kubernetes.io"
     inference-perf                  = "group:k8s-infra-staging-inference-perf@kubernetes.io"
     infra-tools                     = "group:k8s-infra-staging-infra-tools@kubernetes.io"

--- a/registry.k8s.io/images/k8s-staging-gateway-api-conformance-images/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-gateway-api-conformance-images/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - bowei
+  - rikatz
+  - robscott
+  - youngnick
+
+labels:
+  - sig/network

--- a/registry.k8s.io/manifests/k8s-staging-gateway-api-conformance-images/promoter-manifest.yaml
+++ b/registry.k8s.io/manifests/k8s-staging-gateway-api-conformance-images/promoter-manifest.yaml
@@ -1,0 +1,48 @@
+# google group for us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-conformance-images is k8s-infra-staging-gateway-api@kubernetes.io
+registries:
+  - name: us-central1-docker.pkg.dev/k8s-staging-images/gateway-api-conformance-images
+    src: true
+  - name: asia-east1-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia-south1-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia-northeast1-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: asia-northeast2-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: australia-southeast1-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-north1-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-southwest1-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west1-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west2-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west3-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west4-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west8-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west9-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: europe-west10-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: southamerica-west1-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-central1-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-east1-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-east4-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-east5-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-south1-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-west1-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  - name: us-west2-docker.pkg.dev/k8s-artifacts-prod/images/gateway-api-conformance-images
+    service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com


### PR DESCRIPTION
**What this PR does / why we need it**:

Gateway API conformance images has a new home at k-sigs/gateway-api-conformance-images.

This PR adds the required manifests to bootstrap the new AR and set the right permissions on Gateway API group

