### PR TITLE
fix a bug with pod mutation and insert cloud metadata into the test container

### DIFF
--- a/kubernetes/aks-prow-build/prow/kyverno.yaml
+++ b/kubernetes/aks-prow-build/prow/kyverno.yaml
@@ -1,64 +1,130 @@
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
-  name: insert-gcp-credentials
+  name: prow
 spec:
+  background: false
   rules:
-    - name: add-creds
+    - name: add-location-metadata-to-pod
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod/binding
+              namespaces:
+                - test-pods
+      context:
+        - name: node
+          variable:
+            jmesPath: request.object.target.name
+            default: ''
+        - name: zone
+          apiCall:
+            urlPath: '/api/v1/nodes/{{node}}'
+            jmesPath: 'metadata.labels."topology.kubernetes.io/zone" || ''empty'''
+        - name: region
+          apiCall:
+            urlPath: '/api/v1/nodes/{{node}}'
+            jmesPath: 'metadata.labels."topology.kubernetes.io/region" || ''empty'''
+      mutate:
+        patchStrategicMerge:
+          metadata:
+            annotations:
+              topology.kubernetes.io/zone: '{{ zone }}'
+              topology.kubernetes.io/region: '{{ region }}'
+    - name: add-prow-sidecar-creds
       match:
         any:
           - resources:
               kinds:
                 - Pod
-            operations:
-              - CREATE # we want to ignore prow update operations
+              operations:
+                - CREATE # we want to ignore prow update operations
       preconditions:
-        any:
+        all:
           - key: '{{request.object.metadata.labels."created-by-prow" || ""}}'
             operator: Equals
             value: "true"
+          - key: initupload
+            operator: In
+            value: "{{ request.object.spec.initContainers[].name || `[]` }}"
+          - key: test
+            operator: In
+            value: "{{ request.object.spec.containers[].name || `[]` }}"
+          - key: sidecar
+            operator: In
+            value: "{{ request.object.spec.containers[].name || `[]` }}"
       mutate:
-        patchStrategicMerge:
-          spec:
-            initContainers:
-              # pod order matters
-              - name: clonerefs
-              - (name): "initupload"
-                env:
-                  - name: GOOGLE_APPLICATION_CREDENTIALS
-                    value: /etc/google/adc.json
-                volumeMounts:
-                  - mountPath: /var/run/secrets/google-iam-token/serviceaccount
-                    name: google-iam-token
-                    readOnly: true
-                  - mountPath: /etc/google
-                    name: google-adc
-                    readOnly: true
-            containers:
-              - name: test
-              - (name): sidecar
-                env:
-                  - name: GOOGLE_APPLICATION_CREDENTIALS
-                    value: /etc/google/adc.json
-                volumeMounts:
-                  - mountPath: /var/run/secrets/google-iam-token/serviceaccount
-                    name: google-iam-token
-                    readOnly: true
-                  - mountPath: /etc/google
-                    name: google-adc
-                    readOnly: true
-            volumes:
-              - name: google-iam-token
-                projected:
-                  defaultMode: 420
-                  sources:
-                    - serviceAccountToken:
-                        audience: sts.googleapis.com
-                        expirationSeconds: 86400
-                        path: token
-              - name: google-adc
-                configMap:
-                  name: google-adc
+        foreach:
+          - list: "request.object.spec.initContainers[?name=='clonerefs'] || `[]`"
+            patchStrategicMerge:
+              spec:
+                initContainers:
+                  # pod order matters
+                  - name: clonerefs
+                  - (name): "initupload"
+                    env:
+                      - name: GOOGLE_APPLICATION_CREDENTIALS
+                        value: /etc/google/adc.json
+                    volumeMounts: &volumeMounts
+                      - mountPath: /var/run/secrets/google-iam-token/serviceaccount
+                        name: google-iam-token
+                        readOnly: true
+                      - mountPath: /etc/google
+                        name: google-adc
+                        readOnly: true
+                containers: &containers
+                  - name: test
+                    env:
+                      - name: PROW_CLOUD_PROVIDER
+                        value: azure
+                      - name: PROW_NODE_REGION
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['topology.kubernetes.io/region']
+                      - name: PROW_NODE_ZONE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['topology.kubernetes.io/zone']
+                  - (name): sidecar
+                    env:
+                      - name: GOOGLE_APPLICATION_CREDENTIALS
+                        value: /etc/google/adc.json
+                    volumeMounts:
+                      - mountPath: /var/run/secrets/google-iam-token/serviceaccount
+                        name: google-iam-token
+                        readOnly: true
+                      - mountPath: /etc/google
+                        name: google-adc
+                        readOnly: true
+                volumes: &volumes
+                  - name: google-iam-token
+                    projected:
+                      defaultMode: 420
+                      sources:
+                        - serviceAccountToken:
+                            audience: sts.googleapis.com
+                            expirationSeconds: 86400
+                            path: token
+                  - name: google-adc
+                    configMap:
+                      name: google-adc
+          - list: "request.object.spec.initContainers[?name=='initupload'] || `[]`"
+            preconditions:
+              all:
+                - key: clonerefs
+                  operator: NotIn
+                  value: "{{ request.object.spec.initContainers[].name || `[]` }}"
+            patchStrategicMerge:
+              spec:
+                initContainers:
+                  - (name): "initupload"
+                    env:
+                      - name: GOOGLE_APPLICATION_CREDENTIALS
+                        value: /etc/google/adc.json
+                    volumeMounts: *volumeMounts
+                containers: *containers
+                volumes: *volumes
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/kubernetes/apps/kyverno.yaml
+++ b/kubernetes/apps/kyverno.yaml
@@ -23,6 +23,8 @@ spec:
   template:
     metadata:
       name: "kyverno-{{ .name }}"
