### PR TITLE
start using cdn.registry.k8s.io in registry-sandbox.registry.k8s.io

### DIFF
--- a/infra/gcp/terraform/k8s-infra-oci-proxy/iam.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy/iam.tf
@@ -24,13 +24,13 @@ module "iam" {
 
   bindings = {
     "roles/storage.objectAdmin" = [
-      "principal://iam.googleapis.com/projects/180382678033/locations/global/workloadIdentityPools/k8s-infra-prow-build-trusted.svc.id.goog/subject/ns/test-pods/sa/infra-tools"
+      "serviceAccount:infra-tools-sa@k8s-staging-images.iam.gserviceaccount.com"
     ],
     "roles/run.admin" = [
-      "principal://iam.googleapis.com/projects/180382678033/locations/global/workloadIdentityPools/k8s-infra-prow-build-trusted.svc.id.goog/subject/ns/test-pods/sa/infra-tools"
+      "serviceAccount:infra-tools-sa@k8s-staging-images.iam.gserviceaccount.com"
     ],
     "roles/viewer" = [
-      "principal://iam.googleapis.com/projects/180382678033/locations/global/workloadIdentityPools/k8s-infra-prow-build-trusted.svc.id.goog/subject/ns/test-pods/sa/infra-tools"
+      "serviceAccount:infra-tools-sa@k8s-staging-images.iam.gserviceaccount.com"
     ]
   }
 }

--- a/infra/gcp/terraform/k8s-infra-oci-proxy/main.tf
+++ b/infra/gcp/terraform/k8s-infra-oci-proxy/main.tf
@@ -35,4 +35,5 @@ module "oci-proxy" {
   // Manually created. Monitoring channels can't be created with Terraform.
   // See: https://github.com/hashicorp/terraform-provider-google/issues/1134
   notification_channel_id = "3237876589275698022"
+  global_aws_base_url     = "https://cdn.registry.k8s.io"
 }

