### PR TITLE
Replace wdc06 DC with eu-de-1 region in boskos on ibm ppc64le

### DIFF
--- a/kubernetes/ibm-ppc64le/prow/boskos-resources-configmap.yaml
+++ b/kubernetes/ibm-ppc64le/prow/boskos-resources-configmap.yaml
@@ -3,9 +3,9 @@ data:
   config: |
     resources:
     - names:
-      - k8s-boskos-powervs-wdc06-01
-      - k8s-boskos-powervs-wdc06-02
-      - k8s-boskos-powervs-wdc06-03
+      - k8s-boskos-powervs-eu-de-1-01
+      - k8s-boskos-powervs-eu-de-1-02
+      - k8s-boskos-powervs-eu-de-1-03
       - k8s-boskos-powervs-eu-de-2-01
       - k8s-boskos-powervs-eu-de-2-02
       - k8s-boskos-powervs-eu-de-2-03


### PR DESCRIPTION
Removing old workspaces in wdc04 zone and adding eu-de-1 back.