### PR TITLE
increase store gateway storage size to 50gb

### DIFF
--- a/kubernetes/gke-utility/helm/mimir.yaml
+++ b/kubernetes/gke-utility/helm/mimir.yaml
@@ -60,7 +60,7 @@ alertmanager:
   persistentVolume:
     enabled: true
     storageClass: hyperdisk-balanced
-    size: 20Gi
+    size: 50Gi
   replicas: 2
   resources:
     limits:
@@ -73,7 +73,7 @@ alertmanager:
 
 compactor:
   persistentVolume:
-    size: 20Gi
+    size: 50Gi
     storageClass: hyperdisk-balanced
   resources:
     limits:
@@ -164,7 +164,7 @@ store_gateway:
   zoneAwareReplication:
     enabled: false
   persistentVolume:
-    size: 20Gi
+    size: 50Gi
     storageClass: hyperdisk-balanced
   replicas: 3
   resources:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR increases the store-gateway and alertmanager persistent volume sizes to 50Gi so their PVCs can be provisioned.

cc @upodroid 