### PR TITLE
Kueue: grant approver permissions to the release team

### DIFF
--- a/registry.k8s.io/images/k8s-staging-kueue/OWNERS
+++ b/registry.k8s.io/images/k8s-staging-kueue/OWNERS
@@ -4,9 +4,8 @@
 approvers:
 - tenzen-y
 - mimowo
-
-reviewers:
-- gabesaba
+- mbobrovskyi
+- Singularity23x0
 
 emeritus_approvers:
 - ahg-g


### PR DESCRIPTION
**What this PR does / why we need it**:
Grant approver permissions to the kueue release team.

Part of kubernetes-sigs/kueue#14300