### PR TITLE
dns: add *.k8s.dev service records mirroring *.k8s.io (#9622)

### DIFF
--- a/dns/zone-configs/k8s.dev._0_base.yaml
+++ b/dns/zone-configs/k8s.dev._0_base.yaml
@@ -45,3 +45,39 @@ _acme-challenge.dl:
 _gh-kubernetes-e:
   type: TXT
   value: 3e7f816ba3
+# .io mitigation: mirror *.k8s.io services on *.k8s.dev
+# https://github.com/kubernetes/k8s.io/issues/9622
+
+# GCP redirector services (shared LB via redirect.k8s.io)
+pkgs:
+  type: CNAME
+  value: pkgs.k8s.io.
+git:
+  type: CNAME
+  value: git.k8s.io.
+go:
+  type: CNAME
+  value: go.k8s.io.
+issues:
+  type: CNAME
+  value: issues.k8s.io.
+sigs:
+  type: CNAME
+  value: sigs.k8s.io.
+kep:
+  type: CNAME
+  value: kep.k8s.io.
+
+# Dedicated GCP LB services
+registry:
+  type: CNAME
+  value: registry.k8s.io.
+prow:
+  type: CNAME
+  value: prow.k8s.io.
+testgrid:
+  type: CNAME
+  value: testgrid.k8s.io.
+cs:
+  type: CNAME
+  value: cs.k8s.io.


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds DNS records to `dns/zone-configs/k8s.dev._0_base.yaml` so `*.k8s.dev` service hostnames resolve, mirroring their `*.k8s.io` counterparts, per the DNS checkboxes in #9622 (backend types 2 and 3):

* **Shared redirector services:** `pkgs`, `git`, `go`, `issues`, `sigs`, `kep` → CNAME to their `.k8s.io` counterparts
* **Dedicated GCP LB services:** `registry`, `prow`, `testgrid`, `cs` → CNAME to their `.k8s.io` counterparts

This covers the DNS layer only. HTTPS on these hostnames will not work until the corresponding GCP LB frontends and TLS certs cover `*.k8s.dev` (the remaining admin-side checkboxes in #9622).

**Special notes for your reviewer**:

* Record style follows the example in #9622 (`pkgs.k8s.dev CNAME pkgs.k8s.io.`). If direct records (CNAME → `redirect.k8s.io.` for the redirector six, A/AAAA for the dedicated-LB four, matching the `.io` zone style) are preferred for `.io`-mitigation robustness, happy to switch.
* Per the discussion in #9621, `.dev` hostnames haven't served prod traffic yet — these records make the names resolve but backends still need the LB/TLS work before serving.
* Apex/www records and `kubernetes.dev` zone are intentionally untouched (blocked on kubernetes/contributor-site#791).

Ref: #9622