### PR TITLE
Add most-allocated custom scheduler to improve node utilization by pa…

### DIFF
--- a/kubernetes/eks-prow-build/kube-system/kustomization.yaml
+++ b/kubernetes/eks-prow-build/kube-system/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: kube-system
 resources:
   - ec2nodeclass.yaml
   - daemonsets.yaml
+  - most-allocated-scheduler.yaml
   - nodepools.yaml
   - npd.yaml
   - npd-config.yaml

--- a/kubernetes/eks-prow-build/kube-system/most-allocated-scheduler.yaml
+++ b/kubernetes/eks-prow-build/kube-system/most-allocated-scheduler.yaml
@@ -1,0 +1,96 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: most-allocated-scheduler
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: most-allocated-scheduler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kube-scheduler
+subjects:
+  - kind: ServiceAccount
+    name: most-allocated-scheduler
+    namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: most-allocated-volume-scheduler
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:volume-scheduler
+subjects:
+  - kind: ServiceAccount
+    name: most-allocated-scheduler
+    namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: most-allocated-scheduler
+  namespace: kube-system
+data:
+  config.yaml: |
+    apiVersion: kubescheduler.config.k8s.io/v1
+    kind: KubeSchedulerConfiguration
+    profiles:
+      - schedulerName: most-allocated-scheduler
+        pluginConfig:
+          - name: NodeResourcesFit
+            args:
+              scoringStrategy:
+                type: MostAllocated
+                resources:
+                  - name: cpu
+                    weight: 1
+                  - name: memory
+                    weight: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: most-allocated-scheduler
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: most-allocated-scheduler
+  template:
+    metadata:
+      labels:
+        app: most-allocated-scheduler
+    spec:
+      serviceAccountName: most-allocated-scheduler
+      nodeSelector:
+        node-group: stable
+      tolerations:
+        - key: node-group
+          operator: Equal
+          value: stable
+          effect: NoSchedule
+      containers:
+        - name: kube-scheduler
+          image: registry.k8s.io/kube-scheduler:v1.35.0
+          command:
+            - kube-scheduler
+            - --config=/etc/kubernetes/scheduler/config.yaml
+            - --leader-elect=false
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - name: config
+              mountPath: /etc/kubernetes/scheduler
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: most-allocated-scheduler


### PR DESCRIPTION
…cking prow jobs onto fewer nodes.

**What this PR does / why we need it**:
Add most-allocated custom scheduler to improve node utilization by packing prow jobs onto fewer nodes.
**Special notes for your reviewer**:
https://github.com/kubernetes-sigs/kueue/issues/12739#issuecomment-5117659817
**If you are promoting an image, please make sure you have done the following:**

- [ ] I have verified the digest with [gcrane](https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md) and added it as a comment to the PR or in the body.

- [ ] I'm promoting a multi-arch image that matches all the [supported](https://github.com/kubernetes/sig-release/tree/master/release-engineering/platforms) platforms of Kubernetes.

- [ ] I'm not promoting a tag that resolves to latest or moving tags as these are not supported

- [ ] registry.k8s.io is an immutable registry and I'll need to cut a new release if the digest is wrong.
