### PR TITLE
create bq dataset and pass asn values to archeio

### DIFF
--- a/.atlantis.yaml
+++ b/.atlantis.yaml
@@ -42,3 +42,15 @@ projects:
     when_modified:
       - "**/*"
       - "../cdn/**/*"
+  - dir: infra/gcp/terraform/k8s-infra-oci-proxy
+    branch: /main/
+    autoplan:
+      when_modified:
+        - "**/*"
+        - "../modules/oci-proxy/**/*"
+  - dir: infra/gcp/terraform/k8s-infra-oci-proxy-prod
+    branch: /main/
+    autoplan:
+      when_modified:
+        - "**/*"
+        - "../modules/oci-proxy/**/*"

--- a/infra/gcp/terraform/modules/oci-proxy/analysis.tf
+++ b/infra/gcp/terraform/modules/oci-proxy/analysis.tf
@@ -1,0 +1,39 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+module "log_export" {
+  source  = "terraform-google-modules/log-export/google"
+  version = "~> 11.1"
+
+  destination_uri      = module.destination.destination_uri
+  filter               = "jsonPayload.message = image_pull"
+  log_sink_name        = "analytics"
+  parent_resource_id   = var.project_id
+  parent_resource_type = "project"
+  bigquery_options = {
+    use_partitioned_tables = false
+  }
+}
+
+module "destination" {
+  source  = "terraform-google-modules/log-export/google//modules/bigquery"
+  version = "~> 11.1"
+
+  project_id               = var.project_id
+  dataset_name             = "analytics"
+  log_sink_writer_identity = module.log_export.writer_identity
+}

--- a/infra/gcp/terraform/modules/oci-proxy/network.tf
+++ b/infra/gcp/terraform/modules/oci-proxy/network.tf
@@ -158,8 +158,9 @@ resource "google_compute_backend_service" "default" {
   project = var.project_id
   name    = "${var.project_id}-default-bes"
 
-  enable_cdn      = false
-  security_policy = google_compute_security_policy.cloud-armor.self_link
+  enable_cdn             = false
+  security_policy        = google_compute_security_policy.cloud-armor.self_link
+  custom_request_headers = ["X-Client-ASN: {asn}"]
 
   dynamic "backend" {
     for_each = google_compute_region_network_endpoint_group.default


### PR DESCRIPTION
Create BQ analysis datasets and capture the ASN calculated by GCP.

```
WITH events AS (
  SELECT
    jsonPayload.traceid,
    jsonPayload.image,
    jsonPayload.reference,
    jsonPayload.type,
    jsonPayload.useragent,
    jsonPayload.cloud,
    jsonPayload.region,
    jsonPayload.backend,
    timestamp
  FROM
    `k8s-infra-oci-proxy.analytics.run_googleapis_com_stderr_*`
  WHERE
    jsonPayload.traceid IS NOT NULL
),

per_trace AS (
  SELECT
    traceid,
    COUNTIF(type = 'manifest') AS manifest_events,
    COUNTIF(type = 'blob') AS blob_events,

    ARRAY_AGG(
      image IGNORE NULLS
      ORDER BY timestamp
      LIMIT 1
    )[SAFE_OFFSET(0)] AS image,

    ARRAY_AGG(
      IF(
        type = 'manifest'
        AND NOT STARTS_WITH(reference, 'sha256:'),
        reference,
        NULL
      )
      IGNORE NULLS
      ORDER BY timestamp
      LIMIT 1
    )[SAFE_OFFSET(0)] AS tag,

    ARRAY_AGG(
      cloud IGNORE NULLS
      ORDER BY timestamp
      LIMIT 1
    )[SAFE_OFFSET(0)] AS cloud,

    ARRAY_AGG(
      region IGNORE NULLS
      ORDER BY timestamp
      LIMIT 1
    )[SAFE_OFFSET(0)] AS region
  FROM events
  GROUP BY traceid
),

complete_pulls AS (
  SELECT *
  FROM per_trace
  WHERE
    manifest_events > 0
    AND blob_events > 0
)

SELECT
  CONCAT('registry.k8s.io/', image) AS image,
  tag,
  COUNT(*) AS complete_pulls
FROM complete_pulls
GROUP BY image, tag
ORDER BY complete_pulls DESC;
```

```
Row	image	tag	complete_pulls
1	registry.k8s.io/pause	3.5	47
2	registry.k8s.io/pause	3.2	46
3	registry.k8s.io/pause	3.1	46
4	registry.k8s.io/pause	3.9	46	
```