### PR TITLE
Add permissions for v1.38 release team leads and subteam leads

### DIFF
--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -50,14 +50,12 @@ groups:
       - elieser.pereiraa@gmail.com
       - gveronicalg@gmail.com
       - jameswangel@gmail.com
-      - jenny.shu@solo.io # v1.37 BM shadow
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
       - michellengnx@gmail.com
       - mudrinic.mare@gmail.com
       - neoaggelos@gmail.com
       - pal.nabarun95@gmail.com
-      - rytswd@gmail.com # v1.37 BM shadow
       - saschagrunert@gmail.com
       - satyampsoni@gmail.com
       - sreeramvenkitesh@gmail.com
@@ -72,18 +70,18 @@ groups:
     members:
       - k8s-infra-release-editors@kubernetes.io
       - k8s-infra-google-build-admins@kubernetes.io
-      - agustina.barbetta@gmail.com # v1.37 Release Lead Shadow
+      - agustina.barbetta@gmail.com # v1.38 Release Lead Shadow
       - ameukam@gmail.com
       - cicih@google.com
       - fsmunoz@gmail.com # Subproject owner
-      - gmail@yudocaa.in # v1.37 Release Lead Shadow
       - jameswangel@gmail.com
       - joseph.r.sandoval@gmail.com
       - kat.cosgrove@gmail.com # Subproject owner
+      - muhammad.adil.ghaffar@est.tech # v1.38 Release Lead Shadow 
       - pal.nabarun95@gmail.com
-      - prajyotparab19@gmail.com # v1.37 Release Lead Shadow
-      - rawat.dipesh@gmail.com # v1.37 Release Lead
-      - rayandas91@gmail.com # v1.37 Release Lead Shadow
+      - prajyotparab19@gmail.com # v1.38 Release Lead Shadow
+      - rayandas91@gmail.com # v1.38 Release Lead Shadow
+      - sreeramvenkitesh@gmail.com # v1.38 Release Lead
   - email-id: k8s-infra-staging-artifact-promoter@kubernetes.io
     name: k8s-infra-staging-artifact-promoter
     description: |-
@@ -212,14 +210,14 @@ groups:
       - k8s@auggie.dev
       - saschagrunert@gmail.com
     members:
-      - agustina.barbetta@gmail.com # v1.37 Release Lead Shadow
+      - agustina.barbetta@gmail.com # v1.38 Release Lead Shadow
+      - arshsharma461@gmail.com # v1.37 Communications Lead
       - fsmunoz@gmail.com # Subproject owner
-      - gmail@yudocaa.in # v1.37 Release Lead Shadow
       - kat.cosgrove@gmail.com # Subproject owner
-      - prajyotparab19@gmail.com # v1.37 Release Lead Shadow
-      - rawat.dipesh@gmail.com # v1.37 Release Lead
-      - rayandas91@gmail.com # v1.37 Release Lead Shadow
-      - swrao21@gmail.com # v1.37 Communications Lead
+      - muhammad.adil.ghaffar@est.tech # v1.38 Release Lead Shadow 
+      - prajyotparab19@gmail.com # v1.38 Release Lead Shadow
+      - rayandas91@gmail.com # v1.38 Release Lead Shadow
+      - sreeramvenkitesh@gmail.com # v1.38 Release Lead
 
   - email-id: release-managers-private@kubernetes.io
     name: release-managers-private
@@ -260,23 +258,22 @@ groups:
       - saschagrunert@gmail.com
     members:
       - release-managers-private@kubernetes.io
-      - agustina.barbetta@gmail.com # v1.37 Release Lead Shadow
+      - agustina.barbetta@gmail.com # v1.38 Release Lead Shadow
       - ameukam@gmail.com
       - antheabjung@gmail.com
       - bentheelder@google.com
       - fsmunoz@gmail.com # Subproject owner
-      - gmail@yudocaa.in # v1.37 Release Lead Shadow
       - gmccloskey@google.com
       - jameswangel@gmail.com
       - joseph.r.sandoval@gmail.com
       - kat.cosgrove@gmail.com # Subproject owner
       - mudrinic.mare@gmail.com
-      - prajyotparab19@gmail.com # v1.37 Release Lead Shadow
-      - rawat.dipesh@gmail.com # v1.37 Release Lead
-      - rayandas91@gmail.com # v1.37 Release Lead Shadow
+      - muhammad.adil.ghaffar@est.tech # v1.38 Release Lead Shadow 
+      - prajyotparab19@gmail.com # v1.38 Release Lead Shadow
+      - rayandas91@gmail.com # v1.38 Release Lead Shadow
       - saugustus2@bloomberg.net
       - spiffxp@google.com
