### PR TITLE
promote kindnet to 1.0.1

### DIFF
--- a/registry.k8s.io/images/k8s-staging-networking/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-networking/images.yaml
@@ -58,6 +58,7 @@
     "sha256:7eb7b3cee4d33c10c49893ad3c386232b86d4067de5251294d4c620d6e072b93": ["v1.10.11"]
 - name: kindnet
   dmap:
+    "sha256:f54f1d3c78c8c910b8dc7afff75feb437e9fdb48428117be67eec2e1e8d2cdf3": ["v1.0.1"]
     "sha256:b64448f2424c8c45a98102b80a2a050e7573ece120808106689c2324bf1fe842": ["v1.0.0"]
 - name: kube-network-policies
   dmap:


### PR DESCRIPTION
crane digest gcr.io/k8s-staging-networking/kindnet:v20260728-3306fed sha256:f54f1d3c78c8c910b8dc7afff75feb437e9fdb48428117be67eec2e1e8d2cdf3


/assign @hakman @michaelasp 