### PR TITLE
fix(infra): add IPv6 egress firewall rule for Prow VPC network

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow/vpc.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/vpc.tf
@@ -67,3 +67,18 @@ module "nat" {
   router        = "prow-nat"
   name          = "prow-nat"
 }
+
+resource "google_compute_firewall" "allow_ipv6_egress" {
+  name        = "prow-allow-ipv6-egress"
+  project     = module.project.project_id
+  network     = module.vpc.network_name
+  direction   = "EGRESS"
+  priority    = 1000
+
+  allow {
+    protocol = "all"
+  }
+
+  destination_ranges = ["::/0"]
+}
+


### PR DESCRIPTION
GCP VPC networks configured with external IPv6 subnets do not automatically permit outbound IPv6 egress traffic. Without an explicit egress firewall rule targeting ::/0, outbound IPv6 connections from Prow nodes and CI workloads time out.
This change adds an outbound firewall rule allowing all IPv6 egress traffic (destination ::/0) in the Prow VPC.
Ref: https://github.com/kubernetes/kubernetes/issues/140489

**What this PR does / why we need it**:

Adds an explicit outbound IPv6 firewall rule (`prow-allow-ipv6-egress` for destination `::/0`) to the Prow VPC network in `infra/gcp/terraform/k8s-infra-prow/vpc.tf`. GCP VPC networks configured with external IPv6 subnets (`ipv6_access_type = "EXTERNAL"`) do not automatically permit outbound IPv6 egress traffic by default, causing outbound IPv6 connections from Prow nodes and CI job workloads to time out.

**Special notes for your reviewer**:

Tested and verified in a sandbox GCP project with fresh VPC network. Before adding the egress firewall rule, outbound IPv6 requests (`curl -6 https://ipv6.google.com`) timed out (`CURL_EXIT_CODE: 28`). After applying the firewall rule, outbound IPv6 HTTP/2 connections succeeded (`CURL_EXIT_CODE: 0`, `HTTP 200 OK`).

**If you are promoting an image, please make sure you have done the following:**

- [ ] I have verified the digest with [gcrane](https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md) and added it as a comment to the PR or in the body.
- [ ] I'm promoting a multi-arch image that matches all the [supported](https://github.com/kubernetes/sig-release/tree/master/release-engineering/platforms) platforms of Kubernetes.
- [ ] I'm not promoting a tag that resolves to latest or moving tags as these are not supported
- [ ] registry.k8s.io is an immutable registry and I'll need to cut a new release if the digest is wrong.