+      annotations:
+        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:
       destination:
         namespace: kyverno
@@ -36,6 +38,24 @@ spec:
             releaseName: kyverno
             valueFiles:
               - $values/kubernetes/{{ .name }}/helm/kyverno.yaml
+            valuesObject:
+              config:
+                resourceFiltersExclude:
+                  - "[Binding,*,*]"
+                  - "[Pod/binding,*,*]"
+              features:
+                logging:
+                  format: json
+              admissionController:
+                rbac:
+                  clusterRole:
+                    extraResources:
+                      - apiGroups:
+                          - ""
+                        resources:
+                          - nodes
+                        verbs:
+                          - get
         - repoURL: "https://github.com/kubernetes/k8s.io.git"
           targetRevision: main
           ref: values
@@ -45,4 +65,3 @@ spec:
           selfHeal: true
         syncOptions:
           - CreateNamespace=true
-          - Replace=true

--- a/kubernetes/ibm-ppc64le/prow/kyverno.yaml
+++ b/kubernetes/ibm-ppc64le/prow/kyverno.yaml
@@ -1,54 +1,91 @@
 apiVersion: kyverno.io/v1
-kind: ClusterPolicy
+kind: Policy
 metadata:
-  name: insert-gcp-credentials
+  name: prow
 spec:
+  background: false
   rules:
-    - name: add-creds
+    - name: add-prow-sidecar-creds
       match:
         any:
           - resources:
               kinds:
                 - Pod
-            operations:
-              - CREATE # we want to ignore prow update operations
+              operations:
+                - CREATE # we want to ignore prow update operations
       preconditions:
-        any:
+        all:
           - key: '{{request.object.metadata.labels."created-by-prow" || ""}}'
             operator: Equals
             value: "true"
+          - key: initupload
+            operator: In
+            value: "{{ request.object.spec.initContainers[].name || `[]` }}"
+          - key: test
+            operator: In
+            value: "{{ request.object.spec.containers[].name || `[]` }}"
+          - key: sidecar
+            operator: In
+            value: "{{ request.object.spec.containers[].name || `[]` }}"
       mutate:
