### PR TITLE
add cdn.registry.k8s.io dns records

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -308,9 +308,12 @@ prs:
   value: redirect.k8s.io.
 # Cloudfront endpoint for the distribution shielding
 # the S3 buckets hosting the container images blobs
-cloudfront.registry:
+_288cec1bf94324319ed9254f459ec0cb.cdn.registry:
   type: CNAME
-  value: d39mqg4b1dx9z1.cloudfront.net.
+  value: _51b6e82daf494ea5e5a2ef0746a82946.jkddzztszm.acm-validations.aws.
+cdn.registry:
+  type: CNAME
+  value: d1be1w964nk82h.cloudfront.net.
 # Sandbox OCI redirector service. (@ameukam)
 registry-sandbox:
   - type: A


### PR DESCRIPTION
<img width="452" height="559" alt="image" src="https://github.com/user-attachments/assets/da45082e-6267-404f-a1e3-c89f10f34c0a" />


I'm working on a putting the S3 registry.k8s.io blobs behind a CDN and I'm getting so great numbers. Look at the Blob section.

The old record wasn't set up fully.