### PR TITLE
Promote node-feature-discovery 0.19.0 chart

### DIFF
--- a/registry.k8s.io/images/k8s-staging-nfd/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-nfd/images.yaml
@@ -125,6 +125,7 @@
     "sha256:9f80bc5cb0e01ba9630ac7fa2f8e603e3fe1a63485d3940d9a3c47b8060928ff": ["0.18.1"]
     "sha256:477874562824750aad0de4718a5f4b1606448b680af2beb0a5422619bc6be6c3": ["0.18.2"]
     "sha256:c134ee667d7e4403889ff1c1cd7e1c78c0094e3b3c3b7d241e1d5d13b67efcc1": ["0.18.3"]
+    "sha256:c74eeb7fe33c060e49e42cc8d588eeeddfbda6ae9bcd0835e0e398e02c5c2223": ["0.19.0"]
 - name: node-feature-discovery-operator
   dmap:
     "sha256:36a9a2c9d40b08a72df2878fcb602a86c7cf5b71ee9a786bff67fb84b64dcd16": ["v0.2.0"]


### PR DESCRIPTION
#9697 promoted the v0.19.0 container images but missed the OCI helm chart digest, so:

```
$ helm pull oci://registry.k8s.io/nfd/charts/node-feature-discovery:0.19.0
Error: failed to perform "FetchReference" on source: registry.k8s.io/nfd/charts/node-feature-discovery:0.19.0: not found
```

Downstream consumers (NVIDIA gpu-operator, Mellanox network-operator) depend on this chart via `oci://registry.k8s.io/nfd/charts`.

The chart exists in staging (`gcr.io/k8s-staging-nfd/charts/node-feature-discovery:0.19.0`). This PR adds its digest to the chart dmap, same pattern as the 0.18.x promotions.

Digest verified two independent ways, both returning `sha256:c74eeb7fe33c060e49e42cc8d588eeeddfbda6ae9bcd0835e0e398e02c5c2223`:
- `helm pull oci://gcr.io/k8s-staging-nfd/charts/node-feature-discovery --version 0.19.0`
- GCR v2 manifests API `docker-content-digest`

Control check: the existing 0.18.3 dmap entry matches the digest registry.k8s.io serves today (`sha256:c134ee66…`).