-        patchStrategicMerge:
-          spec:
-            initContainers:
-              # pod order matters
-              - name: clonerefs
-              - (name): "initupload"
-                # prow passes the json path directly, uncomment this once the feature is disabled in prow
-                # env:
-                #   - name: GOOGLE_APPLICATION_CREDENTIALS
-                #     value: /secrets/gcs/service-account.json
-                volumeMounts:
-                  - mountPath: /var/run/secrets/google-iam-token/serviceaccount
-                    name: google-iam-token
-                    readOnly: true
-            containers:
-              - name: test
-              - (name): sidecar
-                # prow passes the json path directly, uncomment this once the feature is disabled in prow
-                # env:
-                #   - name: GOOGLE_APPLICATION_CREDENTIALS
-                #     value: /secrets/gcs/service-account.json
-                volumeMounts:
-                  - mountPath: /var/run/secrets/google-iam-token/serviceaccount
-                    name: google-iam-token
-                    readOnly: true
-            volumes:
-              - name: google-iam-token
-                projected:
-                  defaultMode: 420
-                  sources:
-                    - serviceAccountToken:
-                        audience: sts.googleapis.com
-                        expirationSeconds: 86400
-                        path: token
+        foreach:
+          - list: "request.object.spec.initContainers[?name=='clonerefs'] || `[]`"
+            patchStrategicMerge:
+              spec:
+                initContainers:
+                  # pod order matters
+                  - name: clonerefs
+                  - (name): "initupload"
+                    # prow passes the json path directly, uncomment this once the feature is disabled in prow
+                    # env:
+                    #   - name: GOOGLE_APPLICATION_CREDENTIALS
+                    #     value: /etc/google/adc.json
+                    volumeMounts: &volumeMounts
+                      - mountPath: /var/run/secrets/google-iam-token/serviceaccount
+                        name: google-iam-token
+                        readOnly: true
+                      - mountPath: /etc/google
+                        name: google-adc
+                        readOnly: true
+                containers: &containers
+                  - name: test
+                  - (name): sidecar
+                    # prow passes the json path directly, uncomment this once the feature is disabled in prow
+                    # env:
+                    #   - name: GOOGLE_APPLICATION_CREDENTIALS
+                    #     value: /etc/google/adc.json
+                    volumeMounts:
+                      - mountPath: /var/run/secrets/google-iam-token/serviceaccount
+                        name: google-iam-token
+                        readOnly: true
+                      - mountPath: /etc/google
+                        name: google-adc
+                        readOnly: true
+                volumes: &volumes
+                  - name: google-iam-token
+                    projected:
+                      defaultMode: 420
+                      sources:
+                        - serviceAccountToken:
+                            audience: sts.googleapis.com
+                            expirationSeconds: 86400
+                            path: token
+                  - name: google-adc
+                    configMap:
+                      name: google-adc
+          - list: "request.object.spec.initContainers[?name=='initupload'] || `[]`"
+            preconditions:
+              all:
+                - key: clonerefs
+                  operator: NotIn
+                  value: "{{ request.object.spec.initContainers[].name || `[]` }}"
+            patchStrategicMerge:
+              spec:
+                initContainers:
+                  - (name): "initupload"
+                    env:
+                      - name: GOOGLE_APPLICATION_CREDENTIALS
+                        value: /etc/google/adc.json
+                    volumeMounts: *volumeMounts
+                containers: *containers
+                volumes: *volumes

--- a/kubernetes/ibm-s390x/prow/kyverno.yaml
+++ b/kubernetes/ibm-s390x/prow/kyverno.yaml
@@ -1,54 +1,91 @@
 apiVersion: kyverno.io/v1
-kind: ClusterPolicy
+kind: Policy
 metadata:
-  name: insert-gcp-credentials
+  name: prow
 spec:
+  background: false
   rules:
-    - name: add-creds
+    - name: add-prow-sidecar-creds
       match:
         any:
           - resources:
               kinds:
                 - Pod
-            operations:
-              - CREATE # we want to ignore prow update operations
+              operations:
+                - CREATE # we want to ignore prow update operations
       preconditions:
-        any:
+        all:
           - key: '{{request.object.metadata.labels."created-by-prow" || ""}}'
             operator: Equals
             value: "true"
+          - key: initupload
+            operator: In
+            value: "{{ request.object.spec.initContainers[].name || `[]` }}"
+          - key: test
+            operator: In
+            value: "{{ request.object.spec.containers[].name || `[]` }}"
+          - key: sidecar
+            operator: In
+            value: "{{ request.object.spec.containers[].name || `[]` }}"
       mutate:
