### PR TITLE
add docs for rotating cluster credentials

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -12,6 +12,8 @@ We use ArgoCD to manage our cluster, you can access it at argo.k8s.io, to access
 - be a member of the kubernetes github org
 - add your github user to the AuthorizationPolicy in this file: `kubernetes/gke-utility/argocd/extras.yaml#L62`
 
+[![App Status](https://argo.k8s.io/api/badge?name=apps&revision=true&showAppName=true)](https://argo.k8s.io/applications/apps)
+
 ## Clusters managed here
 
 Cluster directories under `kubernetes/` correspond to the clusters Argo CD manages:
@@ -40,3 +42,88 @@ This repo manages many workloads; common examples include:
 ### Note
 
 - The `gke-aaa` kubernetes manifests are not being managed by ArgoCD yet, you can find them in the `apps` folder
+
+## Updating Cluster Credentials
+
+Most of our clusters use Workload Identity Federation and their kubeconfigs only change when the underlying cluster object is deleted, however the following clusters use client certificates for authentication:
+
+- k8s-infra-ppc64le-prow-build
+- k8s-infra-s390x-prow-build.
+
+We store secrets in Google Cloud Secret Manager and there are 3 secrets that need to be populated.
+- a secret that K8s Infra SREs and Cluster Operators have access to.
+- a secret consumed by Prow directly which only K8s Infra SREs can access and write to.
+- a secret consumed by ArgoCD that needs to be in a special format that K8s Infra SREs will generate.
+
+
+In order to rotate their credentials, you must do the following:
+
+### Helper utilities
+
+1. Run the following commands before starting:
+    ```sh
+    rename-kube() {
+        CTX="$1" yq -i '
+        (.contexts[] | select(.name == strenv(CTX))) as $ctx |
+        $ctx.context.cluster as $cluster |
+        $ctx.context.user as $user |
+        (.clusters[] | select(.name == $cluster) | .name) = strenv(PROW_CLUSTER_NAME) |
+        (.users[] | select(.name == $user) | .name) = strenv(PROW_CLUSTER_NAME) |
+        (.contexts[] | select(.name == strenv(CTX)) | .name) = strenv(PROW_CLUSTER_NAME)|
+        (.contexts[] | select(.context.cluster == $cluster) | .context.cluster) = strenv(PROW_CLUSTER_NAME) |
+        (.contexts[] | select(.context.user == $user) | .context.user) = strenv(PROW_CLUSTER_NAME) |
+        .["current-context"] = strenv(PROW_CLUSTER_NAME)
+    ' "${KUBECONFIG:-}"
+    }
+
+    kube-tls-json() {
+        kubectl --context "${1:?context required}" config view --raw --flatten --minify -o json |
+            jq '{
+            tlsClientConfig: {
+                insecure: (.clusters[0].cluster["insecure-skip-tls-verify"] // false),
+                caData: (.clusters[0].cluster["certificate-authority-data"] // ""),
+                CertData: (.users[0].user["client-certificate-data"] // ""),
+                KeyData: (.users[0].user["client-key-data"] // "")
+            }
+        }'
+    }
+    ```
+
+### k8s-infra-ppc64le-prow-build
+
+1. Make sure the cluster operator is a member of the `k8s-infra-ibm-ppc64le-admins@kubernetes.io` Google Group
+1. Use gcloud to add the kubeconfig to the secret `ppc64le-kubeconfig-external` [here](https://console.cloud.google.com/security/secret-manager/secret/ppc64le-kubeconfig-external/versions?project=k8s-infra-prow).
+1. Ask someone from SIG K8s Infra Leads to run the remaining commands:
+    1. Add the secrets for Prow:
+        ```bash
+        export KUBECONFIG=/tmp/kubeconfig
+        gcloud secrets versions access latest --secret ppc64le-kubeconfig-external --project k8s-infra-prow > /tmp/kubeconfig
+        kubectl get nodes # validate the cluster
+        export PROW_CLUSTER_NAME=k8s-infra-ppc64le-prow-build # Note: this is the name of the cluster in prow
+        rename-kube $(kubectl config current-context)
+        gcloud secrets versions add k8s-infra-ppc64le-prow-build-kubeconfig --project k8s-infra-prow --data-file /tmp/kubeconfig
+        ```
+    1. Add the secrets for ArgoCD:
+        ```bash
+        kube-tls-json $(kubectl config current-context) | gcloud secrets versions add ibm-ppc64le-argo-secret --project k8s-infra-prow --data-file=-
+        ```
+
+### k8s-infra-s390x-prow-build
+
+1. Make sure the cluster operator is a member of the `k8s-infra-ibm-s390x-admins@kubernetes.io` Google Group
+1. Use gcloud to add the kubeconfig to the secret `s390x-kubeconfig-external` [here](https://console.cloud.google.com/security/secret-manager/secret/s390x-kubeconfig-external/versions?project=k8s-infra-prow).
+`gcloud secrets versions add k8s-infra-s390x-prow-build-kubeconfig --project k8s-infra-prow --data-file /foo/bar`
+1. Ask someone from SIG K8s Infra Leads to run the remaining commands:
+    1. Add the secrets for Prow:
+        ```bash
+        export KUBECONFIG=/tmp/kubeconfig
+        gcloud secrets versions access latest --secret s390x-kubeconfig-external --project k8s-infra-prow > /tmp/kubeconfig
+        kubectl get nodes # validate the cluster
+        export PROW_CLUSTER_NAME=k8s-infra-s390x-prow-build
+        rename-kube $(kubectl config current-context)
+        gcloud secrets versions add k8s-infra-s390x-prow-build-kubeconfig --project k8s-infra-prow --data-file /tmp/kubeconfig
+        ```
+    1. Add the secrets for ArgoCD:
+        ```bash
+        kube-tls-json $(kubectl config current-context) | gcloud secrets versions add ibm-s390x-argo-secret --project k8s-infra-prow --data-file=-
+        ```

--- a/kubernetes/aks-prow-build/README.md
+++ b/kubernetes/aks-prow-build/README.md
@@ -1,0 +1,13 @@
+# aks-prow-build
+
+`aks-prow-build` is the production AKS Prow build cluster for Kubernetes CI
+jobs.
+
+## Argo CD Applications
+
+| App name | Badge |
+| --- | --- |
+| `aks-prow-build` | [![App Status](https://argo.k8s.io/api/badge?name=aks-prow-build&revision=true&showAppName=false&width=250)](https://argo.k8s.io/applications/aks-prow-build) |
+| `datadog-aks-prow-build` | [![App Status](https://argo.k8s.io/api/badge?name=datadog-aks-prow-build&revision=true&showAppName=false&width=250)](https://argo.k8s.io/applications/datadog-aks-prow-build) |
+| `external-secrets-aks-prow-build` | [![App Status](https://argo.k8s.io/api/badge?name=external-secrets-aks-prow-build&revision=true&showAppName=false&width=250)](https://argo.k8s.io/applications/external-secrets-aks-prow-build) |
+| `kube-system-aks-prow-build` | [![App Status](https://argo.k8s.io/api/badge?name=kube-system-aks-prow-build&revision=true&showAppName=false&width=250)](https://argo.k8s.io/applications/kube-system-aks-prow-build) |

--- a/kubernetes/gke-prow-build-trusted/README.md
+++ b/kubernetes/gke-prow-build-trusted/README.md
@@ -1,0 +1,12 @@
+# gke-prow-build-trusted
+
+`gke-prow-build-trusted` is the production GKE Prow build cluster for Kubernetes CI's Trusted Jobs.
+jobs.
+
+## Argo CD Applications
+
+| App name | Badge |
+| --- | --- |
+| `gke-prow-build-trusted` | [![App Status](https://argo.k8s.io/api/badge?name=gke-prow-build-trusted&revision=true&showAppName=false&width=250)](https://argo.k8s.io/applications/gke-prow-build-trusted) |
+| `datadog-gke-prow-build-trusted` | [![App Status](https://argo.k8s.io/api/badge?name=datadog-gke-prow-build-trusted&revision=true&showAppName=false&width=250)](https://argo.k8s.io/applications/datadog-gke-prow-build-trusted) |
+| `external-secrets-gke-prow-build-trusted` | [![App Status](https://argo.k8s.io/api/badge?name=external-secrets-gke-prow-build-trusted&revision=true&showAppName=false&width=250)](https://argo.k8s.io/applications/external-secrets-gke-prow-build-trusted) |

--- a/kubernetes/gke-prow/README.md
+++ b/kubernetes/gke-prow/README.md
@@ -1,0 +1,11 @@
+# gke-prow
+
+`gke-prow` is the production GKE cluster that hosts the Prow Control Plane.
+
+## Argo CD Applications
+
+| App name | Badge |
+| --- | --- |
+| `gke-prow` | [![App Status](https://argo.k8s.io/api/badge?name=gke-prow&revision=true&showAppName=false&width=250)](https://argo.k8s.io/applications/gke-prow) |
+| `datadog-gke-prow` | [![App Status](https://argo.k8s.io/api/badge?name=datadog-gke-prow&revision=true&showAppName=false&width=250)](https://argo.k8s.io/applications/datadog-gke-prow) |
+| `external-secrets-gke-prow` | [![App Status](https://argo.k8s.io/api/badge?name=external-secrets-gke-prow&revision=true&showAppName=false&width=250)](https://argo.k8s.io/applications/external-secrets-gke-prow) |

--- a/kubernetes/ibm-ppc64le/README.md
+++ b/kubernetes/ibm-ppc64le/README.md
@@ -1,0 +1,18 @@
+# ibm-ppc64le
+
+`ibm-ppc64le` is the production Prow Build cluster that runs ppc64le jobs.
+
+## Argo CD Applications
+
+| App name | Badge |
+| --- | --- |
+| `ibm-ppc64le` | [![App Status](https://argo.k8s.io/api/badge?name=ibm-ppc64le&revision=true&showAppName=false&width=250)](https://argo.k8s.io/applications/ibm-ppc64le) |
+| `kube-system-eks-prow-build` | [![App Status](https://argo.k8s.io/api/badge?name=kube-system-eks-prow-build&revision=true&showAppName=false&width=250)](https://argo.k8s.io/applications/kube-system-eks-prow-build) |
+| `external-secrets-ibm-ppc64le` | [![App Status](https://argo.k8s.io/api/badge?name=external-secrets-ibm-ppc64le&revision=true&showAppName=false&width=250)](https://argo.k8s.io/applications/external-secrets-ibm-ppc64le) |
+
+
+## Maintainers
+
+- mkumatag
+- Prajyot-Parab
+- Rajalakshmi-Girish

--- a/kubernetes/ibm-s390x/README.md
+++ b/kubernetes/ibm-s390x/README.md
@@ -1,0 +1,18 @@
+# ibm-s390x
+
+`ibm-s390x` is the production Prow Build cluster that runs s390x jobs.
+
+## Argo CD Applications
+
+| App name | Badge |
+| --- | --- |
+| `ibm-s390x` | [![App Status](https://argo.k8s.io/api/badge?name=ibm-s390x&revision=true&showAppName=false&width=250)](https://argo.k8s.io/applications/ibm-s390x) |
+| `kube-system-eks-prow-build` | [![App Status](https://argo.k8s.io/api/badge?name=kube-system-eks-prow-build&revision=true&showAppName=false&width=250)](https://argo.k8s.io/applications/kube-system-eks-prow-build) |
+| `external-secrets-ibm-s390x` | [![App Status](https://argo.k8s.io/api/badge?name=external-secrets-ibm-s390x&revision=true&showAppName=false&width=250)](https://argo.k8s.io/applications/external-secrets-ibm-s390x) |
+
+
+## Maintainers
+
+- mkumatag
+- Prajyot-Parab
+- Rajalakshmi-Girish


### PR DESCRIPTION
I added docs to show how we rotate credentials for IBM build clusters that don't use Workload Identity. I also added minimal readmes to every cluster + argocd status badges.