### PR TITLE
Promote agent-sandbox/sandbox-router-go v1.0.0

### DIFF
--- a/registry.k8s.io/images/k8s-staging-agent-sandbox/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-agent-sandbox/images.yaml
@@ -77,3 +77,7 @@
 - name: python_runtime_sandbox # we don't use this anymore
   dmap:
     "sha256:7c8a124aa02534656f53f9b9f53ef8b4f1d1a1e390f27a8b7873b7e87a368f42": ["v0.1.0-rc.2"]
+- name: sandbox-router-go
+  dmap:
+    "sha256:ba55502a8b95a63f2919365d95d282785a59c8f47301b65e32d1e8aa1fc5f543": ["v1.0.0"]
+


### PR DESCRIPTION
**What this PR does / why we need it**:
Promote `sandbox-router-go` image for `agent-sandbox` release `v1.0.0`.
This image was omitted from #9882 because `sandbox-router-go` did not previously have an entry in `images.yaml`.

Digest: `sha256:ba55502a8b95a63f2919365d95d282785a59c8f47301b65e32d1e8aa1fc5f543`

**Special notes for your reviewer**:
Follow-up to #9882. The image was built in the official staging release workflow: https://github.com/kubernetes-sigs/agent-sandbox/actions/runs/33199043392

ref https://github.com/kubernetes-sigs/agent-sandbox/issues/1058

**If you are promoting an image, please make sure you have done the following:**

- [x] I have verified the digest with [gcrane](https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md) and added it as a comment to the PR or in the body.

- [x] I'm promoting a multi-arch image that matches all the [supported](https://github.com/kubernetes/sig-release/tree/master/release-engineering/platforms) platforms of Kubernetes.

- [x] I'm not promoting a tag that resolves to latest or moving tags as these are not supported

- [x] registry.k8s.io is an immutable registry and I'll need to cut a new release if the digest is wrong.