### PR TITLE
feat: setup kafka cluster for mimir

### DIFF
--- a/infra/gcp/terraform/k8s-infra-prow/iam.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/iam.tf
@@ -39,6 +39,10 @@ module "iam" {
       "serviceAccount:${google_service_account.image_builder.email}",
     ]
 
+    "roles/managedkafka.client" = [
+      "principal://iam.googleapis.com/projects/16065310909/locations/global/workloadIdentityPools/k8s-infra-prow.svc.id.goog/subject/ns/mimir/sa/mimir",
+    ]
+
     "roles/secretmanager.secretAccessor" = [
       "principal://iam.googleapis.com/projects/16065310909/locations/global/workloadIdentityPools/k8s-infra-prow.svc.id.goog/subject/ns/external-secrets/sa/external-secrets",
     ]

--- a/infra/gcp/terraform/k8s-infra-prow/kafka.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/kafka.tf
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+// Create kafka cluster with 3vcpu, 12MB memory and autorebalance
+resource "google_managed_kafka_cluster" "mimir_cluster" {
+  project    = module.project.project_id
+  cluster_id = "mimir-cluster"
+  location   = "us-central1"
+  capacity_config {
+    vcpu_count   = 3
+    memory_bytes = 12884901888
+  }
+  gcp_config {
+    access_config {
+      network_configs {
+        subnet = module.vpc.subnets["us-central1/subnet-01"].id
+      }
+    }
+  }
+  rebalance_config {
+    mode = "AUTO_REBALANCE_ON_SCALE_UP"
+  }
+}
+
+// Create mimir-ingest topic with 12 partition count
+resource "google_managed_kafka_topic" "mimir_ingest" {
+  project            = module.project.project_id
+  topic_id           = "mimir-ingest"
+  cluster            = google_managed_kafka_cluster.mimir_cluster.cluster_id
+  location           = "us-central1"
+  partition_count    = 12 # must be >= ingesters per zone
+  replication_factor = 3  # Managed Kafka requires >= 3
+
+  // Set max byte to 16MB because mimir default is 15.2MB
+  configs = {
+    "max.message.bytes" = "16000000"
+  }
+}

--- a/infra/gcp/terraform/k8s-infra-prow/main.tf
+++ b/infra/gcp/terraform/k8s-infra-prow/main.tf
@@ -41,6 +41,7 @@ module "project" {
     "certificatemanager.googleapis.com",
     "artifactregistry.googleapis.com",
     "secretmanager.googleapis.com",
-    "cloudbuild.googleapis.com"
+    "cloudbuild.googleapis.com",
+    "managedkafka.googleapis.com"
   ]
 }

--- a/kubernetes/gke-utility/helm/mimir.yaml
+++ b/kubernetes/gke-utility/helm/mimir.yaml
@@ -1,6 +1,8 @@
 serviceAccount:
   create: true
   name: mimir
+  annotations:
+    iam.gke.io/return-principal-id-as-email: "true"
 
 minio:
   enabled: false
@@ -30,15 +32,18 @@ mimir:
       ingestion_rate: 200000
       ingestion_burst_size: 3000000
     ingest_storage:
-      enabled: false
+      enabled: true
       kafka:
-        address: null
-        topic: null
-        auto_create_topic_default_partitions: null
+        address: bootstrap.mimir-cluster.us-central1.managedkafka.k8s-infra-prow.cloud.goog:9092
+        topic: mimir-ingest
+        auto_create_topic_enabled: false
+        tls_enabled: true
+        sasl_mechanism: OAUTHBEARER
+        sasl_oauthbearer_file_path: /var/run/kafka-token/token.json
     distributor:
       remote_timeout: null
     ingester:
-      push_grpc_method_enabled: true
+      push_grpc_method_enabled: false
     common:
       storage:
         backend: gcs
@@ -97,6 +102,157 @@ distributor:
     requests:
       cpu: 1
       memory: 2Gi
