### PR TITLE
fix: avoid Grafana RWO rolling update deadlock

### DIFF
--- a/kubernetes/gke-utility/helm/monitoring.yaml
+++ b/kubernetes/gke-utility/helm/monitoring.yaml
@@ -2,7 +2,10 @@ grafana:
   enabled: true
   defaultDashboardsEnabled: false
   deploymentStrategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
   service:
     type: ClusterIP
   sidecar:


### PR DESCRIPTION
**What this PR does / why we need it**:
Use a zero-surge rolling update so the existing Grafana pod releases its ReadWriteOnce volume before Kubernetes creates the replacement. Keeping the strategy type as RollingUpdate also allows Argo server-side apply to update the existing Deployment without Kubernetes rejecting the retained rollingUpdate field.
