### PR TITLE
slack: modify to a 302 Found redirect

### DIFF
--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -361,7 +361,7 @@ data:
         listen 80;
 
         location / {
-          rewrite ^/.*$ https://inviter.co/kubernetes permanent;
+          rewrite ^/.*$ https://inviter.co/kubernetes redirect;
         }
       }
 

--- a/apps/k8s-io/test.py
+++ b/apps/k8s-io/test.py
@@ -354,8 +354,8 @@ class RedirTest(HTTPTestCase):
 
     def test_slack(self):
         for base in ('slack.k8s.io', 'slack.kubernetes.io'):
-            self.assert_permanent_redirect(base, 'https://inviter.co/kubernetes')
-            self.assert_permanent_redirect(base + '/$path', 'https://inviter.co/kubernetes',
+            self.assert_temp_redirect(base, 'https://inviter.co/kubernetes')
+            self.assert_temp_redirect(base + '/$path', 'https://inviter.co/kubernetes',
                                       path=rand_num())
 
     def test_submit_queue(self):


### PR DESCRIPTION
**What this PR does / why we need it**:
301 Moved Permanently redirects are aggressively cached by browsers, which can make changing the target of the redirect more difficult if it ever experiences problems (such as the change from communityinviter.com to inviter.co done in https://github.com/kubernetes/k8s.io/pull/9740 and related discussion in https://kubernetes.slack.com/archives/C4M06S5HS/p1739578731492559). 302 Found redirects are followed every time.

LLM assistant disclosure: [Antigravity CLI](https://antigravity.google/product/antigravity-cli) was used to validate the changes in a GKE cluster.

**Special notes for your reviewer**:

**If you are promoting an image, please make sure you have done the following:**

N/A, no image promotion in this PR.

- [ ] I have verified the digest with [gcrane](https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md) and added it as a comment to the PR or in the body.

- [ ] I'm promoting a multi-arch image that matches all the [supported](https://github.com/kubernetes/sig-release/tree/master/release-engineering/platforms) platforms of Kubernetes.

- [ ] I'm not promoting a tag that resolves to latest or moving tags as these are not supported

- [ ] registry.k8s.io is an immutable registry and I'll need to cut a new release if the digest is wrong.