+  initContainers: &kafkaTokenSidecars
+    - name: kafka-token
+      image: mirror.gcr.io/alpine:3.22
+      imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+      command:
+        - /bin/sh
+        - -c
+        - |
+          set -u
+          umask 077
+
+          MD="http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default"
+          HDR="Metadata-Flavor: Google"
+          TOKEN_FILE="/var/run/kafka-token/token.json"
+          REFRESH_FILE="/var/run/kafka-token/refreshed-at"
+
+          # RFC 7515 base64url: URL-safe alphabet, no padding or newlines.
+          b64url() {
+            base64 | tr -d '\n' | tr '+/' '-_' | tr -d '='
+          }
+
+          while true; do
+            if response="$(wget -qO- --header="$HDR" "$MD/token")" &&
+              principal="$(wget -qO- --header="$HDR" "$MD/email")"; then
+
+              access_token="$(
+                printf '%s' "$response" |
+                  sed -n 's/.*"access_token"[ ]*:[ ]*"\([^"]*\)".*/\1/p'
+              )"
+
+              expires_in="$(
+                printf '%s' "$response" |
+                  sed -n 's/.*"expires_in"[ ]*:[ ]*\([0-9]*\).*/\1/p'
+              )"
+
+              case "$expires_in" in
+                ''|*[!0-9]*) expires_in=3600 ;;
+              esac
+
+              if [ -n "$access_token" ] && [ -n "$principal" ]; then
+                now="$(date +%s)"
+
+                # Managed Kafka expects Google's GOOG_OAUTH2_TOKEN envelope,
+                # not the raw Google OAuth access token.
+                token="$(
+                  printf '%s' \
+                    '{"typ":"JWT","alg":"GOOG_OAUTH2_TOKEN"}' |
+                    b64url
+                )"
+
+                token="$token.$(
+                  printf \
+                    '{"exp":%s,"iss":"Google","iat":%s,"sub":"%s"}' \
+                    "$((now + expires_in))" \
+                    "$now" \
+                    "$principal" |
+                    b64url
+                )"
+
+                token="$token.$(
+                  printf '%s' "$access_token" |
+                    b64url
+                )"
+
+                # Atomic rename prevents Mimir reading a partially-written token.
+                printf '{"token":"%s"}' "$token" > "$TOKEN_FILE.tmp"
+                mv "$TOKEN_FILE.tmp" "$TOKEN_FILE"
+
+                # Used by the liveness probe to detect a stalled refresh loop.
+                printf '%s\n' "$now" > "$REFRESH_FILE.tmp"
+                mv "$REFRESH_FILE.tmp" "$REFRESH_FILE"
+
+                echo "Kafka OAUTHBEARER token refreshed"
+
+                sleep_for="$((expires_in - 300))"
+                [ "$sleep_for" -ge 60 ] || sleep_for=60
+
+                sleep "$sleep_for"
+                continue
+              fi
+            fi
+
+            echo "Failed to refresh Google Managed Kafka token" >&2
+            sleep 10
+          done
+
+      startupProbe:
+        exec:
+          command:
+            - /bin/sh
+            - -c
+            - |
+              test -s /var/run/kafka-token/token.json &&
+              test -s /var/run/kafka-token/refreshed-at
+
+        periodSeconds: 1
+        timeoutSeconds: 1
+        failureThreshold: 60
+
+      livenessProbe:
+        exec:
+          command:
+            - /bin/sh
+            - -c
+            - |
+              test -s /var/run/kafka-token/token.json &&
+              test -s /var/run/kafka-token/refreshed-at &&
+              refreshed="$(cat /var/run/kafka-token/refreshed-at)" &&
+              now="$(date +%s)" &&
+              age="$((now - refreshed))" &&
+              [ "$age" -lt 4200 ]
+
+        initialDelaySeconds: 60
+        periodSeconds: 60
+        timeoutSeconds: 5
+        failureThreshold: 3
+
+
+      resources:
+        requests:
+          cpu: 10m
+          memory: 16Mi
+        limits:
+          memory: 32Mi
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+
+        capabilities:
+          drop:
+            - ALL
+      volumeMounts:
+        - name: kafka-token
+          mountPath: /var/run/kafka-token
+
+  # Memory-backed volume containing the short-lived Kafka credential.
+  extraVolumes: &kafkaTokenVolumes
+    - name: kafka-token
+      emptyDir:
+        medium: Memory
+
+
+  # Mimir only needs to read credentials.
+  extraVolumeMounts: &kafkaTokenMimirMounts
+    - name: kafka-token
+      mountPath: /var/run/kafka-token
+      readOnly: true
 
 ingester:
   zoneAwareReplication:
@@ -112,6 +268,9 @@ ingester:
       cpu: 3.5
       memory: 8Gi
   topologySpreadConstraints: {}
+  initContainers: *kafkaTokenSidecars
+  extraVolumes: *kafkaTokenVolumes
+  extraVolumeMounts: *kafkaTokenMimirMounts
 
 chunks-cache:
   enabled: true
@@ -157,6 +316,9 @@ query_frontend:
     requests:
       cpu: 1
       memory: 2Gi
+  initContainers: *kafkaTokenSidecars
+  extraVolumes: *kafkaTokenVolumes
+  extraVolumeMounts: *kafkaTokenMimirMounts
 
 ruler:
   replicas: 1
@@ -166,6 +328,9 @@ ruler:
     requests:
       cpu: 1
       memory: 2Gi
+  initContainers: *kafkaTokenSidecars
+  extraVolumes: *kafkaTokenVolumes
+  extraVolumeMounts: *kafkaTokenMimirMounts
 
 store_gateway:
   zoneAwareReplication:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR setups gcp managed kafka cluster for mimir.
- enables managed kafka api
- configure mimir with kafka.

/cc @upodroid 
