### PR TITLE
switch to using fastly cdn for registy.k8s.io

### DIFF
--- a/dns/zone-configs/k8s.io._0_base.yaml
+++ b/dns/zone-configs/k8s.io._0_base.yaml
@@ -312,8 +312,21 @@ _288cec1bf94324319ed9254f459ec0cb.cdn.registry:
   type: CNAME
   value: _51b6e82daf494ea5e5a2ef0746a82946.jkddzztszm.acm-validations.aws.
 cdn.registry:
+  - type: A
+    values:
+      - 151.101.1.91
+      - 151.101.65.91
+      - 151.101.129.91
+      - 151.101.193.91
+  - type: AAAA
+    values:
+      - 2a04:4e42::347
+      - 2a04:4e42:200::347
+      - 2a04:4e42:400::347
+      - 2a04:4e42:600::347
+_acme-challenge.cdn:
   type: CNAME
-  value: d1be1w964nk82h.cloudfront.net.
+  value: e9fwbc453g5raz00on.fastly-validations.com.
 # Sandbox OCI redirector service. (@ameukam)
 registry-sandbox:
   - type: A

--- a/infra/fastly/terraform/cdn.registry.k8s.io/data.tf
+++ b/infra/fastly/terraform/cdn.registry.k8s.io/data.tf
@@ -1,0 +1,25 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+data "google_secret_manager_secret_version_access" "datadog_api_key" {
+  secret  = "datadog_fastly_logs_streaming"
+  project = "k8s-infra-releases-prod"
+}
+
+data "google_secret_manager_secret_version_access" "fastly_api_key" {
+  secret  = "fastly-api-key"
+  project = "k8s-infra-prow"
+}

--- a/infra/fastly/terraform/cdn.registry.k8s.io/main.tf
+++ b/infra/fastly/terraform/cdn.registry.k8s.io/main.tf
@@ -1,0 +1,35 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+module "cdn" {
+  source = "../cdn"
+  domain = "cdn.registry.k8s.io"
+  datadog_config = {
+    token        = data.google_secret_manager_secret_version_access.datadog_api_key.secret_data,
+    service_name = "cdn.registry.k8s.io",
+    env          = "prod",
+  }
+  cloud     = "aws"
+  cache_ttl = 2592000 # 30 days
+  bucket_configs = [
+    {
+      name   = "prod-registry-k8s-io-us-east-2",
+      region = "us-east-2",
+      public = true
+    },
+  ]
+}

--- a/infra/fastly/terraform/cdn.registry.k8s.io/provider.tf
+++ b/infra/fastly/terraform/cdn.registry.k8s.io/provider.tf
@@ -1,0 +1,44 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+This file defines:
+- Required provider versions
+- Storage backend details
+*/
+
+terraform {
+  required_version = "1.12.2"
+  backend "gcs" {
+    bucket = "k8s-infra-terraform"
+    prefix = "cdn.registry.k8s.io"
+  }
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 7.8.0"
+    }
+    fastly = {
+      source = "fastly/fastly"
+    }
+  }
+}
+
+
+provider "fastly" {
+  api_key = data.google_secret_manager_secret_version_access.fastly_api_key.secret_data
+}


### PR DESCRIPTION
The service is deployed, and I manually created the acme record, so the cert has been created and it's ready to serve traffic.
/hold

