### PR TITLE
Add secrets.yaml to Kustomization.yaml

### DIFF
--- a/kubernetes/ibm-ppc64le/kube-system/kustomization.yaml
+++ b/kubernetes/ibm-ppc64le/kube-system/kustomization.yaml
@@ -3,3 +3,4 @@ kind: Kustomization
 namespace: kube-system
 resources:
   - daemonsets.yaml
+  - secrets.yaml


### PR DESCRIPTION
As a continuation to https://github.com/kubernetes/k8s.io/pull/9925 to deploy newly added secret to ppc64le build cluster, this addition to `kustomization.yaml` is needed.