### PR TITLE
Promote NFD v0.19.0

### DIFF
--- a/registry.k8s.io/images/k8s-staging-nfd/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-nfd/images.yaml
@@ -117,6 +117,8 @@
     "sha256:fdd3416e0842b618cd52da7c1958c2f8ce40e978f10f0e192a951bc1dcb9435a": ["v0.18.2-full"]
     "sha256:f9ef2ebee55141a1758d3c0a87bb701f5db2adf6856f7218b11bc2bac7b63862": ["v0.18.3","v0.18.3-minimal"]
     "sha256:283b58bea30c58ef21f689592c1d8f0d81e69897d3ae2d597699c30c3e284e26": ["v0.18.3-full"]
+    "sha256:2fa1c99ad09bdf2c8ad97706a4ad2fd548c84d5ecd70ba32a6152c667b96c4d2": ["v0.19.0","v0.19.0-minimal"]
+    "sha256:3395db873c6f10a8f30da851a686e6555c4d455983a83545bc4b5830d5b0ff73": ["v0.19.0-full"]
 - name: charts/node-feature-discovery
   dmap:
     "sha256:cb4bfd81acce68798b65ad3d33f3efc503ad1410504b6a1a3929b514d8ba1205": ["0.18.0"]


### PR DESCRIPTION
Promotes the `node-feature-discovery` v0.19.0 staging images to `registry.k8s.io`.

Digest -> tag mappings:
- `sha256:2fa1c99ad09bdf2c8ad97706a4ad2fd548c84d5ecd70ba32a6152c667b96c4d2` -> `v0.19.0`, `v0.19.0-minimal`
- `sha256:3395db873c6f10a8f30da851a686e6555c4d455983a83545bc4b5830d5b0ff73` -> `v0.19.0-full`

The staging images were built by `post-node-feature-discovery-push-images` from signed tag `v0.19.0` @ `45d276ed9`.

Release tracker: kubernetes-sigs/node-feature-discovery#2420