### PR TITLE
Increase store gateway storage size

### DIFF
--- a/kubernetes/gke-utility/helm/mimir.yaml
+++ b/kubernetes/gke-utility/helm/mimir.yaml
@@ -60,6 +60,7 @@ alertmanager:
   persistentVolume:
     enabled: true
     storageClass: hyperdisk-balanced
+    size: 20Gi
   replicas: 2
   resources:
     limits:
@@ -163,7 +164,7 @@ store_gateway:
   zoneAwareReplication:
     enabled: false
   persistentVolume:
-    size: 10Gi
+    size: 20Gi
     storageClass: hyperdisk-balanced
   replicas: 3
   resources:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR increases the store-gateway and alertmanager persistent volume sizes to 20Gi so their PVCs can be provisioned.


cc @upodroid 