### PR TITLE
External secret IAM credential for PowerVS CSI Driver on ppc64le build cluster

### DIFF
--- a/kubernetes/ibm-ppc64le/kube-system/secrets.yaml
+++ b/kubernetes/ibm-ppc64le/kube-system/secrets.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: powervs-csi-driver-api-key
+  namespace: kube-system
+spec:
+  refreshInterval: 30m
+  secretStoreRef:
+    name: secretstore-ibm-k8s
+    kind: ClusterSecretStore
+  target:
+    name: ibm-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: IBMCLOUD_API_KEY
+      remoteRef:
+        key: iam_credentials/b6edf285-6dd7-1957-34e1-cfae2cb3e56f


### PR DESCRIPTION
Add ibm secret that will be used by PowerVS CSI Driver on ppc64le build cluster.

The IAM credential external secret created in IBM Cloud's Secret Manager is mapped to an access group that has role with following permissions:

```
power-iaas.cloud-instance.read
power-iaas.workspace.read

power-iaas.cloud-instance-volume.create
power-iaas.cloud-instance-volume.delete
power-iaas.cloud-instance-volume.list
power-iaas.cloud-instance-volume.read
power-iaas.cloud-instance-volume.update

power-iaas.pvm-instance.list
power-iaas.pvm-instance.read

power-iaas.pvm-instance-volume.create
power-iaas.pvm-instance-volume.delete
power-iaas.pvm-instance-volume.list
power-iaas.pvm-instance-volume.read
power-iaas.pvm-instance-volume.update

resource-controller.instance.retrieve

power-iaas.storage-tier.read
```
