### PR TITLE
go.k8s.io/sig-testing-notes redirect to replace bitly

### DIFF
--- a/apps/k8s-io/README.md
+++ b/apps/k8s-io/README.md
@@ -54,6 +54,7 @@ NOTE: please see k8s.io/k8s.io/configmap-nginx.yaml for `server` definitions
 - https://go.k8s.io/sig-k8s-infra
 - https://go.k8s.io/sig-k8s-infra-notes
 - https://go.k8s.io/sig-k8s-infra-playlist
+- https://go.k8s.io/sig-testing-notes
 - https://go.k8s.io/start
 - https://go.k8s.io/stuck-prs
 - https://go.k8s.io/test-health

--- a/apps/k8s-io/configmap-nginx.yaml
+++ b/apps/k8s-io/configmap-nginx.yaml
@@ -299,6 +299,7 @@ data:
           rewrite ^/sig-k8s-infra$    https://github.com/kubernetes/community/tree/master/sig-k8s-infra redirect;
           rewrite ^/sig-k8s-infra-notes$ https://docs.google.com/document/d/1VGMyAn_Pixdg0mTwbjxRcq_-oI7xtyomG9Hoa_RpryQ redirect;
           rewrite ^/sig-k8s-infra-playlist$ https://www.youtube.com/playlist?list=PL69nYSiGNLP2Ghq7VW8rFbMFoHwvORuDL redirect;
+          rewrite ^/sig-testing-notes$  https://docs.google.com/document/d/1z8MQpr_jTwhmjLMUaqQyBk1EYG_Y_3D4y4YdMJ7V1Kk/edit redirect;
           rewrite ^/start$           https://kubernetes.io/docs/setup/ redirect;
           rewrite ^/stuck-prs$       https://github.com/kubernetes/kubernetes/pulls?utf8=%E2%9C%93&q=is%3Apr%20is%3Aopen%20label%3Algtm%20label%3Aapproved%20-label%3Ado-not-merge%20-label%3Aneeds-rebase%20sort%3Aupdated-asc%20-status%3Asuccess redirect;
           rewrite ^/test-history$    https://storage.googleapis.com/kubernetes-test-history/static/index.html redirect;

--- a/apps/k8s-io/test.py
+++ b/apps/k8s-io/test.py
@@ -214,6 +214,9 @@ class RedirTest(HTTPTestCase):
                 base + 'contact/$groupname',
                 'https://github.com/kubernetes/community/tree/master/$groupname#contact',
                 groupname=rand_num())
+            self.assert_temp_redirect(
+                base + 'sig-testing-notes',
+                'https://docs.google.com/document/d/1z8MQpr_jTwhmjLMUaqQyBk1EYG_Y_3D4y4YdMJ7V1Kk/edit')
 
     def test_yum(self):
         for base in ('yum.k8s.io', 'yum.kubernetes.io'):


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds go.k8s.io/sig-testing-notes

**Special notes for your reviewer**:

AI assited PR.

**If you are promoting an image, please make sure you have done the following:**

N/A.

/sig testing

- [ ] I have verified the digest with [gcrane](https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md) and added it as a comment to the PR or in the body.

- [ ] I'm promoting a multi-arch image that matches all the [supported](https://github.com/kubernetes/sig-release/tree/master/release-engineering/platforms) platforms of Kubernetes.

- [ ] I'm not promoting a tag that resolves to latest or moving tags as these are not supported

- [ ] registry.k8s.io is an immutable registry and I'll need to cut a new release if the digest is wrong.
