### PR TITLE
fix: use Recreate strategy for Grafana on gke-utility

### DIFF
--- a/kubernetes/gke-utility/helm/monitoring.yaml
+++ b/kubernetes/gke-utility/helm/monitoring.yaml
@@ -1,6 +1,8 @@
 grafana:
   enabled: true
   defaultDashboardsEnabled: false
+  deploymentStrategy:
+    type: Recreate
   service:
     type: ClusterIP
   sidecar:


### PR DESCRIPTION
Grafana uses a ReadWriteOnce persistent volume. RollingUpdate can schedule the replacement pod on another node while the existing pod still holds the volume, leaving the rollout stuck until it exceeds its progress deadline. Recreate releases the volume before starting the replacement pod.
