### PR TITLE
feat: bump datadog to 3.244.0

### DIFF
--- a/kubernetes/aks-prow-build/datadog/kustomization.yaml
+++ b/kubernetes/aks-prow-build/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.202.2
+    version: 3.244.0
     kubeVersion: "1.33"
     valuesFile: values.yaml
 

--- a/kubernetes/eks-prow-build/datadog/kustomization.yaml
+++ b/kubernetes/eks-prow-build/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.229.0
+    version: 3.244.0
     kubeVersion: "1.35"
     valuesFile: values.yaml
 

--- a/kubernetes/eks-prow-kops/datadog/kustomization.yaml
+++ b/kubernetes/eks-prow-kops/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.202.2
+    version: 3.244.0
     kubeVersion: "1.30"
     valuesFile: values.yaml
 

--- a/kubernetes/gke-aaa/datadog/kustomization.yaml
+++ b/kubernetes/gke-aaa/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.202.2
+    version: 3.244.0
     valuesFile: values.yaml
 
 resources:

--- a/kubernetes/gke-prow-build-trusted/datadog/kustomization.yaml
+++ b/kubernetes/gke-prow-build-trusted/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.202.2
+    version: 3.244.0
     valuesFile: values.yaml
 
 resources:

--- a/kubernetes/gke-prow-build/datadog/kustomization.yaml
+++ b/kubernetes/gke-prow-build/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.202.2
+    version: 3.244.0
     valuesFile: values.yaml
 
 resources:

--- a/kubernetes/gke-prow/datadog/kustomization.yaml
+++ b/kubernetes/gke-prow/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.202.2
+    version: 3.244.0
     valuesFile: values.yaml
 
 resources:

--- a/kubernetes/gke-utility/datadog/kustomization.yaml
+++ b/kubernetes/gke-utility/datadog/kustomization.yaml
@@ -6,7 +6,7 @@ helmCharts:
   - name: datadog
     repo: https://helm.datadoghq.com
     releaseName: datadog
-    version: 3.229.0
+    version: 3.244.0
     valuesFile: values.yaml
 
 resources:


### PR DESCRIPTION
**What this PR does / why we need it**:

bumps datadog to 3.244.0

/cc @upodroid 