### PR TITLE
Fix mimir tls verification error

### DIFF
--- a/kubernetes/gke-utility/istio-system/gateway.yaml
+++ b/kubernetes/gke-utility/istio-system/gateway.yaml
@@ -56,3 +56,4 @@ spec:
   dnsNames:
   - '*.k8s.io'
   - 'monitoring.prow.k8s.io'
+  - 'mimir.prow.k8s.io'


### PR DESCRIPTION
**What this PR does / why we need it**:

Add mimir.prow.k8s.io to the k8s-io-wild cert SANs so build-cluster Prometheus can remote-write to Mimir over TLS.