### PR TITLE
Fix: Slack inviter link

### DIFF
--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -361,7 +361,7 @@ data:
         listen 80;
 
         location / {
-          rewrite ^/.*$ https://communityinviter.com/apps/kubernetes/community permanent;
+          rewrite ^/.*$ https://inviter.co/kubernetes permanent;
         }
       }
 

--- a/apps/k8s-io/test.py
+++ b/apps/k8s-io/test.py
@@ -354,8 +354,8 @@ class RedirTest(HTTPTestCase):
 
     def test_slack(self):
         for base in ('slack.k8s.io', 'slack.kubernetes.io'):
-            self.assert_permanent_redirect(base, 'https://communityinviter.com/apps/kubernetes/community')
-            self.assert_permanent_redirect(base + '/$path', 'https://communityinviter.com/apps/kubernetes/community',
+            self.assert_permanent_redirect(base, 'https://inviter.co/kubernetes')
+            self.assert_permanent_redirect(base + '/$path', 'https://inviter.co/kubernetes',
                                       path=rand_num())
 
     def test_submit_queue(self):


### PR DESCRIPTION
**What this PR does / why we need it**:

communityinviter.com has been deprecated; they have moved to inviter.co

**Special notes for your reviewer**:

> Community Inviter has been deprecated. Please continue with the latest experience at inviter.co.