--- a/infra/gcp/terraform/modules/oci-proxy/main.tf
+++ b/infra/gcp/terraform/modules/oci-proxy/main.tf
@@ -22,7 +22,7 @@ locals {
         {
           name = "DEFAULT_AWS_BASE_URL",
           // AWS Cloudfront
-          value = "https://d39mqg4b1dx9z1.cloudfront.net",
+          value = coalesce(var.global_aws_base_url, "https://d39mqg4b1dx9z1.cloudfront.net")
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -44,7 +44,7 @@ locals {
         {
           name = "DEFAULT_AWS_BASE_URL",
           // AWS ap-northeast-1 is Tokyo
-          value = "https://prod-registry-k8s-io-ap-northeast-1.s3.dualstack.ap-northeast-1.amazonaws.com",
+          value = coalesce(var.global_aws_base_url, "https://prod-registry-k8s-io-ap-northeast-1.s3.dualstack.ap-northeast-1.amazonaws.com"),
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -66,7 +66,7 @@ locals {
         {
           name = "DEFAULT_AWS_BASE_URL",
           // AWS ap-northeast-1 is Tokyo
-          value = "https://prod-registry-k8s-io-ap-northeast-1.s3.dualstack.ap-northeast-1.amazonaws.com",
+          value = coalesce(var.global_aws_base_url, "https://prod-registry-k8s-io-ap-northeast-1.s3.dualstack.ap-northeast-1.amazonaws.com"),
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -88,7 +88,7 @@ locals {
         {
           name = "DEFAULT_AWS_BASE_URL",
           // AWS ap-south-1 is Mumbai
-          value = "https://prod-registry-k8s-io-ap-south-1.s3.dualstack.ap-south-1.amazonaws.com",
+          value = coalesce(var.global_aws_base_url, "https://prod-registry-k8s-io-ap-south-1.s3.dualstack.ap-south-1.amazonaws.com"),
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -110,7 +110,7 @@ locals {
         {
           name = "DEFAULT_AWS_BASE_URL",
           // AWS ap-southeast-1 is Singapore
-          value = "https://prod-registry-k8s-io-ap-southeast-1.s3.dualstack.ap-southeast-1.amazonaws.com",
+          value = coalesce(var.global_aws_base_url, "https://prod-registry-k8s-io-ap-southeast-1.s3.dualstack.ap-southeast-1.amazonaws.com"),
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -132,7 +132,7 @@ locals {
         {
           name = "DEFAULT_AWS_BASE_URL",
           // AWS eu-central-1 is Frankfurt
-          value = "https://prod-registry-k8s-io-eu-central-1.s3.dualstack.eu-central-1.amazonaws.com",
+          value = coalesce(var.global_aws_base_url, "https://prod-registry-k8s-io-eu-central-1.s3.dualstack.eu-central-1.amazonaws.com"),
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -154,7 +154,7 @@ locals {
         {
           name = "DEFAULT_AWS_BASE_URL",
           // AWS eu-central-1 is Frankfurt
-          value = "https://prod-registry-k8s-io-eu-central-1.s3.dualstack.eu-central-1.amazonaws.com",
+          value = coalesce(var.global_aws_base_url, "https://prod-registry-k8s-io-eu-central-1.s3.dualstack.eu-central-1.amazonaws.com"),
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -176,7 +176,7 @@ locals {
         {
           name = "DEFAULT_AWS_BASE_URL",
           // AWS Cloudfront
-          value = "https://d39mqg4b1dx9z1.cloudfront.net",
+          value = coalesce(var.global_aws_base_url, "https://d39mqg4b1dx9z1.cloudfront.net"),
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -198,7 +198,7 @@ locals {
         {
           name = "DEFAULT_AWS_BASE_URL",
           // AWS eu-central-1 is Frankfurt
-          value = "https://prod-registry-k8s-io-eu-central-1.s3.dualstack.eu-central-1.amazonaws.com",
+          value = coalesce(var.global_aws_base_url, "https://prod-registry-k8s-io-eu-central-1.s3.dualstack.eu-central-1.amazonaws.com"),
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -220,7 +220,7 @@ locals {
         {
           name = "DEFAULT_AWS_BASE_URL",
           // AWS eu-west-1 is Ireland
-          value = "https://prod-registry-k8s-io-eu-west-1.s3.dualstack.eu-west-1.amazonaws.com",
+          value = coalesce(var.global_aws_base_url, "https://prod-registry-k8s-io-eu-west-1.s3.dualstack.eu-west-1.amazonaws.com"),
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -242,7 +242,7 @@ locals {
         {
           name = "DEFAULT_AWS_BASE_URL",
           // AWS eu-central-1 is Frankfurt
-          value = "https://prod-registry-k8s-io-eu-central-1.s3.dualstack.eu-central-1.amazonaws.com",
+          value = coalesce(var.global_aws_base_url, "https://prod-registry-k8s-io-eu-central-1.s3.dualstack.eu-central-1.amazonaws.com"),
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -264,7 +264,7 @@ locals {
         {
           name = "DEFAULT_AWS_BASE_URL",
           // AWS Cloudfront
-          value = "https://d39mqg4b1dx9z1.cloudfront.net",
+          value = coalesce(var.global_aws_base_url, "https://d39mqg4b1dx9z1.cloudfront.net"),
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -286,7 +286,7 @@ locals {
         {
           name = "DEFAULT_AWS_BASE_URL",
           // AWS eu-south-1 is Milan
-          value = "https://prod-registry-k8s-io-eu-south-1.s3.dualstack.eu-south-1.amazonaws.com",
+          value = coalesce(var.global_aws_base_url, "https://prod-registry-k8s-io-eu-south-1.s3.dualstack.eu-south-1.amazonaws.com"),
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -308,7 +308,7 @@ locals {
         {
           name = "DEFAULT_AWS_BASE_URL",
           // AWS eu-west-3 is in Paris
-          value = "https://prod-registry-k8s-io-eu-west-3.s3.dualstack.eu-west-3.amazonaws.com",
+          value = coalesce(var.global_aws_base_url, "https://prod-registry-k8s-io-eu-west-3.s3.dualstack.eu-west-3.amazonaws.com"),
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -329,7 +329,7 @@ locals {
       environment_variables = [
         {
           name  = "DEFAULT_AWS_BASE_URL",
-          value = "https://d39mqg4b1dx9z1.cloudfront.net",
+          value = coalesce(var.global_aws_base_url, "https://d39mqg4b1dx9z1.cloudfront.net"),
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -351,7 +351,7 @@ locals {
         {
           name = "DEFAULT_AWS_BASE_URL",
           // AWS us-east-2 is Ohio, USA
-          value = "https://prod-registry-k8s-io-us-east-2.s3.dualstack.us-east-2.amazonaws.com",
+          value = coalesce(var.global_aws_base_url, "https://prod-registry-k8s-io-us-east-2.s3.dualstack.us-east-2.amazonaws.com"),
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -373,7 +373,7 @@ locals {
         {
           name = "DEFAULT_AWS_BASE_URL",
           // AWS us-east-1 is Virginia, USA
-          value = "https://prod-registry-k8s-io-us-east-1.s3.dualstack.us-east-1.amazonaws.com",
+          value = coalesce(var.global_aws_base_url, "https://prod-registry-k8s-io-us-east-1.s3.dualstack.us-east-1.amazonaws.com"),
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -395,7 +395,7 @@ locals {
         {
           name = "DEFAULT_AWS_BASE_URL",
           // AWS us-east-1 is Virginia, USA
-          value = "https://prod-registry-k8s-io-us-east-1.s3.dualstack.us-east-1.amazonaws.com",
+          value = coalesce(var.global_aws_base_url, "https://prod-registry-k8s-io-us-east-1.s3.dualstack.us-east-1.amazonaws.com"),
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -417,7 +417,7 @@ locals {
         {
           name = "DEFAULT_AWS_BASE_URL",
           // AWS us-east-2 is Ohio, USA
-          value = "https://prod-registry-k8s-io-us-east-2.s3.dualstack.us-east-2.amazonaws.com",
+          value = coalesce(var.global_aws_base_url, "https://prod-registry-k8s-io-us-east-2.s3.dualstack.us-east-2.amazonaws.com"),
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -439,7 +439,7 @@ locals {
         {
           name = "DEFAULT_AWS_BASE_URL",
           // AWS us-east-2 is Ohio, USA
-          value = "https://prod-registry-k8s-io-us-east-2.s3.dualstack.us-east-2.amazonaws.com",
+          value = coalesce(var.global_aws_base_url, "https://prod-registry-k8s-io-us-east-2.s3.dualstack.us-east-2.amazonaws.com"),
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -461,7 +461,7 @@ locals {
         {
           name = "DEFAULT_AWS_BASE_URL",
           // AWS us-west-2 is Oregon, USA
-          value = "https://prod-registry-k8s-io-us-west-2.s3.dualstack.us-west-2.amazonaws.com",
+          value = coalesce(var.global_aws_base_url, "https://prod-registry-k8s-io-us-west-2.s3.dualstack.us-west-2.amazonaws.com"),
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",
@@ -483,7 +483,7 @@ locals {
         {
           name = "DEFAULT_AWS_BASE_URL",
           // AWS us-west-1 is California, USA
-          value = "https://prod-registry-k8s-io-us-west-1.s3.dualstack.us-west-1.amazonaws.com",
+          value = coalesce(var.global_aws_base_url, "https://prod-registry-k8s-io-us-west-1.s3.dualstack.us-west-1.amazonaws.com"),
         },
         {
           name  = "UPSTREAM_REGISTRY_ENDPOINT",

--- a/infra/gcp/terraform/modules/oci-proxy/variables.tf
+++ b/infra/gcp/terraform/modules/oci-proxy/variables.tf
@@ -38,3 +38,8 @@ variable "notification_channel_id" {
 variable "service_account_name" {
   type = string
 }
+
+variable "global_aws_base_url" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
cdn.registry.k8s.io was provisioned in #8819, and I'm rolling it out on our sandbox instance.

The IAM change is to fix the broken prowjob https://prow.k8s.io/view/gs/kubernetes-ci-logs/logs/post-registry-push-images/2082519543736963072