### PR TITLE
Bump TestGrid API memory limit.

### DIFF
--- a/kubernetes/gke-prow/prow/testgrid.yaml
+++ b/kubernetes/gke-prow/prow/testgrid.yaml
@@ -31,10 +31,10 @@ spec:
         resources:
           requests:
             cpu: 1
-            memory: 2Gi
+            memory: 8Gi
           limits:
             cpu: 2
-            memory: 4Gi
+            memory: 8Gi
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
I want to bump this up to see if the API performance improves with more memory.