### PR TITLE
Configure mimir limits for max_labels, ingest_rate, burst_size

### DIFF
--- a/kubernetes/gke-utility/helm/mimir.yaml
+++ b/kubernetes/gke-utility/helm/mimir.yaml
@@ -26,6 +26,9 @@ mimir:
   structuredConfig:
     limits:
       max_global_series_per_user: 500000
+      max_label_names_per_series: 50
+      ingestion_rate: 100000
+      ingestion_burst_size: 2000000
     ingest_storage:
       enabled: false
       kafka:


### PR DESCRIPTION
**What this PR does / why we need it**:
      
Configures the following limits for mimir

- max_label_names_per_series: 50
- ingestion_rate: 100000
- ingestion_burst_size: 2000000
