### PR TITLE
Add node selector label for ESO on IBM ppc64le build cluster

### DIFF
--- a/kubernetes/ibm-ppc64le/helm/external-secrets.yaml
+++ b/kubernetes/ibm-ppc64le/helm/external-secrets.yaml
@@ -1,3 +1,6 @@
+global:
+  nodeSelector:
+    role: infra
 extraObjects:
   - apiVersion: external-secrets.io/v1
     kind: ClusterSecretStore


### PR DESCRIPTION
This PR helps us use our build cluster resources better by running infra-related components on a dedicated node.

It adds a parameter to ensure the following External Secrets components run on a specific node in our ppc64le cluster.

This setup improves resource usage and keeps infra workloads isolated.

Ref: https://artifacthub.io/packages/helm/external-secrets-operator/external-secrets