### PR TITLE
use unified ssh paths in the aws secret

### DIFF
--- a/kubernetes/eks-prow-build/prow/externalsecrets.yaml
+++ b/kubernetes/eks-prow-build/prow/externalsecrets.yaml
@@ -127,6 +127,14 @@ spec:
       key: gke_k8s-prow-builds_us-central1-f_prow__test-pods__aws-ssh-key-secret
       property: aws-ssh-public
     secretKey: aws-ssh-public
+  - remoteRef:
+      key: gke_k8s-prow-builds_us-central1-f_prow__test-pods__aws-ssh-key-secret
+      property: aws-ssh-private
+    secretKey: ssh-private
+  - remoteRef:
+      key: gke_k8s-prow-builds_us-central1-f_prow__test-pods__aws-ssh-key-secret
+      property: aws-ssh-public
+    secretKey: ssh-public
   secretStoreRef:
     kind: ClusterSecretStore
     name: k8s-infra-prow-build


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/issues/37561

This is the first step in setting unified SSH key paths for AWS jobs.

After this change, we can set the following env variables:

```
KUBE_SSH_USER=prow
KUBE_SSH_PUBLIC_KEY_PATH=/etc/ssh-key-secret/ssh-public
KUBE_SSH_PRIVATE_KEY_PATH=/etc/ssh-key-secret/ssh-private
```