### PR TITLE
Raise ingesters replica count to 12

### DIFF
--- a/kubernetes/gke-utility/helm/mimir.yaml
+++ b/kubernetes/gke-utility/helm/mimir.yaml
@@ -260,7 +260,7 @@ ingester:
   persistentVolume:
     size: 50Gi
     storageClass: hyperdisk-balanced
-  replicas: 6
+  replicas: 12
   resources:
     limits:
       memory: 12Gi


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR raises ingester replica count to 12 to prevent OOM pod failures as current ingester pods are nearing request limits.


/cc @upodroid 