### PR TITLE
create a fallback nodepool and keep the nodes around longer

### DIFF
--- a/kubernetes/eks-prow-build/README.md
+++ b/kubernetes/eks-prow-build/README.md
@@ -1,0 +1,14 @@
+# eks-prow-build
+
+`eks-prow-build` is the production EKS Prow build cluster for Kubernetes CI
+jobs.
+
+## Argo CD Applications
+
+| App name | Badge |
+| --- | --- |
+| `eks-prow-build` | [![App Status](https://argo.k8s.io/api/badge?name=eks-prow-build&revision=true&showAppName=false&width=250)](https://argo.k8s.io/applications/eks-prow-build) |
+| `datadog-eks-prow-build` | [![App Status](https://argo.k8s.io/api/badge?name=datadog-eks-prow-build&revision=true&showAppName=false&width=250)](https://argo.k8s.io/applications/datadog-eks-prow-build) |
+| `external-secrets-eks-prow-build` | [![App Status](https://argo.k8s.io/api/badge?name=external-secrets-eks-prow-build&revision=true&showAppName=false&width=250)](https://argo.k8s.io/applications/external-secrets-eks-prow-build) |
+| `kube-system-eks-prow-build` | [![App Status](https://argo.k8s.io/api/badge?name=kube-system-eks-prow-build&revision=true&showAppName=false&width=250)](https://argo.k8s.io/applications/kube-system-eks-prow-build) |
+| `monitoring-eks-prow-build` | [![App Status](https://argo.k8s.io/api/badge?name=monitoring-eks-prow-build&revision=true&showAppName=false&width=250)](https://argo.k8s.io/applications/monitoring-eks-prow-build) |

--- a/kubernetes/eks-prow-build/datadog/kustomization.yaml
+++ b/kubernetes/eks-prow-build/datadog/kustomization.yaml
@@ -6,8 +6,8 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.202.2
-    kubeVersion: "1.32"
+    version: 3.229.0
+    kubeVersion: "1.35"
     valuesFile: values.yaml
 
 resources:

--- a/kubernetes/eks-prow-build/kube-system/nodepools.yaml
+++ b/kubernetes/eks-prow-build/kube-system/nodepools.yaml
@@ -1,8 +1,9 @@
 apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
-  name: amd64
+  name: amd64-latest
 spec:
+  weight: 100
   template:
     spec:
       expireAfter: 720h
@@ -27,7 +28,41 @@ spec:
     cpu: "2400" # 300 VMs
   disruption:
     consolidationPolicy: WhenEmpty
-    consolidateAfter: 5m
+    consolidateAfter: 20m
+    budgets:
+      - nodes: "20%" # Allowing rotating 20% of instances at any given time
+---
+# The new generation instances are capacity constrained, create older-nodes if necessary
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: amd64-fallback
+spec:
+  weight: 10
+  template:
+    spec:
+      expireAfter: 720h
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: default
+      requirements:
+        - key: topology.kubernetes.io/zone
+          operator: In
+          values: ["us-east-2a", "us-east-2b", "us-east-2c"]
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: node.kubernetes.io/instance-type
+          operator: In
+          values:
+            - m6id.2xlarge
+            - m6idn.2xlarge
+  limits:
+    cpu: "400" # 50 VMs
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 30s
     budgets:
       - nodes: "20%" # Allowing rotating 20% of instances at any given time
 ---


### PR DESCRIPTION
The nodes we use for EKS are capacity constrained so I created a fallback nodepool, also we'll keep the nodes around a bit longer to deal with spiky jobs.


```
creating instance, insufficient capacity, with fleet error(s), InsufficientInstanceCapacity: We currently do not have sufficient m8id.2xlarge capacity in the Availability Zone you requested (us-east-2a). Our system will be working on provisioning additional capacity. You can currently get m8id.2xlarge capacity by not specifying an Availability Zone in your request or choosing us-east-2b, us-east-2c.; InsufficientInstanceCapacity: We currently do not have sufficient m8id.2xlarge capacity in the Availability Zone you requested (us-east-2b). Our system will be working on provisioning additional capacity. You can currently get m8id.2xlarge capacity by not specifying an Availability Zone in your request or choosing us-east-2a, us-east-2c.; InsufficientInstanceCapacity: We currently do not have sufficient m8id.2xlarge capacity in the Availability Zone you requested (us-east-2c). Our system will be working on provisioning additional capacity. You can currently get m8id.2xlarge capacity by not specifying an Availability Zone in your request or choosing us-east-2a, us-east-2b. (aws-error-code=UnfulfillableCapacity, aws-operation-name=CreateFleet, aws-request-id=8a0b6a25-36fd-46ac-9249-21d75af94758, aws-service-name=EC2, aws-status-code=200)
```