### PR TITLE
Promote regression-issue-74839 to 1.5

### DIFF
--- a/registry.k8s.io/images/k8s-staging-e2e-test-images/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-e2e-test-images/images.yaml
@@ -190,6 +190,7 @@
   dmap:
     "sha256:b4f1d8d61bdad84bd50442d161d5460e4019d53e989b64220fdbc62fc87d76bf": ["1.2"]
     "sha256:55cf49aeaafe4b3e8ce90783e6bb59e5a8b1b6b41aaeced7d0b26562a149ffb0": ["1.4"]
+    "sha256:ed3425d5ebd5d0cad5e8e2ca2c9756fcf7d25f2d4a9ed8efa80333952bdfe2a5": ["1.5"]
 - name: resource-consumer
   dmap:
     "sha256:74e800780d7656d42fb0f28e153619044a826e5f532d1871cac4b7c4d66d946f": ["1.6"]


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow-up PR of https://github.com/kubernetes/kubernetes/pull/139874 for promoting regression-issue-74839 to 1.5.
The hash was pushed here: https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-kubernetes-push-e2e-regression-issue-74839-test-images/2072767342110052352

https://github.com/kubernetes/kubernetes/issues/139873

Validated using `gcrane`:
```shell
$ gcrane validate --remote gcr.io/k8s-staging-e2e-test-images/regression-issue-74839:1.5
PASS: gcr.io/k8s-staging-e2e-test-images/regression-issue-74839:1.5
```

**Special notes for your reviewer**:

**If you are promoting an image, please make sure you have done the following:**

- [X] I have verified the digest with [gcrane](https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md) and added it as a comment to the PR or in the body.

- [ ] I'm promoting a multi-arch image that matches all the [supported](https://github.com/kubernetes/sig-release/tree/master/release-engineering/platforms) platforms of Kubernetes.

- [x] I'm not promoting a tag that resolves to latest or moving tags as these are not supported

- [ ] registry.k8s.io is an immutable registry and I'll need to cut a new release if the digest is wrong.