-
+      - sreeramvenkitesh@gmail.com # v1.38 Release Lead
   - email-id: security-release-team@kubernetes.io
     name: security-release-team
     description: |-
@@ -347,41 +344,18 @@ groups:
       - k8s@auggie.dev
       - saschagrunert@gmail.com
     managers:
-      - agustina.barbetta@gmail.com # v1.37 Release Lead Shadow
+      - agustina.barbetta@gmail.com # v1.38 Release Lead Shadow
       - fsmunoz@gmail.com # Subproject owner
-      - gmail@yudocaa.in # v1.37 Release Lead Shadow
       - kat.cosgrove@gmail.com # Subproject owner
-      - prajyotparab19@gmail.com # v1.37 Release Lead Shadow
-      - rawat.dipesh@gmail.com # v1.37 Release Lead
-      - rayandas91@gmail.com # v1.37 Release Lead Shadow
+      - muhammad.adil.ghaffar@est.tech # v1.38 Release Lead Shadow 
+      - prajyotparab19@gmail.com # v1.38 Release Lead Shadow
+      - rayandas91@gmail.com # v1.38 Release Lead Shadow
+      - sreeramvenkitesh@gmail.com # v1.38 Release Lead
     members:
-      - arshsharma461@gmail.com # v1.37 Release Comms Shadow
-      - christophertineo02@gmail.com # v1.37 Release Comms Shadow
-      - kirtigoyal328@gmail.com # v1.37 Release Comms Shadow
-      - sophiagentle72@gmail.com # v1.37 Release Comms Shadow
-      - troy0820@gmail.com # v1.37 Release Comms Shadow
-      - amanshrivastava118@gmail.com # v1.37 Release Signal Shadow
-      - chadmcrowell@gmail.com # v1.37 Docs Shadow
-      - destinyerhabor6@gmail.com # v1.37 Docs Shadow
-      - dhanisha.6@gmail.com # v1.37 Enhancements Shadow
-      - j@mickey.dev # v1.37 Docs Shadow
-      - jenny.shu@solo.io # v1.37 BM shadow
-      - junaidshaukat546@gmail.com # v1.37 Release Signal Shadow
-      - k.130.email@gmail.com # v1.37 Release Signal Shadow
-      - karimzakzouk@outlook.com # v1.37 Enhancements Shadow
-      - lauri.d.apple@gmail.com # v1.37 Enhancements Shadow
-      - mahdi.svt5@gmail.com # v1.37 Release Signal Shadow
-      - misrayashasvi27@gmail.com # v1.37 Docs Shadow
-      - muhammad.adil.ghaffar@est.tech # v1.37 Release Signal Lead
-      - ofircohenn@gmail.com # v1.37 Enhancements Shadow
-      - peppi-lotta.kurjenhovi@est.tech # v1.37 Release Signal Shadow
-      - rytswd@gmail.com # v1.37 BM shadow
-      - singh1203.ss@gmail.com # v1.37 Docs Shadow
-      - subhasmitaswain232@gmail.com # v1.37 Enhancements Lead
-      - swrao21@gmail.com # v1.37 Communications Lead
-      - tatiana.sel@gmail.com # v1.37 Release Lead Shadow
-      - tico88612@gmail.com # v1.37 Enhancements Shadow
-      - tusharmittalworkm@gmail.com # v1.37 Docs Lead
+      - arshsharma461@gmail.com # v1.38 Release Comms Lead
+      - destinyerhabor6@gmail.com # v1.38 Docs Lead
+      - k.130.email@gmail.com # v1.38 Release Signal Lead
+      - tico88612@gmail.com # v1.38 Enhancements Shadow
 
   - email-id: release-team-shadows@kubernetes.io
     name: release-team-shadows
@@ -401,37 +375,16 @@ groups:
     managers:
       - fsmunoz@gmail.com # Subproject owner
       - kat.cosgrove@gmail.com # Subproject owner
-      - rawat.dipesh@gmail.com # v1.37 Release Lead
+      - sreeramvenkitesh@gmail.com # v1.38 Release Lead
     members:
