### PR TITLE
Image promotion for sp-operator seccomp base profiles and test fixtures

### DIFF
--- a/registry.k8s.io/images/k8s-staging-sp-operator/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-sp-operator/images.yaml
@@ -1,3 +1,11 @@
+- name: seccomp-test-profiles
+  dmap:
+    "sha256:15a0050ff613b742d960e7bf4ed3df77c91adee1e1472d5aea57718884ad8261": ["baseprofile-crun"]
+    "sha256:04dfbc1a053a100754ad3e4f8fbc1b521d715e684311084fc9dc56877c402263": ["baseprofile-runc"]
+    "sha256:9b9d6cb98e5c58448c341628db6b20e7c4866abc53fbd5e1f5a938739b26fbe6": ["deny-chmod"]
+    "sha256:9dcf79f9985870bfe05bf0c94beb0ec24cd2391e762f8e3bb1853693cd3c904d": ["invalid"]
+    "sha256:49e08cf9b77aae392eb555fa1d9a3ea833052626746322151319fbd42f177e36": ["oversized"]
+    "sha256:e7279f26947707f3328552d72167700d80431179f3023e8efaa7a86f08dc5176": ["permissive"]
 - name: security-profiles-operator
   dmap:
     "sha256:67c97995264f949ab2d2e028cc6fb981cf5fe4646442abb8b422e9559c6a5732": ["v0.1.0"]

--- a/registry.k8s.io/images/k8s-staging-sp-operator/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-sp-operator/images.yaml
@@ -1,3 +1,9 @@
+- name: base/crun
+  dmap:
+    "sha256:63cf5c33cb3c45b0e0f37b03cd3dfa630bf6f37fdc582b84ba6f7520da872a76": ["v1.29.1"]
+- name: base/runc
+  dmap:
+    "sha256:7e3cc47105b0b005555dcb3295595234f631c71e7f9982337117ca4675d0506f": ["v1.5.1"]
 - name: seccomp-test-profiles
   dmap:
     "sha256:9b9d6cb98e5c58448c341628db6b20e7c4866abc53fbd5e1f5a938739b26fbe6": ["deny-chmod"]

--- a/registry.k8s.io/images/k8s-staging-sp-operator/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-sp-operator/images.yaml
@@ -1,7 +1,5 @@
 - name: seccomp-test-profiles
   dmap:
-    "sha256:15a0050ff613b742d960e7bf4ed3df77c91adee1e1472d5aea57718884ad8261": ["baseprofile-crun"]
-    "sha256:04dfbc1a053a100754ad3e4f8fbc1b521d715e684311084fc9dc56877c402263": ["baseprofile-runc"]
     "sha256:9b9d6cb98e5c58448c341628db6b20e7c4866abc53fbd5e1f5a938739b26fbe6": ["deny-chmod"]
     "sha256:9dcf79f9985870bfe05bf0c94beb0ec24cd2391e762f8e3bb1853693cd3c904d": ["invalid"]
     "sha256:49e08cf9b77aae392eb555fa1d9a3ea833052626746322151319fbd42f177e36": ["oversized"]


### PR DESCRIPTION
Image promotion for sp-operator seccomp profiles, generated with `kpromo` and extended by hand for the base profiles.

Two kinds of artifact, both in the KEP-6061 runtime format, a single layer holding an OCI runtime-spec seccomp profile identified by `application/vnd.cncf.seccomp-profile.config.v1+json`:

- `base/runc` and `base/crun` are the base profiles the operator records against the container runtimes it supports. Container runtimes consume them for `type: OCI` seccomp profiles and the operator reads them for `oci://` base profiles.
- `seccomp-test-profiles` holds fixtures for the Kubernetes `e2e_node` tests: a profile that constrains an observable syscall, one more permissive than any node baseline, one a runtime has to reject, and one above the default size limit.

Only versioned tags are promoted. The staging registry also carries a `latest` tag for the base profiles, which is deliberately left out, since tags here cannot be repointed and a promoted `latest` would be frozen at whatever it pointed to first.

/cc @kubernetes/release-engineering
