### PR TITLE
modify how ibm test pods ADC is loaded

### DIFF
--- a/kubernetes/apps/kyverno.yaml
+++ b/kubernetes/apps/kyverno.yaml
@@ -65,3 +65,4 @@ spec:
           selfHeal: true
         syncOptions:
           - CreateNamespace=true
+          - ServerSideApply=true

--- a/kubernetes/ibm-ppc64le/prow/kyverno.yaml
+++ b/kubernetes/ibm-ppc64le/prow/kyverno.yaml
@@ -36,10 +36,9 @@ spec:
                   # pod order matters
                   - name: clonerefs
                   - (name): "initupload"
-                    # prow passes the json path directly, uncomment this once the feature is disabled in prow
-                    # env:
-                    #   - name: GOOGLE_APPLICATION_CREDENTIALS
-                    #     value: /etc/google/adc.json
+                    env:
+                      - name: GOOGLE_APPLICATION_CREDENTIALS
+                        value: /etc/google/adc.json
                     volumeMounts: &volumeMounts
                       - mountPath: /var/run/secrets/google-iam-token/serviceaccount
                         name: google-iam-token
@@ -50,10 +49,9 @@ spec:
                 containers: &containers
                   - name: test
                   - (name): sidecar
-                    # prow passes the json path directly, uncomment this once the feature is disabled in prow
-                    # env:
-                    #   - name: GOOGLE_APPLICATION_CREDENTIALS
-                    #     value: /etc/google/adc.json
+                    env:
+                      - name: GOOGLE_APPLICATION_CREDENTIALS
+                        value: /etc/google/adc.json
                     volumeMounts:
                       - mountPath: /var/run/secrets/google-iam-token/serviceaccount
                         name: google-iam-token
@@ -89,3 +87,23 @@ spec:
                     volumeMounts: *volumeMounts
                 containers: *containers
                 volumes: *volumes
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: google-adc
+data:
+  adc.json: |
+    {
+      "universe_domain": "googleapis.com",
+      "type": "external_account",
+      "audience": "//iam.googleapis.com/projects/16065310909/locations/global/workloadIdentityPools/ibm-clusters/providers/ppc64le",
+      "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+      "token_url": "https://sts.googleapis.com/v1/token",
+      "credential_source": {
+        "file": "/var/run/secrets/google-iam-token/serviceaccount/token",
+        "format": {
+          "type": "text"
+        }
+      }
+    }

--- a/kubernetes/ibm-ppc64le/prow/secrets.yaml
+++ b/kubernetes/ibm-ppc64le/prow/secrets.yaml
@@ -1,23 +1,3 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: service-account
-  namespace: test-pods
-stringData:
-  service-account.json: |
-    {
-      "universe_domain": "googleapis.com",
-      "type": "external_account",
-      "audience": "//iam.googleapis.com/projects/16065310909/locations/global/workloadIdentityPools/ibm-clusters/providers/ppc64le",
-      "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
-      "token_url": "https://sts.googleapis.com/v1/token",
-      "credential_source": {
-        "file": "/var/run/secrets/google-iam-token/serviceaccount/token",
-        "format": {
-          "type": "text"
-        }
-      }
-    }
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret

--- a/kubernetes/ibm-s390x/prow/kyverno.yaml
+++ b/kubernetes/ibm-s390x/prow/kyverno.yaml
@@ -36,10 +36,9 @@ spec:
                   # pod order matters
                   - name: clonerefs
                   - (name): "initupload"
-                    # prow passes the json path directly, uncomment this once the feature is disabled in prow
-                    # env:
-                    #   - name: GOOGLE_APPLICATION_CREDENTIALS
-                    #     value: /etc/google/adc.json
+                    env:
+                      - name: GOOGLE_APPLICATION_CREDENTIALS
+                        value: /etc/google/adc.json
                     volumeMounts: &volumeMounts
                       - mountPath: /var/run/secrets/google-iam-token/serviceaccount
                         name: google-iam-token
@@ -50,10 +49,9 @@ spec:
                 containers: &containers
                   - name: test
                   - (name): sidecar
-                    # prow passes the json path directly, uncomment this once the feature is disabled in prow
-                    # env:
-                    #   - name: GOOGLE_APPLICATION_CREDENTIALS
-                    #     value: /etc/google/adc.json
+                    env:
+                      - name: GOOGLE_APPLICATION_CREDENTIALS
+                        value: /etc/google/adc.json
                     volumeMounts:
                       - mountPath: /var/run/secrets/google-iam-token/serviceaccount
                         name: google-iam-token
@@ -89,3 +87,23 @@ spec:
                     volumeMounts: *volumeMounts
                 containers: *containers
                 volumes: *volumes
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: google-adc
+data:
+  adc.json: |
+    {
+      "universe_domain": "googleapis.com",
+      "type": "external_account",
+      "audience": "//iam.googleapis.com/projects/16065310909/locations/global/workloadIdentityPools/ibm-clusters/providers/s390x",
+      "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+      "token_url": "https://sts.googleapis.com/v1/token",
+      "credential_source": {
+        "file": "/var/run/secrets/google-iam-token/serviceaccount/token",
+        "format": {
+          "type": "text"
+        }
+      }
+    }

--- a/kubernetes/ibm-s390x/prow/secrets.yaml
+++ b/kubernetes/ibm-s390x/prow/secrets.yaml
@@ -1,24 +1,3 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: service-account
-  namespace: test-pods
-stringData:
-  service-account.json: |
-    {
-      "universe_domain": "googleapis.com",
-      "type": "external_account",
-      "audience": "//iam.googleapis.com/projects/16065310909/locations/global/workloadIdentityPools/ibm-clusters/providers/s390x",
-      "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
-      "token_url": "https://sts.googleapis.com/v1/token",
-      "credential_source": {
-        "file": "/var/run/secrets/google-iam-token/serviceaccount/token",
-        "format": {
-          "type": "text"
-        }
-      }
-    }
-
 ---
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret


### PR DESCRIPTION
When I updated the kyverno policy, I took the newer approach that fully uses Workload Identity Federation instead of loading a service account key.

This PR fixes this issue.

The goal is to eliminate this value from prow. https://github.com/kubernetes/test-infra/blob/06525d81d9d588c8064d4ecd0483b03d3497fc81/config/prow/config.yaml#L35

/hold