-      - agustina.barbetta@gmail.com # v1.37 Release Lead Shadow
-      - arshsharma461@gmail.com # v1.37 Release Comms Shadow
-      - christophertineo02@gmail.com # v1.37 Release Comms Shadow
-      - kirtigoyal328@gmail.com # v1.37 Release Comms Shadow
-      - amanshrivastava118@gmail.com # v1.37 Release Signal Shadow
-      - chadmcrowell@gmail.com # v1.37 Docs Shadow
-      - destinyerhabor6@gmail.com # v1.37 Docs Shadow
-      - dhanisha.6@gmail.com # v1.37 Enhancements Shadow
-      - gmail@yudocaa.in # v1.37 Release Lead Shadow
-      - j@mickey.dev # v1.37 Docs Shadow
-      - junaidshaukat546@gmail.com # v1.37 Release Signal Shadow
-      - k.130.email@gmail.com # v1.37 Release Signal Shadow
-      - karimzakzouk@outlook.com # v1.37 Enhancements Shadow
-      - lauri.d.apple@gmail.com # v1.37 Enhancements Shadow
-      - mahdi.svt5@gmail.com # v1.37 Release Signal Shadow
-      - misrayashasvi27@gmail.com # v1.37 Docs Shadow
-      - muhammad.adil.ghaffar@est.tech # v1.37 Release Signal Lead
-      - ofircohenn@gmail.com # v1.37 Enhancements Shadow
-      - peppi-lotta.kurjenhovi@est.tech # v1.37 Release Signal Shadow
-      - prajyotparab19@gmail.com # v1.37 Release Lead Shadow
-      - rayandas91@gmail.com # v1.37 Release Lead Shadow
-      - sophiagentle72@gmail.com # v1.37 Release Comms Shadow
-      - troy0820@gmail.com # v1.37 Release Comms Shadow
-      - singh1203.ss@gmail.com # v1.37 Docs Shadow
-      - subhasmitaswain232@gmail.com # v1.37 Enhancements Lead
-      - swrao21@gmail.com # v1.37 Communications Lead
-      - tatiana.sel@gmail.com # v1.37 Release Lead Shadow
-      - tico88612@gmail.com # v1.37 Enhancements Shadow
-      - tusharmittalworkm@gmail.com # v1.37 Docs Lead
+      - agustina.barbetta@gmail.com # v1.38 Release Lead Shadow
+      - arshsharma461@gmail.com # v1.38 Release Comms Lead
+      - destinyerhabor6@gmail.com # v1.38 Docs Lead
+      - k.130.email@gmail.com # v1.38 Release Signal Lead
+      - muhammad.adil.ghaffar@est.tech # v1.38 Release Lead Shadow
+      - prajyotparab19@gmail.com # v1.38 Release Lead Shadow
+      - rayandas91@gmail.com # v1.38 Release Lead Shadow
+      - tico88612@gmail.com # v1.38 Enhancements Shadow
   # RBAC groups:
   # - grant access to the `namespace-user` role for a single namespace on the `aaa` cluster
   # - must have WhoCanViewMemberShip: "ALL_MEMBERS_CAN_VIEW"
@@ -474,7 +427,7 @@ groups:
       WhoCanViewMembership: "ALL_MEMBERS_CAN_VIEW"
     members:
       - k8s-infra-release-viewers@kubernetes.io
-      - muhammad.adil.ghaffar@est.tech # v1.37 Release Signal Lead
+      - k.130.email@gmail.com # v1.38 Release Signal Lead
 
   - email-id: release-team-enhancements@kubernetes.io
     name: release-team-enhancements
@@ -492,19 +445,14 @@ groups:
       - k8s@auggie.dev
       - saschagrunert@gmail.com
     members:
-      - agustina.barbetta@gmail.com # v1.37 Release Lead Shadow
-      - dhanisha.6@gmail.com # v1.37 Enhancements Shadow
+      - agustina.barbetta@gmail.com # v1.38 Release Lead Shadow
       - fsmunoz@gmail.com # Subproject owner
-      - gmail@yudocaa.in # v1.37 Release Lead Shadow
-      - karimzakzouk@outlook.com # v1.37 Enhancements Shadow
       - kat.cosgrove@gmail.com # Subproject owner
-      - lauri.d.apple@gmail.com # v1.37 Enhancements Shadow
-      - ofircohenn@gmail.com # v1.37 Enhancements Shadow
-      - prajyotparab19@gmail.com # v1.37 Release Lead Shadow
-      - rawat.dipesh@gmail.com # v1.37 Release Lead
-      - rayandas91@gmail.com # v1.37 Release Lead Shadow
-      - subhasmitaswain232@gmail.com # v1.37 Enhancements Lead
-      - tico88612@gmail.com # v1.37 Enhancements Shadow
+      - muhammad.adil.ghaffar@est.tech # v1.38 Release Lead Shadow
+      - prajyotparab19@gmail.com # v1.38 Release Lead Shadow
+      - rayandas91@gmail.com # v1.38 Release Lead Shadow
+      - sreeramvenkitesh@gmail.com # v1.38 Release Lead
+      - tico88612@gmail.com # v1.38 Enhancements Lead
   - email-id: k8s-infra-staging-zeitgeist@kubernetes.io
     name: k8s-infra-staging-zeitgeist
     description: |-

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -77,7 +77,7 @@ groups:
       - jameswangel@gmail.com
       - joseph.r.sandoval@gmail.com
       - kat.cosgrove@gmail.com # Subproject owner
