### PR TITLE
upgrade mimir chart to 6.1.0

### DIFF
--- a/kubernetes/apps/mimir.yaml
+++ b/kubernetes/apps/mimir.yaml
@@ -25,7 +25,7 @@ spec:
       sources:
         - chart: mimir-distributed
           repoURL: https://grafana.github.io/helm-charts
-          targetRevision: 5.5.1
+          targetRevision: 6.1.0
           helm:
             releaseName: mimir
             valueFiles:

--- a/kubernetes/gke-utility/helm/mimir.yaml
+++ b/kubernetes/gke-utility/helm/mimir.yaml
@@ -2,9 +2,6 @@ serviceAccount:
   create: true
   name: mimir
 
-nginx:
-  enabled: false
-
 minio:
   enabled: false
 
@@ -36,7 +33,7 @@ mimir:
     distributor:
       remote_timeout: null
     ingester:
-      push_grpc_method_enabled: null
+      push_grpc_method_enabled: true
     common:
       storage:
         backend: gcs
@@ -55,6 +52,9 @@ mimir:
 metaMonitoring:
   serviceMonitor:
     enabled: true
+
+rollout_operator:
+  enabled: true
 
 alertmanager:
   persistentVolume:
@@ -91,6 +91,8 @@ distributor:
       memory: 2Gi
 
 ingester:
+  zoneAwareReplication:
+    enabled: false
   persistentVolume:
     size: 50Gi
     storageClass: hyperdisk-balanced
@@ -158,6 +160,8 @@ ruler:
       memory: 2Gi
 
 store_gateway:
+  zoneAwareReplication:
+    enabled: false
   persistentVolume:
     size: 10Gi
     storageClass: hyperdisk-balanced


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR upgrades mimir chart to v6.1.0 and fixes the http route gateway error.

cc @upodroid 