-        patchStrategicMerge:
-          spec:
-            initContainers:
-              # pod order matters
-              - name: clonerefs
-              - (name): "initupload"
-                # prow passes the json path directly, uncomment this once the feature is disabled in prow
-                # env:
-                #   - name: GOOGLE_APPLICATION_CREDENTIALS
-                #     value: /secrets/gcs/service-account.json
-                volumeMounts:
-                  - mountPath: /var/run/secrets/google-iam-token/serviceaccount
-                    name: google-iam-token
-                    readOnly: true
-            containers:
-              - name: test
-              - (name): sidecar
-                # prow passes the json path directly, uncomment this once the feature is disabled in prow
-                # env:
-                #   - name: GOOGLE_APPLICATION_CREDENTIALS
-                #     value: /secrets/gcs/service-account.json
-                volumeMounts:
-                  - mountPath: /var/run/secrets/google-iam-token/serviceaccount
-                    name: google-iam-token
-                    readOnly: true
-            volumes:
-              - name: google-iam-token
-                projected:
-                  defaultMode: 420
-                  sources:
-                    - serviceAccountToken:
-                        audience: sts.googleapis.com
-                        expirationSeconds: 86400
-                        path: token
+        foreach:
+          - list: "request.object.spec.initContainers[?name=='clonerefs'] || `[]`"
+            patchStrategicMerge:
+              spec:
+                initContainers:
+                  # pod order matters
+                  - name: clonerefs
+                  - (name): "initupload"
+                    # prow passes the json path directly, uncomment this once the feature is disabled in prow
+                    # env:
+                    #   - name: GOOGLE_APPLICATION_CREDENTIALS
+                    #     value: /etc/google/adc.json
+                    volumeMounts: &volumeMounts
+                      - mountPath: /var/run/secrets/google-iam-token/serviceaccount
+                        name: google-iam-token
+                        readOnly: true
+                      - mountPath: /etc/google
+                        name: google-adc
+                        readOnly: true
+                containers: &containers
+                  - name: test
+                  - (name): sidecar
+                    # prow passes the json path directly, uncomment this once the feature is disabled in prow
+                    # env:
+                    #   - name: GOOGLE_APPLICATION_CREDENTIALS
+                    #     value: /etc/google/adc.json
+                    volumeMounts:
+                      - mountPath: /var/run/secrets/google-iam-token/serviceaccount
+                        name: google-iam-token
+                        readOnly: true
+                      - mountPath: /etc/google
+                        name: google-adc
+                        readOnly: true
+                volumes: &volumes
+                  - name: google-iam-token
+                    projected:
+                      defaultMode: 420
+                      sources:
+                        - serviceAccountToken:
+                            audience: sts.googleapis.com
+                            expirationSeconds: 86400
+                            path: token
+                  - name: google-adc
+                    configMap:
+                      name: google-adc
+          - list: "request.object.spec.initContainers[?name=='initupload'] || `[]`"
+            preconditions:
+              all:
+                - key: clonerefs
+                  operator: NotIn
+                  value: "{{ request.object.spec.initContainers[].name || `[]` }}"
+            patchStrategicMerge:
+              spec:
+                initContainers:
+                  - (name): "initupload"
+                    env:
+                      - name: GOOGLE_APPLICATION_CREDENTIALS
+                        value: /etc/google/adc.json
+                    volumeMounts: *volumeMounts
+                containers: *containers
+                volumes: *volumes


### PR DESCRIPTION
**What this PR does / why we need it**:

Some prowjobs don't check out repositories and therefore fail to be mutated successfully.

Improvements:
- json logging so we can view logs correctly in Datadog
- fixed some argocd sync errors by following https://kyverno.io/docs/installation/platform-notes/

New feature:
- I switched to a namespaced Policy and added a new mutator for AKS that inserts 3 magic variables called `PROW_CLOUD_PROVIDER`, `PROW_NODE_REGION` and `PROW_NODE_ZONE`. I'm planning on updating our runner.sh script to pick the correct docker mirrors based on the value PROW_CLOUD_PROVIDER instead of using mirror.gcr.io everywhere.  

The idea came from a Kyverno blog https://kyverno.io/blog/2024/02/19/assigning-node-metadata-to-pods/

I'll rollout kyverno to the EKS cluster along with an image mutator next.