### PR TITLE
fix: eliminate monitoring Argo drift

### DIFF
--- a/kubernetes/apps/monitoring.yaml
+++ b/kubernetes/apps/monitoring.yaml
@@ -18,8 +18,6 @@ spec:
   template:
     metadata:
       name: 'monitoring-{{ .name }}'
-      annotations:
-        argocd.argoproj.io/compare-options: ServerSideDiff=true,IncludeMutationWebhook=true
     spec:
       destination:
         namespace: monitoring
@@ -39,12 +37,32 @@ spec:
         - path: kubernetes/{{ .name }}/monitoring/
           repoURL: https://github.com/kubernetes/k8s.io
           targetRevision: main
+      ignoreDifferences:
+        - group: ""
+          kind: Secret
+          name: monitoring-grafana
+          namespace: monitoring
+          jsonPointers:
+            - /data/admin-password
+        - group: apps
+          kind: Deployment
+          name: monitoring-grafana
+          namespace: monitoring
+          jqPathExpressions:
+            - '.spec.template.metadata.annotations["checksum/secret"]'
+        - group: external-secrets.io
+          kind: ExternalSecret
+          name: mimir-credentials
+          namespace: monitoring
+          jsonPointers:
+            - /metadata/finalizers
       syncPolicy:
         automated:
           prune: true
           selfHeal: true
         syncOptions:
           - CreateNamespace=true
+          - RespectIgnoreDifferences=true
           - ServerSideApply=true
         managedNamespaceMetadata:
           labels:

--- a/kubernetes/gke-utility/monitoring/httproute.yaml
+++ b/kubernetes/gke-utility/monitoring/httproute.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: monitoring
 spec:
   parentRefs:
-    - name: istio-ingressgateway
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: istio-ingressgateway
       namespace: istio-system
       sectionName: https
   hostnames:
@@ -16,5 +18,8 @@ spec:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: monitoring-grafana
+        - group: ""
+          kind: Service
+          name: monitoring-grafana
           port: 80
+          weight: 1

--- a/kubernetes/gke-utility/monitoring/secrets.yaml
+++ b/kubernetes/gke-utility/monitoring/secrets.yaml
@@ -3,15 +3,27 @@ kind: ExternalSecret
 metadata:
   name: mimir-credentials
 spec:
+  refreshInterval: 1h0m0s
   data:
     - secretKey: username
       remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
         key: mimir-credentials
+        metadataPolicy: None
+        nullBytePolicy: Ignore
         property: username
     - secretKey: password
       remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
         key: mimir-credentials
+        metadataPolicy: None
+        nullBytePolicy: Ignore
         property: password
   secretStoreRef:
     kind: ClusterSecretStore
     name: k8s-infra-prow
+  target:
+    creationPolicy: Owner
+    deletionPolicy: Retain


### PR DESCRIPTION
Remove server-side diff from the monitoring ApplicationSet because it treats legacy field-manager ownership as live drift after the Argo upgrade.

Preserve Grafana's chart-generated admin password and checksum during syncs, and explicitly declare ExternalSecret and HTTPRoute defaults that Argo cannot infer from CRD schemas. This lets the monitoring applications converge without rotating credentials or restarting Grafana.