-      - muhammad.adil.ghaffar@est.tech # v1.38 Release Lead Shadow 
+      - muhammad.adil.ghaffar@est.tech # v1.38 Release Lead Shadow
       - pal.nabarun95@gmail.com
       - prajyotparab19@gmail.com # v1.38 Release Lead Shadow
       - rayandas91@gmail.com # v1.38 Release Lead Shadow
@@ -214,7 +214,7 @@ groups:
       - arshsharma461@gmail.com # v1.37 Communications Lead
       - fsmunoz@gmail.com # Subproject owner
       - kat.cosgrove@gmail.com # Subproject owner
-      - muhammad.adil.ghaffar@est.tech # v1.38 Release Lead Shadow 
+      - muhammad.adil.ghaffar@est.tech # v1.38 Release Lead Shadow
       - prajyotparab19@gmail.com # v1.38 Release Lead Shadow
       - rayandas91@gmail.com # v1.38 Release Lead Shadow
       - sreeramvenkitesh@gmail.com # v1.38 Release Lead
@@ -268,7 +268,7 @@ groups:
       - joseph.r.sandoval@gmail.com
       - kat.cosgrove@gmail.com # Subproject owner
       - mudrinic.mare@gmail.com
-      - muhammad.adil.ghaffar@est.tech # v1.38 Release Lead Shadow 
+      - muhammad.adil.ghaffar@est.tech # v1.38 Release Lead Shadow
       - prajyotparab19@gmail.com # v1.38 Release Lead Shadow
       - rayandas91@gmail.com # v1.38 Release Lead Shadow
       - saugustus2@bloomberg.net
@@ -347,7 +347,7 @@ groups:
       - agustina.barbetta@gmail.com # v1.38 Release Lead Shadow
       - fsmunoz@gmail.com # Subproject owner
       - kat.cosgrove@gmail.com # Subproject owner
-      - muhammad.adil.ghaffar@est.tech # v1.38 Release Lead Shadow 
+      - muhammad.adil.ghaffar@est.tech # v1.38 Release Lead Shadow
       - prajyotparab19@gmail.com # v1.38 Release Lead Shadow
       - rayandas91@gmail.com # v1.38 Release Lead Shadow
       - sreeramvenkitesh@gmail.com # v1.38 Release Lead

--- a/groups/sig-release/groups.yaml
+++ b/groups/sig-release/groups.yaml
@@ -50,12 +50,14 @@ groups:
       - elieser.pereiraa@gmail.com
       - gveronicalg@gmail.com
       - jameswangel@gmail.com
+      - jenny.shu@solo.io # v1.38 BM shadow
       - jeremy.r.rickard@gmail.com
       - k8s@auggie.dev
       - michellengnx@gmail.com
       - mudrinic.mare@gmail.com
       - neoaggelos@gmail.com
       - pal.nabarun95@gmail.com
+      - rytswd@gmail.com # v1.38 BM shadow
       - saschagrunert@gmail.com
       - satyampsoni@gmail.com
       - sreeramvenkitesh@gmail.com
@@ -354,7 +356,9 @@ groups:
     members:
       - arshsharma461@gmail.com # v1.38 Release Comms Lead
       - destinyerhabor6@gmail.com # v1.38 Docs Lead
+      - jenny.shu@solo.io # v1.38 BM shadow
       - k.130.email@gmail.com # v1.38 Release Signal Lead
+      - rytswd@gmail.com # v1.38 BM shadow
       - tico88612@gmail.com # v1.38 Enhancements Shadow
 
   - email-id: release-team-shadows@kubernetes.io


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the following groups for v1.38 release team:

- `k8s-infra-release-viewers@kubernetes.io`
- `release-comms@kubernetes.io`
- `release-managers@kubernetes.io`
- `release-team@kubernetes.io`
- `release-team-shadows@kubernetes.io`
- `k8s-infra-staging-tg-exporter@kubernetes.io`
- `release-team-enhancements@kubernetes.io`

Ref: https://github.com/kubernetes/sig-release/issues/3087

