### PR TITLE
Promote gateway-api-inference-extension v1.6.1 lwepp image

### DIFF
--- a/registry.k8s.io/images/k8s-staging-gateway-api-inference-extension/images.yaml
+++ b/registry.k8s.io/images/k8s-staging-gateway-api-inference-extension/images.yaml
@@ -1,6 +1,7 @@
 - name: lwepp
   dmap:
     "sha256:66059c328f975965eaaab4bdf5adbc3035c964aea7e47d59ecead6a6a17af677": ["v1.6.0"]
+    "sha256:33413317d159fd6e2b7598dfae2cd51b407b8bc711431bab923b685af12d3ada": ["v1.6.1"]
 
 ## Everything below are deprecated, no new images will be added, but old ones will be kept.
 - name: charts/inferencepool


### PR DESCRIPTION
**What this PR does / why we need it**:
Promote gateway-api-inference-extension images for v1.6.1.

Source tag: v1.6.1
Release tracker: https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/3047

**Special notes for your reviewer**:

**If you are promoting an image, please make sure you have done the following:**

- [x] I have verified the digest with [gcrane](https://github.com/google/go-containerregistry/blob/main/cmd/gcrane/README.md) and added it as a comment to the PR or in the body.

- [x] I'm promoting a multi-arch image that matches all the [supported](https://github.com/kubernetes/sig-release/tree/master/release-engineering/platforms) platforms of Kubernetes.

- [x] I'm not promoting a tag that resolves to latest or moving tags as these are not supported

- [x] registry.k8s.io is an immutable registry and I'll need to cut a new release if the digest is wrong.
