### PR TITLE
promote gcb-docker-gcloud docker image - v20260806

### DIFF
--- a/registry.k8s.io/images/k8s-staging-releng/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-releng/images.yaml
@@ -1,6 +1,9 @@
 - name: kubepkg
   dmap:
     "sha256:caef826cde3d4cc884ccbac3a1805769ae59fe07f6f8234bf22dbfeb82312a99": ["v0.1.0","v20201103-v0.5.0-63-ga247d79"]
+- name: gcb-docker-gcloud
+  dmap:
+    "sha256:b2651f57b579d925a243e308c41546d4fd895f705de091a5a8a39060e6192604": ["v20260806"]
 - name: kubepkg-rpm
   dmap:
     "sha256:f5fc791f5ef03c5fe3329fff3a40b80a44029a6e236981a2e5133ebf9597f9dd": ["v0.1.0","v20201103-v0.5.0-63-ga247d79"]


### PR DESCRIPTION
**What this PR does / why we need it**:

**Special notes for your reviewer**:

**If you are promoting an image, please make sure you have done the following:**

- [X] I have verified the digest with [gcrane](https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md) and added it as a comment to the PR or in the body.

- [X] I'm promoting a multi-arch image that matches all the [supported](https://github.com/kubernetes/sig-release/tree/master/release-engineering/platforms) platforms of Kubernetes.

- [X] I'm not promoting a tag that resolves to latest or moving tags as these are not supported

- [X] registry.k8s.io is an immutable registry and I'll need to cut a new release if the digest is wrong.


```
 mahamed  DIAPLT128  ~  Desktop  Git  k8s.io   promote-gcb-docker-gcloud  11✎  3⚑  $  gcrane digest gcr.io/k8s-staging-releng/gcb-docker-gcloud:latest
sha256:b2651f57b579d925a243e308c41546d4fd895f705de091a5a8a39060e6192604
```

This image will be versioned by build date; we'll publish a new one every month or so