### PR TITLE
Add geewynn to argocd auth policy

### DIFF
--- a/kubernetes/gke-utility/argocd/extras.yaml
+++ b/kubernetes/gke-utility/argocd/extras.yaml
@@ -75,3 +75,4 @@ spec:
             - iftachk
             - upodroid
             - xmudrii
+            - geewynn

--- a/kubernetes/gke-utility/helm/monitoring.yaml
+++ b/kubernetes/gke-utility/helm/monitoring.yaml
@@ -15,6 +15,7 @@ grafana:
         foldersFromFilesStructure: true
     datasources:
       enabled: true
+      isDefaultDatasource: false
   persistence:
     enabled: true
     storageClassName: hyperdisk-balanced


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds geewynn to argocd auth policy and also fixes gke utility monitoring grafana datasource error.