### PR TITLE
GCP: add k8s-infra-agentic-ai project

### DIFF
--- a/infra/gcp/terraform/k8s-infra-agentic-ai/main.tf
+++ b/infra/gcp/terraform/k8s-infra-agentic-ai/main.tf
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Hosts the Antigravity CLI (agy) usage from prowjobs. See:
+// https://github.com/kubernetes-sigs/maintainer-tools/blob/main/images/antigravity/Dockerfile
+
+module "project" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 18.3"
+
+  name            = "k8s-infra-agentic-ai"
+  org_id          = "758905017065"
+  billing_account = "018801-93540E-22A20E"
+
+  # Sane project defaults
+  disable_services_on_destroy = false
+  create_project_sa           = false
+  random_project_id           = false
+  auto_create_network         = false
+
+  deletion_policy = "DELETE"
+
+  labels = {
+    "owner" : "ameukam",
+    "project" : "agentic-ai"
+  }
+}
+
+module "services" {
+  source     = "terraform-google-modules/project-factory/google//modules/project_services"
+  version    = "~> 18.3"
+  project_id = module.project.project_id
+
+  activate_apis = [
+    "aiplatform.googleapis.com",
+    "cloudaicompanion.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "iam.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "serviceusage.googleapis.com",
+    "storage.googleapis.com"
+  ]
+
+  depends_on = [module.project]
+}
+
+resource "time_sleep" "project_services" {
+  depends_on = [
+    module.services
+  ]
+
+  create_duration = "45s"
+}

--- a/infra/gcp/terraform/k8s-infra-agentic-ai/provider.tf
+++ b/infra/gcp/terraform/k8s-infra-agentic-ai/provider.tf
@@ -1,0 +1,35 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+terraform {
+  required_version = "~> 1.10"
+
+  backend "gcs" {
+    bucket = "k8s-infra-terraform"
+    prefix = "k8s-infra-agentic-ai"
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.39"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 7.39"
+    }
+  }
+}

--- a/infra/gcp/terraform/k8s-infra-agentic-ai/serviceaccounts.tf
+++ b/infra/gcp/terraform/k8s-infra-agentic-ai/serviceaccounts.tf
@@ -1,0 +1,34 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Service account assumed by prowjobs running the antigravity image in the
+// test-pods namespace of the k8s-infra-prow-build cluster, via Workload
+// Identity. The matching KSA lives in
+// kubernetes/gke-prow-build/prow/build-serviceaccounts.yaml.
+module "agy_agent_service_account" {
+  source             = "../modules/workload-identity-service-account"
+  project_id         = module.project.project_id
+  name               = "agy-agent"
+  description        = "used by prowjobs to call Vertex AI with the Antigravity CLI"
+  cluster_project_id = "k8s-infra-prow-build"
+  cluster_namespace  = "test-pods"
+  project_roles = [
+    "roles/aiplatform.user",
+    "roles/serviceusage.serviceUsageConsumer"
+  ]
+
+  depends_on = [time_sleep.project_services]
+}

--- a/kubernetes/gke-prow-build/prow/build-serviceaccounts.yaml
+++ b/kubernetes/gke-prow-build/prow/build-serviceaccounts.yaml
@@ -24,3 +24,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: azure
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: agy-agent@k8s-infra-agentic-ai.iam.gserviceaccount.com
+  name: agy-agent


### PR DESCRIPTION
Host Vertex AI usage for prowjobs. Bind the agy-agent service account to test-pods/agy-agent in k8s-infra-prow-build via workload identity.

Related to:
 - https://github.com/kubernetes/k8s.io/issues/9606

/hold
